### PR TITLE
fix(installation config): derive encryption key from secret_key_base when env var is unset

### DIFF
--- a/app/models/installation_config.rb
+++ b/app/models/installation_config.rb
@@ -34,8 +34,29 @@ class InstallationConfig < ApplicationRecord
 
   after_commit :clear_cache
 
+  ENCRYPTION_KEY_DERIVATION_SALT = 'installation_config_encryption_v1'
+
   def self.encryption_key
-    ENV.fetch('ENCRYPTION_KEY') { raise 'ENCRYPTION_KEY environment variable is required' }
+    @encryption_key ||= resolve_encryption_key
+  end
+
+  def self.reset_encryption_key_cache!
+    @encryption_key = nil
+  end
+
+  def self.resolve_encryption_key
+    ENV['ENCRYPTION_KEY'].presence || derive_encryption_key_from_secret_key_base
+  end
+
+  def self.derive_encryption_key_from_secret_key_base
+    secret = ENV['SECRET_KEY_BASE'].presence ||
+             (defined?(Rails) && Rails.application&.secret_key_base.presence)
+    raise 'ENCRYPTION_KEY or SECRET_KEY_BASE must be set' if secret.blank?
+
+    key_material = ActiveSupport::KeyGenerator.new(secret).generate_key(
+      ENCRYPTION_KEY_DERIVATION_SALT, 32
+    )
+    Base64.urlsafe_encode64(key_material)
   end
 
   def sensitive?

--- a/config/initializers/installation_config_encryption.rb
+++ b/config/initializers/installation_config_encryption.rb
@@ -1,0 +1,5 @@
+Rails.application.config.after_initialize do
+  next if Rails.env.test?
+
+  InstallationConfig.encryption_key
+end

--- a/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
@@ -16,10 +16,12 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
 
   before do
     ENV['ENCRYPTION_KEY'] = 'test-encryption-key-for-fernet!!'
+    InstallationConfig.reset_encryption_key_cache!
   end
 
   after do
     Current.reset
+    InstallationConfig.reset_encryption_key_cache!
   end
 
   shared_context 'authenticated admin' do

--- a/spec/lib/email_configuration_spec.rb
+++ b/spec/lib/email_configuration_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Email Configuration (Story 2.1)' do
   before do
     ENV['ENCRYPTION_KEY'] = 'test-encryption-key-for-fernet!!'
+    InstallationConfig.reset_encryption_key_cache!
     # Stub Redis to avoid cache pollution between tests
     redis_double = double('redis')
     allow($alfred).to receive(:with).and_yield(redis_double)

--- a/spec/migrations/rename_sensitive_keys_and_encrypt_spec.rb
+++ b/spec/migrations/rename_sensitive_keys_and_encrypt_spec.rb
@@ -8,9 +8,16 @@ RSpec.describe 'RenameSensitiveKeysAndEncrypt migration', type: :model do
   let(:migration) { migration_class.new }
 
   before do
+    InstallationConfig.reset_encryption_key_cache!
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('ENCRYPTION_KEY').and_return(encryption_key)
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('ENCRYPTION_KEY').and_return(encryption_key)
     allow(ENV).to receive(:fetch).with('ENCRYPTION_KEY', nil).and_return(encryption_key)
+  end
+
+  after do
+    InstallationConfig.reset_encryption_key_cache!
   end
 
   # Use migration's local model to avoid app model callbacks

--- a/spec/models/installation_config_spec.rb
+++ b/spec/models/installation_config_spec.rb
@@ -4,8 +4,15 @@ RSpec.describe InstallationConfig, type: :model do
   let(:encryption_key) { Base64.urlsafe_encode64(SecureRandom.random_bytes(32)) }
 
   before do
+    described_class.reset_encryption_key_cache!
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('ENCRYPTION_KEY').and_return(encryption_key)
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with('ENCRYPTION_KEY').and_return(encryption_key)
+  end
+
+  after do
+    described_class.reset_encryption_key_cache!
   end
 
   describe '#sensitive?' do
@@ -138,9 +145,38 @@ RSpec.describe InstallationConfig, type: :model do
   end
 
   describe '.encryption_key' do
-    it 'raises error when ENCRYPTION_KEY is not set' do
-      allow(ENV).to receive(:fetch).with('ENCRYPTION_KEY').and_yield
-      expect { described_class.encryption_key }.to raise_error(RuntimeError, /ENCRYPTION_KEY/)
+    it 'returns the ENCRYPTION_KEY env var when present' do
+      expect(described_class.encryption_key).to eq(encryption_key)
+    end
+
+    context 'when ENCRYPTION_KEY is not set' do
+      before do
+        described_class.reset_encryption_key_cache!
+        allow(ENV).to receive(:[]).with('ENCRYPTION_KEY').and_return(nil)
+      end
+
+      it 'derives a deterministic key from SECRET_KEY_BASE' do
+        first = described_class.encryption_key
+        described_class.reset_encryption_key_cache!
+        second = described_class.encryption_key
+
+        expect(first).to be_present
+        expect(first).to eq(second)
+      end
+
+      it 'derives a valid Fernet key usable for encrypt/decrypt' do
+        key = described_class.encryption_key
+        token = Fernet.generate(key, 'roundtrip')
+        verifier = Fernet.verifier(key, token, enforce_ttl: false)
+        expect(verifier.valid?).to be true
+        expect(verifier.message).to eq('roundtrip')
+      end
+
+      it 'raises when SECRET_KEY_BASE is also absent' do
+        allow(ENV).to receive(:[]).with('SECRET_KEY_BASE').and_return(nil)
+        allow(Rails.application).to receive(:secret_key_base).and_return(nil)
+        expect { described_class.encryption_key }.to raise_error(RuntimeError, /ENCRYPTION_KEY/)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

`InstallationConfig.encryption_key` previously raised a `RuntimeError` whenever `ENCRYPTION_KEY` was missing from the environment. Any admin config save that persisted a `_SECRET` field (Facebook, WhatsApp, Instagram, etc.) called this from a `before_save` callback and exploded at request time, surfacing as a generic `INTERNAL_ERROR` 500 to the user.

The resolver now:

1. Reads `ENV['ENCRYPTION_KEY']` first.
2. Falls back to a deterministic Fernet key derived from `SECRET_KEY_BASE` via `ActiveSupport::KeyGenerator` (PBKDF2-HMAC-SHA1, 32 bytes, base64url-encoded). Since Rails always has a `secret_key_base`, the app works out of the box.
3. Memoizes the resolved key at the class level (specs expose `reset_encryption_key_cache!` to clear between examples).

A new initializer (`config/initializers/installation_config_encryption.rb`) calls `InstallationConfig.encryption_key` during boot so the process **fails fast** if neither value is available, rather than surfacing the error on a later request.

Specs were updated to stub `ENV['ENCRYPTION_KEY']` (in addition to the legacy `ENV.fetch` stub) and to reset the cache between examples.

Issue: [EVO-937](https://linear.app/evoai/issue/EVO-937)

## Test plan

- [ ] `bundle exec rspec spec/models/installation_config_spec.rb`
- [ ] `bundle exec rspec spec/controllers/api/v1/admin/app_configs_controller_spec.rb`
- [ ] `bundle exec rspec spec/lib/email_configuration_spec.rb`
- [ ] `bundle exec rspec spec/migrations/rename_sensitive_keys_and_encrypt_spec.rb`
- [ ] In a clean dev env without `ENCRYPTION_KEY` set, save Facebook credentials via `/settings/admin/channels` and verify the secret is persisted (encrypted) and re-read correctly.
- [ ] Boot the app with both `ENCRYPTION_KEY` and `SECRET_KEY_BASE` unset and verify the initializer aborts with a clear error.