### PR TITLE
fix(db): drop FKs to removed users table so db:migrate completes

### DIFF
--- a/db/migrate/20251114140050_create_facebook_comment_moderations.rb
+++ b/db/migrate/20251114140050_create_facebook_comment_moderations.rb
@@ -11,7 +11,7 @@ class CreateFacebookCommentModerations < ActiveRecord::Migration[7.1]
       t.string :action_type, null: false # 'delete_comment', 'block_user', 'send_response'
       t.text :response_content # Generated response content (if applicable)
       t.text :rejection_reason # Reason for rejection
-      t.references :moderated_by, null: true, foreign_key: { to_table: :users }, type: :uuid
+      t.uuid :moderated_by_id
       t.datetime :moderated_at
 
       t.timestamps
@@ -21,6 +21,6 @@ class CreateFacebookCommentModerations < ActiveRecord::Migration[7.1]
     add_index :facebook_comment_moderations, :moderation_type unless index_exists?(:facebook_comment_moderations, :moderation_type)
     add_index :facebook_comment_moderations, :comment_id unless index_exists?(:facebook_comment_moderations, :comment_id)
     add_index :facebook_comment_moderations, [:status, :moderation_type] unless index_exists?(:facebook_comment_moderations, [:status, :moderation_type])
-    # Note: conversation_id, message_id, and moderated_by_id indexes are automatically created by t.references
+    add_index :facebook_comment_moderations, :moderated_by_id unless index_exists?(:facebook_comment_moderations, :moderated_by_id)
   end
 end

--- a/db/migrate/20251121132530_create_scheduled_actions.rb
+++ b/db/migrate/20251121132530_create_scheduled_actions.rb
@@ -34,7 +34,6 @@ class CreateScheduledActions < ActiveRecord::Migration[7.0]
 
     add_foreign_key :scheduled_actions, :contacts, on_delete: :cascade
     add_foreign_key :scheduled_actions, :conversations, on_delete: :cascade
-    add_foreign_key :scheduled_actions, :users, column: :created_by, on_delete: :cascade
   end
 end
 

--- a/db/migrate/20251124163127_create_pipeline_tasks.rb
+++ b/db/migrate/20251124163127_create_pipeline_tasks.rb
@@ -2,8 +2,8 @@ class CreatePipelineTasks < ActiveRecord::Migration[7.0]
   def change
     create_table :pipeline_tasks, id: :uuid do |t|
       t.references :pipeline_item, type: :uuid, null: false, foreign_key: true
-      t.references :created_by, type: :uuid, null: false, foreign_key: { to_table: :users }
-      t.references :assigned_to, type: :uuid, foreign_key: { to_table: :users }
+      t.uuid :created_by_id, null: false
+      t.uuid :assigned_to_id
 
       t.string :title, null: false, limit: 255
       t.text :description
@@ -28,6 +28,7 @@ class CreatePipelineTasks < ActiveRecord::Migration[7.0]
 
     add_index :pipeline_tasks, [:pipeline_item_id, :status]
     add_index :pipeline_tasks, [:assigned_to_id, :status, :due_date]
+    add_index :pipeline_tasks, :created_by_id
     add_index :pipeline_tasks, [:due_date]
     add_index :pipeline_tasks, [:status, :due_date], where: "status = 0", name: 'index_pipeline_tasks_on_pending_status_and_due_date'
   end

--- a/db/migrate/20251125120000_create_scheduled_action_templates.rb
+++ b/db/migrate/20251125120000_create_scheduled_action_templates.rb
@@ -18,7 +18,5 @@ class CreateScheduledActionTemplates < ActiveRecord::Migration[7.0]
     add_index :scheduled_action_templates, :action_type
     add_index :scheduled_action_templates, :is_default, name: 'idx_templates_default'
     add_index :scheduled_action_templates, :is_public, name: 'idx_templates_public'
-
-    add_foreign_key :scheduled_action_templates, :users, column: :created_by, on_delete: :cascade
   end
 end

--- a/db/migrate/20251125120001_add_notification_fields_to_scheduled_actions.rb
+++ b/db/migrate/20251125120001_add_notification_fields_to_scheduled_actions.rb
@@ -6,6 +6,5 @@ class AddNotificationFieldsToScheduledActions < ActiveRecord::Migration[7.0]
     add_column :scheduled_actions, :notification_sent_at, :datetime
 
     add_index :scheduled_actions, :notify_user_id
-    add_foreign_key :scheduled_actions, :users, column: :notify_user_id, on_delete: :nullify
   end
 end

--- a/db/migrate/20251125120002_create_scheduled_action_notifications.rb
+++ b/db/migrate/20251125120002_create_scheduled_action_notifications.rb
@@ -21,6 +21,5 @@ class CreateScheduledActionNotifications < ActiveRecord::Migration[7.0]
     add_index :scheduled_action_notifications, [:scheduled_action_id, :notification_type], name: 'idx_notifications_action_type'
 
     add_foreign_key :scheduled_action_notifications, :scheduled_actions, on_delete: :cascade
-    add_foreign_key :scheduled_action_notifications, :users, on_delete: :cascade
   end
 end

--- a/db/migrate/20260414120000_create_user_tours.rb
+++ b/db/migrate/20260414120000_create_user_tours.rb
@@ -1,7 +1,7 @@
 class CreateUserTours < ActiveRecord::Migration[7.1]
   def change
     create_table :user_tours do |t|
-      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.uuid :user_id, null: false
       t.string :tour_key, null: false
       t.string :status, null: false, default: 'completed'
       t.datetime :completed_at

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -74,11 +74,10 @@ vite: bundle exec vite dev
 EOF
 
 echo "🗄️ Preparing database..."
-# Run database migrations and seeds if needed
-bundle exec rails db:create 2>/dev/null || true
-bundle exec rails db:migrate 2>/dev/null || true
-# Use the evolution_prepare task from Makefile which handles everything
-bundle exec rails db:evolution_prepare 2>/dev/null || echo "Database preparation completed (or already prepared)"
+# db:evolution_prepare handles create + schema:load (on empty DB) + migrate (always).
+# Do NOT redirect stderr or mask failures — a broken migration must stop the boot
+# instead of leaving the database in a half-migrated state.
+bundle exec rails db:evolution_prepare
 
 echo "🧹 Cleaning up..."
 rm -f ./.overmind.sock


### PR DESCRIPTION
## Summary

- Seven migrations still referenced a `users` table that no longer exists in community (removed in `9944be0` when identity moved to `evo-auth-service`). `db:migrate` aborted on the first of them (`CreateFacebookCommentModerations`), blocking `MakeAttachmentPolymorphic` and leaving `attachments` stuck with the legacy `message_id` column. Sidekiq/Puma then crashed with `PG::UndefinedColumn: attachments.attachable_id does not exist` on any media webhook or contact deletion.
- Each `foreign_key: { to_table: :users }` / `add_foreign_key …, :users` swapped for a plain `uuid` column (same name, so models keep working) plus manual indexes where the auto-generated ones went away.
- `docker/docker-entrypoint.sh`: collapsed the `db:create` / `db:migrate` / `db:evolution_prepare` trio (all masked by `2>/dev/null || true`) into a single unmasked `bundle exec rails db:evolution_prepare`. The mask is what hid the abort in the first place — a broken migration must stop the boot.

### Root cause

The account/user removal refactor (`9944be0`) only touched `db/schema.rb`; the downstream migrations that reference `:users` were never scrubbed. The `version: 9025_08_19_224901` bump in that same commit papers over the problem via `assume_migrated_upto_version` — it only works on the `db:schema:load` path. Any `db:migrate` on an empty DB still walks the migrations in chronological order and hits the FK abort.

## Test plan

- [x] `db:migrate` against a clean Postgres completes: 51/51 migrations applied, 0 pending.
- [x] `\d attachments` on the resulting DB shows `attachable_type` / `attachable_id` (with `index_attachments_on_attachable_type_and_attachable_id`) and no `message_id`.
- [x] `schema_migrations` contains `20251119155458` (the previously-blocked polymorphic migration).
- [ ] Deploy against an existing installation that already patched the columns manually: confirm `MakeAttachmentPolymorphic` idempotency (may need a follow-up guard).
- [ ] Smoke the Sidekiq webhook receiving media and the contact deletion flow end-to-end once the image is rebuilt.