### PR TITLE
fix(evolution_go): persist api_url and admin_token from GlobalConfig into provider_config

### DIFF
--- a/app/controllers/concerns/evolution_go_concern.rb
+++ b/app/controllers/concerns/evolution_go_concern.rb
@@ -48,7 +48,8 @@ module EvolutionGoConcern
   end
 
   def webhook_url
-    api_url = ENV.fetch('BACKEND_URL', 'https://api.evoai.app')
-    "#{api_url.chomp('/')}/webhooks/whatsapp/evolution_go"
+    backend_url = ENV['BACKEND_URL'].presence ||
+                  GlobalConfigService.load('BACKEND_URL', 'https://api.evoai.app').to_s.strip
+    "#{backend_url.chomp('/')}/webhooks/whatsapp/evolution_go"
   end
 end

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -26,6 +26,7 @@ class Channel::Whatsapp < ApplicationRecord
   # default at the moment is 360dialog lets change later.
   PROVIDERS = %w[default whatsapp_cloud baileys evolution evolution_go notificame zapi].freeze
   before_validation :ensure_webhook_verify_token
+  before_validation :merge_evolution_go_global_config, if: -> { provider == 'evolution_go' }
 
   validates :provider, inclusion: { in: PROVIDERS }
   validates :phone_number, presence: true, uniqueness: true
@@ -189,6 +190,18 @@ class Channel::Whatsapp < ApplicationRecord
 
   def ensure_webhook_verify_token
     provider_config['webhook_verify_token'] ||= SecureRandom.hex(16) if provider.in?(%w[whatsapp_cloud baileys notificame])
+  end
+
+  def merge_evolution_go_global_config
+    self.provider_config ||= {}
+    if provider_config['api_url'].blank?
+      global_url = GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip
+      provider_config['api_url'] = global_url if global_url.present?
+    end
+    if provider_config['admin_token'].blank?
+      global_token = GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
+      provider_config['admin_token'] = global_token if global_token.present?
+    end
   end
 
   def validate_provider_config

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Channel::Whatsapp, type: :model do
+  describe '#merge_evolution_go_global_config' do
+    let(:base_config) do
+      {
+        'instance_name' => 'test-instance',
+        'instance_uuid' => SecureRandom.uuid,
+        'instance_token' => SecureRandom.uuid,
+        'always_online' => true,
+        'reject_call' => true,
+        'read_messages' => true,
+        'ignore_groups' => false,
+        'ignore_status' => true
+      }
+    end
+
+    context 'when GlobalConfig has api_url and admin_token and provider_config lacks them' do
+      it 'merges api_url and admin_token from GlobalConfig before validation' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://evo.example.com')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('secret-token')
+
+        channel = described_class.new(provider: 'evolution_go', provider_config: base_config)
+        channel.valid?
+
+        expect(channel.provider_config['api_url']).to eq('http://evo.example.com')
+        expect(channel.provider_config['admin_token']).to eq('secret-token')
+      end
+    end
+
+    context 'when provider_config already has api_url and admin_token' do
+      it 'does not overwrite existing values' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+        config = base_config.merge('api_url' => 'http://explicit.example.com', 'admin_token' => 'explicit-token')
+        channel = described_class.new(provider: 'evolution_go', provider_config: config)
+        channel.valid?
+
+        expect(channel.provider_config['api_url']).to eq('http://explicit.example.com')
+        expect(channel.provider_config['admin_token']).to eq('explicit-token')
+      end
+    end
+
+    context 'when GlobalConfig is empty and provider_config lacks api_url' do
+      it 'leaves provider_config unchanged' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('')
+
+        channel = described_class.new(provider: 'evolution_go', provider_config: base_config)
+        channel.valid?
+
+        expect(channel.provider_config['api_url']).to be_nil
+        expect(channel.provider_config['admin_token']).to be_nil
+      end
+    end
+
+    context 'when provider is not evolution_go' do
+      it 'does not call GlobalConfigService for evolution_go keys' do
+        expect(GlobalConfigService).not_to receive(:load).with('EVOLUTION_GO_API_URL', anything)
+        expect(GlobalConfigService).not_to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', anything)
+
+        channel = described_class.new(provider: 'whatsapp_cloud', provider_config: {})
+        channel.valid?
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- When `EVOLUTION_GO_API_URL` and `EVOLUTION_GO_ADMIN_SECRET` are set in Admin Settings, the frontend intentionally omits these values from API requests (security design). The backend resolved them via `GlobalConfigService` to create the Evolution Go instance but never persisted them into `channel_whatsapp.provider_config`, causing all subsequent calls (`connect`, `qrcode`, `fetch`) to fail with `400 Bad Request`.
- Adds `before_validation` callback `merge_evolution_go_global_config` on `Channel::Whatsapp` that fills in `api_url` and `admin_token` from GlobalConfig when blank in `provider_config`, without overwriting explicitly provided values.
- Fixes `webhook_url` helper in `EvolutionGoConcern` to fall back to `GlobalConfigService.load('BACKEND_URL')` when `ENV['BACKEND_URL']` is unset.

Fixes EvolutionAPI/evo-crm-community#29

## Test plan

- [ ] Set `EVOLUTION_GO_API_URL` and `EVOLUTION_GO_ADMIN_SECRET` in Admin Settings → Channels → Evolution Go
- [ ] Create a new Evolution Go channel through the UI
- [ ] Confirm `provider_config` contains `api_url` and `admin_token` in the database
- [ ] Click **Connect** → QR Code generates without errors
- [ ] Run model specs: `bundle exec rspec spec/models/channel/whatsapp_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Persist Evolution Go WhatsApp provider configuration values from global settings and ensure webhook URLs fall back to configurable backend URLs.

Bug Fixes:
- Populate Evolution Go WhatsApp channel api_url and admin_token from GlobalConfig when missing in provider_config so subsequent operations succeed.
- Resolve webhook URL generation for Evolution Go by falling back to a stored BACKEND_URL when the environment variable is not set.

Tests:
- Add model specs for Channel::Whatsapp to cover Evolution Go provider configuration merging from global settings.