### PR TITLE
fix(crm): accept filters payload alias and add pipeline_id + contact_id (EVO-974)

### DIFF
--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -61,6 +61,8 @@ module Filters::FilterHelper
       date_filter(current_filter, query_hash, filter_operator_value)
     when 'labels'
       tag_filter_query(query_hash, current_index)
+    when 'pipeline'
+      pipeline_filter_query(query_hash, current_index)
     when 'text_case_insensitive'
       text_case_insensitive_filter(query_hash, filter_operator_value)
     else

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -106,6 +106,28 @@ class FilterService
     ]
   end
 
+  def pipeline_filter_query(query_hash, current_index)
+    table_name = filter_config[:table_name]
+    query_operator = query_hash[:query_operator]
+    @filter_values["value_#{current_index}"] = query_hash['values']
+
+    base_relation_query =
+      "SELECT 1 FROM pipeline_items WHERE pipeline_items.conversation_id = #{table_name}.id"
+    id_filter =
+      "AND pipeline_items.pipeline_id IN (:value_#{current_index})"
+
+    case query_hash[:filter_operator]
+    when 'equal_to'
+      "EXISTS (#{base_relation_query} #{id_filter}) #{query_operator}"
+    when 'not_equal_to'
+      "NOT EXISTS (#{base_relation_query} #{id_filter}) #{query_operator}"
+    when 'is_present'
+      "EXISTS (#{base_relation_query}) #{query_operator}"
+    when 'is_not_present'
+      "NOT EXISTS (#{base_relation_query}) #{query_operator}"
+    end
+  end
+
   def tag_filter_query(query_hash, current_index)
     model_name = filter_config[:entity]
     table_name = filter_config[:table_name]
@@ -195,15 +217,40 @@ class FilterService
   end
 
   def query_builder(model_filters)
-    @params[:payload].each_with_index do |query_hash, current_index|
-      @query_string += " #{build_condition_query(model_filters, query_hash, current_index).strip}"
+    rows = filter_payload
+    clauses = rows.each_with_index.map do |query_hash, current_index|
+      raw = build_condition_query(model_filters, query_hash, current_index).strip
+      # Existing per-attribute handlers emit the query_operator as a trailing
+      # suffix of their own clause, which produces invalid SQL when clauses
+      # are concatenated (e.g. "cond_0  cond_1 AND"). Strip any trailing
+      # AND/OR here so the connector can be injected deterministically below.
+      raw.sub(/\s+(AND|OR)\s*\z/i, '').strip
     end
+
+    return base_relation if clauses.empty?
+
+    @query_string = clauses.first
+    clauses[1..].each_with_index do |clause, i|
+      row = rows[i + 1]
+      op = row.nil? ? nil : (row[:query_operator] || row['query_operator'])
+      connector = (op.presence || 'AND').to_s.upcase
+      @query_string += " #{connector} #{clause}"
+    end
+
     base_relation.where(@query_string, @filter_values.with_indifferent_access)
   end
 
   def validate_query_operator
-    @params[:payload].each do |query_hash|
+    filter_payload.each do |query_hash|
       validate_single_condition(query_hash)
     end
+  end
+
+  # Backward-compat: accept either `payload` (upstream Chatwoot) or `filters`
+  # (evo frontend) as the filter rows key. Returns [] if neither is present
+  # so a malformed request produces a clean empty result rather than
+  # NoMethodError.
+  def filter_payload
+    @params[:payload].presence || @params[:filters].presence || []
   end
 end

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -217,22 +217,27 @@ class FilterService
   end
 
   def query_builder(model_filters)
-    rows = filter_payload
-    clauses = rows.each_with_index.map do |query_hash, current_index|
+    # Each row is paired with its built clause so row↔clause stay aligned
+    # even when a handler legitimately returns an empty clause (e.g.
+    # `custom_attribute_query` returns `''` when the attribute is not a
+    # registered custom attribute). Dropping empty pairs here — before
+    # joining — prevents SQL like "cond_0 AND  AND cond_2" from being
+    # emitted if the upstream guard in `build_condition_query` is ever
+    # bypassed or relaxed.
+    pairs = filter_payload.each_with_index.map do |query_hash, current_index|
       raw = build_condition_query(model_filters, query_hash, current_index).strip
-      # Existing per-attribute handlers emit the query_operator as a trailing
-      # suffix of their own clause, which produces invalid SQL when clauses
-      # are concatenated (e.g. "cond_0  cond_1 AND"). Strip any trailing
-      # AND/OR here so the connector can be injected deterministically below.
-      raw.sub(/\s+(AND|OR)\s*\z/i, '').strip
-    end
+      # Per-attribute handlers emit the query_operator as a trailing suffix
+      # of their own clause; strip it so the connector is injected
+      # deterministically between clauses below.
+      clause = raw.sub(/\s+(AND|OR)\s*\z/i, '').strip
+      [query_hash, clause]
+    end.reject { |_row, clause| clause.empty? }
 
-    return base_relation if clauses.empty?
+    return base_relation if pairs.empty?
 
-    @query_string = clauses.first
-    clauses[1..].each_with_index do |clause, i|
-      row = rows[i + 1]
-      op = row.nil? ? nil : (row[:query_operator] || row['query_operator'])
+    @query_string = pairs.first.last
+    pairs[1..].each do |row, clause|
+      op = row[:query_operator] || row['query_operator']
       connector = (op.presence || 'AND').to_s.upcase
       @query_string += " #{connector} #{clause}"
     end

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -80,6 +80,22 @@ conversations:
       - "not_equal_to"
       - "is_present"
       - "is_not_present"
+  contact_id:
+    attribute_type: "standard"
+    data_type: "text"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
+  pipeline_id:
+    attribute_type: "standard"
+    data_type: "pipeline"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   browser_language:
     attribute_type: "additional_attributes"
     data_type: "text"

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -40,4 +40,30 @@ RSpec.describe Conversations::FilterService do
       expect { service.send(:validate_query_operator) }.not_to raise_error
     end
   end
+
+  describe '#query_builder (empty-clause handling)' do
+    let(:user) { instance_double(User) }
+
+    it 'drops rows whose built clause is empty without desyncing the operator of the next row' do
+      rows = [
+        { 'attribute_key' => 'a', 'filter_operator' => 'equal_to', 'values' => ['x'], 'query_operator' => nil },
+        { 'attribute_key' => 'b', 'filter_operator' => 'equal_to', 'values' => ['y'], 'query_operator' => 'OR' },
+        { 'attribute_key' => 'c', 'filter_operator' => 'equal_to', 'values' => ['z'], 'query_operator' => 'AND' }
+      ]
+      service = described_class.new({ filters: rows }, user)
+
+      allow(service).to receive(:build_condition_query) do |_m, _q, idx|
+        # Middle clause is empty (simulates a handler that returned '' on a
+        # path that bypasses the InvalidAttribute guard). Last clause still
+        # carries its trailing operator suffix to exercise the strip regex.
+        ['c0', '', 'c2 AND'][idx]
+      end
+
+      relation = double('Relation')
+      allow(service).to receive(:base_relation).and_return(relation)
+      expect(relation).to receive(:where).with('c0 AND c2', anything).and_return(relation)
+
+      service.send(:query_builder, {})
+    end
+  end
 end

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -17,4 +17,27 @@ RSpec.describe Conversations::FilterService do
       service.conversations
     end
   end
+
+  describe '#filter_payload (key aliasing)' do
+    let(:user) { instance_double(User) }
+    let(:rows) do
+      [{ 'attribute_key' => 'status', 'filter_operator' => 'equal_to', 'values' => ['open'], 'query_operator' => nil }]
+    end
+
+    it 'reads rows from :payload (upstream Chatwoot contract)' do
+      service = described_class.new({ payload: rows }, user)
+      expect(service.send(:filter_payload)).to eq(rows)
+    end
+
+    it 'reads rows from :filters as a compat alias for the evo frontend' do
+      service = described_class.new({ filters: rows }, user)
+      expect(service.send(:filter_payload)).to eq(rows)
+    end
+
+    it 'returns an empty array when neither key is provided, avoiding NoMethodError' do
+      service = described_class.new({}, user)
+      expect(service.send(:filter_payload)).to eq([])
+      expect { service.send(:validate_query_operator) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Conversation filter endpoint (`POST /conversations/filter`) was unusable for multi-row filters because the service iterated `@params[:payload]` while the evo frontend sends the rows under `:filters`. A `filter_payload` helper now accepts either key with a nil-safe guard — malformed bodies produce an empty relation instead of `NoMethodError: undefined method 'each' for nil`.
- Rewrote `FilterService#query_builder` so that trailing AND/OR emitted by per-attribute handlers is stripped, and the connector is re-injected as an infix between clauses. Fixes the pre-existing `cond_0  cond_1 AND` → invalid-SQL pattern for any multi-row filter.
- Registered `pipeline_id` in `filter_keys.yml` and added a dedicated `pipeline_filter_query` handler (EXISTS-checks `pipeline_items`). Previously `pipeline_id` raised `InvalidAttribute`.
- Registered `contact_id` in `filter_keys.yml` for the new Contact filter on the frontend (served by the generic `default_filter` handler).

## Security
- No new SQL string interpolation of user-controlled values. The `pipeline_filter_query` uses bind variables (`:value_#{current_index}`) just like `tag_filter_query`.
- `filter_payload` does not expand access scope — it only changes which key is read from already-permitted params.

## Known limitation (documented for follow-up)
SQL-standard operator precedence applies: in a multi-row filter that mixes AND and OR, `A OR B AND C` parses as `A OR (B AND C)`. This matches upstream Chatwoot and common filter-UI conventions. Explicit grouping (parentheses per clause) would not change precedence; honoring user-intended grouping would require a UI redesign (explicit group/nest controls).

## Test plan
- `bundle exec rspec spec/services/conversations/filter_service_spec.rb` — 4 examples, 0 failures (covers `filter_payload` key alias, nil-safe validate, and existing ordering test).
- Ruby syntax check on all changed `.rb` files — OK.
- YAML parse check on `filter_keys.yml` — OK.
- Manual: POST `/conversations/filter` with 2-row body mixing `status=snoozed` OR `inbox_id=<uuid>` now returns the inbox matches; single-filter `pipeline_id=<uuid>` returns conversations on that pipeline; multi-filter AND combinations still work.

## Changed Files
- `lib/filters/filter_keys.yml` — `pipeline_id` + `contact_id` entries under `conversations:`.
- `app/services/filter_service.rb` — `filter_payload` helper, `query_builder` refactor, new `pipeline_filter_query`.
- `app/helpers/filters/filter_helper.rb` — `'pipeline'` data_type dispatch.
- `spec/services/conversations/filter_service_spec.rb` — alias + guard specs.

## Related PRs
- Frontend: evo-ai-frontend-community PR to be linked after creation (same `fix/EVO-974` branch).

## Linked Issue
- [EVO-974](https://linear.app/evoai/issue/EVO-974)