### PR TITLE
fix(crm): route message template creation through provider sync for upstream channels (EVO-1002 follow-up)

### DIFF
--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -362,7 +362,19 @@ module Api
               template_params = extract_message_template_params
               Rails.logger.info "Creating template with params: #{template_params.inspect}"
 
-              template = @inbox.channel.create_message_template(template_params)
+              # For providers that publish templates to an external service
+              # (WhatsApp Cloud, Notificame, Evolution Go …), submit the
+              # template upstream and rely on the provider's sync flow to
+              # persist the record locally with the real approval status
+              # (PENDING/APPROVED/REJECTED). For channels without upstream
+              # template approval (Api, Email, etc.), fall back to the
+              # local-only path so behaviour is unchanged.
+              template =
+                if @inbox.channel.respond_to?(:create_template)
+                  @inbox.channel.create_template(template_params.to_h.stringify_keys)
+                else
+                  @inbox.channel.create_message_template(template_params)
+                end
 
               # Reload channel to clear any cached associations
               @inbox.channel.reload


### PR DESCRIPTION
## Summary

- In `POST /api/v1/inboxes/:id/message_templates`, detect whether the channel responds to `create_template` (i.e. has an upstream provider that owns template approval — WhatsApp Cloud, Notificame, Evolution Go) and route the template through it.
- For channels without upstream approval (`Channel::Api`, `Channel::Email`, …), keep the previous local-only path via `channel.create_message_template(...)`. No regression for non-upstream channels.

## Root cause

The endpoint was hard-coded to `channel.create_message_template(template_params)` — the `ChannelMessageTemplates` concern method that only saves the record locally with `settings: {}`. Meta was never told the template existed, `settings.status` stayed empty, and the top-level `status` field (mirrored from `settings.status` by the serializer merged in #10) stayed `null`.

End result: after creating a template for a WhatsApp Cloud inbox, the UI showed "Aguardando aprovação" forever, users had to manually hit the "Sincronizar" button (and even that wouldn't help because the template was never actually submitted to Meta's approval queue).

## Behaviour after this PR

- WhatsApp Cloud: create → POST to Meta → sync reads back Meta's response with `status: 'PENDING'` (or rejection) → template saved locally with correct status → frontend shows "Aguardando aprovação" with the real pending state, and transitions to "Aprovado" when Meta approves.
- Non-upstream channels: unchanged.

## Test plan

- [ ] Create a WhatsApp Cloud template in the UI → inspect `GET /inboxes/:id/message_templates` response → `status` is `"PENDING"` (not `null`).
- [ ] Meta approves asynchronously → next sync brings `status: "APPROVED"`.
- [ ] Invalid template → Meta rejects → `status: "REJECTED"` with rejected_reason in metadata.
- [ ] Create an Email template (non-upstream) → still works via local path, `status` stays `null` (no upstream to report to).
- [ ] No regression on `PUT` / `DELETE` endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route inbox message template creation through upstream providers when available while preserving existing behavior for non-upstream channels.

New Features:
- Support creating inbox message templates via upstream provider-specific template creation when the channel exposes a create_template interface.

Bug Fixes:
- Ensure WhatsApp Cloud and other upstream channels correctly submit and persist message templates with real approval status instead of only creating local records.

Enhancements:
- Fallback to the existing local message template creation path for channels without upstream template approval to avoid regressions.