### PR TITLE
fix(crm): don't flip active to false on sync for PENDING/REJECTED templates (EVO-1002 follow-up)

### DIFF
--- a/app/services/whatsapp/providers/concerns/template_sync.rb
+++ b/app/services/whatsapp/providers/concerns/template_sync.rb
@@ -8,32 +8,41 @@ module Whatsapp
 
         def sync_template_to_database(template_data)
           content = extract_template_content(template_data)
-          
-          MessageTemplate.find_or_initialize_by(
+
+          template = MessageTemplate.find_or_initialize_by(
             channel: whatsapp_channel,
             name: template_data['name'],
             language: template_data['language'] || 'pt_BR'
-          ).tap do |template|
-            template.assign_attributes(
-              content: content,
-              category: template_data['category'],
-              template_type: determine_template_type(template_data),
-              components: extract_components_hash(template_data),
-              variables: extract_template_variables(template_data),
-              settings: {
-                'status' => template_data['status'],
-                'quality_score' => template_data['quality_score'],
-                'source' => template_data['source']
-              }.compact,
-              metadata: {
-                'external_id' => template_data['id'],
-                'namespace' => template_data['namespace'],
-                'rejected_reason' => template_data['rejected_reason']
-              }.compact,
-              active: template_data['status'] == 'APPROVED' || template_data['status'].nil?
-            )
-            template.save!
-          end
+          )
+
+          attrs = {
+            content: content,
+            category: template_data['category'],
+            template_type: determine_template_type(template_data),
+            components: extract_components_hash(template_data),
+            variables: extract_template_variables(template_data),
+            settings: {
+              'status' => template_data['status'],
+              'quality_score' => template_data['quality_score'],
+              'source' => template_data['source']
+            }.compact,
+            metadata: {
+              'external_id' => template_data['id'],
+              'namespace' => template_data['namespace'],
+              'rejected_reason' => template_data['rejected_reason']
+            }.compact
+          }
+
+          # The `active` column is a user-controlled toggle (show/hide in
+          # pickers), not a mirror of Meta approval. Keep it separate:
+          # - On first sync (new record), default to true so the template
+          #   shows up in the management table with a real "pending" badge
+          #   instead of being silently hidden.
+          # - On subsequent syncs, preserve whatever the user set.
+          attrs[:active] = true if template.new_record?
+
+          template.assign_attributes(attrs)
+          template.save!
         rescue StandardError => e
           Rails.logger.error "Error syncing template #{template_data['name']}: #{e.message}"
           Rails.logger.error e.backtrace.join("\n")


### PR DESCRIPTION
## Summary

- `sync_template_to_database` no longer derives `active` from Meta approval status. The column is a user-controlled toggle, not a mirror of the upstream enum.
- New templates default to `active: true` on first sync so they appear in the management table with a real "Aguardando aprovação" badge — instead of being silently hidden because the pre-#12 expression `status == 'APPROVED' || status.nil?` evaluated to `false` for `PENDING`.
- Re-syncs of an existing record preserve whatever `active` the user set. Meta status transitions (PENDING → APPROVED → PAUSED → …) no longer stomp the toggle.

## Root cause

Observed after merging #12 (create routes to provider): `POST /inboxes/:id/message_templates` returned a valid record with `status: "PENDING"` but `active: false`; the subsequent `GET /inboxes/:id/message_templates` came back empty because the list is scoped to `.active` (see `inboxes_controller.rb:316`).

The culprit was at `template_sync.rb:33`:

```ruby
active: template_data['status'] == 'APPROVED' || template_data['status'].nil?
```

Meta returns `'PENDING'` on fresh template creation → right-hand side is false → record saved as inactive → filtered out of the list.

## Behaviour after this PR

| Flow | Before | After |
|---|---|---|
| POST new template → Meta returns PENDING | saved `active: false`, vanished from GET | saved `active: true`, shows in table with "Aguardando aprovação" |
| Meta approves via webhook/sync | `active: true` (status.nil? branch failed once it became APPROVED) | `active` unchanged (whatever user set) |
| User toggles `active: false` to hide template, Meta re-syncs later | `active` flipped back based on status | `active: false` preserved |

## Test plan

- [ ] Create a WhatsApp Cloud template via UI → status PENDING, appears in management table with yellow badge.
- [ ] Wait for Meta approval → status becomes APPROVED, `active` stays true, badge turns green.
- [ ] Toggle `active: false` on an approved template → it disappears from the composer picker but still appears in the management table.
- [ ] Sync runs again → `active: false` is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve user-controlled activation of WhatsApp message templates during sync and ensure newly synced templates default to active so they are visible in management views.

Bug Fixes:
- Prevent template sync from deactivating templates based on Meta approval status, avoiding hidden PENDING or REJECTED templates.

Enhancements:
- Default new WhatsApp templates to active on initial sync while preserving existing active flags on subsequent syncs.