### PR TITLE
fix(crm): resolve label UUIDs when tagging and rendering conversations (EVO-1001)

### DIFF
--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -40,7 +40,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
         include_labels: true,
         unread_counts: unread_counts_map(conversation_ids),
         last_non_activity_messages: last_non_activity_messages_map(conversation_ids),
-        labels_by_title: labels_by_title
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
       ),
       meta: conversations_pagination_meta,
       message: 'Conversations retrieved successfully'
@@ -70,7 +71,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
         include_labels: true,
         unread_counts: unread_counts_map(conversation_ids),
         last_non_activity_messages: last_non_activity_messages_map(conversation_ids),
-        labels_by_title: labels_by_title
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
       ),
       meta: conversations_pagination_meta,
       message: 'Conversations search completed successfully'
@@ -110,7 +112,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
 
   def show
     success_response(
-      data: ConversationSerializer.serialize(@conversation, include_messages: true, include_labels: true),
+      data: ConversationSerializer.serialize(
+        @conversation,
+        include_messages: true,
+        include_labels: true,
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
+      ),
       message: 'Conversation retrieved successfully'
     )
   end
@@ -121,7 +129,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
       Messages::MessageBuilder.new(Current.user, @conversation, params[:message]).perform if params[:message].present?
       
       success_response(
-        data: ConversationSerializer.serialize(@conversation, include_messages: true, include_labels: true),
+        data: ConversationSerializer.serialize(
+          @conversation,
+          include_messages: true,
+          include_labels: true,
+          labels_by_title: labels_by_title,
+          labels_by_id: labels_by_id
+        ),
         message: 'Conversation created successfully',
         status: :created
       )
@@ -139,7 +153,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   def update
     if @conversation.update(permitted_update_params)
       success_response(
-        data: ConversationSerializer.serialize(@conversation, include_messages: false, include_labels: true),
+        data: ConversationSerializer.serialize(
+          @conversation,
+          include_messages: false,
+          include_labels: true,
+          labels_by_title: labels_by_title,
+          labels_by_id: labels_by_id
+        ),
         message: 'Conversation updated successfully'
       )
     else
@@ -165,7 +185,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
         include_labels: true,
         unread_counts: unread_counts_map(conversation_ids),
         last_non_activity_messages: last_non_activity_messages_map(conversation_ids),
-        labels_by_title: labels_by_title
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
       ),
       meta: conversations_pagination_meta,
       message: 'Conversations filtered successfully'
@@ -330,7 +351,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
 
     if @conversation.update(custom_attributes: custom_attributes)
       success_response(
-        data: ConversationSerializer.serialize(@conversation, include_messages: false, include_labels: true),
+        data: ConversationSerializer.serialize(
+          @conversation,
+          include_messages: false,
+          include_labels: true,
+          labels_by_title: labels_by_title,
+          labels_by_id: labels_by_id
+        ),
         message: success_message
       )
     else
@@ -414,7 +441,21 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   end
 
   def labels_by_title
-    @labels_by_title ||= Label.all.index_by { |label| label.title.to_s.downcase }
+    label_indexes[:by_title]
+  end
+
+  def labels_by_id
+    label_indexes[:by_id]
+  end
+
+  def label_indexes
+    @label_indexes ||= begin
+      all_labels = Label.all.to_a
+      {
+        by_title: all_labels.index_by { |label| label.title.to_s.downcase },
+        by_id: all_labels.index_by { |label| label.id.to_s }
+      }
+    end
   end
 
   def conversations_pagination_meta
@@ -440,7 +481,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
     @conversation.save!
     
     success_response(
-      data: ConversationSerializer.serialize(@conversation, include_messages: false, include_labels: true),
+      data: ConversationSerializer.serialize(
+        @conversation,
+        include_messages: false,
+        include_labels: true,
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
+      ),
       message: 'Conversation custom attributes updated successfully'
     )
   rescue StandardError => e

--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -1,10 +1,33 @@
 module LabelConcern
+  UUID_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
   def create
-    model.update_labels(permitted_params[:labels])
+    model.update_labels(resolve_label_titles(permitted_params[:labels]))
     @labels = model.label_list
   end
 
   def index
     @labels = model.label_list
+  end
+
+  private
+
+  # Clients historically sent label identifiers as UUIDs (matching the Label
+  # PK exposed by the `/labels` endpoint). `acts_as_taggable_on :labels`
+  # stores whatever string it receives as `tags.name`, so passing UUIDs caused
+  # two downstream problems: activity messages rendered UUIDs instead of
+  # human-readable titles, and `filter_service#tag_filter_query` (which
+  # compares against `tags.name`) could not match on the user-configured
+  # title. Translate UUID-shaped inputs to titles here; leave other strings
+  # untouched for back-compat with any caller that already sends titles.
+  def resolve_label_titles(labels)
+    return labels if labels.blank?
+
+    uuids, non_uuids = Array(labels).map(&:to_s).partition { |value| UUID_REGEX.match?(value) }
+    return non_uuids if uuids.empty?
+
+    titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h
+    resolved = uuids.filter_map { |id| titles_by_id[id] }
+    (non_uuids + resolved).uniq
   end
 end

--- a/app/serializers/conversation_serializer.rb
+++ b/app/serializers/conversation_serializer.rb
@@ -30,7 +30,8 @@ module ConversationSerializer
     include_inbox: true,
     unread_counts: nil,
     last_non_activity_messages: nil,
-    labels_by_title: nil
+    labels_by_title: nil,
+    labels_by_id: nil
   )
     result = conversation.as_json(
       only: [:id, :inbox_id, :status, :assignee_id, :team_id,
@@ -100,9 +101,14 @@ module ConversationSerializer
 
     # Conditionally include labels
     if include_labels
-      label_index = labels_by_title || {}
-      result['labels'] = conversation.cached_label_list_array.filter_map do |label_title|
-        label_record = label_index[label_title.to_s.downcase]
+      # Historical cached_label_list entries may be either human-readable titles
+      # (post label_concern UUID→title normalization) or raw UUIDs (pre-fix data).
+      # Resolve both so conversation cards keep rendering for legacy rows.
+      title_index = labels_by_title || {}
+      id_index = labels_by_id || {}
+      result['labels'] = conversation.cached_label_list_array.filter_map do |tag|
+        tag_str = tag.to_s
+        label_record = title_index[tag_str.downcase] || id_index[tag_str]
         label_record ? LabelSerializer.serialize(label_record) : nil
       end
     else

--- a/spec/controllers/concerns/label_concern_spec.rb
+++ b/spec/controllers/concerns/label_concern_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit-level coverage for LabelConcern's UUID→title resolution. Exercises the
+# private `resolve_label_titles` directly via an anonymous host class, since
+# the bug class (UUID leaking into `tags.name`) was the regression EVO-1001
+# fixed at this seam.
+RSpec.describe LabelConcern, type: :concern do
+  let(:host_class) do
+    Class.new do
+      include LabelConcern
+
+      # Make the private helper reachable from specs without polluting the
+      # public surface of real controllers that include this concern.
+      public :resolve_label_titles
+    end
+  end
+
+  let(:host) { host_class.new }
+
+  describe '#resolve_label_titles' do
+    context 'when input is blank' do
+      it 'passes nil through untouched' do
+        expect(host.resolve_label_titles(nil)).to be_nil
+      end
+
+      it 'passes empty array through untouched' do
+        expect(host.resolve_label_titles([])).to eq([])
+      end
+    end
+
+    context 'with non-UUID strings (titles)' do
+      it 'leaves human-readable titles untouched' do
+        expect(host.resolve_label_titles(['hot-lead', 'vip'])).to eq(['hot-lead', 'vip'])
+      end
+
+      it 'does not query the labels table when no UUID is present' do
+        expect(Label).not_to receive(:where)
+        host.resolve_label_titles(['plain-string'])
+      end
+    end
+
+    context 'with UUID inputs' do
+      let(:hot_lead_id) { '550e8400-e29b-41d4-a716-446655440000' }
+      let(:vip_id) { '6ba7b810-9dad-11d1-80b4-00c04fd430c8' }
+
+      before do
+        # Stub the UUID→title lookup in isolation. The concern only relies on
+        # `Label.where(id: uuids).pluck(:id, :title)`, so we mock that surface
+        # rather than touching the database.
+        relation = double('Label::Relation')
+        allow(Label).to receive(:where).with(id: array_including(hot_lead_id, vip_id))
+                                       .and_return(relation)
+        allow(relation).to receive(:pluck).with(:id, :title).and_return(
+          [[hot_lead_id, 'hot-lead'], [vip_id, 'vip']]
+        )
+      end
+
+      it 'resolves all UUIDs to their titles' do
+        expect(host.resolve_label_titles([hot_lead_id, vip_id])).to match_array(['hot-lead', 'vip'])
+      end
+
+      it 'merges resolved titles with existing title-form entries and dedupes' do
+        result = host.resolve_label_titles(['hot-lead', vip_id])
+        expect(result).to match_array(['hot-lead', 'vip'])
+      end
+    end
+
+    context 'with unresolvable UUIDs' do
+      let(:ghost_id) { '00000000-0000-0000-0000-000000000000' }
+
+      before do
+        relation = double('Label::Relation', pluck: [])
+        allow(Label).to receive(:where).with(id: [ghost_id]).and_return(relation)
+      end
+
+      it 'silently drops UUIDs that no longer correspond to a label' do
+        expect(host.resolve_label_titles([ghost_id])).to eq([])
+      end
+
+      it 'preserves non-UUID entries even when all UUIDs are unresolvable' do
+        expect(host.resolve_label_titles(['vip', ghost_id])).to eq(['vip'])
+      end
+    end
+  end
+end

--- a/spec/serializers/conversation_serializer_spec.rb
+++ b/spec/serializers/conversation_serializer_spec.rb
@@ -70,4 +70,123 @@ RSpec.describe ConversationSerializer do
       expect(result['last_activity_at']).to be_nil
     end
   end
+
+  describe '.serialize with include_labels (EVO-1001)' do
+    let(:now) { Time.zone.parse('2026-04-24 12:00:00') }
+    let(:label_uuid) { '550e8400-e29b-41d4-a716-446655440000' }
+    let(:label_record) do
+      double('Label',
+             id: label_uuid,
+             title: 'hot-lead',
+             description: nil,
+             color: '#ff0000',
+             show_on_sidebar: true,
+             created_at: now,
+             updated_at: now)
+    end
+
+    def build_conversation(cached_label_list_array)
+      conversation = double('Conversation',
+                            as_json: { 'id' => 1, 'inbox_id' => 1, 'status' => 'open',
+                                       'assignee_id' => nil, 'team_id' => nil, 'campaign_id' => nil,
+                                       'display_id' => 1, 'additional_attributes' => {}, 'priority' => nil },
+                            created_at: now,
+                            updated_at: now,
+                            agent_last_seen_at: nil,
+                            contact_last_seen_at: nil,
+                            waiting_since: nil,
+                            first_reply_created_at: nil,
+                            snoozed_until: nil,
+                            last_activity_at: now,
+                            custom_attributes: {},
+                            unread_incoming_messages: double('Relation', count: 0),
+                            contact: nil,
+                            inbox: nil,
+                            assignee: nil,
+                            team: nil,
+                            cached_label_list_array: cached_label_list_array,
+                            messages: double('Relation', last: nil))
+      allow(conversation).to receive(:association).and_return(double(loaded?: false))
+      conversation
+    end
+
+    it 'resolves a tag stored as title via labels_by_title' do
+      conversation = build_conversation(['hot-lead'])
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: { 'hot-lead' => label_record },
+        labels_by_id: {}
+      )
+
+      expect(result['labels'].size).to eq(1)
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'resolves a tag stored as legacy UUID via labels_by_id fallback' do
+      # Pre-fix data: cached_label_list still holds the Label PK as a string.
+      # The serializer must fall back to labels_by_id and keep rendering the
+      # human-readable label so conversation cards do not silently lose badges.
+      conversation = build_conversation([label_uuid])
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: {},
+        labels_by_id: { label_uuid => label_record }
+      )
+
+      expect(result['labels'].size).to eq(1)
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'prefers title match over id match when both indexes contain the tag' do
+      conversation = build_conversation(['hot-lead'])
+      other_label = double('Label',
+                           id: 'other', title: 'other', description: nil,
+                           color: '#000', show_on_sidebar: true,
+                           created_at: now, updated_at: now)
+
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: { 'hot-lead' => label_record },
+        labels_by_id: { 'hot-lead' => other_label }
+      )
+
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'drops tags that resolve in neither index' do
+      conversation = build_conversation(['ghost-tag', label_uuid])
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: {},
+        labels_by_id: { label_uuid => label_record }
+      )
+
+      expect(result['labels'].size).to eq(1)
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'returns empty labels array when include_labels is false' do
+      conversation = build_conversation([label_uuid])
+      result = described_class.serialize(
+        conversation,
+        include_labels: false,
+        include_contact: false,
+        include_inbox: false
+      )
+
+      expect(result['labels']).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes two label-related defects on the conversations view that shared the same root cause (UUIDs leaking into `cached_label_list`):

- **Activity message renders UUID** — when a client sends label identifiers as UUIDs to `POST /conversations/:id/labels`, `acts_as_taggable_on` stores the UUID verbatim as `tags.name`, which then bubbles up into the activity timeline.
- **Labels disappear from conversation cards** — for legacy rows already storing UUIDs, `ConversationSerializer` could not match the tag against `labels_by_title` and returned `labels: []`, so `ConversationBadges.tsx` rendered nothing.

## Changes

- `app/controllers/concerns/label_concern.rb` — `#create` runs `resolve_label_titles` which converts UUID-shaped inputs to their `Label#title` before `update_labels`. Non-UUID strings pass through untouched for back-compat with callers that already send titles.
- `app/serializers/conversation_serializer.rb` — `serialize` accepts `labels_by_id:` in addition to `labels_by_title:` and resolves tags via `title_index[tag.downcase] || id_index[tag]`, so legacy UUID-stored conversations keep rendering `{id, title, color}` objects.
- `app/controllers/api/v1/conversations_controller.rb` — computes both indexes in a single `Label.all.to_a` pass (request-memoised) and passes both to every `ConversationSerializer` call with `include_labels: true` (`#index`, `#search`, `#filter`, `#show`, `#create`, `#update`, `#update_custom_attribute`, `#custom_attributes`). Previously only the collection endpoints passed `labels_by_title`, so single-conversation endpoints also returned `labels: []`.

## Validation

- `ruby -c app/controllers/api/v1/conversations_controller.rb` — Syntax OK
- `ruby -c app/controllers/concerns/label_concern.rb` — Syntax OK
- `ruby -c app/serializers/conversation_serializer.rb` — Syntax OK
- `bundle exec rubocop app/controllers/concerns/label_concern.rb` — 0 offenses (other files have pre-existing offenses in lines not touched by this PR)
- `RAILS_ENV=test bundle exec rspec spec/serializers/conversation_serializer_spec.rb spec/requests/api/v1/labels_spec.rb spec/requests/api/v1/conversations_pin_archive_spec.rb spec/services/conversations/filter_service_spec.rb` — 23 examples, 0 failures

## Changed Files

- `app/controllers/concerns/label_concern.rb`
- `app/serializers/conversation_serializer.rb`
- `app/controllers/api/v1/conversations_controller.rb`

## Linked Issue

- EVO-1001 — https://linear.app/evoai/issue/EVO-1001

## Related PRs

- Frontend counterpart: will be linked after creation

## Summary by Sourcery

Normalize and correctly resolve conversation labels so both legacy UUID-stored tags and new title-based tags render consistently across all conversation endpoints.

Bug Fixes:
- Ensure labels applied via the labels API are stored and displayed using human-readable titles instead of leaking UUIDs into activity messages and conversation views.
- Restore label badges on conversation cards for legacy conversations whose cached labels were stored as UUIDs rather than titles across all conversation endpoints.

Enhancements:
- Add centralized label title resolution in the shared label concern to transparently convert UUID inputs to label titles while preserving backward compatibility for title-based callers.
- Extend the conversation serializer and controller to use both title- and ID-based label indexes so label metadata is correctly attached whenever labels are included in responses.