### PR TITLE
fix(migrations): add idempotency guards to prevent errors on re-run

### DIFF
--- a/db/migrate/20251114150000_add_sentiment_analysis_fields_to_facebook_comment_moderations.rb
+++ b/db/migrate/20251114150000_add_sentiment_analysis_fields_to_facebook_comment_moderations.rb
@@ -1,8 +1,8 @@
 class AddSentimentAnalysisFieldsToFacebookCommentModerations < ActiveRecord::Migration[7.1]
   def change
-    add_column :facebook_comment_moderations, :sentiment_offensive, :boolean, default: false, null: false
-    add_column :facebook_comment_moderations, :sentiment_confidence, :float, default: 0.0, null: false
-    add_column :facebook_comment_moderations, :sentiment_reason, :text
+    add_column :facebook_comment_moderations, :sentiment_offensive, :boolean, default: false, null: false, if_not_exists: true
+    add_column :facebook_comment_moderations, :sentiment_confidence, :float, default: 0.0, null: false, if_not_exists: true
+    add_column :facebook_comment_moderations, :sentiment_reason, :text, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251117132621_add_type_to_contacts.rb
+++ b/db/migrate/20251117132621_add_type_to_contacts.rb
@@ -2,15 +2,21 @@ class AddTypeToContacts < ActiveRecord::Migration[7.1]
   def up
     # Criar tipo ENUM no PostgreSQL
     execute <<-SQL
-      CREATE TYPE contact_type_enum AS ENUM ('person', 'company');
+      DO $$ BEGIN
+        CREATE TYPE contact_type_enum AS ENUM ('person', 'company');
+      EXCEPTION
+        WHEN duplicate_object THEN null;
+      END $$;
     SQL
-    
-    # Adicionar coluna com ENUM
-    add_column :contacts, :type, :contact_type_enum, default: 'person', null: false
-    add_index :contacts, :type
 
-    # Atualizar contatos existentes para 'person'
-    Contact.where(type: nil).update_all(type: 'person')
+    # Adicionar coluna com ENUM
+    unless column_exists?(:contacts, :type)
+      add_column :contacts, :type, :contact_type_enum, default: 'person', null: false
+      add_index :contacts, :type unless index_exists?(:contacts, :type)
+
+      # Atualizar contatos existentes para 'person'
+      Contact.where(type: nil).update_all(type: 'person')
+    end
   end
 
   def down

--- a/db/migrate/20251117132621_add_type_to_contacts.rb
+++ b/db/migrate/20251117132621_add_type_to_contacts.rb
@@ -12,11 +12,12 @@ class AddTypeToContacts < ActiveRecord::Migration[7.1]
     # Adicionar coluna com ENUM
     unless column_exists?(:contacts, :type)
       add_column :contacts, :type, :contact_type_enum, default: 'person', null: false
-      add_index :contacts, :type unless index_exists?(:contacts, :type)
-
-      # Atualizar contatos existentes para 'person'
-      Contact.where(type: nil).update_all(type: 'person')
     end
+
+    add_index :contacts, :type unless index_exists?(:contacts, :type)
+
+    # Atualizar contatos existentes para 'person'
+    Contact.where(type: nil).update_all(type: 'person') if column_exists?(:contacts, :type)
   end
 
   def down

--- a/db/migrate/20251119155458_make_attachment_polymorphic.rb
+++ b/db/migrate/20251119155458_make_attachment_polymorphic.rb
@@ -15,7 +15,9 @@ class MakeAttachmentPolymorphic < ActiveRecord::Migration[7.1]
     end
 
     # Adicionar índice polimórfico
-    add_index :attachments, [:attachable_type, :attachable_id] unless index_exists?(:attachments, [:attachable_type, :attachable_id])
+    if column_exists?(:attachments, :attachable_type) && column_exists?(:attachments, :attachable_id)
+      add_index :attachments, [:attachable_type, :attachable_id] unless index_exists?(:attachments, [:attachable_type, :attachable_id])
+    end
 
     # Remover coluna antiga e índice antigo
     if column_exists?(:attachments, :message_id)

--- a/db/migrate/20251119155458_make_attachment_polymorphic.rb
+++ b/db/migrate/20251119155458_make_attachment_polymorphic.rb
@@ -1,26 +1,27 @@
 class MakeAttachmentPolymorphic < ActiveRecord::Migration[7.1]
   def up
     # Adicionar colunas polimórficas
-    add_column :attachments, :attachable_type, :string
-    add_column :attachments, :attachable_id, :uuid
+    add_column :attachments, :attachable_type, :string unless column_exists?(:attachments, :attachable_type)
+    add_column :attachments, :attachable_id, :uuid unless column_exists?(:attachments, :attachable_id)
 
     # Migrar dados existentes (Message -> attachable)
-    reversible do |dir|
-      dir.up do
-        execute <<-SQL
-          UPDATE attachments
-          SET attachable_type = 'Message',
-              attachable_id = message_id
-        SQL
-      end
+    if column_exists?(:attachments, :message_id)
+      execute <<-SQL
+        UPDATE attachments
+        SET attachable_type = 'Message',
+            attachable_id = message_id
+        WHERE message_id IS NOT NULL AND attachable_type IS NULL
+      SQL
     end
 
     # Adicionar índice polimórfico
-    add_index :attachments, [:attachable_type, :attachable_id]
+    add_index :attachments, [:attachable_type, :attachable_id] unless index_exists?(:attachments, [:attachable_type, :attachable_id])
 
     # Remover coluna antiga e índice antigo
-    remove_index :attachments, :message_id if index_exists?(:attachments, :message_id)
-    remove_column :attachments, :message_id
+    if column_exists?(:attachments, :message_id)
+      remove_index :attachments, :message_id if index_exists?(:attachments, :message_id)
+      remove_column :attachments, :message_id
+    end
   end
 
   def down

--- a/db/migrate/20260414120000_create_user_tours.rb
+++ b/db/migrate/20260414120000_create_user_tours.rb
@@ -1,16 +1,16 @@
 class CreateUserTours < ActiveRecord::Migration[7.1]
   def change
-    return if table_exists?(:user_tours)
-
-    create_table :user_tours do |t|
-      t.uuid :user_id, null: false
-      t.string :tour_key, null: false
-      t.string :status, null: false, default: 'completed'
-      t.datetime :completed_at
-      t.timestamps
+    unless table_exists?(:user_tours)
+      create_table :user_tours do |t|
+        t.uuid :user_id, null: false
+        t.string :tour_key, null: false
+        t.string :status, null: false, default: 'completed'
+        t.datetime :completed_at
+        t.timestamps
+      end
     end
 
-    add_index :user_tours, [:user_id, :tour_key], unique: true
-    add_index :user_tours, :user_id
+    add_index :user_tours, [:user_id, :tour_key], unique: true unless index_exists?(:user_tours, [:user_id, :tour_key])
+    add_index :user_tours, :user_id unless index_exists?(:user_tours, :user_id)
   end
 end

--- a/db/migrate/20260414120000_create_user_tours.rb
+++ b/db/migrate/20260414120000_create_user_tours.rb
@@ -1,5 +1,7 @@
 class CreateUserTours < ActiveRecord::Migration[7.1]
   def change
+    return if table_exists?(:user_tours)
+
     create_table :user_tours do |t|
       t.uuid :user_id, null: false
       t.string :tour_key, null: false
@@ -7,6 +9,8 @@ class CreateUserTours < ActiveRecord::Migration[7.1]
       t.datetime :completed_at
       t.timestamps
     end
+
     add_index :user_tours, [:user_id, :tour_key], unique: true
+    add_index :user_tours, :user_id
   end
 end


### PR DESCRIPTION
## Problem

When running `db:migrate` on a database with partial state (e.g., after a failed migration, environment reset, or shared setup with another Rails service), the following migrations failed with fatal errors:

- `20251114150000` — `PG::DuplicateColumn`: tried to add columns `sentiment_offensive`, `sentiment_confidence`, `sentiment_reason` that already existed
- `20251117132621` — `PG::DuplicateObject`: `CREATE TYPE contact_type_enum` failed if the type already existed in PostgreSQL
- `20251119155458` — `PG::DuplicateColumn`: tried to add `attachable_type` and `attachable_id` columns that were already present
- `20260414120000` — `PG::DuplicateTable`: tried to create `user_tours` which already existed; additionally, the FK to `users` (a table owned by `evo-auth`) caused `PG::UndefinedTable` on a fresh `db:migrate` run in an isolated setup

## Fix

- **`add_sentiment_analysis_fields`**: added `if_not_exists: true` to all three `add_column` calls
- **`add_type_to_contacts`**: wrapped `CREATE TYPE` in a `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN null END $$` block; added `unless column_exists?` guard before `add_column` and `add_index`
- **`make_attachment_polymorphic`**: added `unless column_exists?` and `unless index_exists?` guards on each operation; `message_id` removal conditioned on `if column_exists?`
- **`create_user_tours`**: added `return if table_exists?` guard; removed cross-service FK to `users` (table is owned by `evo-auth`, not the CRM — a cross-service FK in a migration causes failure in isolated setup)

## Testing

Validated on a fresh setup using `db:schema:load` followed by `db:migrate` on a clean database — no errors. Also validated on a database with partial state (tables already existing) — migrations execute without failure.

## Summary by Sourcery

Harden database migrations to be idempotent and safe to run against partially-migrated or pre-populated databases.

Bug Fixes:
- Prevent duplicate column errors when re-running sentiment analysis and attachment polymorphism migrations on databases where the columns already exist.
- Avoid failures when creating the contact type enum and associated column/index if they were already created in a previous run.
- Prevent duplicate table creation and missing foreign table errors when running the user tours migration in different deployment topologies.

Enhancements:
- Add additional index on user_tours.user_id to improve querying by user.