### PR TITLE
fix(crm): return 422 (not 401) on team-member validation failures (EVO-1000)

### DIFF
--- a/app/controllers/api/v1/team_members_controller.rb
+++ b/app/controllers/api/v1/team_members_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::TeamMembersController < Api::V1::BaseController
     destroy: 'team_members.delete'
   })
   before_action :fetch_team
+  before_action :require_user_ids_array, only: [:create, :update, :destroy]
 
   def index
     @team_members = @team.team_members.map(&:user)
@@ -86,5 +87,15 @@ class Api::V1::TeamMembersController < Api::V1::BaseController
 
   def fetch_team
     @team = Team.find(params[:team_id])
+  end
+
+  def require_user_ids_array
+    return if params[:user_ids].is_a?(Array)
+
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'user_ids must be an array of user UUIDs',
+      status: :unprocessable_entity
+    )
   end
 end

--- a/app/controllers/api/v1/team_members_controller.rb
+++ b/app/controllers/api/v1/team_members_controller.rb
@@ -7,12 +7,10 @@ class Api::V1::TeamMembersController < Api::V1::BaseController
     destroy: 'team_members.delete'
   })
   before_action :fetch_team
-  
-  before_action :validate_member_id_params, only: [:create, :update, :destroy]
 
   def index
     @team_members = @team.team_members.map(&:user)
-    
+
     success_response(
       data: TeamMemberSerializer.serialize_collection(@team_members),
       message: 'Team members retrieved successfully'
@@ -23,15 +21,16 @@ class Api::V1::TeamMembersController < Api::V1::BaseController
     ActiveRecord::Base.transaction do
       @team_members = @team.add_members(members_to_be_added_ids)
     end
-    
+
     success_response(
       data: TeamMemberSerializer.serialize_collection(@team_members),
       message: 'Team members added successfully'
     )
-  rescue ActiveRecord::RecordInvalid => e
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::InvalidForeignKey => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message,
+      status: :unprocessable_entity
     )
   end
 
@@ -41,15 +40,16 @@ class Api::V1::TeamMembersController < Api::V1::BaseController
       @team.remove_members(members_to_be_removed_ids)
     end
     @team_members = @team.members
-    
+
     success_response(
       data: TeamMemberSerializer.serialize_collection(@team_members),
       message: 'Team members updated successfully'
     )
-  rescue ActiveRecord::RecordInvalid => e
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::InvalidForeignKey => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message,
+      status: :unprocessable_entity
     )
   end
 
@@ -57,15 +57,16 @@ class Api::V1::TeamMembersController < Api::V1::BaseController
     ActiveRecord::Base.transaction do
       @team.remove_members(params[:user_ids])
     end
-    
+
     success_response(
       data: nil,
       message: 'Team members removed successfully'
     )
-  rescue ActiveRecord::RecordInvalid => e
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::InvalidForeignKey => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message,
+      status: :unprocessable_entity
     )
   end
 
@@ -85,11 +86,5 @@ class Api::V1::TeamMembersController < Api::V1::BaseController
 
   def fetch_team
     @team = Team.find(params[:team_id])
-  end
-
-  def validate_member_id_params
-    invalid_ids = params[:user_ids].map(&:to_i) - User.pluck(:id)
-
-    render json: { error: 'Invalid User IDs' }, status: :unauthorized and return if invalid_ids.present?
   end
 end

--- a/spec/requests/api/v1/team_members_spec.rb
+++ b/spec/requests/api/v1/team_members_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/teams/:team_id/team_members', type: :request do
+  let(:team) { Team.create!(name: "Spec Team #{SecureRandom.hex(4)}") }
+  let(:user) { User.create!(email: "user-#{SecureRandom.hex(4)}@example.com", name: 'Member User') }
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  it 'adds a valid user UUID to the team and returns 200' do
+    post "/api/v1/teams/#{team.id}/team_members",
+         params: { user_ids: [user.id] },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(team.reload.members.pluck(:id)).to include(user.id)
+    expect(json_response['success']).to be(true)
+  end
+
+  it 'returns 422 with VALIDATION_ERROR (not 401) when a user_id does not reference an existing user' do
+    missing_uuid = SecureRandom.uuid
+
+    post "/api/v1/teams/#{team.id}/team_members",
+         params: { user_ids: [missing_uuid] },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response).not_to have_http_status(:unauthorized)
+    expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
+    expect(team.reload.members).to be_empty
+  end
+
+  it 'is idempotent for users already in the team' do
+    team.add_members([user.id])
+
+    # The controller subtracts current_members_ids from params[:user_ids] before
+    # add_members runs, so re-posting an existing member is a no-op (200), not
+    # a 401 or 422.
+    post "/api/v1/teams/#{team.id}/team_members",
+         params: { user_ids: [user.id] },
+         headers: headers,
+         as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(team.reload.members.pluck(:id)).to eq([user.id])
+  end
+end

--- a/spec/requests/api/v1/team_members_spec.rb
+++ b/spec/requests/api/v1/team_members_spec.rb
@@ -2,60 +2,137 @@
 
 require 'rails_helper'
 
-RSpec.describe 'POST /api/v1/teams/:team_id/team_members', type: :request do
+RSpec.describe 'Api::V1::TeamMembers', type: :request do
   let(:team) { Team.create!(name: "Spec Team #{SecureRandom.hex(4)}") }
   let(:user) { User.create!(email: "user-#{SecureRandom.hex(4)}@example.com", name: 'Member User') }
   let(:service_token) { 'spec-service-token' }
   let(:headers) { { 'X-Service-Token' => service_token } }
 
-  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
-
-  after do
-    ENV.delete('EVOAI_CRM_API_TOKEN')
-    Current.reset
+  around do |example|
+    original = ENV.fetch('EVOAI_CRM_API_TOKEN', nil)
+    ENV['EVOAI_CRM_API_TOKEN'] = service_token
+    begin
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete('EVOAI_CRM_API_TOKEN')
+      else
+        ENV['EVOAI_CRM_API_TOKEN'] = original
+      end
+      Current.reset
+    end
   end
 
   def json_response
     JSON.parse(response.body)
   end
 
-  it 'adds a valid user UUID to the team and returns 200' do
-    post "/api/v1/teams/#{team.id}/team_members",
-         params: { user_ids: [user.id] },
-         headers: headers,
-         as: :json
+  describe 'POST /api/v1/teams/:team_id/team_members' do
+    it 'adds a valid user UUID to the team and returns 200' do
+      post "/api/v1/teams/#{team.id}/team_members",
+           params: { user_ids: [user.id] },
+           headers: headers,
+           as: :json
 
-    expect(response).to have_http_status(:ok)
-    expect(team.reload.members.pluck(:id)).to include(user.id)
-    expect(json_response['success']).to be(true)
+      expect(response).to have_http_status(:ok)
+      expect(team.reload.members.pluck(:id)).to include(user.id)
+      expect(json_response['success']).to be(true)
+    end
+
+    it 'returns 422 with VALIDATION_ERROR (not 401) when a user_id does not reference an existing user' do
+      missing_uuid = SecureRandom.uuid
+
+      post "/api/v1/teams/#{team.id}/team_members",
+           params: { user_ids: [missing_uuid] },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).not_to have_http_status(:unauthorized)
+      expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
+      expect(team.reload.members).to be_empty
+    end
+
+    it 'is idempotent for users already in the team' do
+      team.add_members([user.id])
+
+      post "/api/v1/teams/#{team.id}/team_members",
+           params: { user_ids: [user.id] },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(team.reload.members.pluck(:id)).to eq([user.id])
+    end
+
+    it 'returns 422 (not 500) when user_ids is missing entirely' do
+      post "/api/v1/teams/#{team.id}/team_members",
+           params: {},
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
+    end
+
+    it 'returns 422 when user_ids is a single string instead of an array' do
+      post "/api/v1/teams/#{team.id}/team_members",
+           params: { user_ids: user.id },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
+    end
   end
 
-  it 'returns 422 with VALIDATION_ERROR (not 401) when a user_id does not reference an existing user' do
-    missing_uuid = SecureRandom.uuid
+  describe 'PATCH /api/v1/teams/:team_id/team_members' do
+    it 'returns 422 with VALIDATION_ERROR (not 401) when a user_id does not reference an existing user' do
+      missing_uuid = SecureRandom.uuid
 
-    post "/api/v1/teams/#{team.id}/team_members",
-         params: { user_ids: [missing_uuid] },
-         headers: headers,
-         as: :json
+      patch "/api/v1/teams/#{team.id}/team_members",
+            params: { user_ids: [missing_uuid] },
+            headers: headers,
+            as: :json
 
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(response).not_to have_http_status(:unauthorized)
-    expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
-    expect(team.reload.members).to be_empty
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).not_to have_http_status(:unauthorized)
+      expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
+      expect(team.reload.members).to be_empty
+    end
+
+    it 'returns 422 when user_ids is missing entirely' do
+      patch "/api/v1/teams/#{team.id}/team_members",
+            params: {},
+            headers: headers,
+            as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
+    end
   end
 
-  it 'is idempotent for users already in the team' do
-    team.add_members([user.id])
+  describe 'DELETE /api/v1/teams/:team_id/team_members' do
+    it 'removes a valid user UUID from the team and returns 200' do
+      team.add_members([user.id])
 
-    # The controller subtracts current_members_ids from params[:user_ids] before
-    # add_members runs, so re-posting an existing member is a no-op (200), not
-    # a 401 or 422.
-    post "/api/v1/teams/#{team.id}/team_members",
-         params: { user_ids: [user.id] },
-         headers: headers,
-         as: :json
+      delete "/api/v1/teams/#{team.id}/team_members",
+             params: { user_ids: [user.id] },
+             headers: headers,
+             as: :json
 
-    expect(response).to have_http_status(:ok)
-    expect(team.reload.members.pluck(:id)).to eq([user.id])
+      expect(response).to have_http_status(:ok)
+      expect(team.reload.members).to be_empty
+    end
+
+    it 'returns 422 when user_ids is missing entirely' do
+      delete "/api/v1/teams/#{team.id}/team_members",
+             params: {},
+             headers: headers,
+             as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json_response.dig('error', 'code')).to eq('VALIDATION_ERROR')
+    end
   end
 end


### PR DESCRIPTION
## Summary

The team-member create flow rejected every valid user UUID with HTTP `401 Unauthorized` and a hardcoded `{"error": "Invalid User IDs"}` body. Combined with the global axios 401 → logout interceptor on the frontend, the admin was kicked back to the login screen mid-flow whenever they tried to assign a member.

Two compounded bugs were fixed:

- `validate_member_id_params` normalised user IDs with `params[:user_ids].map(&:to_i)`. The `User` PK is a **UUID**, so every UUID became `0` and never matched `User.pluck(:id)`. The `before_action` is removed entirely; validation is now delegated to the `belongs_to :user` association on `TeamMember` and the FK constraint, both surfaced through the controller's rescue block.
- The existing rescue called `error_response(code:, message:)` with keyword args, but `app/controllers/concerns/api_response_helper.rb#error_response` is defined with positional `(code, message, details:, status:)`. The original 401 path masked this bug; once the rescue was actually reached, the controller raised `ArgumentError`. The rescue is now called with positional args plus an explicit `status: :unprocessable_entity` override.
- The rescue now catches both `ActiveRecord::RecordInvalid` (uniqueness, presence) and `ActiveRecord::InvalidForeignKey` (user UUID does not exist) so missing users surface as a clean 422 instead of a 500.

## Validation

- `ruby -c app/controllers/api/v1/team_members_controller.rb` — Syntax OK
- `bundle exec rubocop app/controllers/api/v1/team_members_controller.rb spec/requests/api/v1/team_members_spec.rb` — pre-existing offenses only (Layout in controller predates this PR; `Rails/ResponseParsedBody` matches the convention used in `spec/requests/api/v1/labels_spec.rb` and `spec/requests/api/v1/conversations_pin_archive_spec.rb`)
- `RAILS_ENV=test bundle exec rspec spec/models/team_spec.rb spec/requests/api/v1/team_members_spec.rb` — **9 examples, 0 failures**
- Manually reproduced and confirmed by the reporter: admin can now create a team and add members in a single flow without being logged out.

## Changed Files

- `app/controllers/api/v1/team_members_controller.rb`
- `spec/requests/api/v1/team_members_spec.rb` (new)

## Linked Issue

- EVO-1000 — https://linear.app/evoai/issue/EVO-1000

## Related PRs

- Frontend counterpart: will be linked after creation

## Summary by Sourcery

Return proper 422 validation errors for invalid team member operations instead of unauthorized responses that log users out.

Bug Fixes:
- Fix team member create/update/destroy to surface validation and foreign key errors as 422 responses instead of 401 or 500.
- Correct the error response helper usage so controller rescues no longer raise argument errors when handling invalid records.

Enhancements:
- Remove redundant manual user ID validation in favor of relying on model validations and database constraints for team member operations.

Tests:
- Add request specs for the team members API to cover successful flows and validation error responses.