### PR TITLE
fix(crm): persist pipeline_stage_id on pipeline_items#update (EVO-1005)

### DIFF
--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -160,19 +160,53 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def update
-    @pipeline_item.update!(pipeline_item_params)
-    
+    new_stage_id = params[:pipeline_stage_id]
+    stage_changed = false
+
+    if new_stage_id.present? && new_stage_id.to_s != @pipeline_item.pipeline_stage_id.to_s
+      new_stage = @pipeline.pipeline_stages.find(new_stage_id)
+
+      unless @pipeline_item.move_to_stage(new_stage, Current.user)
+        return error_response(
+          ApiErrorCodes::OPERATION_FAILED,
+          'Failed to move item to new stage',
+          status: :unprocessable_entity
+        )
+      end
+
+      stage_changed = true
+    end
+
+    @pipeline_item.update!(custom_fields: params[:custom_fields]) if params[:custom_fields].present?
+
+    if params[:notes].present? && stage_changed
+      latest_movement = @pipeline_item.stage_movements.order(:created_at).last
+      latest_movement&.update!(notes: params[:notes])
+    end
+
+    dispatch_conversation_updated_event(@pipeline_item.conversation) if stage_changed
+
     success_response(
-      data: PipelineItemSerializer.serialize(@pipeline_item, include_entity: true),
+      data: PipelineItemSerializer.serialize(@pipeline_item.reload, include_entity: true),
       message: 'Pipeline item updated successfully'
+    )
+  rescue ActiveRecord::RecordNotFound
+    error_response(
+      ApiErrorCodes::RESOURCE_NOT_FOUND,
+      'Stage not found in this pipeline',
+      status: :not_found
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
       ApiErrorCodes::VALIDATION_ERROR,
-      e.message
+      e.message,
+      details: format_validation_errors(e.record.errors),
+      status: :unprocessable_entity
     )
   end
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def update_notesconversation

--- a/spec/controllers/api/v1/pipeline_items_controller_spec.rb
+++ b/spec/controllers/api/v1/pipeline_items_controller_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::PipelineItemsController, type: :controller do
+  let(:user) { User.create!(email: 'pipeline-items-spec@example.com', name: 'Spec User') }
+  let(:pipeline) do
+    Pipeline.create!(name: 'Sales Pipeline', pipeline_type: 'sales', created_by: user)
+  end
+  let!(:stage_one) { PipelineStage.create!(pipeline: pipeline, name: 'Lead', position: 1) }
+  let!(:stage_two) { PipelineStage.create!(pipeline: pipeline, name: 'Qualified', position: 2) }
+  let(:contact) { Contact.create!(name: 'Jane Doe', email: 'jane@example.com') }
+  let!(:pipeline_item) do
+    PipelineItem.create!(
+      pipeline: pipeline,
+      pipeline_stage: stage_one,
+      contact: contact,
+      assigned_by: user
+    )
+  end
+
+  before do
+    Current.user = user
+    Current.service_authenticated = true
+    Current.authentication_method = 'service_token'
+
+    allow(controller).to receive(:authenticate_request!).and_return(true)
+    allow(controller).to receive(:authorize).and_return(true)
+    allow(controller).to receive(:pundit_user).and_return({ user: user, account_user: nil })
+  end
+
+  after { Current.reset }
+
+  describe 'PATCH #update' do
+    context 'when changing the pipeline stage (EVO-1005)' do
+      it 'persists the new pipeline_stage_id' do
+        patch :update, params: {
+          pipeline_id: pipeline.id,
+          id: pipeline_item.id,
+          pipeline_stage_id: stage_two.id
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(pipeline_item.reload.pipeline_stage_id).to eq(stage_two.id)
+      end
+
+      it 'creates a stage_movement audit row for the change' do
+        expect do
+          patch :update, params: {
+            pipeline_id: pipeline.id,
+            id: pipeline_item.id,
+            pipeline_stage_id: stage_two.id
+          }
+        end.to change { pipeline_item.stage_movements.count }.by(1)
+
+        movement = pipeline_item.stage_movements.order(:created_at).last
+        expect(movement.from_stage_id).to eq(stage_one.id)
+        expect(movement.to_stage_id).to eq(stage_two.id)
+        expect(movement.movement_type).to eq('manual')
+      end
+
+      it 'attaches notes to the new stage_movement when provided' do
+        patch :update, params: {
+          pipeline_id: pipeline.id,
+          id: pipeline_item.id,
+          pipeline_stage_id: stage_two.id,
+          notes: 'Moved after qualification call'
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(pipeline_item.stage_movements.order(:created_at).last.notes)
+          .to eq('Moved after qualification call')
+      end
+
+      it 'returns the serialized item with the new stage' do
+        patch :update, params: {
+          pipeline_id: pipeline.id,
+          id: pipeline_item.id,
+          pipeline_stage_id: stage_two.id
+        }
+
+        body = response.parsed_body
+        expect(body.dig('data', 'pipeline_stage_id') || body.dig('data', 'stage_id') ||
+               body.dig('data', 'pipeline_stage', 'id')).to eq(stage_two.id)
+      end
+
+      it 'rejects a stage that belongs to a different pipeline (404)' do
+        other_pipeline = Pipeline.create!(name: 'Other', pipeline_type: 'sales', created_by: user)
+        foreign_stage = PipelineStage.create!(pipeline: other_pipeline, name: 'Foreign', position: 1)
+
+        patch :update, params: {
+          pipeline_id: pipeline.id,
+          id: pipeline_item.id,
+          pipeline_stage_id: foreign_stage.id
+        }
+
+        expect(response).to have_http_status(:not_found)
+        expect(pipeline_item.reload.pipeline_stage_id).to eq(stage_one.id)
+      end
+    end
+
+    context 'when stage is unchanged' do
+      it 'does not create a new stage_movement' do
+        expect do
+          patch :update, params: {
+            pipeline_id: pipeline.id,
+            id: pipeline_item.id,
+            pipeline_stage_id: stage_one.id,
+            custom_fields: { currency: 'BRL' }
+          }
+        end.not_to(change { pipeline_item.stage_movements.count })
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when only custom_fields are provided' do
+      it 'updates custom_fields without touching the stage' do
+        patch :update, params: {
+          pipeline_id: pipeline.id,
+          id: pipeline_item.id,
+          custom_fields: { currency: 'USD' }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(pipeline_item.reload.custom_fields['currency']).to eq('USD')
+        expect(pipeline_item.pipeline_stage_id).to eq(stage_one.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Linear

[EVO-1005 — Pipeline: manual stage change from conversation profile does not persist](https://linear.app/evoai/issue/EVO-1005/pipeline-manual-stage-change-from-conversation-profile-does-not)

## Root cause

`Api::V1::PipelineItemsController#update` was calling `@pipeline_item.update!(pipeline_item_params)`, where `pipeline_item_params` only permitted `custom_fields: {}`. Strong-params silently dropped `pipeline_stage_id` and `notes`, so the stage change submitted from the conversation profile panel was never persisted. The UI optimistically reflected the new stage, then reloaded from the API and showed the unchanged record — the user-visible "revert".

## Fix

Rewrite `#update` to:

1. Resolve `params[:pipeline_stage_id]` against `@pipeline.pipeline_stages` (scoped find — rejects stages from other pipelines with **404**, no silent data corruption).
2. Move via `PipelineItem#move_to_stage` to preserve the cross-pipeline guard, the `stage_movements` audit row (created via `after_update :create_stage_change_movement`), and the `pipeline_stage_updated` automation event.
3. Update `custom_fields` separately when present.
4. Attach `notes` to the new movement when both are present.
5. Dispatch `CONVERSATION_UPDATED` so kanban / conversation list refresh in real time.

Error paths now return **404** for foreign stage and **422** with `format_validation_errors` details, matching the rest of the controller.

`Api::V1::Oauth::PipelineItemsController` inherits `update` unchanged → fix propagates without duplication.

## Tests

New `spec/controllers/api/v1/pipeline_items_controller_spec.rb` — **7 examples, all passing**:

| # | Case |
|---|---|
| 1 | Stage change persists `pipeline_stage_id` |
| 2 | Audit row in `stage_movements` (+1, correct `from`/`to`/`manual`) |
| 3 | `notes` attached to the new movement |
| 4 | Serialized response carries the new stage |
| 5 | Stage from another pipeline → 404, item unchanged |
| 6 | No-op stage change → no extra movement |
| 7 | Custom fields only → stage untouched |

```
$ bundle exec rspec spec/controllers/api/v1/pipeline_items_controller_spec.rb
.......
7 examples, 0 failures
```

## Out of scope (follow-ups)

- Dead `update_notesconversation` action (typo, aliased to route `update_conversation`) is unreachable from the frontend; cleaning it up is a separate PR.
- No frontend change required (`ContactPipelineItem.tsx` already sends the right payload).

## Test plan

- [x] `bundle exec rspec spec/controllers/api/v1/pipeline_items_controller_spec.rb` green
- [ ] Manual smoke: open conversation → profile → pipeline tab → change stage → save → reload → stage stays
- [ ] Manual smoke: same flow on the kanban board → card moves and persists

## Coordination

PR #26 (EVO-975, pipeline default-stage on create) does **not** touch this controller. No conflict (`gh pr diff 26` confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure pipeline item updates correctly persist stage changes, notes, and custom fields while enforcing pipeline scoping and error handling.

Bug Fixes:
- Persist pipeline_stage_id changes when updating pipeline items, including correct API error responses for invalid stages or validation failures.
- Attach notes to the latest stage movement when a manual stage change occurs and keep stages unchanged on custom-fields-only updates.

Tests:
- Add controller specs for pipeline item updates covering stage persistence, audit movements, notes attachment, serialized response, foreign-stage rejection, no-op stage changes, and custom-fields-only updates.