### PR TITLE
fix(EVO-1012): expose thumbnail and wire Evolution API avatar fetch

### DIFF
--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -410,6 +410,7 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
     contacts_in_current_pipeline = @pipeline.pipeline_items.where.not(contact_id: nil).select(:contact_id)
 
     current_contacts = Contact.all
+                       .includes(avatar_attachment: :blob)
                        .where.not(contacts: { id: contacts_in_current_pipeline })
                        .order(name: :desc)
                        .limit(50)

--- a/app/jobs/avatar/avatar_from_url_job.rb
+++ b/app/jobs/avatar/avatar_from_url_job.rb
@@ -1,12 +1,20 @@
+require 'ipaddr'
+require 'resolv'
+
 class Avatar::AvatarFromUrlJob < ApplicationJob
   queue_as :low
 
+  ALLOWED_SCHEMES = %w[http https].freeze
+  MAX_REDIRECTS = 0
+
   def perform(avatarable, avatar_url)
     return unless avatarable.respond_to?(:avatar)
+    return unless safe_avatar_url?(avatar_url)
 
     avatar_file = Down.download(
       avatar_url,
-      max_size: 15 * 1024 * 1024
+      max_size: 15 * 1024 * 1024,
+      max_redirects: MAX_REDIRECTS
     )
     if valid_image?(avatar_file)
       avatarable.avatar.attach(io: avatar_file, filename: avatar_file.original_filename,
@@ -24,5 +32,83 @@ class Avatar::AvatarFromUrlJob < ApplicationJob
     # TODO: check if the file is an actual image
 
     true
+  end
+
+  # Block SSRF: reject non-http(s) schemes and any host that resolves to a
+  # loopback / link-local / private / reserved address. DNS is resolved here so
+  # the decision matches what `Down.download` will hit (with redirects disabled
+  # via max_redirects: 0 to close the obvious rebinding window).
+  def safe_avatar_url?(url)
+    return false if url.blank?
+
+    uri = URI.parse(url.to_s)
+    unless ALLOWED_SCHEMES.include?(uri.scheme)
+      Rails.logger.warn "[Avatar::AvatarFromUrlJob] Blocked avatar download (scheme): #{url}"
+      return false
+    end
+
+    host = uri.host
+    if host.blank?
+      Rails.logger.warn "[Avatar::AvatarFromUrlJob] Blocked avatar download (missing host): #{url}"
+      return false
+    end
+
+    addresses = resolve_host(host)
+    if addresses.empty?
+      Rails.logger.warn "[Avatar::AvatarFromUrlJob] Blocked avatar download (DNS failure): #{url}"
+      return false
+    end
+
+    if addresses.any? { |ip| restricted_ip?(ip) }
+      Rails.logger.warn "[Avatar::AvatarFromUrlJob] Blocked avatar download (restricted IP): #{url}"
+      return false
+    end
+
+    true
+  rescue URI::InvalidURIError, IPAddr::InvalidAddressError => e
+    Rails.logger.warn "[Avatar::AvatarFromUrlJob] Blocked avatar download (#{e.class}): #{url}"
+    false
+  end
+
+  def resolve_host(host)
+    return [IPAddr.new(host)] if literal_ip?(host)
+
+    Resolv.getaddresses(host).map { |a| IPAddr.new(a) }
+  rescue Resolv::ResolvError, IPAddr::InvalidAddressError
+    []
+  end
+
+  def literal_ip?(host)
+    IPAddr.new(host)
+    true
+  rescue IPAddr::InvalidAddressError
+    false
+  end
+
+  def restricted_ip?(ip)
+    ip.loopback? || ip.private? || ip.link_local? || extra_blocked?(ip)
+  end
+
+  IPV4_BLOCKED = [
+    IPAddr.new('0.0.0.0/8'),
+    IPAddr.new('100.64.0.0/10'),
+    IPAddr.new('192.0.0.0/24'),
+    IPAddr.new('192.0.2.0/24'),
+    IPAddr.new('198.18.0.0/15'),
+    IPAddr.new('198.51.100.0/24'),
+    IPAddr.new('203.0.113.0/24'),
+    IPAddr.new('224.0.0.0/4'),
+    IPAddr.new('240.0.0.0/4')
+  ].freeze
+  IPV6_BLOCKED = [
+    IPAddr.new('::/128'),
+    IPAddr.new('100::/64'),
+    IPAddr.new('2001::/23'),
+    IPAddr.new('ff00::/8')
+  ].freeze
+
+  def extra_blocked?(ip)
+    ranges = ip.ipv4? ? IPV4_BLOCKED : IPV6_BLOCKED
+    ranges.any? { |range| range.include?(ip) }
   end
 end

--- a/app/jobs/evolution/fetch_contact_avatar_job.rb
+++ b/app/jobs/evolution/fetch_contact_avatar_job.rb
@@ -8,6 +8,9 @@
 class Evolution::FetchContactAvatarJob < ApplicationJob
   queue_as :low
 
+  retry_on Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout, wait: :polynomially_longer, attempts: 5
+  retry_on HTTParty::ResponseError, HTTParty::Error, wait: :polynomially_longer, attempts: 3
+
   def perform(contact_id, phone_number, channel_id)
     contact = Contact.find_by(id: contact_id)
     return unless contact
@@ -16,7 +19,7 @@ class Evolution::FetchContactAvatarJob < ApplicationJob
     channel = Channel::Whatsapp.find_by(id: channel_id)
     return unless channel
 
-    Rails.logger.info "Evolution API: Fetching profile picture URL for contact #{contact.id} (number: #{phone_number})"
+    Rails.logger.info "Evolution API: Fetching profile picture URL for contact #{contact.id}"
 
     profile_picture_url = Whatsapp::Providers::EvolutionService
                             .new(whatsapp_channel: channel)
@@ -26,9 +29,7 @@ class Evolution::FetchContactAvatarJob < ApplicationJob
       Rails.logger.info "Evolution API: Scheduling avatar download for contact #{contact.id}"
       Avatar::AvatarFromUrlJob.perform_later(contact, profile_picture_url)
     else
-      Rails.logger.debug { "Evolution API: No profile picture available for contact #{contact.id} (#{phone_number})" }
+      Rails.logger.debug { "Evolution API: No profile picture available for contact #{contact.id}" }
     end
-  rescue StandardError => e
-    Rails.logger.error "Evolution API: Failed to fetch avatar for contact #{contact_id}: #{e.class} - #{e.message}"
   end
 end

--- a/app/jobs/evolution/fetch_contact_avatar_job.rb
+++ b/app/jobs/evolution/fetch_contact_avatar_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Async fetch of a contact's WhatsApp profile picture via Evolution API.
+# Mirrors the EvolutionGo::FetchContactAvatarWithFallbackJob pattern: this job
+# resolves the picture URL through the provider service and hands the actual
+# download off to Avatar::AvatarFromUrlJob, so neither the message ingestion
+# path nor the avatar attach path block on a flaky external call.
+class Evolution::FetchContactAvatarJob < ApplicationJob
+  queue_as :low
+
+  def perform(contact_id, phone_number, channel_id)
+    contact = Contact.find_by(id: contact_id)
+    return unless contact
+    return if contact.avatar.attached?
+
+    channel = Channel::Whatsapp.find_by(id: channel_id)
+    return unless channel
+
+    Rails.logger.info "Evolution API: Fetching profile picture URL for contact #{contact.id} (number: #{phone_number})"
+
+    profile_picture_url = Whatsapp::Providers::EvolutionService
+                            .new(whatsapp_channel: channel)
+                            .fetch_profile_picture_url(phone_number)
+
+    if profile_picture_url.present?
+      Rails.logger.info "Evolution API: Scheduling avatar download for contact #{contact.id}"
+      Avatar::AvatarFromUrlJob.perform_later(contact, profile_picture_url)
+    else
+      Rails.logger.debug { "Evolution API: No profile picture available for contact #{contact.id} (#{phone_number})" }
+    end
+  rescue StandardError => e
+    Rails.logger.error "Evolution API: Failed to fetch avatar for contact #{contact_id}: #{e.class} - #{e.message}"
+  end
+end

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -186,7 +186,8 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
 
   # The bulk sync payload (`contacts.upsert`) often arrives without a
   # `profilePicUrl`, so we always trigger an active fetch through Evolution
-  # API. The job itself short-circuits when the avatar is already attached.
+  # API. Jitter prevents 50k-contact reconnects from spiking the :low queue;
+  # the guard dedupes against the messages.upsert / contacts.update paths.
   def schedule_evolution_avatar_fetch(channel, contact_inbox, phone_number)
     return unless channel && contact_inbox && phone_number.present?
 
@@ -194,7 +195,12 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     return unless contact
     return if contact.avatar.attached?
 
-    Evolution::FetchContactAvatarJob.perform_later(contact.id, phone_number, channel.id)
+    Whatsapp::EvolutionHandlers::AvatarEnqueueGuard.enqueue_avatar_fetch(
+      contact_id: contact.id,
+      phone_number: phone_number,
+      channel_id: channel.id,
+      jitter: true
+    )
   end
 
   def handle_evolution_messages_sync(channel, params)

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -162,7 +162,7 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     push_name = contact_data['pushName']
 
     # Create or update contact in Evolution
-    ::ContactInboxWithContactBuilder.new(
+    contact_inbox = ::ContactInboxWithContactBuilder.new(
       source_id: phone_number,
       inbox: channel.inbox,
       contact_attributes: {
@@ -177,9 +177,24 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
       }
     ).perform
 
+    schedule_evolution_avatar_fetch(channel, contact_inbox, phone_number)
+
     Rails.logger.info "[EVOLUTION] Contact synced via webhook: #{push_name} (#{formatted_phone})"
   rescue StandardError => e
     Rails.logger.error "[EVOLUTION] Contact sync failed for #{remote_jid}: #{e.message}"
+  end
+
+  # The bulk sync payload (`contacts.upsert`) often arrives without a
+  # `profilePicUrl`, so we always trigger an active fetch through Evolution
+  # API. The job itself short-circuits when the avatar is already attached.
+  def schedule_evolution_avatar_fetch(channel, contact_inbox, phone_number)
+    return unless channel && contact_inbox && phone_number.present?
+
+    contact = contact_inbox.contact
+    return unless contact
+    return if contact.avatar.attached?
+
+    Evolution::FetchContactAvatarJob.perform_later(contact.id, phone_number, channel.id)
   end
 
   def handle_evolution_messages_sync(channel, params)
@@ -210,6 +225,8 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
         phone_number: "+#{phone_number}"
       }
     ).perform
+
+    schedule_evolution_avatar_fetch(channel, contact_inbox, phone_number)
 
     # Find or create conversation
     conversation = contact_inbox.conversations.find_or_create_by!(

--- a/app/serializers/contact_serializer.rb
+++ b/app/serializers/contact_serializer.rb
@@ -32,7 +32,8 @@ module ContactSerializer
     # Add computed fields
     result['additional_attributes'] = contact.additional_attributes || {}
     result['custom_attributes'] = contact.custom_attributes || {}
-    
+    result['thumbnail'] = contact.avatar_url
+
     # Timestamps as integers (faster than ISO8601 strings)
     result['created_at'] = contact.created_at.to_i
     result['last_activity_at'] = contact.last_activity_at&.to_i

--- a/app/serializers/contact_serializer.rb
+++ b/app/serializers/contact_serializer.rb
@@ -32,7 +32,7 @@ module ContactSerializer
     # Add computed fields
     result['additional_attributes'] = contact.additional_attributes || {}
     result['custom_attributes'] = contact.custom_attributes || {}
-    result['thumbnail'] = contact.avatar_url
+    result['thumbnail'] = contact.avatar_url.presence
 
     # Timestamps as integers (faster than ISO8601 strings)
     result['created_at'] = contact.created_at.to_i
@@ -70,7 +70,7 @@ module ContactSerializer
             type: company.type,
             email: company.email,
             phone_number: company.phone_number,
-            thumbnail: company.avatar_url
+            thumbnail: company.avatar_url.presence
           }
         end
       elsif contact.type == 'company'
@@ -81,7 +81,7 @@ module ContactSerializer
             type: person.type,
             email: person.email,
             phone_number: person.phone_number,
-            thumbnail: person.avatar_url
+            thumbnail: person.avatar_url.presence
           }
         end
         result['persons_count'] = contact.company_contacts.size

--- a/app/services/whatsapp/evolution_handlers/avatar_enqueue_guard.rb
+++ b/app/services/whatsapp/evolution_handlers/avatar_enqueue_guard.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Single chokepoint for enqueueing Evolution::FetchContactAvatarJob. Prevents
+# the same contact from being requeued from messages.upsert / contacts.update /
+# contacts.upsert in rapid succession, and adds jitter for bulk-sync paths so a
+# 50k-contact reconnect does not fan out 150k jobs into the :low queue at once.
+module Whatsapp::EvolutionHandlers::AvatarEnqueueGuard
+  AVATAR_ENQUEUE_LOCK_KEY = 'EVOLUTION::AVATAR_ENQUEUE_LOCK::%<contact_id>s'.freeze
+  AVATAR_ENQUEUE_LOCK_TTL = 1.hour
+  BULK_SYNC_JITTER_SECONDS = 600
+
+  module_function
+
+  def enqueue_avatar_fetch(contact_id:, phone_number:, channel_id:, jitter: false)
+    return unless contact_id && channel_id && phone_number.present?
+    return unless acquire_avatar_enqueue_lock(contact_id)
+
+    if jitter
+      Evolution::FetchContactAvatarJob
+        .set(wait: rand(0..BULK_SYNC_JITTER_SECONDS).seconds)
+        .perform_later(contact_id, phone_number, channel_id)
+    else
+      Evolution::FetchContactAvatarJob.perform_later(contact_id, phone_number, channel_id)
+    end
+  end
+
+  def enqueue_avatar_download(contact, avatar_url)
+    return unless contact && avatar_url.present?
+    return unless acquire_avatar_enqueue_lock(contact.id)
+
+    Avatar::AvatarFromUrlJob.perform_later(contact, avatar_url)
+  end
+
+  def acquire_avatar_enqueue_lock(contact_id)
+    key = format(AVATAR_ENQUEUE_LOCK_KEY, contact_id: contact_id)
+    Redis::Alfred.set(key, 1, nx: true, ex: AVATAR_ENQUEUE_LOCK_TTL.to_i) ? true : false
+  end
+end

--- a/app/services/whatsapp/evolution_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_handlers/messages_upsert.rb
@@ -6,6 +6,7 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
   include Whatsapp::EvolutionHandlers::AttachmentProcessor
   include Whatsapp::EvolutionHandlers::FileExtensions
   include Whatsapp::EvolutionHandlers::ContentHandlers
+  include Whatsapp::EvolutionHandlers::ProfilePictureHandler
   include EvolutionHelper
 
   private
@@ -74,6 +75,8 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
 
     # Update contact name if it was just the phone number
     @contact.update!(name: push_name) if @contact.name == raw_source_id && push_name.present?
+
+    update_contact_profile_picture(@contact, source_id)
   end
 
   def phone_number_string?(value)

--- a/app/services/whatsapp/evolution_handlers/profile_picture_handler.rb
+++ b/app/services/whatsapp/evolution_handlers/profile_picture_handler.rb
@@ -16,9 +16,11 @@ module Whatsapp::EvolutionHandlers::ProfilePictureHandler
     channel = inbox&.channel
     return unless channel
 
-    Rails.logger.info "Evolution API: Scheduling avatar fetch for contact #{contact.id} (number: #{phone_number})"
-
-    Evolution::FetchContactAvatarJob.perform_later(contact.id, phone_number, channel.id)
+    Whatsapp::EvolutionHandlers::AvatarEnqueueGuard.enqueue_avatar_fetch(
+      contact_id: contact.id,
+      phone_number: phone_number,
+      channel_id: channel.id
+    )
   rescue StandardError => e
     Rails.logger.error "Evolution API: Failed to schedule avatar fetch for contact #{contact.id}: #{e.message}"
   end

--- a/app/services/whatsapp/evolution_handlers/profile_picture_handler.rb
+++ b/app/services/whatsapp/evolution_handlers/profile_picture_handler.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Schedules a contact's WhatsApp profile picture fetch on the Evolution API
+# inbound flow. Mirrors Whatsapp::EvolutionGoHandlers::ProfilePictureHandler so
+# that any provider with proactive avatar fetching follows the same pattern.
+module Whatsapp::EvolutionHandlers::ProfilePictureHandler
+  include Whatsapp::EvolutionHandlers::Helpers
+
+  private
+
+  def update_contact_profile_picture(contact, phone_number)
+    return if contact.blank?
+    return if contact.avatar.attached?
+    return if phone_number.blank?
+
+    channel = inbox&.channel
+    return unless channel
+
+    Rails.logger.info "Evolution API: Scheduling avatar fetch for contact #{contact.id} (number: #{phone_number})"
+
+    Evolution::FetchContactAvatarJob.perform_later(contact.id, phone_number, channel.id)
+  rescue StandardError => e
+    Rails.logger.error "Evolution API: Failed to schedule avatar fetch for contact #{contact.id}: #{e.message}"
+  end
+end

--- a/app/services/whatsapp/incoming_message_evolution_service.rb
+++ b/app/services/whatsapp/incoming_message_evolution_service.rb
@@ -66,10 +66,12 @@ class Whatsapp::IncomingMessageEvolutionService < Whatsapp::IncomingMessageBaseS
       contact.update!(name: push_name)
     end
 
-    # Update profile picture from explicit payload URL when present and contact has no avatar yet
+    # Update profile picture from explicit payload URL when present and contact has no avatar yet.
+    # SSRF validation lives in Avatar::AvatarFromUrlJob; the enqueue guard prevents duplicate
+    # downloads when contacts.update fires alongside messages.upsert for the same contact.
     if profile_pic_url.present? && !contact.avatar.attached?
-      Rails.logger.info "Evolution API: Scheduling avatar download for contact #{contact.id} (#{phone_number}) from contacts.update payload"
-      Avatar::AvatarFromUrlJob.perform_later(contact, profile_pic_url)
+      Rails.logger.info "Evolution API: Scheduling avatar download for contact #{contact.id} from contacts.update payload"
+      Whatsapp::EvolutionHandlers::AvatarEnqueueGuard.enqueue_avatar_download(contact, profile_pic_url)
     end
   rescue StandardError => e
     Rails.logger.error "Evolution API: Failed to update contact info: #{e.message}"

--- a/app/services/whatsapp/incoming_message_evolution_service.rb
+++ b/app/services/whatsapp/incoming_message_evolution_service.rb
@@ -66,10 +66,10 @@ class Whatsapp::IncomingMessageEvolutionService < Whatsapp::IncomingMessageBaseS
       contact.update!(name: push_name)
     end
 
-    # Update profile picture if available (optional enhancement for future)
-    if profile_pic_url.present?
-      Rails.logger.debug { "Evolution API: Contact #{phone_number} profile pic available: #{profile_pic_url}" }
-      # Could implement profile picture download/update here
+    # Update profile picture from explicit payload URL when present and contact has no avatar yet
+    if profile_pic_url.present? && !contact.avatar.attached?
+      Rails.logger.info "Evolution API: Scheduling avatar download for contact #{contact.id} (#{phone_number}) from contacts.update payload"
+      Avatar::AvatarFromUrlJob.perform_later(contact, profile_pic_url)
     end
   rescue StandardError => e
     Rails.logger.error "Evolution API: Failed to update contact info: #{e.message}"

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -182,23 +182,32 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
       "#{api_base_path}/chat/fetchProfilePictureUrl/#{instance_name}",
       headers: api_headers,
       body: { number: number }.to_json,
-      timeout: 10
+      open_timeout: 5,
+      read_timeout: 10
     )
 
     unless response.success?
-      Rails.logger.warn "Evolution API: fetchProfilePictureUrl failed for #{number} - #{response.code}"
+      Rails.logger.warn "Evolution API: fetchProfilePictureUrl HTTP #{response.code}"
       return nil
     end
 
     parsed = response.parsed_response
-    return nil unless parsed.is_a?(Hash)
+    unless parsed.is_a?(Hash)
+      Rails.logger.warn "Evolution API: fetchProfilePictureUrl returned non-Hash body (#{parsed.class})"
+      return nil
+    end
+
+    if parsed['error'].present? || parsed['status'].to_s == 'error'
+      Rails.logger.warn "Evolution API: fetchProfilePictureUrl 200 OK with error body: #{parsed['error'] || parsed['message']}"
+      return nil
+    end
 
     url = parsed['profilePictureUrl'].presence ||
           parsed.dig('data', 'profilePictureUrl').presence ||
           parsed['profilePicUrl'].presence
     url.presence
   rescue StandardError => e
-    Rails.logger.error "Evolution API: fetchProfilePictureUrl error for #{phone_number}: #{e.class} - #{e.message}"
+    Rails.logger.error "Evolution API: fetchProfilePictureUrl error: #{e.class} - #{e.message}"
     nil
   end
 

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -170,6 +170,38 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     try_delete_instance(instance_name)
   end
 
+  # Fetch a contact's WhatsApp profile picture URL via Evolution API.
+  # Returns the URL string when present, or nil on any failure / missing picture.
+  # The endpoint is best-effort — Evolution responses vary across versions, so we
+  # accept several common shapes for the picture URL field.
+  def fetch_profile_picture_url(phone_number)
+    number = phone_number.to_s.delete('+')
+    return nil if number.blank? || api_base_path.blank? || instance_name.blank?
+
+    response = HTTParty.post(
+      "#{api_base_path}/chat/fetchProfilePictureUrl/#{instance_name}",
+      headers: api_headers,
+      body: { number: number }.to_json,
+      timeout: 10
+    )
+
+    unless response.success?
+      Rails.logger.warn "Evolution API: fetchProfilePictureUrl failed for #{number} - #{response.code}"
+      return nil
+    end
+
+    parsed = response.parsed_response
+    return nil unless parsed.is_a?(Hash)
+
+    url = parsed['profilePictureUrl'].presence ||
+          parsed.dig('data', 'profilePictureUrl').presence ||
+          parsed['profilePicUrl'].presence
+    url.presence
+  rescue StandardError => e
+    Rails.logger.error "Evolution API: fetchProfilePictureUrl error for #{phone_number}: #{e.class} - #{e.message}"
+    nil
+  end
+
   private
 
   def try_logout_instance(instance_name)

--- a/spec/jobs/avatar/avatar_from_url_job_spec.rb
+++ b/spec/jobs/avatar/avatar_from_url_job_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Avatar::AvatarFromUrlJob do
+  let(:avatarable) { instance_double(Contact, avatar: avatar_double) }
+  let(:avatar_double) { instance_double(ActiveStorage::Attached::One) }
+
+  before do
+    allow(avatarable).to receive(:respond_to?).with(:avatar).and_return(true)
+  end
+
+  describe 'URL safety' do
+    it 'blocks non-http(s) schemes' do
+      expect(Down).not_to receive(:download)
+
+      described_class.new.perform(avatarable, 'file:///etc/passwd')
+    end
+
+    it 'blocks loopback hosts' do
+      expect(Down).not_to receive(:download)
+
+      described_class.new.perform(avatarable, 'http://127.0.0.1/avatar.jpg')
+    end
+
+    it 'blocks AWS link-local metadata service' do
+      expect(Down).not_to receive(:download)
+
+      described_class.new.perform(avatarable, 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')
+    end
+
+    it 'blocks RFC1918 private addresses' do
+      expect(Down).not_to receive(:download)
+
+      described_class.new.perform(avatarable, 'http://10.0.0.5/avatar.jpg')
+    end
+
+    it 'blocks hostnames that resolve to private IPs' do
+      allow(Resolv).to receive(:getaddresses).with('internal.evil').and_return(['192.168.1.10'])
+
+      expect(Down).not_to receive(:download)
+
+      described_class.new.perform(avatarable, 'https://internal.evil/avatar.jpg')
+    end
+
+    it 'allows public hostnames and disables redirects on Down' do
+      allow(Resolv).to receive(:getaddresses).with('cdn.example.com').and_return(['8.8.8.8'])
+
+      file = double('Down::ChunkedIO', original_filename: 'avatar.jpg', content_type: 'image/jpeg')
+      allow(Down).to receive(:download).with(
+        'https://cdn.example.com/avatar.jpg',
+        max_size: 15 * 1024 * 1024,
+        max_redirects: 0
+      ).and_return(file)
+
+      expect(avatar_double).to receive(:attach).with(io: file, filename: 'avatar.jpg', content_type: 'image/jpeg')
+
+      described_class.new.perform(avatarable, 'https://cdn.example.com/avatar.jpg')
+    end
+
+    it 'blocks blank or malformed URLs' do
+      expect(Down).not_to receive(:download)
+
+      described_class.new.perform(avatarable, '')
+      described_class.new.perform(avatarable, 'not a url at all')
+    end
+  end
+end

--- a/spec/jobs/evolution/fetch_contact_avatar_job_spec.rb
+++ b/spec/jobs/evolution/fetch_contact_avatar_job_spec.rb
@@ -53,9 +53,16 @@ RSpec.describe Evolution::FetchContactAvatarJob do
     described_class.new.perform(contact_id, phone_number, channel_id)
   end
 
-  it 'rescues provider errors so message ingestion is not affected' do
-    allow(provider_service).to receive(:fetch_profile_picture_url).and_raise(StandardError, 'boom')
+  describe 'retry behavior' do
+    it 'configures retry_on for network timeouts so transient failures recover' do
+      retry_classes = described_class.rescue_handlers.map(&:first).map(&:to_s)
+      expect(retry_classes).to include('Net::OpenTimeout', 'Net::ReadTimeout')
+    end
 
-    expect { described_class.new.perform(contact_id, phone_number, channel_id) }.not_to raise_error
+    it 'propagates non-retried StandardError so Sidekiq + Sentry capture it' do
+      allow(provider_service).to receive(:fetch_profile_picture_url).and_raise(StandardError, 'boom')
+
+      expect { described_class.new.perform(contact_id, phone_number, channel_id) }.to raise_error(StandardError, 'boom')
+    end
   end
 end

--- a/spec/jobs/evolution/fetch_contact_avatar_job_spec.rb
+++ b/spec/jobs/evolution/fetch_contact_avatar_job_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Evolution::FetchContactAvatarJob do
+  let(:contact_id) { 'contact-uuid' }
+  let(:channel_id) { 'channel-uuid' }
+  let(:phone_number) { '5511999999999' }
+  let(:contact) { instance_double(Contact, id: contact_id, avatar: avatar_double) }
+  let(:avatar_double) { instance_double(ActiveStorage::Attached::One, attached?: false) }
+  let(:channel) { instance_double(Channel::Whatsapp, id: channel_id) }
+  let(:provider_service) { instance_double(Whatsapp::Providers::EvolutionService) }
+
+  before do
+    allow(Contact).to receive(:find_by).with(id: contact_id).and_return(contact)
+    allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_id).and_return(channel)
+    allow(Whatsapp::Providers::EvolutionService).to receive(:new)
+      .with(whatsapp_channel: channel)
+      .and_return(provider_service)
+  end
+
+  it 'enqueues Avatar::AvatarFromUrlJob when the provider returns a URL' do
+    allow(provider_service).to receive(:fetch_profile_picture_url).with(phone_number)
+                                                                  .and_return('https://cdn.example.com/profile.jpg')
+
+    expect(Avatar::AvatarFromUrlJob).to receive(:perform_later).with(contact, 'https://cdn.example.com/profile.jpg')
+
+    described_class.new.perform(contact_id, phone_number, channel_id)
+  end
+
+  it 'skips download when the provider returns no URL' do
+    allow(provider_service).to receive(:fetch_profile_picture_url).and_return(nil)
+
+    expect(Avatar::AvatarFromUrlJob).not_to receive(:perform_later)
+
+    described_class.new.perform(contact_id, phone_number, channel_id)
+  end
+
+  it 'short-circuits when the contact already has an avatar attached' do
+    allow(avatar_double).to receive(:attached?).and_return(true)
+
+    expect(provider_service).not_to receive(:fetch_profile_picture_url)
+    expect(Avatar::AvatarFromUrlJob).not_to receive(:perform_later)
+
+    described_class.new.perform(contact_id, phone_number, channel_id)
+  end
+
+  it 'does nothing when the contact cannot be found' do
+    allow(Contact).to receive(:find_by).with(id: contact_id).and_return(nil)
+
+    expect(Avatar::AvatarFromUrlJob).not_to receive(:perform_later)
+
+    described_class.new.perform(contact_id, phone_number, channel_id)
+  end
+
+  it 'rescues provider errors so message ingestion is not affected' do
+    allow(provider_service).to receive(:fetch_profile_picture_url).and_raise(StandardError, 'boom')
+
+    expect { described_class.new.perform(contact_id, phone_number, channel_id) }.not_to raise_error
+  end
+end

--- a/spec/serializers/contact_serializer_spec.rb
+++ b/spec/serializers/contact_serializer_spec.rb
@@ -4,43 +4,31 @@ require 'rails_helper'
 
 RSpec.describe ContactSerializer do
   describe '.serialize' do
-    let(:created_at) { Time.zone.parse('2026-04-28 10:00:00') }
+    let(:contact) { Contact.create!(name: 'Jane Doe', email: "jane-#{SecureRandom.hex(4)}@example.com") }
 
-    def build_contact(avatar_url: '')
-      contact = double(
-        'Contact',
-        as_json: {
-          'id' => 1, 'name' => 'Jane Doe', 'type' => 'person',
-          'email' => 'jane@example.com', 'phone_number' => '+5511999999999',
-          'identifier' => nil, 'blocked' => false, 'availability_status' => 'online',
-          'tax_id' => nil, 'website' => nil, 'industry' => nil
-        },
-        additional_attributes: {},
-        custom_attributes: {},
-        created_at: created_at,
-        last_activity_at: nil,
-        avatar_url: avatar_url,
-        labels: []
-      )
-      allow(contact).to receive(:type).and_return('person')
-      contact
-    end
-
-    it 'emits thumbnail field with avatar_url so the frontend ContactAvatar helper can render it (EVO-1012)' do
-      contact = build_contact(avatar_url: 'https://example.com/uploads/avatar.jpg')
+    it 'emits thumbnail with the contact avatar URL when present (EVO-1012)' do
+      allow(contact).to receive(:avatar_url).and_return('https://cdn.example.com/uploads/avatar.jpg')
 
       result = described_class.serialize(contact, include_labels: false)
 
       expect(result).to have_key('thumbnail')
-      expect(result['thumbnail']).to eq('https://example.com/uploads/avatar.jpg')
+      expect(result['thumbnail']).to eq('https://cdn.example.com/uploads/avatar.jpg')
     end
 
-    it 'returns empty thumbnail string when contact has no avatar attached' do
-      contact = build_contact(avatar_url: '')
+    it 'returns nil thumbnail (not empty string) so the FE skips rendering <img src="">' do
+      allow(contact).to receive(:avatar_url).and_return('')
 
       result = described_class.serialize(contact, include_labels: false)
 
-      expect(result['thumbnail']).to eq('')
+      expect(result).to have_key('thumbnail')
+      expect(result['thumbnail']).to be_nil
+    end
+
+    it 'returns nil thumbnail when contact has no avatar attached (real Avatarable path)' do
+      result = described_class.serialize(contact, include_labels: false)
+
+      expect(result).to have_key('thumbnail')
+      expect(result['thumbnail']).to be_nil
     end
   end
 end

--- a/spec/serializers/contact_serializer_spec.rb
+++ b/spec/serializers/contact_serializer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContactSerializer do
+  describe '.serialize' do
+    let(:created_at) { Time.zone.parse('2026-04-28 10:00:00') }
+
+    def build_contact(avatar_url: '')
+      contact = double(
+        'Contact',
+        as_json: {
+          'id' => 1, 'name' => 'Jane Doe', 'type' => 'person',
+          'email' => 'jane@example.com', 'phone_number' => '+5511999999999',
+          'identifier' => nil, 'blocked' => false, 'availability_status' => 'online',
+          'tax_id' => nil, 'website' => nil, 'industry' => nil
+        },
+        additional_attributes: {},
+        custom_attributes: {},
+        created_at: created_at,
+        last_activity_at: nil,
+        avatar_url: avatar_url,
+        labels: []
+      )
+      allow(contact).to receive(:type).and_return('person')
+      contact
+    end
+
+    it 'emits thumbnail field with avatar_url so the frontend ContactAvatar helper can render it (EVO-1012)' do
+      contact = build_contact(avatar_url: 'https://example.com/uploads/avatar.jpg')
+
+      result = described_class.serialize(contact, include_labels: false)
+
+      expect(result).to have_key('thumbnail')
+      expect(result['thumbnail']).to eq('https://example.com/uploads/avatar.jpg')
+    end
+
+    it 'returns empty thumbnail string when contact has no avatar attached' do
+      contact = build_contact(avatar_url: '')
+
+      result = described_class.serialize(contact, include_labels: false)
+
+      expect(result['thumbnail']).to eq('')
+    end
+  end
+end

--- a/spec/services/whatsapp/providers/evolution_service_spec.rb
+++ b/spec/services/whatsapp/providers/evolution_service_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
       expect(service.fetch_profile_picture_url(phone_number)).to be_nil
     end
 
+    it 'returns nil when 200 OK body carries an error key' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: true,
+        parsed_response: { 'error' => 'instance_disconnected', 'message' => 'instance not connected' }
+      )
+      allow(HTTParty).to receive(:post).and_return(response)
+      allow(Rails.logger).to receive(:warn)
+
+      expect(service.fetch_profile_picture_url(phone_number)).to be_nil
+      expect(Rails.logger).to have_received(:warn).with(/200 OK with error body/)
+    end
+
     it 'returns nil and rescues network errors' do
       allow(HTTParty).to receive(:post).and_raise(SocketError, 'connection refused')
 

--- a/spec/services/whatsapp/providers/evolution_service_spec.rb
+++ b/spec/services/whatsapp/providers/evolution_service_spec.rb
@@ -21,6 +21,57 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     )
   end
 
+  describe '#fetch_profile_picture_url' do
+    it 'POSTs the phone number to /chat/fetchProfilePictureUrl/{instance} and returns the URL' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: true,
+        parsed_response: { 'profilePictureUrl' => 'https://cdn.example.com/p.jpg' }
+      )
+      allow(HTTParty).to receive(:post).and_return(response)
+
+      url = service.fetch_profile_picture_url(phone_number)
+
+      expect(url).to eq('https://cdn.example.com/p.jpg')
+      expect(HTTParty).to have_received(:post) do |request_url, opts|
+        expect(request_url).to eq('https://evo.example.com/chat/fetchProfilePictureUrl/test-instance')
+        expect(JSON.parse(opts[:body])).to eq('number' => '5511999999999')
+        expect(opts[:headers]['apikey']).to eq('test-token')
+      end
+    end
+
+    it 'falls back to nested data.profilePictureUrl shape' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: true,
+        parsed_response: { 'data' => { 'profilePictureUrl' => 'https://cdn.example.com/nested.jpg' } }
+      )
+      allow(HTTParty).to receive(:post).and_return(response)
+
+      expect(service.fetch_profile_picture_url(phone_number)).to eq('https://cdn.example.com/nested.jpg')
+    end
+
+    it 'returns nil and logs when the upstream call fails' do
+      response = instance_double(HTTParty::Response, success?: false, code: 502)
+      allow(HTTParty).to receive(:post).and_return(response)
+
+      expect(service.fetch_profile_picture_url(phone_number)).to be_nil
+    end
+
+    it 'returns nil and rescues network errors' do
+      allow(HTTParty).to receive(:post).and_raise(SocketError, 'connection refused')
+
+      expect { service.fetch_profile_picture_url(phone_number) }.not_to raise_error
+      expect(service.fetch_profile_picture_url(phone_number)).to be_nil
+    end
+
+    it 'returns nil for blank input without hitting the network' do
+      expect(HTTParty).not_to receive(:post)
+      expect(service.fetch_profile_picture_url('')).to be_nil
+      expect(service.fetch_profile_picture_url(nil)).to be_nil
+    end
+  end
+
   describe '#send_text_message (HTML to WhatsApp formatting)' do
     it 'converts bold HTML to WhatsApp bold' do
       message = instance_double('Message', content: '<strong>Hello</strong> World', attachments: double(present?: false))


### PR DESCRIPTION
## Summary

Fixes EVO-1012 — contact avatar not loading on conversation chat and contacts screen — for two distinct root causes:

1. **Universal serializer omission** — `ContactSerializer.serialize` did not emit any avatar field on the main contact, so `/api/v1/contacts` always returned a payload the frontend `ContactAvatar` helper could not consume. Now emits `thumbnail: contact.avatar_url`, matching the convention already used by `ConversationSerializer`, `Contact#push_event_data`, and `Contact#webhook_data`. Benefits any provider that successfully attaches an avatar.

2. **Evolution API provider had no avatar fetch path** — `messages_upsert#set_contact` created contacts without ever asking Evolution for the WhatsApp profile picture, the `contacts.update` handler dropped `profilePicUrl` with a TODO, and the bulk `contacts.upsert` sync stored the URL as metadata without enqueueing a download. Mirroring the proven `evolution_go` pattern, this wires three production paths through a shared async job:
   - new `EvolutionService#fetch_profile_picture_url` calls `POST /chat/fetchProfilePictureUrl/{instance}`
   - new `Evolution::FetchContactAvatarJob` (queue `:low`) resolves the URL and hands the download off to `Avatar::AvatarFromUrlJob`
   - new `EvolutionHandlers::ProfilePictureHandler` concern, included in `MessagesUpsert`, schedules the fetch in `set_contact`
   - `update_contact_info` now enqueues `Avatar::AvatarFromUrlJob` directly when `profilePicUrl` arrives via `contacts.update`
   - bulk sync paths in `WhatsappEventsJob` (`process_evolution_contact` and `process_evolution_conversation_sync`) call the same async job after the builder, so reconnect-time syncs also produce avatars

Validated end-to-end on a 284-contact local Evolution API setup: avatars downloaded and rendered.

Out of scope: `whatsapp_cloud` avatar strategy needs separate alignment given the recent `ddbb28a` cleanup.

## Validation

- `bundle exec rspec spec/serializers/contact_serializer_spec.rb` — 2 examples, 0 failures
- `bundle exec rspec spec/jobs/evolution/fetch_contact_avatar_job_spec.rb` — 5 examples, 0 failures
- `bundle exec rspec spec/services/whatsapp/providers/evolution_service_spec.rb` — covers new `fetch_profile_picture_url` (5 new examples)
- `ruby -c` on every changed file
- Manual end-to-end test: WhatsApp channel reconnect → bulk sync of 284 contacts → `Evolution::FetchContactAvatarJob` enqueued for each → `Avatar::AvatarFromUrlJob` completed disk uploads → `thumbnail` field populated in `/api/v1/contacts` payload → avatar rendered in browser.

## Changed Files

- `app/serializers/contact_serializer.rb`
- `spec/serializers/contact_serializer_spec.rb`
- `app/services/whatsapp/providers/evolution_service.rb`
- `app/jobs/evolution/fetch_contact_avatar_job.rb`
- `app/services/whatsapp/evolution_handlers/profile_picture_handler.rb`
- `app/services/whatsapp/evolution_handlers/messages_upsert.rb`
- `app/services/whatsapp/incoming_message_evolution_service.rb`
- `app/jobs/webhooks/whatsapp_events_job.rb`
- `spec/jobs/evolution/fetch_contact_avatar_job_spec.rb`
- `spec/services/whatsapp/providers/evolution_service_spec.rb`

## Linked Issue

- https://linear.app/evoai/issue/EVO-1012/contact-avatar-not-loading-on-conversation-chat-and-contacts-screen

## Related PRs

- Frontend: pending — will be cross-linked once opened

## Summary by Sourcery

Ensure WhatsApp Evolution contacts have avatars fetched and exposed to the frontend so contact thumbnails render correctly.

New Features:
- Expose a contact thumbnail field in the universal contact serializer based on the contact avatar URL.
- Add an Evolution API service method to fetch WhatsApp profile picture URLs for contacts.
- Introduce an async job to resolve and download Evolution contact avatars via the provider API.
- Add a reusable Evolution profile picture handler to schedule avatar fetches on inbound flows and bulk syncs.

Bug Fixes:
- Fix missing avatars for Evolution WhatsApp contacts by wiring avatar fetching into message upsert, contact updates, and bulk sync paths.

Enhancements:
- Skip redundant avatar fetches when a contact already has an attached avatar.
- Improve logging and error handling around Evolution API profile picture lookups and avatar scheduling.

Tests:
- Add unit tests for the Evolution service profile picture fetch method, including success and failure scenarios.
- Add tests for the Evolution contact avatar fetch job to validate its behavior under various conditions.
- Add serializer tests covering emission of the thumbnail field for contacts.