### PR TITLE
fix(pipeline_items): set @pipeline_item before update_custom_fields

### DIFF
--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
   include Events::Types
 
   before_action :set_pipeline
-  before_action :set_pipeline_item, only: [:update, :destroy, :move_to_stage, :update_conversation]
+  before_action :set_pipeline_item, only: [:update, :destroy, :move_to_stage, :update_conversation, :update_custom_fields]
   before_action :ensure_authorized_user
 
   def index


### PR DESCRIPTION
## Summary

`Api::V1::PipelineItemsController#update_custom_fields` runs `@pipeline_item.update!` but the `before_action :set_pipeline_item` list omits `:update_custom_fields`, so `@pipeline_item` is `nil` and every call raises `NoMethodError`.

## Repro

```bash
curl -X PATCH \
  "http://localhost:3000/api/v1/pipelines/<pipeline_uuid>/pipeline_items/<item_uuid>/update_custom_fields" \
  -H "api_access_token: <token>" \
  -H "Content-Type: application/json" \
  -d '{"custom_fields":{"foo":"bar"}}'
```

**Before:** `500 Internal Server Error`
```
NoMethodError - undefined method 'update!' for nil
  app/controllers/api/v1/pipeline_items_controller.rb:348:in 'update_custom_fields'
```

**After:** `200 OK` with the updated `custom_fields` JSON.

## Fix

```diff
- before_action :set_pipeline_item, only: [:update, :destroy, :move_to_stage, :update_conversation]
+ before_action :set_pipeline_item, only: [:update, :destroy, :move_to_stage, :update_conversation, :update_custom_fields]
```

Same pattern as the other write actions on the same controller — no behavior change beyond loading `@pipeline_item`.

Closes #7

## Test plan

- [ ] PATCH `/api/v1/pipelines/:pipeline_id/pipeline_items/:id/update_custom_fields` with a valid item now returns 200
- [ ] PATCH with a non-existent item id returns 404 (set_pipeline_item raises ActiveRecord::RecordNotFound)
- [ ] Other actions on the controller still behave as before

## Summary by Sourcery

Bug Fixes:
- Fix update_custom_fields pipeline item endpoint by loading the pipeline item before performing the update.