### PR TITLE
fix(agents): drop redundant current_user from EvoAiCoreService calls

### DIFF
--- a/app/controllers/api/v1/agents_controller.rb
+++ b/app/controllers/api/v1/agents_controller.rb
@@ -8,22 +8,22 @@ class Api::V1::AgentsController < Api::V1::BaseController
   
   
   def index
-    result = EvoAiCoreService.list_agents(current_user, index_params)
+    result = EvoAiCoreService.list_agents(index_params, request.headers)
     render json: result
   end
-  
+
   def create
-    result = EvoAiCoreService.create_agent(current_user, agent_params)
+    result = EvoAiCoreService.create_agent(agent_params, request.headers)
     render json: result, status: :created
   end
-  
+
   def update
-    result = EvoAiCoreService.update_agent(current_user, params[:id], agent_params)
+    result = EvoAiCoreService.update_agent(params[:id], agent_params, request.headers)
     render json: result
   end
-  
+
   def destroy
-    EvoAiCoreService.delete_agent(current_user, params[:id])
+    EvoAiCoreService.delete_agent(params[:id], request.headers)
     head :no_content
   end
   


### PR DESCRIPTION
## Summary

Two related issues prevented every endpoint under `/api/v1/agents` from working:

### Issue 1 — `current_user` in the wrong slot

`Api::V1::AgentsController` passes `current_user` as the **first** positional argument to every `EvoAiCoreService.*_agent` method. The service signatures expect `params` / `agent_data` / `agent_id` first — passing the user shifts every subsequent argument so the service either crashes or fires the upstream HTTP call with the wrong query/body.

### Issue 2 — Authorization header never forwarded

`EvoAiCoreService.build_headers` only forwards the inbound `Authorization` header to evo-core when the caller passes `request_headers`. The current controller doesn't pass anything, so evo-core receives **no token** and returns **401 `EvoAuth: No authentication token found`** — surfaced to the client as `500 Internal Server Error: StandardError: Unauthorized` (raised in `handle_response`).

Without both fixes the endpoint stays 500. Validated locally:

```text
# Before this PR
HTTP 500
{"success":false,"error":{"code":"INTERNAL_ERROR","message":"Unauthorized", ...}}
# evo-core log: "EvoAuth: No authentication token found" → 401
# evo-crm log:  "EvoAiCoreService.list_agents - Params: {}" then handle_response raises

# After this PR
HTTP 200
# evo-crm log:  "EvoAiCoreService.list_agents - Response code: 200, Body: ..."
# evo-core log: 200 OK with the agent list
```

## Fix

```diff
 def index
-  result = EvoAiCoreService.list_agents(current_user, index_params)
+  result = EvoAiCoreService.list_agents(index_params, request.headers)
   render json: result
 end
 # ... same pattern for create/update/destroy
```

`build_headers(request_headers)` then pulls the Bearer token out of `request.headers.env['HTTP_AUTHORIZATION']` and forwards it to evo-core. `Current.user` is still resolved internally by `build_headers` (used to set `X-User-Id`), so the previous `current_user` argument was both wrong and redundant.

> Same pattern bug exists in `agents/apikeys_controller`, `agents/folders_controller`, `agents/folders/shared_controller` and a few others. I scoped this PR strictly to `agents_controller.rb` to keep the diff reviewable. Happy to follow up with separate PRs for the others.

Closes #18

## Test plan

- [x] `GET /api/v1/agents` with valid Bearer returns 200 (verified against running stack)
- [ ] `POST /api/v1/agents` with valid payload returns 201
- [ ] `PATCH /api/v1/agents/:id` returns 200
- [ ] `DELETE /api/v1/agents/:id` returns 204
- [ ] Authentication context still works (`Current.user` resolved through `build_headers`, `X-User-Id` header still set)

## Summary by Sourcery

Fix EvoAiCoreService calls in the agents API controller to pass params and request headers instead of the current user so authentication and argument ordering are correct.

Bug Fixes:
- Correct argument ordering for EvoAiCoreService agent operations to prevent failures caused by passing current_user as the first parameter.
- Ensure Authorization headers are forwarded to EvoAiCoreService from the agents controller so authenticated calls to evo-core succeed.