### PR TITLE
fix(contact_company): define must_belong_to_same_account as no-op

### DIFF
--- a/app/models/contact_company.rb
+++ b/app/models/contact_company.rb
@@ -64,5 +64,14 @@ class ContactCompany < ApplicationRecord
     errors.add(:base, 'Cannot link contact to itself')
   end
 
+  # Single-tenant Community edition: contact and company always live in
+  # the same account, so no cross-account check is needed. Kept as a
+  # no-op so the `validate :must_belong_to_same_account` declaration on
+  # line 36 has a corresponding method (it is inherited from the SaaS
+  # tree where this guard is meaningful).
+  def must_belong_to_same_account
+    # no-op
+  end
+
 end
 


### PR DESCRIPTION
## Summary

`ContactCompany` declares `validate :must_belong_to_same_account` but the method is never defined anywhere in the class or its includes. Every save raises `NoMethodError` before any other validation runs, so the whole contact ↔ company linking API is dead in the Community edition.

## Repro

```bash
curl -X POST "http://localhost:3000/api/v1/contacts/<person_uuid>/companies" \
  -H "api_access_token: <token>" \
  -H "Content-Type: application/json" \
  -d '{"company_id":"<company_uuid>"}'
```

**Before:** `500 Internal Server Error`
```
NoMethodError - undefined method 'must_belong_to_same_account' for an instance of ContactCompany
```

**After:** `200 OK` (or `422` if another validation legitimately fails — e.g. contact not a person, link already exists, etc.)

## Fix

Define the method as a no-op in `app/models/contact_company.rb`. The Community edition is single-tenant — contact and company always live in the same account, so there is no cross-account check to perform. Keeping the `validate` line (rather than deleting it) keeps the file aligned with the SaaS tree where this hook is meaningful.

```ruby
def must_belong_to_same_account
  # no-op
end
```

Closes #6

## Test plan

- [ ] `POST /api/v1/contacts/:id/companies` with valid params returns 200
- [ ] Trying to link a non-person contact returns 422 with the proper validation message
- [ ] Trying to link to a non-company contact returns 422
- [ ] Trying to link a contact to itself returns 422 ("Cannot link contact to itself")
- [ ] Existing model specs (if any) still pass

## Summary by Sourcery

Bug Fixes:
- Prevent NoMethodError when saving ContactCompany records by providing a no-op must_belong_to_same_account method in the Community edition.