### PR TITLE
fix(contact_companies): pass error_response args positionally

### DIFF
--- a/app/controllers/api/v1/contact_companies_controller.rb
+++ b/app/controllers/api/v1/contact_companies_controller.rb
@@ -32,8 +32,8 @@ class Api::V1::ContactCompaniesController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::BUSINESS_RULE_VIOLATION,
-        message: service_result[:error]
+        ApiErrorCodes::BUSINESS_RULE_VIOLATION,
+        service_result[:error]
       )
     end
   end
@@ -63,8 +63,8 @@ class Api::V1::ContactCompaniesController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::BUSINESS_RULE_VIOLATION,
-        message: service_result[:error]
+        ApiErrorCodes::BUSINESS_RULE_VIOLATION,
+        service_result[:error]
       )
     end
   end


### PR DESCRIPTION
## Summary

`Api::V1::ContactCompaniesController#create` and `#destroy` call `error_response(code:, message:)` with kwargs. The helper in `app/controllers/concerns/api_response_helper.rb:82` is defined with positional `code, message` (`details:` / `status:` are the only kwargs), so every call raises `ArgumentError: wrong number of arguments (given 0, expected 2)` and the endpoint responds 500 on the very validation failure it was trying to report.

## Repro

After #6 is fixed (so `must_belong_to_same_account` no longer crashes), trigger any business-rule failure such as a duplicate link:

```bash
# first call: 200
curl -X POST "http://localhost:3000/api/v1/contacts/<c>/companies" \
  -H "api_access_token: <t>" -H "Content-Type: application/json" \
  -d '{"company_id":"<co>"}'

# second call: SHOULD be 400, currently 500
curl -X POST "http://localhost:3000/api/v1/contacts/<c>/companies" \
  -H "api_access_token: <t>" -H "Content-Type: application/json" \
  -d '{"company_id":"<co>"}'
```

**Before:** `500` with log `ArgumentError - wrong number of arguments (given 0, expected 2)`
**After:** `400` with `{"success":false,"error":{"code":"BUSINESS_RULE_VIOLATION","message":"<service error>"}}`

## Fix

```diff
 error_response(
-  code: ApiErrorCodes::BUSINESS_RULE_VIOLATION,
-  message: service_result[:error]
+  ApiErrorCodes::BUSINESS_RULE_VIOLATION,
+  service_result[:error]
 )
```

Same change in both `create` and `destroy`.

Closes #8

## Test plan

- [ ] Successful link returns 200 (unchanged)
- [ ] Failed link returns 400 with the `BUSINESS_RULE_VIOLATION` envelope (no longer 500)
- [ ] Successful unlink returns 200 (unchanged)
- [ ] Failed unlink returns 400 with the `BUSINESS_RULE_VIOLATION` envelope

## Summary by Sourcery

Bug Fixes:
- Correct error_response invocation in contact company create and destroy actions so business rule violations return a 400 error with the expected payload instead of a 500.