### PR TITLE
fix(oauth/applications): wrap index in standard success_response envelope

### DIFF
--- a/app/controllers/api/v1/oauth/applications_controller.rb
+++ b/app/controllers/api/v1/oauth/applications_controller.rb
@@ -10,8 +10,18 @@ class Api::V1::Oauth::ApplicationsController < Api::V1::BaseController
   before_action :set_application, only: [:show, :update, :destroy, :regenerate_secret]
 
   def index
-    @applications = OauthApplication.all.order(:created_at)
-    render json: @applications.map { |app| application_serializer(app) }
+    apps = OauthApplication.all.order(:created_at).map { |app| application_serializer(app) }
+    success_response(
+      data: apps,
+      meta: {
+        pagination: {
+          page: 1,
+          page_size: apps.length,
+          total: apps.length,
+          total_pages: 1
+        }
+      }
+    )
   end
 
   def show


### PR DESCRIPTION
## Summary

`GET /api/v1/oauth/applications` returns a plain JSON array, but the frontend wraps every admin response with `ln(response)` which expects the standard `{success, data, meta, message}` envelope and reads `meta.pagination.*`. Result: `/settings/integrations/oauth-apps` crashes in the console with `TypeError: Cannot read properties of undefined (reading 'pagination')` and never renders the list, even when applications exist.

## Repro

1. Seed at least one record into `oauth_applications`
2. Open `/settings/integrations/oauth-apps`
3. DevTools console: `Error loading OAuth apps: TypeError: Cannot read properties of undefined (reading 'pagination')`
4. Page shows the empty state

## Fix

Switch the action to use `success_response` (the helper every other v1 controller uses) and emit a single-page pagination block so the frontend's `meta.pagination.*` reader has something to read. The list is not actually paginated server-side today, so the values reflect the full result set.

```diff
 def index
-  @applications = OauthApplication.all.order(:created_at)
-  render json: @applications.map { |app| application_serializer(app) }
+  apps = OauthApplication.all.order(:created_at).map { |app| application_serializer(app) }
+  success_response(
+    data: apps,
+    meta: {
+      pagination: {
+        page: 1,
+        page_size: apps.length,
+        total: apps.length,
+        total_pages: 1
+      }
+    }
+  )
 end
```

The pagination key shape (`page`, `page_size`, `total`, `total_pages`) matches the one produced by `paginated_response` in the same helper, so it lines up with the frontend reader used by other endpoints.

Closes #20

## Test plan

- [ ] `GET /api/v1/oauth/applications` now returns `{success, data, meta: {pagination, timestamp}, ...}`
- [ ] `/settings/integrations/oauth-apps` renders the list (empty or populated) without console errors
- [ ] Other actions on the controller (show/create/update/destroy/regenerate_secret) are unchanged and could be wrapped in a follow-up if desired

## Summary by Sourcery

Bug Fixes:
- Fix OAuth applications index endpoint returning a bare JSON array that caused the integrations settings page to crash when reading pagination metadata.