### PR TITLE
fix(contact_company): dispatch events through SyncDispatcher and tolerate missing account

### DIFF
--- a/app/listeners/contact_company_listener.rb
+++ b/app/listeners/contact_company_listener.rb
@@ -4,7 +4,7 @@ class ContactCompanyListener < BaseListener
   def contact_company_linked(event)
     contact = event.data[:contact]
     company = event.data[:company]
-    account = event.data[:account]
+    account = event.data[:account] || single_tenant_account
 
     return unless contact.present? && company.present? && account.present?
 
@@ -19,7 +19,7 @@ class ContactCompanyListener < BaseListener
   def contact_company_unlinked(event)
     contact = event.data[:contact]
     company = event.data[:company]
-    account = event.data[:account]
+    account = event.data[:account] || single_tenant_account
 
     return unless contact.present? && company.present? && account.present?
 
@@ -35,7 +35,7 @@ class ContactCompanyListener < BaseListener
     contacts = event.data[:contacts]
     from_company = event.data[:from_company]
     to_company = event.data[:to_company]
-    account = event.data[:account]
+    account = event.data[:account] || single_tenant_account
 
     return unless contacts.present? && from_company.present? && to_company.present? && account.present?
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -339,10 +339,12 @@ class Contact < ApplicationRecord
     return false if companies.include?(company)
 
     companies << company
-    publish(:contact_company_linked, data: {
+    Rails.configuration.dispatcher.dispatch(
+      'contact_company_linked',
+      Time.zone.now,
       contact: self,
       company: company
-    })
+    )
     true
   rescue ActiveRecord::RecordInvalid
     false
@@ -352,10 +354,12 @@ class Contact < ApplicationRecord
     return false unless companies.include?(company)
 
     companies.delete(company)
-    publish(:contact_company_unlinked, data: {
+    Rails.configuration.dispatcher.dispatch(
+      'contact_company_unlinked',
+      Time.zone.now,
       contact: self,
       company: company
-    })
+    )
     true
   end
 

--- a/app/services/contacts/link_company_service.rb
+++ b/app/services/contacts/link_company_service.rb
@@ -1,7 +1,5 @@
 # Service Object para vincular pessoa a empresa
 class Contacts::LinkCompanyService
-  include Wisper::Publisher
-
   def initialize(contact:, company:, account: nil)
     @contact = contact
     @company = company
@@ -38,10 +36,12 @@ class Contacts::LinkCompanyService
   end
 
   def publish_events
-    publish(:contact_company_linked, data: {
+    Rails.configuration.dispatcher.dispatch(
+      'contact_company_linked',
+      Time.zone.now,
       contact: contact,
       company: company
-    })
+    )
   end
 
   def success_response

--- a/app/services/contacts/unlink_company_service.rb
+++ b/app/services/contacts/unlink_company_service.rb
@@ -1,7 +1,5 @@
 # Service Object para desvincular pessoa de empresa
 class Contacts::UnlinkCompanyService
-  include Wisper::Publisher
-
   def initialize(contact:, company:, account: nil)
     @contact = contact
     @company = company
@@ -36,10 +34,12 @@ class Contacts::UnlinkCompanyService
   end
 
   def publish_events
-    publish(:contact_company_unlinked, data: {
+    Rails.configuration.dispatcher.dispatch(
+      'contact_company_unlinked',
+      Time.zone.now,
       contact: contact,
       company: company
-    })
+    )
   end
 
   def success_response


### PR DESCRIPTION
## Summary

Linking a contact ↔ company emits a noisy backend error and the realtime ActionCable broadcast (`CONTACT_COMPANY_LINKED`) never fires, so subscribed UIs silently miss the event. Two related issues are responsible.

### Issue 1 — events published outside the dispatcher

`Contacts::LinkCompanyService`, `Contacts::UnlinkCompanyService` and the `Contact#add_company` / `#remove_company` helpers all publish through Wisper directly:

```ruby
publish(:contact_company_linked, data: { contact: c, company: co })
```

But every listener in this codebase (including `ContactCompanyListener`) reads the payload as `event.data[:contact]`, expecting the `Events::Base` wrapper that `SyncDispatcher` builds. Wisper instead delivers the raw kwargs hash, so `event.data` raises:

```
ContactCompanyListener - contact_company_linked failed:
undefined method 'data' for an instance of Hash
```

The listener swallows the exception (`rescue StandardError`), so the API call still returns 200 — but the broadcast never reaches the realtime channel.

### Issue 2 — broadcast skipped because `account` is missing

Even if a proper `Events::Base` reached the listener, the early return

```ruby
return unless contact.present? && company.present? && account.present?
```

would still skip the broadcast: none of the publishers pass `:account`, and there is no per-account scoping in the Community edition. `BaseListener` already exposes `single_tenant_account` (`RuntimeConfig.account`) for exactly this reason — the listener just wasn't using it.

## Fix

1. Replace 4 direct `publish(...)` calls with `Rails.configuration.dispatcher.dispatch(...)` — the same pattern used by every other service in the repo (`Pipelines::ConversationService`, `Conversations::TypingStatusManager`, `Messages::AudioTranscriptionService`, etc).
2. Drop `include Wisper::Publisher` from the two services (the dispatcher publishes through Wisper internally).
3. In `ContactCompanyListener`, fall back to `single_tenant_account` when `event.data[:account]` is nil so the broadcast actually fires in the Community edition.

## Repro

```bash
# Create a person + a company, then link them
curl -X POST "http://localhost:3000/api/v1/contacts/<person_uuid>/companies" \
  -H "Authorization: Bearer <jwt>" -H "Content-Type: application/json" \
  -d '{"company_id":"<company_uuid>"}'
```

**Before this PR:**
- API: `200 OK`
- Backend log: `ContactCompanyListener - contact_company_linked failed: undefined method 'data' for an instance of Hash`
- No `ActionCableBroadcastJob` enqueued — UIs subscribed to the realtime channel never see the event.

**After this PR:**
- API: `200 OK` (unchanged)
- Backend log: `ContactCompanyListener - contact_company_linked: contact=<id>, company=<id>`
- `Enqueued ActionCableBroadcastJob ... "CONTACT_COMPANY_LINKED" ...` — the realtime broadcast goes out as designed.

## Test plan

- [x] `POST /api/v1/contacts/:id/companies` returns 200, log shows the listener succeeded, `ActionCableBroadcastJob` is enqueued (verified locally against the running stack)
- [ ] `DELETE /api/v1/contacts/:id/companies/:company_id` → same shape, `CONTACT_COMPANY_UNLINKED` enqueued
- [ ] `Contact#add_company` / `#remove_company` (used by other flows) fire via the dispatcher with no listener error
- [ ] Bulk transfer flow continues to work and falls back to `single_tenant_account` when no `:account` is supplied

## Notes

- Discovered while validating the fixes for #6 / #8 against the running Community stack. The error appears in the logs whenever those flows are exercised but does not surface as a 5xx, which is why it didn't have an issue yet.
- Out of scope here, but worth a follow-up: `LinkCompanyService` *and* `Contact#add_company` both fire `contact_company_linked` for the same operation today, so the listener runs twice per link. That's a separate dedup question on the publisher side.

## Summary by Sourcery

Route contact–company link/unlink events through the centralized dispatcher and ensure listeners can resolve an account in single-tenant setups so realtime broadcasts are emitted reliably.

Bug Fixes:
- Fix contact–company link/unlink events being published with the wrong payload shape so listeners no longer fail when handling them.
- Ensure contact–company listener falls back to the single-tenant account when no account is present in the event payload so broadcasts are not skipped.

Enhancements:
- Standardize contact–company link/unlink publishers to use the shared SyncDispatcher instead of direct Wisper publishing.