### PR TITLE
fix(EVO-1006): pass include_labels through pipeline serialization chain

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build & Publish Docker Image
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags: ["v*.*.*"]
 
 permissions:
@@ -100,6 +100,8 @@ jobs:
             TAGS="${IMAGE}:${VERSION},${IMAGE}:latest"
           elif [[ "${GH_REF}" == refs/heads/main ]]; then
             TAGS="${IMAGE}:latest,${IMAGE}:main-${SHA_SHORT}"
+          elif [[ "${GH_REF}" == refs/heads/develop ]]; then
+            TAGS="${IMAGE}:develop,${IMAGE}:develop-${SHA_SHORT}"
           fi
 
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -40,7 +40,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
         include_labels: true,
         unread_counts: unread_counts_map(conversation_ids),
         last_non_activity_messages: last_non_activity_messages_map(conversation_ids),
-        labels_by_title: labels_by_title
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
       ),
       meta: conversations_pagination_meta,
       message: 'Conversations retrieved successfully'
@@ -70,7 +71,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
         include_labels: true,
         unread_counts: unread_counts_map(conversation_ids),
         last_non_activity_messages: last_non_activity_messages_map(conversation_ids),
-        labels_by_title: labels_by_title
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
       ),
       meta: conversations_pagination_meta,
       message: 'Conversations search completed successfully'
@@ -110,7 +112,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
 
   def show
     success_response(
-      data: ConversationSerializer.serialize(@conversation, include_messages: true, include_labels: true),
+      data: ConversationSerializer.serialize(
+        @conversation,
+        include_messages: true,
+        include_labels: true,
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
+      ),
       message: 'Conversation retrieved successfully'
     )
   end
@@ -121,7 +129,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
       Messages::MessageBuilder.new(Current.user, @conversation, params[:message]).perform if params[:message].present?
       
       success_response(
-        data: ConversationSerializer.serialize(@conversation, include_messages: true, include_labels: true),
+        data: ConversationSerializer.serialize(
+          @conversation,
+          include_messages: true,
+          include_labels: true,
+          labels_by_title: labels_by_title,
+          labels_by_id: labels_by_id
+        ),
         message: 'Conversation created successfully',
         status: :created
       )
@@ -139,7 +153,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   def update
     if @conversation.update(permitted_update_params)
       success_response(
-        data: ConversationSerializer.serialize(@conversation, include_messages: false, include_labels: true),
+        data: ConversationSerializer.serialize(
+          @conversation,
+          include_messages: false,
+          include_labels: true,
+          labels_by_title: labels_by_title,
+          labels_by_id: labels_by_id
+        ),
         message: 'Conversation updated successfully'
       )
     else
@@ -165,7 +185,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
         include_labels: true,
         unread_counts: unread_counts_map(conversation_ids),
         last_non_activity_messages: last_non_activity_messages_map(conversation_ids),
-        labels_by_title: labels_by_title
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
       ),
       meta: conversations_pagination_meta,
       message: 'Conversations filtered successfully'
@@ -330,7 +351,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
 
     if @conversation.update(custom_attributes: custom_attributes)
       success_response(
-        data: ConversationSerializer.serialize(@conversation, include_messages: false, include_labels: true),
+        data: ConversationSerializer.serialize(
+          @conversation,
+          include_messages: false,
+          include_labels: true,
+          labels_by_title: labels_by_title,
+          labels_by_id: labels_by_id
+        ),
         message: success_message
       )
     else
@@ -414,7 +441,21 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   end
 
   def labels_by_title
-    @labels_by_title ||= Label.all.index_by { |label| label.title.to_s.downcase }
+    label_indexes[:by_title]
+  end
+
+  def labels_by_id
+    label_indexes[:by_id]
+  end
+
+  def label_indexes
+    @label_indexes ||= begin
+      all_labels = Label.all.to_a
+      {
+        by_title: all_labels.index_by { |label| label.title.to_s.downcase },
+        by_id: all_labels.index_by { |label| label.id.to_s }
+      }
+    end
   end
 
   def conversations_pagination_meta
@@ -440,7 +481,13 @@ class Api::V1::ConversationsController < Api::V1::BaseController
     @conversation.save!
     
     success_response(
-      data: ConversationSerializer.serialize(@conversation, include_messages: false, include_labels: true),
+      data: ConversationSerializer.serialize(
+        @conversation,
+        include_messages: false,
+        include_labels: true,
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
+      ),
       message: 'Conversation custom attributes updated successfully'
     )
   rescue StandardError => e

--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -362,7 +362,19 @@ module Api
               template_params = extract_message_template_params
               Rails.logger.info "Creating template with params: #{template_params.inspect}"
 
-              template = @inbox.channel.create_message_template(template_params)
+              # For providers that publish templates to an external service
+              # (WhatsApp Cloud, Notificame, Evolution Go …), submit the
+              # template upstream and rely on the provider's sync flow to
+              # persist the record locally with the real approval status
+              # (PENDING/APPROVED/REJECTED). For channels without upstream
+              # template approval (Api, Email, etc.), fall back to the
+              # local-only path so behaviour is unchanged.
+              template =
+                if @inbox.channel.respond_to?(:create_template)
+                  @inbox.channel.create_template(template_params.to_h.stringify_keys)
+                else
+                  @inbox.channel.create_message_template(template_params)
+                end
 
               # Reload channel to clear any cached associations
               @inbox.channel.reload

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -56,7 +56,8 @@ class Api::V1::PipelinesController < Api::V1::BaseController
         include_stages: true,
         include_items: true,
         include_tasks_info: true,
-        include_services_info: true
+        include_services_info: true,
+        include_labels: true
       ),
       message: 'Pipeline retrieved successfully'
     )

--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -1,10 +1,33 @@
 module LabelConcern
+  UUID_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
   def create
-    model.update_labels(permitted_params[:labels])
+    model.update_labels(resolve_label_titles(permitted_params[:labels]))
     @labels = model.label_list
   end
 
   def index
     @labels = model.label_list
+  end
+
+  private
+
+  # Clients historically sent label identifiers as UUIDs (matching the Label
+  # PK exposed by the `/labels` endpoint). `acts_as_taggable_on :labels`
+  # stores whatever string it receives as `tags.name`, so passing UUIDs caused
+  # two downstream problems: activity messages rendered UUIDs instead of
+  # human-readable titles, and `filter_service#tag_filter_query` (which
+  # compares against `tags.name`) could not match on the user-configured
+  # title. Translate UUID-shaped inputs to titles here; leave other strings
+  # untouched for back-compat with any caller that already sends titles.
+  def resolve_label_titles(labels)
+    return labels if labels.blank?
+
+    uuids, non_uuids = Array(labels).map(&:to_s).partition { |value| UUID_REGEX.match?(value) }
+    return non_uuids if uuids.empty?
+
+    titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h
+    resolved = uuids.filter_map { |id| titles_by_id[id] }
+    (non_uuids + resolved).uniq
   end
 end

--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -61,6 +61,8 @@ module Filters::FilterHelper
       date_filter(current_filter, query_hash, filter_operator_value)
     when 'labels'
       tag_filter_query(query_hash, current_index)
+    when 'pipeline'
+      pipeline_filter_query(query_hash, current_index)
     when 'text_case_insensitive'
       text_case_insensitive_filter(query_hash, filter_operator_value)
     else

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -33,7 +33,7 @@ class ActionCableListener < BaseListener
   def message_created(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]
+    tokens = (user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]).compact
 
     broadcast(account, tokens, MESSAGE_CREATED, message.push_event_data)
   end
@@ -41,7 +41,7 @@ class ActionCableListener < BaseListener
   def message_updated(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]
+    tokens = (user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]).compact
 
     broadcast(account, tokens, MESSAGE_UPDATED, message.push_event_data.merge(previous_changes: event.data[:previous_changes]))
   end
@@ -56,7 +56,7 @@ class ActionCableListener < BaseListener
 
   def conversation_created(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]
+    tokens = (user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]).compact
 
     broadcast(account, tokens, CONVERSATION_CREATED, conversation.push_event_data)
   end
@@ -77,7 +77,7 @@ class ActionCableListener < BaseListener
 
   def conversation_updated(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]
+    tokens = (user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]).compact
 
     broadcast(account, tokens, CONVERSATION_UPDATED, conversation.push_event_data)
   end
@@ -137,22 +137,22 @@ class ActionCableListener < BaseListener
 
   def contact_created(event)
     contact, account = extract_contact_and_account(event)
-    broadcast(account, [account_token(account)], CONTACT_CREATED, contact.push_event_data)
+    broadcast(account, [account_token(account)].compact, CONTACT_CREATED, contact.push_event_data)
   end
 
   def contact_updated(event)
     contact, account = extract_contact_and_account(event)
-    broadcast(account, [account_token(account)], CONTACT_UPDATED, contact.push_event_data)
+    broadcast(account, [account_token(account)].compact, CONTACT_UPDATED, contact.push_event_data)
   end
 
   def contact_merged(event)
     contact, account = extract_contact_and_account(event)
-    broadcast(account, [account_token(account)], CONTACT_MERGED, contact.push_event_data)
+    broadcast(account, [account_token(account)].compact, CONTACT_MERGED, contact.push_event_data)
   end
 
   def contact_deleted(event)
     contact, account = extract_contact_and_account(event)
-    broadcast(account, [account_token(account)], CONTACT_DELETED, contact.push_event_data)
+    broadcast(account, [account_token(account)].compact, CONTACT_DELETED, contact.push_event_data)
   end
 
   def conversation_mentioned(event)
@@ -165,7 +165,10 @@ class ActionCableListener < BaseListener
   private
 
   def account_token(account)
-    return '' if account.nil?
+    # Return nil (not "") so callers using `[account_token(...)].compact`
+    # actually drop the entry when account is missing — `compact` filters
+    # nil but keeps empty strings. Accept both Hash and AR-object shapes.
+    return nil if account.nil?
 
     id = account.is_a?(Hash) ? account['id'] : account.id
     "account_#{id}"

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -409,14 +409,14 @@ class AgentBotListener < BaseListener
 
       # Use specific comment agent bot if configured, otherwise use main agent bot
       comment_agent_bot = agent_bot_inbox.facebook_comment_agent_bot || agent_bot_inbox.agent_bot
-      Rails.logger.info "[AgentBot Listener] Using agent bot: #{comment_agent_bot.name} (ID: #{comment_agent_bot.id})"
+      Rails.logger.info "[AgentBot Listener] Using agent bot: #{comment_agent_bot&.name} (ID: #{comment_agent_bot&.id})"
       Rails.logger.info "[AgentBot Listener] Is comment-specific bot: #{agent_bot_inbox.facebook_comment_agent_bot.present?}"
 
       return comment_agent_bot
     end
 
     # For regular conversations (including Facebook Messenger direct messages), use main agent bot
-    Rails.logger.info "[AgentBot Listener] Regular conversation, using main agent bot: #{agent_bot_inbox.agent_bot.name}"
+    Rails.logger.info "[AgentBot Listener] Regular conversation, using main agent bot: #{agent_bot_inbox.agent_bot&.name}"
     agent_bot_inbox.agent_bot
   end
 

--- a/app/models/message_template.rb
+++ b/app/models/message_template.rb
@@ -158,6 +158,7 @@ class MessageTemplate < ApplicationRecord
       'language' => language,
       'category' => category,
       'template_type' => template_type,
+      'status' => settings.is_a?(Hash) ? settings['status'] : nil,
       'settings' => settings,
       'components' => components,
       'variables' => variables,

--- a/app/serializers/conversation_serializer.rb
+++ b/app/serializers/conversation_serializer.rb
@@ -30,7 +30,8 @@ module ConversationSerializer
     include_inbox: true,
     unread_counts: nil,
     last_non_activity_messages: nil,
-    labels_by_title: nil
+    labels_by_title: nil,
+    labels_by_id: nil
   )
     result = conversation.as_json(
       only: [:id, :inbox_id, :status, :assignee_id, :team_id,
@@ -100,9 +101,14 @@ module ConversationSerializer
 
     # Conditionally include labels
     if include_labels
-      label_index = labels_by_title || {}
-      result['labels'] = conversation.cached_label_list_array.filter_map do |label_title|
-        label_record = label_index[label_title.to_s.downcase]
+      # Historical cached_label_list entries may be either human-readable titles
+      # (post label_concern UUID→title normalization) or raw UUIDs (pre-fix data).
+      # Resolve both so conversation cards keep rendering for legacy rows.
+      title_index = labels_by_title || {}
+      id_index = labels_by_id || {}
+      result['labels'] = conversation.cached_label_list_array.filter_map do |tag|
+        tag_str = tag.to_s
+        label_record = title_index[tag_str.downcase] || id_index[tag_str]
         label_record ? LabelSerializer.serialize(label_record) : nil
       end
     else

--- a/app/serializers/pipeline_item_serializer.rb
+++ b/app/serializers/pipeline_item_serializer.rb
@@ -18,7 +18,9 @@ module PipelineItemSerializer
   #
   # @return [Hash] Serialized pipeline item ready for Oj
   #
-  def serialize(pipeline_item, include_entity: false, include_tasks_info: false, include_services_info: false)
+  def serialize(pipeline_item, include_entity: false, include_tasks_info: false,
+                include_services_info: false, include_labels: false,
+                labels_by_title: nil, labels_by_id: nil)
     is_orphaned = if pipeline_item.conversation_id.present?
                     !pipeline_item.conversation.present?
                   elsif pipeline_item.contact_id.present?
@@ -49,7 +51,13 @@ module PipelineItemSerializer
 
     return result if is_orphaned
     if include_entity && pipeline_item.conversation.present? && pipeline_item.association(:conversation).loaded? && pipeline_item.conversation
-      result[:conversation] = ConversationSerializer.serialize(pipeline_item.conversation, include_messages: false)
+      result[:conversation] = ConversationSerializer.serialize(
+        pipeline_item.conversation,
+        include_messages: false,
+        include_labels: include_labels,
+        labels_by_title: labels_by_title,
+        labels_by_id: labels_by_id
+      )
       if pipeline_item.conversation.association(:contact).loaded? && pipeline_item.conversation.contact
         result[:contact] = ContactSerializer.serialize(pipeline_item.conversation.contact)
       end

--- a/app/serializers/pipeline_serializer.rb
+++ b/app/serializers/pipeline_serializer.rb
@@ -19,7 +19,9 @@ module PipelineSerializer
   #
   # @return [Hash] Serialized pipeline ready for Oj
   #
-  def serialize(pipeline, include_stages: false, include_items: false, include_tasks_info: false, include_services_info: false)
+  def serialize(pipeline, include_stages: false, include_items: false,
+                include_tasks_info: false, include_services_info: false,
+                include_labels: false, labels_by_title: nil, labels_by_id: nil)
     result = {
       id: pipeline.id,
       name: pipeline.name,
@@ -43,13 +45,25 @@ module PipelineSerializer
       
       # If items are also included, attach them directly to each stage
       if include_items && pipeline.association(:pipeline_items).loaded?
+        # Build label indexes once for the entire pipeline if labels are requested
+        # but no pre-built indexes were provided. Caller can override by passing
+        # labels_by_title / labels_by_id to avoid the Label.all query when batching.
+        if include_labels && (labels_by_title.nil? || labels_by_id.nil?)
+          all_labels = Label.all.to_a
+          labels_by_title ||= all_labels.index_by { |label| label.title.to_s.downcase }
+          labels_by_id ||= all_labels.index_by { |label| label.id.to_s }
+        end
+
         # Serialize all items with full details
         serialized_items = pipeline.pipeline_items.map do |item|
           PipelineItemSerializer.serialize(
             item,
             include_entity: true,
             include_tasks_info: include_tasks_info,
-            include_services_info: include_services_info
+            include_services_info: include_services_info,
+            include_labels: include_labels,
+            labels_by_title: labels_by_title,
+            labels_by_id: labels_by_id
           )
         end
 

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -106,6 +106,28 @@ class FilterService
     ]
   end
 
+  def pipeline_filter_query(query_hash, current_index)
+    table_name = filter_config[:table_name]
+    query_operator = query_hash[:query_operator]
+    @filter_values["value_#{current_index}"] = query_hash['values']
+
+    base_relation_query =
+      "SELECT 1 FROM pipeline_items WHERE pipeline_items.conversation_id = #{table_name}.id"
+    id_filter =
+      "AND pipeline_items.pipeline_id IN (:value_#{current_index})"
+
+    case query_hash[:filter_operator]
+    when 'equal_to'
+      "EXISTS (#{base_relation_query} #{id_filter}) #{query_operator}"
+    when 'not_equal_to'
+      "NOT EXISTS (#{base_relation_query} #{id_filter}) #{query_operator}"
+    when 'is_present'
+      "EXISTS (#{base_relation_query}) #{query_operator}"
+    when 'is_not_present'
+      "NOT EXISTS (#{base_relation_query}) #{query_operator}"
+    end
+  end
+
   def tag_filter_query(query_hash, current_index)
     model_name = filter_config[:entity]
     table_name = filter_config[:table_name]
@@ -195,15 +217,45 @@ class FilterService
   end
 
   def query_builder(model_filters)
-    @params[:payload].each_with_index do |query_hash, current_index|
-      @query_string += " #{build_condition_query(model_filters, query_hash, current_index).strip}"
+    # Each row is paired with its built clause so row↔clause stay aligned
+    # even when a handler legitimately returns an empty clause (e.g.
+    # `custom_attribute_query` returns `''` when the attribute is not a
+    # registered custom attribute). Dropping empty pairs here — before
+    # joining — prevents SQL like "cond_0 AND  AND cond_2" from being
+    # emitted if the upstream guard in `build_condition_query` is ever
+    # bypassed or relaxed.
+    pairs = filter_payload.each_with_index.map do |query_hash, current_index|
+      raw = build_condition_query(model_filters, query_hash, current_index).strip
+      # Per-attribute handlers emit the query_operator as a trailing suffix
+      # of their own clause; strip it so the connector is injected
+      # deterministically between clauses below.
+      clause = raw.sub(/\s+(AND|OR)\s*\z/i, '').strip
+      [query_hash, clause]
+    end.reject { |_row, clause| clause.empty? }
+
+    return base_relation if pairs.empty?
+
+    @query_string = pairs.first.last
+    pairs[1..].each do |row, clause|
+      op = row[:query_operator] || row['query_operator']
+      connector = (op.presence || 'AND').to_s.upcase
+      @query_string += " #{connector} #{clause}"
     end
+
     base_relation.where(@query_string, @filter_values.with_indifferent_access)
   end
 
   def validate_query_operator
-    @params[:payload].each do |query_hash|
+    filter_payload.each do |query_hash|
       validate_single_condition(query_hash)
     end
+  end
+
+  # Backward-compat: accept either `payload` (upstream Chatwoot) or `filters`
+  # (evo frontend) as the filter rows key. Returns [] if neither is present
+  # so a malformed request produces a clean empty result rather than
+  # NoMethodError.
+  def filter_payload
+    @params[:payload].presence || @params[:filters].presence || []
   end
 end

--- a/app/services/whatsapp/evolution_handlers/attachment_processor.rb
+++ b/app/services/whatsapp/evolution_handlers/attachment_processor.rb
@@ -27,14 +27,14 @@ module Whatsapp::EvolutionHandlers::AttachmentProcessor
 
     log_attachment_info(attachment_file, final_filename, final_content_type)
 
-    attachment = @message.attachments.build(
-      file_type: file_content_type.to_s,
-      file: {
-        io: attachment_file,
-        filename: final_filename,
-        content_type: final_content_type
-      }
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: attachment_file,
+      filename: final_filename,
+      content_type: final_content_type
     )
+
+    attachment = @message.attachments.build(file_type: file_content_type.to_s)
+    attachment.file.attach(blob)
 
     configure_audio_metadata(attachment) if audio_voice_note?
     log_attachment_success(attachment)

--- a/app/services/whatsapp/providers/concerns/template_sync.rb
+++ b/app/services/whatsapp/providers/concerns/template_sync.rb
@@ -8,32 +8,41 @@ module Whatsapp
 
         def sync_template_to_database(template_data)
           content = extract_template_content(template_data)
-          
-          MessageTemplate.find_or_initialize_by(
+
+          template = MessageTemplate.find_or_initialize_by(
             channel: whatsapp_channel,
             name: template_data['name'],
             language: template_data['language'] || 'pt_BR'
-          ).tap do |template|
-            template.assign_attributes(
-              content: content,
-              category: template_data['category'],
-              template_type: determine_template_type(template_data),
-              components: extract_components_hash(template_data),
-              variables: extract_template_variables(template_data),
-              settings: {
-                'status' => template_data['status'],
-                'quality_score' => template_data['quality_score'],
-                'source' => template_data['source']
-              }.compact,
-              metadata: {
-                'external_id' => template_data['id'],
-                'namespace' => template_data['namespace'],
-                'rejected_reason' => template_data['rejected_reason']
-              }.compact,
-              active: template_data['status'] == 'APPROVED' || template_data['status'].nil?
-            )
-            template.save!
-          end
+          )
+
+          attrs = {
+            content: content,
+            category: template_data['category'],
+            template_type: determine_template_type(template_data),
+            components: extract_components_hash(template_data),
+            variables: extract_template_variables(template_data),
+            settings: {
+              'status' => template_data['status'],
+              'quality_score' => template_data['quality_score'],
+              'source' => template_data['source']
+            }.compact,
+            metadata: {
+              'external_id' => template_data['id'],
+              'namespace' => template_data['namespace'],
+              'rejected_reason' => template_data['rejected_reason']
+            }.compact
+          }
+
+          # The `active` column is a user-controlled toggle (show/hide in
+          # pickers), not a mirror of Meta approval. Keep it separate:
+          # - On first sync (new record), default to true so the template
+          #   shows up in the management table with a real "pending" badge
+          #   instead of being silently hidden.
+          # - On subsequent syncs, preserve whatever the user set.
+          attrs[:active] = true if template.new_record?
+
+          template.assign_attributes(attrs)
+          template.save!
         rescue StandardError => e
           Rails.logger.error "Error syncing template #{template_data['name']}: #{e.message}"
           Rails.logger.error e.backtrace.join("\n")

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -80,6 +80,22 @@ conversations:
       - "not_equal_to"
       - "is_present"
       - "is_not_present"
+  contact_id:
+    attribute_type: "standard"
+    data_type: "text"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
+  pipeline_id:
+    attribute_type: "standard"
+    data_type: "pipeline"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   browser_language:
     attribute_type: "additional_attributes"
     data_type: "text"

--- a/spec/controllers/concerns/label_concern_spec.rb
+++ b/spec/controllers/concerns/label_concern_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit-level coverage for LabelConcern's UUID→title resolution. Exercises the
+# private `resolve_label_titles` directly via an anonymous host class, since
+# the bug class (UUID leaking into `tags.name`) was the regression EVO-1001
+# fixed at this seam.
+RSpec.describe LabelConcern, type: :concern do
+  let(:host_class) do
+    Class.new do
+      include LabelConcern
+
+      # Make the private helper reachable from specs without polluting the
+      # public surface of real controllers that include this concern.
+      public :resolve_label_titles
+    end
+  end
+
+  let(:host) { host_class.new }
+
+  describe '#resolve_label_titles' do
+    context 'when input is blank' do
+      it 'passes nil through untouched' do
+        expect(host.resolve_label_titles(nil)).to be_nil
+      end
+
+      it 'passes empty array through untouched' do
+        expect(host.resolve_label_titles([])).to eq([])
+      end
+    end
+
+    context 'with non-UUID strings (titles)' do
+      it 'leaves human-readable titles untouched' do
+        expect(host.resolve_label_titles(['hot-lead', 'vip'])).to eq(['hot-lead', 'vip'])
+      end
+
+      it 'does not query the labels table when no UUID is present' do
+        expect(Label).not_to receive(:where)
+        host.resolve_label_titles(['plain-string'])
+      end
+    end
+
+    context 'with UUID inputs' do
+      let(:hot_lead_id) { '550e8400-e29b-41d4-a716-446655440000' }
+      let(:vip_id) { '6ba7b810-9dad-11d1-80b4-00c04fd430c8' }
+
+      before do
+        # Stub the UUID→title lookup in isolation. The concern only relies on
+        # `Label.where(id: uuids).pluck(:id, :title)`, so we mock that surface
+        # rather than touching the database.
+        relation = double('Label::Relation')
+        allow(Label).to receive(:where).with(id: array_including(hot_lead_id, vip_id))
+                                       .and_return(relation)
+        allow(relation).to receive(:pluck).with(:id, :title).and_return(
+          [[hot_lead_id, 'hot-lead'], [vip_id, 'vip']]
+        )
+      end
+
+      it 'resolves all UUIDs to their titles' do
+        expect(host.resolve_label_titles([hot_lead_id, vip_id])).to match_array(['hot-lead', 'vip'])
+      end
+
+      it 'merges resolved titles with existing title-form entries and dedupes' do
+        result = host.resolve_label_titles(['hot-lead', vip_id])
+        expect(result).to match_array(['hot-lead', 'vip'])
+      end
+    end
+
+    context 'with unresolvable UUIDs' do
+      let(:ghost_id) { '00000000-0000-0000-0000-000000000000' }
+
+      before do
+        relation = double('Label::Relation', pluck: [])
+        allow(Label).to receive(:where).with(id: [ghost_id]).and_return(relation)
+      end
+
+      it 'silently drops UUIDs that no longer correspond to a label' do
+        expect(host.resolve_label_titles([ghost_id])).to eq([])
+      end
+
+      it 'preserves non-UUID entries even when all UUIDs are unresolvable' do
+        expect(host.resolve_label_titles(['vip', ghost_id])).to eq(['vip'])
+      end
+    end
+  end
+end

--- a/spec/models/message_template_spec.rb
+++ b/spec/models/message_template_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MessageTemplate, type: :model do
+  describe '#serialized' do
+    let(:template) do
+      described_class.new(
+        name: 'ini_conversa',
+        content: 'Olá, tudo bem?',
+        language: 'pt_BR',
+        category: 'UTILITY',
+        template_type: 'text',
+        components: [{ 'text' => 'Olá, tudo bem?', 'type' => 'BODY' }],
+        variables: [],
+        active: true
+      )
+    end
+
+    it 'mirrors settings.status as a top-level status key when present' do
+      template.settings = { 'status' => 'APPROVED' }
+      expect(template.serialized['status']).to eq('APPROVED')
+    end
+
+    it 'returns nil for top-level status when settings is empty' do
+      template.settings = {}
+      expect(template.serialized).to have_key('status')
+      expect(template.serialized['status']).to be_nil
+    end
+
+    it 'returns nil for top-level status when settings lacks the status key' do
+      template.settings = { 'quality_score' => 'HIGH' }
+      expect(template.serialized['status']).to be_nil
+    end
+
+    it 'does not raise when settings itself is nil' do
+      template.settings = nil
+      expect { template.serialized }.not_to raise_error
+      expect(template.serialized['status']).to be_nil
+    end
+
+    it 'does not raise when settings is not a Hash (defensive guard)' do
+      template.settings = 'malformed'
+      expect { template.serialized }.not_to raise_error
+      expect(template.serialized['status']).to be_nil
+    end
+
+    it 'still exposes the full settings hash alongside the mirrored status' do
+      template.settings = { 'status' => 'PENDING', 'source' => 'meta_api' }
+      serialized = template.serialized
+      expect(serialized['status']).to eq('PENDING')
+      expect(serialized['settings']).to eq({ 'status' => 'PENDING', 'source' => 'meta_api' })
+    end
+  end
+end

--- a/spec/serializers/conversation_serializer_spec.rb
+++ b/spec/serializers/conversation_serializer_spec.rb
@@ -70,4 +70,123 @@ RSpec.describe ConversationSerializer do
       expect(result['last_activity_at']).to be_nil
     end
   end
+
+  describe '.serialize with include_labels (EVO-1001)' do
+    let(:now) { Time.zone.parse('2026-04-24 12:00:00') }
+    let(:label_uuid) { '550e8400-e29b-41d4-a716-446655440000' }
+    let(:label_record) do
+      double('Label',
+             id: label_uuid,
+             title: 'hot-lead',
+             description: nil,
+             color: '#ff0000',
+             show_on_sidebar: true,
+             created_at: now,
+             updated_at: now)
+    end
+
+    def build_conversation(cached_label_list_array)
+      conversation = double('Conversation',
+                            as_json: { 'id' => 1, 'inbox_id' => 1, 'status' => 'open',
+                                       'assignee_id' => nil, 'team_id' => nil, 'campaign_id' => nil,
+                                       'display_id' => 1, 'additional_attributes' => {}, 'priority' => nil },
+                            created_at: now,
+                            updated_at: now,
+                            agent_last_seen_at: nil,
+                            contact_last_seen_at: nil,
+                            waiting_since: nil,
+                            first_reply_created_at: nil,
+                            snoozed_until: nil,
+                            last_activity_at: now,
+                            custom_attributes: {},
+                            unread_incoming_messages: double('Relation', count: 0),
+                            contact: nil,
+                            inbox: nil,
+                            assignee: nil,
+                            team: nil,
+                            cached_label_list_array: cached_label_list_array,
+                            messages: double('Relation', last: nil))
+      allow(conversation).to receive(:association).and_return(double(loaded?: false))
+      conversation
+    end
+
+    it 'resolves a tag stored as title via labels_by_title' do
+      conversation = build_conversation(['hot-lead'])
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: { 'hot-lead' => label_record },
+        labels_by_id: {}
+      )
+
+      expect(result['labels'].size).to eq(1)
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'resolves a tag stored as legacy UUID via labels_by_id fallback' do
+      # Pre-fix data: cached_label_list still holds the Label PK as a string.
+      # The serializer must fall back to labels_by_id and keep rendering the
+      # human-readable label so conversation cards do not silently lose badges.
+      conversation = build_conversation([label_uuid])
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: {},
+        labels_by_id: { label_uuid => label_record }
+      )
+
+      expect(result['labels'].size).to eq(1)
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'prefers title match over id match when both indexes contain the tag' do
+      conversation = build_conversation(['hot-lead'])
+      other_label = double('Label',
+                           id: 'other', title: 'other', description: nil,
+                           color: '#000', show_on_sidebar: true,
+                           created_at: now, updated_at: now)
+
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: { 'hot-lead' => label_record },
+        labels_by_id: { 'hot-lead' => other_label }
+      )
+
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'drops tags that resolve in neither index' do
+      conversation = build_conversation(['ghost-tag', label_uuid])
+      result = described_class.serialize(
+        conversation,
+        include_labels: true,
+        include_contact: false,
+        include_inbox: false,
+        labels_by_title: {},
+        labels_by_id: { label_uuid => label_record }
+      )
+
+      expect(result['labels'].size).to eq(1)
+      expect(result['labels'].first[:title]).to eq('hot-lead')
+    end
+
+    it 'returns empty labels array when include_labels is false' do
+      conversation = build_conversation([label_uuid])
+      result = described_class.serialize(
+        conversation,
+        include_labels: false,
+        include_contact: false,
+        include_inbox: false
+      )
+
+      expect(result['labels']).to eq([])
+    end
+  end
 end

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -17,4 +17,53 @@ RSpec.describe Conversations::FilterService do
       service.conversations
     end
   end
+
+  describe '#filter_payload (key aliasing)' do
+    let(:user) { instance_double(User) }
+    let(:rows) do
+      [{ 'attribute_key' => 'status', 'filter_operator' => 'equal_to', 'values' => ['open'], 'query_operator' => nil }]
+    end
+
+    it 'reads rows from :payload (upstream Chatwoot contract)' do
+      service = described_class.new({ payload: rows }, user)
+      expect(service.send(:filter_payload)).to eq(rows)
+    end
+
+    it 'reads rows from :filters as a compat alias for the evo frontend' do
+      service = described_class.new({ filters: rows }, user)
+      expect(service.send(:filter_payload)).to eq(rows)
+    end
+
+    it 'returns an empty array when neither key is provided, avoiding NoMethodError' do
+      service = described_class.new({}, user)
+      expect(service.send(:filter_payload)).to eq([])
+      expect { service.send(:validate_query_operator) }.not_to raise_error
+    end
+  end
+
+  describe '#query_builder (empty-clause handling)' do
+    let(:user) { instance_double(User) }
+
+    it 'drops rows whose built clause is empty without desyncing the operator of the next row' do
+      rows = [
+        { 'attribute_key' => 'a', 'filter_operator' => 'equal_to', 'values' => ['x'], 'query_operator' => nil },
+        { 'attribute_key' => 'b', 'filter_operator' => 'equal_to', 'values' => ['y'], 'query_operator' => 'OR' },
+        { 'attribute_key' => 'c', 'filter_operator' => 'equal_to', 'values' => ['z'], 'query_operator' => 'AND' }
+      ]
+      service = described_class.new({ filters: rows }, user)
+
+      allow(service).to receive(:build_condition_query) do |_m, _q, idx|
+        # Middle clause is empty (simulates a handler that returned '' on a
+        # path that bypasses the InvalidAttribute guard). Last clause still
+        # carries its trailing operator suffix to exercise the strip regex.
+        ['c0', '', 'c2 AND'][idx]
+      end
+
+      relation = double('Relation')
+      allow(service).to receive(:base_relation).and_return(relation)
+      expect(relation).to receive(:where).with('c0 AND c2', anything).and_return(relation)
+
+      service.send(:query_builder, {})
+    end
+  end
 end

--- a/spec/services/whatsapp/evolution_handlers/attachment_processor_spec.rb
+++ b/spec/services/whatsapp/evolution_handlers/attachment_processor_spec.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+# Specs for Whatsapp::EvolutionHandlers::AttachmentProcessor.
+#
+# Round 2 follow-up to EVO-976 — covers the synchronous-upload migration from
+# `attachments.build` to `ActiveStorage::Blob.create_and_upload!` introduced in
+# the original PR (which had zero coverage). Each test asserts an invariant the
+# previous implementation lacked: blob is uploaded before the message is saved,
+# voice-note metadata flows through, and download failures do not raise.
+
+begin
+  require 'rails_helper'
+rescue LoadError
+  RSpec.describe 'Whatsapp::EvolutionHandlers::AttachmentProcessor' do
+    it 'has spec scaffold ready' do
+      skip 'rails_helper is not available in this workspace snapshot'
+    end
+  end
+end
+
+return unless defined?(Rails) && defined?(ActiveStorage::Blob)
+
+RSpec.describe Whatsapp::EvolutionHandlers::AttachmentProcessor do
+  let(:host_class) do
+    Class.new do
+      include Whatsapp::EvolutionHandlers::AttachmentProcessor
+
+      attr_accessor :raw_message_id, :message_type, :file_content_type,
+                    :file_extension, :inbox
+
+      def initialize(message:, raw_message:)
+        @message = message
+        @raw_message = raw_message
+        @raw_message_id = raw_message.dig(:key, :id) || 'msg-test-1'
+        @message_type = raw_message[:messageType] || 'image'
+        @file_content_type = :image
+        @file_extension = '.jpg'
+      end
+
+      # Stubs for helpers normally provided by sibling modules.
+      def generate_filename_with_extension
+        "#{raw_message_id}#{file_extension}"
+      end
+
+      def determine_content_type
+        message_type == 'audio' ? 'audio/ogg' : 'image/jpeg'
+      end
+
+      def debug_media_info; end
+      def log_attachment_info(*); end
+      def log_attachment_success(*); end
+      def log_base64_processing(*); end
+      def log_tempfile_success(*); end
+      def log_base64_error(*); end
+    end
+  end
+
+  let(:message) do
+    msg = instance_double(Message, attachments: attachments_relation)
+    allow(msg).to receive(:update!)
+    msg
+  end
+
+  let(:attachments_relation) { instance_double('AttachmentsRelation') }
+  let(:built_attachment) do
+    att = instance_double('Attachment', file: file_attachment_proxy)
+    allow(att).to receive(:meta=)
+    att
+  end
+  let(:file_attachment_proxy) do
+    instance_double('FileAttachmentProxy').tap { |proxy| allow(proxy).to receive(:attach) }
+  end
+
+  before do
+    allow(attachments_relation).to receive(:build).and_return(built_attachment)
+  end
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Happy path
+  # ────────────────────────────────────────────────────────────────────────
+  describe '#create_attachment' do
+    let(:processor) do
+      host_class.new(
+        message: message,
+        raw_message: { key: { id: 'msg-1' }, messageType: 'image', message: {} }
+      )
+    end
+
+    let(:tempfile) { Tempfile.new(['img', '.jpg']).tap { |f| f.write('binary'); f.rewind } }
+    let(:fake_blob) { instance_double('ActiveStorage::Blob') }
+
+    after { tempfile.close!; tempfile.unlink rescue nil }
+
+    it 'uploads the blob synchronously via create_and_upload!' do
+      expect(ActiveStorage::Blob).to receive(:create_and_upload!).with(
+        io: tempfile,
+        filename: 'msg-1.jpg',
+        content_type: 'image/jpeg'
+      ).and_return(fake_blob)
+
+      expect(file_attachment_proxy).to receive(:attach).with(fake_blob)
+
+      processor.create_attachment(tempfile)
+    end
+
+    it 'builds the attachment with the resolved file_content_type' do
+      allow(ActiveStorage::Blob).to receive(:create_and_upload!).and_return(fake_blob)
+
+      expect(attachments_relation).to receive(:build).with(file_type: 'image').and_return(built_attachment)
+
+      processor.create_attachment(tempfile)
+    end
+  end
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Voice-note metadata (regression guard for EVO-979 ↔ EVO-976)
+  # ────────────────────────────────────────────────────────────────────────
+  describe 'voice note metadata' do
+    let(:tempfile) { Tempfile.new(['audio', '.ogg']).tap { |f| f.write('opus'); f.rewind } }
+    let(:fake_blob) { instance_double('ActiveStorage::Blob') }
+
+    before { allow(ActiveStorage::Blob).to receive(:create_and_upload!).and_return(fake_blob) }
+    after  { tempfile.close!; tempfile.unlink rescue nil }
+
+    it 'sets is_recorded_audio meta when audioMessage.ptt is true' do
+      processor = host_class.new(
+        message: message,
+        raw_message: {
+          key: { id: 'msg-2' },
+          messageType: 'audio',
+          message: { audioMessage: { ptt: true } }
+        }
+      )
+      processor.message_type = 'audio'
+
+      expect(built_attachment).to receive(:meta=).with(is_recorded_audio: true)
+
+      processor.create_attachment(tempfile)
+    end
+
+    it 'leaves meta unset when audioMessage.ptt is false' do
+      processor = host_class.new(
+        message: message,
+        raw_message: {
+          key: { id: 'msg-3' },
+          messageType: 'audio',
+          message: { audioMessage: { ptt: false } }
+        }
+      )
+      processor.message_type = 'audio'
+
+      expect(built_attachment).not_to receive(:meta=)
+
+      processor.create_attachment(tempfile)
+    end
+  end
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Download error handling — must not raise; must mark message as unsupported
+  # ────────────────────────────────────────────────────────────────────────
+  describe '#handle_attach_media' do
+    let(:processor) do
+      host_class.new(
+        message: message,
+        raw_message: { key: { id: 'msg-4' }, messageType: 'image', message: { mediaUrl: 'https://x' } }
+      )
+    end
+
+    it 'flags the message unsupported when Down::Error is raised' do
+      allow(processor).to receive(:download_attachment_file).and_raise(Down::Error, 'boom')
+      expect(message).to receive(:update!).with(is_unsupported: true)
+
+      expect { processor.handle_attach_media }.not_to raise_error
+    end
+
+    it 'swallows generic StandardError in upload step (logs only — caller does not see exceptions)' do
+      allow(processor).to receive(:download_attachment_file).and_return(Tempfile.new('x'))
+      allow(ActiveStorage::Blob).to receive(:create_and_upload!).and_raise(StandardError, 'storage down')
+
+      expect { processor.handle_attach_media }.not_to raise_error
+    end
+
+    it 'returns nil without uploading when download_attachment_file returns nil' do
+      allow(processor).to receive(:download_attachment_file).and_return(nil)
+
+      expect(ActiveStorage::Blob).not_to receive(:create_and_upload!)
+      processor.handle_attach_media
+    end
+  end
+
+  # ────────────────────────────────────────────────────────────────────────
+  # Base64 path — used when Evolution API ships media inline
+  # ────────────────────────────────────────────────────────────────────────
+  describe '#create_tempfile_from_base64' do
+    let(:processor) do
+      host_class.new(
+        message: message,
+        raw_message: { key: { id: 'msg-5' }, messageType: 'image', message: {} }
+      )
+    end
+
+    it 'decodes a base64 payload and exposes original_filename + content_type' do
+      payload = Base64.strict_encode64('PNG-bytes-here')
+      tempfile = processor.create_tempfile_from_base64(payload)
+
+      expect(tempfile).not_to be_nil
+      expect(tempfile.original_filename).to eq('msg-5.jpg')
+      expect(tempfile.content_type).to eq('image/jpeg')
+      File.read(tempfile.path).then { |contents| expect(contents).to eq('PNG-bytes-here') }
+    ensure
+      tempfile&.close!
+      tempfile&.unlink rescue nil
+    end
+
+    it 'strips data URI prefix before decoding' do
+      payload = "data:image/jpeg;base64,#{Base64.strict_encode64('JPG-bytes')}"
+      tempfile = processor.create_tempfile_from_base64(payload)
+
+      File.read(tempfile.path).then { |contents| expect(contents).to eq('JPG-bytes') }
+    ensure
+      tempfile&.close!
+      tempfile&.unlink rescue nil
+    end
+
+    it 'returns nil on decode failure (no raise)' do
+      allow(Base64).to receive(:decode64).and_raise(ArgumentError, 'bad bytes')
+
+      expect(processor.create_tempfile_from_base64('garbage')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Pipeline kanban frontend (PR EvolutionAPI/evo-ai-frontend-community#30) adds a label filter, but it never matched anything because `PipelineItemSerializer` was calling `ConversationSerializer.serialize` without `include_labels: true`. The default in `ConversationSerializer` is `false`, which forces `result['labels'] = []` regardless of actual `cached_label_list`.
- This PR threads `include_labels` (and the `labels_by_title` / `labels_by_id` lookup indexes) through `PipelineItemSerializer` and `PipelineSerializer`, and turns the flag on for `pipelines#show`.

## Changes

- **`PipelineItemSerializer.serialize`** — accepts `include_labels`, `labels_by_title`, `labels_by_id`; forwards them to `ConversationSerializer`.
- **`PipelineSerializer.serialize`** — accepts the same options. When `include_labels` is true and `pipeline_items` is loaded, it builds the label indexes once per pipeline (`Label.all.index_by`) so we don't re-query per item. Callers can pre-compute and pass the indexes.
- **`pipelines#show`** — passes `include_labels: true`.

## Companion PR

Frontend pairs with EvolutionAPI/evo-ai-frontend-community#30 (latest commit), which:
- Updates the `labels` type from `string[]` to `Array<{id, title, color, ...}>` (the real shape returned by `LabelSerializer`).
- `filterItems` now matches by `.title` instead of string equality.

## Test plan

- [ ] On a pipeline with conversations that have labels, hit GET `/api/v1/accounts/:account_id/pipelines/:id` and confirm `data.stages[].items[].conversation.labels` is now an array of `{id, title, color, ...}` objects.
- [ ] Open the kanban board for that pipeline, confirm the label filter popover appears (only renders when `uniqueLabels.length > 0`) and filtering by a label hides cards without that label.
- [ ] Pipelines with no labels: confirm `labels` is `[]` and the popover does not render — no regression.
- [ ] No N+1: confirm only one `Label.all` query per pipeline render (per `pipelines#show`).

## Linear

EVO-1006

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Propagate label inclusion options through pipeline serialization so pipeline conversations expose label data for kanban filtering.

Bug Fixes:
- Ensure pipeline show responses include conversation labels by enabling label serialization in the pipelines#show endpoint.

Enhancements:
- Extend pipeline and pipeline item serializers to accept and forward label-related options, building label lookup indexes once per pipeline when needed.