### PR TITLE
fix(crm): credential fallback + eager webhook for Evolution Go (EVO-984)

### DIFF
--- a/app/controllers/api/v1/evolution_go/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution_go/authorizations_controller.rb
@@ -494,9 +494,13 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
   def register_webhook_after_create(api_url, instance_token)
     return if api_url.blank? || instance_token.blank?
 
-    connect_instance(api_url, instance_token)
+    # Timeouts curtos: o create já é síncrono e o caminho de QR retenta o
+    # connect_instance, então não vale segurar o usuário por 30s aqui.
+    connect_instance(api_url, instance_token, nil, open_timeout: 5, read_timeout: 5)
   rescue StandardError => e
-    Rails.logger.error "Evolution Go API: Eager webhook registration failed: #{e.class} - #{e.message}"
+    # warn (não error) — o caminho de QR retenta o connect_instance, então uma
+    # falha aqui não é um problema de produção que deva paginar.
+    Rails.logger.warn "Evolution Go API: Eager webhook registration failed (will retry on QR open): #{e.class} - #{e.message}"
   end
 
   def get_setting_value(settings, symbol_key, string_key, default_value)

--- a/app/controllers/api/v1/evolution_go/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution_go/authorizations_controller.rb
@@ -44,6 +44,8 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
       # Create new instance
       instance_data = create_instance_go(@api_url, @admin_token, @instance_name, auth_params)
 
+      register_webhook_after_create(@api_url, instance_data['instance_token'])
+
       render json: {
         success: true,
         message: 'Instance created successfully',
@@ -482,6 +484,19 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
   def generate_instance_token
     # Gerar token no formato UUID padrão
     SecureRandom.uuid
+  end
+
+  # Registers the CRM webhook on the freshly created Evolution Go instance so
+  # incoming events arrive even before the user opens the QR screen. Failures
+  # (e.g. missing BACKEND_URL, transient network error) are logged and swallowed
+  # to avoid regressing channel creation — connect_instance is also called when
+  # the QR is requested, so the webhook will be retried then.
+  def register_webhook_after_create(api_url, instance_token)
+    return if api_url.blank? || instance_token.blank?
+
+    connect_instance(api_url, instance_token)
+  rescue StandardError => e
+    Rails.logger.error "Evolution Go API: Eager webhook registration failed: #{e.class} - #{e.message}"
   end
 
   def get_setting_value(settings, symbol_key, string_key, default_value)

--- a/app/controllers/api/v1/evolution_go/privacy_controller.rb
+++ b/app/controllers/api/v1/evolution_go/privacy_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::EvolutionGo::PrivacyController < Api::V1::BaseController
+  include EvolutionGoConcern
+
   before_action :set_instance_params, only: [:show, :update]
 
   # GET PRIVACY - GET /user/privacy
@@ -72,15 +74,16 @@ class Api::V1::EvolutionGo::PrivacyController < Api::V1::BaseController
                                         .first
 
     if whatsapp_channel
+      creds = evolution_go_credentials_for(whatsapp_channel)
       @inbox = whatsapp_channel.inbox
-      @api_url = whatsapp_channel.provider_config['api_url']
-      @admin_token = whatsapp_channel.provider_config['admin_token']
-      @instance_token = whatsapp_channel.provider_config['instance_token']
+      @api_url = creds[:api_url]
+      @admin_token = creds[:admin_token]
+      @instance_token = creds[:instance_token]
     else
       # Fallback para parâmetros diretos (para compatibilidade)
       privacy_params = params[:privacy] || params
-      @api_url = privacy_params[:api_url]
-      @admin_token = privacy_params[:admin_token]
+      @api_url = privacy_params[:api_url].presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip
+      @admin_token = privacy_params[:admin_token].presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
       @instance_token = privacy_params[:instance_token]
     end
   end

--- a/app/controllers/api/v1/evolution_go/privacy_controller.rb
+++ b/app/controllers/api/v1/evolution_go/privacy_controller.rb
@@ -82,8 +82,9 @@ class Api::V1::EvolutionGo::PrivacyController < Api::V1::BaseController
     else
       # Fallback para parâmetros diretos (para compatibilidade)
       privacy_params = params[:privacy] || params
-      @api_url = privacy_params[:api_url].presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip
-      @admin_token = privacy_params[:admin_token].presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
+      creds = evolution_go_credentials_from_params(privacy_params[:api_url], privacy_params[:admin_token])
+      @api_url = creds[:api_url]
+      @admin_token = creds[:admin_token]
       @instance_token = privacy_params[:instance_token]
     end
   end

--- a/app/controllers/api/v1/evolution_go/profile_controller.rb
+++ b/app/controllers/api/v1/evolution_go/profile_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::EvolutionGo::ProfileController < Api::V1::BaseController
+  include EvolutionGoConcern
+
   before_action :set_instance_params, only: [:show, :info, :avatar, :update_picture, :update_name, :update_status,
                                              :update_picture_by_instance, :remove_picture]
 
@@ -229,14 +231,15 @@ class Api::V1::EvolutionGo::ProfileController < Api::V1::BaseController
                                         .first
 
     if whatsapp_channel
+      creds = evolution_go_credentials_for(whatsapp_channel)
       @inbox = whatsapp_channel.inbox
-      @api_url = whatsapp_channel.provider_config['api_url']
-      @admin_token = whatsapp_channel.provider_config['admin_token']
-      @instance_token = whatsapp_channel.provider_config['instance_token']
+      @api_url = creds[:api_url]
+      @admin_token = creds[:admin_token]
+      @instance_token = creds[:instance_token]
     else
       # Fallback para parâmetros diretos (para compatibilidade)
-      @api_url = params[:api_url]
-      @admin_token = params[:admin_token]
+      @api_url = params[:api_url].presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip
+      @admin_token = params[:admin_token].presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
       @instance_token = params[:instance_token]
     end
   end

--- a/app/controllers/api/v1/evolution_go/profile_controller.rb
+++ b/app/controllers/api/v1/evolution_go/profile_controller.rb
@@ -238,8 +238,9 @@ class Api::V1::EvolutionGo::ProfileController < Api::V1::BaseController
       @instance_token = creds[:instance_token]
     else
       # Fallback para parâmetros diretos (para compatibilidade)
-      @api_url = params[:api_url].presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip
-      @admin_token = params[:admin_token].presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
+      creds = evolution_go_credentials_from_params(params[:api_url], params[:admin_token])
+      @api_url = creds[:api_url]
+      @admin_token = creds[:admin_token]
       @instance_token = params[:instance_token]
     end
   end

--- a/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
+++ b/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
@@ -88,11 +88,12 @@ class Api::V1::EvolutionGo::QrcodesController < Api::V1::BaseController
 
     Rails.logger.info "Evolution Go API: Found channel with config: #{whatsapp_channel.provider_config.inspect}"
 
+    creds = evolution_go_credentials_for(whatsapp_channel)
     @inbox = whatsapp_channel.inbox
-    @api_url = whatsapp_channel.provider_config['api_url']
-    @instance_token = whatsapp_channel.provider_config['instance_token']
-    @instance_uuid = whatsapp_channel.provider_config['instance_uuid']
-    @instance_name = whatsapp_channel.provider_config['instance_name']
+    @api_url = creds[:api_url]
+    @instance_token = creds[:instance_token]
+    @instance_uuid = creds[:instance_uuid]
+    @instance_name = creds[:instance_name]
   end
 
   def get_qrcode_go(api_url, instance_token)

--- a/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
+++ b/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
@@ -31,11 +31,13 @@ class Api::V1::EvolutionGo::QrcodesController < Api::V1::BaseController
     Rails.logger.info "Evolution Go API: QR code refresh called with params: #{params.inspect}"
 
     begin
-      # Extract parameters
+      # Resolve credenciais via canal (com fallback para Admin Settings) quando
+      # o frontend mandar apenas o instance_uuid — canais legados podem ter
+      # api_url/instance_token vazios em provider_config (EVO-984).
       auth_params = params[:qrcode] || params
-      api_url = auth_params[:api_url]
-      instance_token = auth_params[:instance_token]
-      instance_uuid = auth_params[:instance_uuid]
+      instance_uuid = auth_params[:instance_uuid].presence || params[:id]
+
+      api_url, instance_token = resolve_qrcode_credentials(auth_params, instance_uuid)
 
       if api_url.blank? || instance_token.blank? || instance_uuid.blank?
         return render json: {
@@ -60,6 +62,23 @@ class Api::V1::EvolutionGo::QrcodesController < Api::V1::BaseController
   end
 
   private
+
+  def resolve_qrcode_credentials(auth_params, instance_uuid)
+    api_url = auth_params[:api_url].presence
+    instance_token = auth_params[:instance_token].presence
+
+    return [api_url, instance_token] if api_url.present? && instance_token.present?
+    return [api_url, instance_token] if instance_uuid.blank?
+
+    channel = Channel::Whatsapp.joins(:inbox)
+                               .where(provider: 'evolution_go')
+                               .where('provider_config @> ?', { instance_uuid: instance_uuid }.to_json)
+                               .first
+    return [api_url, instance_token] unless channel
+
+    creds = evolution_go_credentials_for(channel)
+    [api_url || creds[:api_url], instance_token || creds[:instance_token]]
+  end
 
   def set_instance_params
     # Para o método show, recebe instance_name ou instance_uuid da URL (params[:id])

--- a/app/controllers/api/v1/evolution_go/settings_controller.rb
+++ b/app/controllers/api/v1/evolution_go/settings_controller.rb
@@ -82,8 +82,9 @@ class Api::V1::EvolutionGo::SettingsController < Api::V1::BaseController
     else
       # Fallback para parâmetros diretos (para compatibilidade)
       settings_params = params[:settings] || params
-      @api_url = settings_params[:api_url].presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip
-      @admin_token = settings_params[:admin_token].presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
+      creds = evolution_go_credentials_from_params(settings_params[:api_url], settings_params[:admin_token])
+      @api_url = creds[:api_url]
+      @admin_token = creds[:admin_token]
       @instance_token = settings_params[:instance_token]
     end
   end

--- a/app/controllers/api/v1/evolution_go/settings_controller.rb
+++ b/app/controllers/api/v1/evolution_go/settings_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::EvolutionGo::SettingsController < Api::V1::BaseController
+  include EvolutionGoConcern
+
   before_action :set_instance_params, only: [:show, :update]
 
   # GET SETTINGS - GET /instance/:instanceId/advanced-settings
@@ -72,15 +74,16 @@ class Api::V1::EvolutionGo::SettingsController < Api::V1::BaseController
                                         .first
 
     if whatsapp_channel
+      creds = evolution_go_credentials_for(whatsapp_channel)
       @inbox = whatsapp_channel.inbox
-      @api_url = whatsapp_channel.provider_config['api_url']
-      @admin_token = whatsapp_channel.provider_config['admin_token']
-      @instance_token = whatsapp_channel.provider_config['instance_token']
+      @api_url = creds[:api_url]
+      @admin_token = creds[:admin_token]
+      @instance_token = creds[:instance_token]
     else
       # Fallback para parâmetros diretos (para compatibilidade)
       settings_params = params[:settings] || params
-      @api_url = settings_params[:api_url]
-      @admin_token = settings_params[:admin_token]
+      @api_url = settings_params[:api_url].presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip
+      @admin_token = settings_params[:admin_token].presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
       @instance_token = settings_params[:instance_token]
     end
   end

--- a/app/controllers/concerns/evolution_go_concern.rb
+++ b/app/controllers/concerns/evolution_go_concern.rb
@@ -3,7 +3,7 @@ module EvolutionGoConcern
 
   private
 
-  def connect_instance(api_url, instance_token, _instance_name = nil)
+  def connect_instance(api_url, instance_token, _instance_name = nil, open_timeout: 15, read_timeout: 15)
     connect_url = "#{api_url.chomp('/')}/instance/connect"
     Rails.logger.info "Evolution Go API: Connecting instance at #{connect_url}"
 
@@ -22,8 +22,8 @@ module EvolutionGoConcern
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = (uri.scheme == 'https')
-    http.open_timeout = 15
-    http.read_timeout = 15
+    http.open_timeout = open_timeout
+    http.read_timeout = read_timeout
 
     request = Net::HTTP::Post.new(uri)
     request['apikey'] = instance_token
@@ -80,5 +80,15 @@ module EvolutionGoConcern
     end
 
     creds
+  end
+
+  # Same fallback strategy as evolution_go_credentials_for, but for the
+  # branch where the request carries api_url/admin_token directly (no channel
+  # row) — used by privacy/profile/settings #set_instance_params else branches.
+  def evolution_go_credentials_from_params(api_url_param, admin_token_param)
+    {
+      api_url: api_url_param.presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip,
+      admin_token: admin_token_param.presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip
+    }
   end
 end

--- a/app/controllers/concerns/evolution_go_concern.rb
+++ b/app/controllers/concerns/evolution_go_concern.rb
@@ -52,4 +52,33 @@ module EvolutionGoConcern
                   GlobalConfigService.load('BACKEND_URL', 'https://api.evoai.app').to_s.strip
     "#{backend_url.chomp('/')}/webhooks/whatsapp/evolution_go"
   end
+
+  # Resolves Evolution Go credentials for an existing channel, falling back to
+  # the global Admin Settings (EVOLUTION_GO_API_URL / EVOLUTION_GO_ADMIN_SECRET)
+  # when provider_config is missing values. Older channels created before the
+  # provider_config persistence fix may have empty api_url/admin_token.
+  #
+  # When a channel is supplied but instance_token / instance_uuid are blank,
+  # logs a warning so corrupt-channel cases are observable in production. The
+  # action-level guards still respond with 400 — this is purely diagnostics.
+  def evolution_go_credentials_for(whatsapp_channel)
+    config = whatsapp_channel&.provider_config || {}
+
+    creds = {
+      api_url: config['api_url'].presence || GlobalConfigService.load('EVOLUTION_GO_API_URL', '').to_s.strip,
+      admin_token: config['admin_token'].presence || GlobalConfigService.load('EVOLUTION_GO_ADMIN_SECRET', '').to_s.strip,
+      instance_token: config['instance_token'],
+      instance_uuid: config['instance_uuid'],
+      instance_name: config['instance_name']
+    }
+
+    if whatsapp_channel && (creds[:instance_token].blank? || creds[:instance_uuid].blank?)
+      Rails.logger.warn(
+        "Evolution Go API: channel #{whatsapp_channel.id} resolved with missing instance credentials " \
+        '(instance_token/instance_uuid blank). Channel may need to be recreated.'
+      )
+    end
+
+    creds
+  end
 end

--- a/spec/controllers/api/v1/evolution_go/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/authorizations_controller_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe Api::V1::EvolutionGo::AuthorizationsController, type: :controller
     let(:api_url) { 'http://evo.example.com' }
     let(:instance_token) { 'instance-token-123' }
 
-    it 'invokes connect_instance with the freshly created instance credentials' do
-      expect(controller_instance).to receive(:connect_instance).with(api_url, instance_token)
+    it 'invokes connect_instance with the freshly created instance credentials and short timeouts' do
+      expect(controller_instance).to receive(:connect_instance).with(api_url, instance_token, nil, open_timeout: 5, read_timeout: 5)
 
       controller_instance.send(:register_webhook_after_create, api_url, instance_token)
     end
 
-    it 'swallows errors raised by connect_instance and logs them' do
+    it 'swallows errors raised by connect_instance and logs them at warn level' do
       allow(controller_instance).to receive(:connect_instance).and_raise(StandardError.new('BACKEND_URL is not configured'))
-      expect(Rails.logger).to receive(:error).with(/Eager webhook registration failed/)
+      expect(Rails.logger).to receive(:warn).with(/Eager webhook registration failed/)
 
       expect do
         controller_instance.send(:register_webhook_after_create, api_url, instance_token)
@@ -68,6 +68,19 @@ RSpec.describe Api::V1::EvolutionGo::AuthorizationsController, type: :controller
       expect(controller_instance).to receive(:register_webhook_after_create).with('http://evo.example.com', 'tok-from-create')
 
       controller_instance.create
+    end
+
+    # Invariante declarado no PR: "Failures are swallowed so a transient webhook
+    # error does not regress channel creation". Sem este teste, alguém remove o
+    # rescue de register_webhook_after_create e o invariante quebra silencioso.
+    it 'still renders success when the eager webhook registration fails' do
+      allow(controller_instance).to receive(:connect_instance).and_raise(StandardError.new('boom'))
+
+      expect(controller_instance).to receive(:render).with(
+        hash_including(json: hash_including(success: true, instance_token: 'tok-from-create'))
+      )
+
+      expect { controller_instance.create }.not_to raise_error
     end
   end
 end

--- a/spec/controllers/api/v1/evolution_go/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/authorizations_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit-level coverage for the eager webhook subscription added on Evolution Go
+# instance creation. The /instance/connect call is what registers the CRM as
+# webhook receiver in Evolution Go — running it right after /instance/create
+# means messages from the connected device flow even before the user opens the
+# QR screen. A failure here MUST NOT regress the create response, since the
+# QR flow re-runs the same call later and would retry the registration.
+RSpec.describe Api::V1::EvolutionGo::AuthorizationsController, type: :controller do
+  describe '#register_webhook_after_create' do
+    let(:controller_instance) { described_class.new }
+    let(:api_url) { 'http://evo.example.com' }
+    let(:instance_token) { 'instance-token-123' }
+
+    it 'invokes connect_instance with the freshly created instance credentials' do
+      expect(controller_instance).to receive(:connect_instance).with(api_url, instance_token)
+
+      controller_instance.send(:register_webhook_after_create, api_url, instance_token)
+    end
+
+    it 'swallows errors raised by connect_instance and logs them' do
+      allow(controller_instance).to receive(:connect_instance).and_raise(StandardError.new('BACKEND_URL is not configured'))
+      expect(Rails.logger).to receive(:error).with(/Eager webhook registration failed/)
+
+      expect do
+        controller_instance.send(:register_webhook_after_create, api_url, instance_token)
+      end.not_to raise_error
+    end
+
+    it 'skips the call entirely when api_url is blank' do
+      expect(controller_instance).not_to receive(:connect_instance)
+
+      controller_instance.send(:register_webhook_after_create, '', instance_token)
+    end
+
+    it 'skips the call entirely when instance_token is blank' do
+      expect(controller_instance).not_to receive(:connect_instance)
+
+      controller_instance.send(:register_webhook_after_create, api_url, nil)
+    end
+  end
+
+  # Pins the wire-up: a refactor that drops the register_webhook_after_create
+  # call from #create would silently regress EVO-984 (instance has no webhook
+  # until QR is opened) and the unit test above would still pass.
+  describe '#create wiring' do
+    let(:controller_instance) { described_class.new }
+
+    before do
+      controller_instance.params = ActionController::Parameters.new(
+        authorization: { mode: 'create', api_url: 'http://evo.example.com', admin_token: 'admin-tok', instance_name: 'inst-name' }
+      )
+      controller_instance.instance_variable_set(:@api_url, 'http://evo.example.com')
+      controller_instance.instance_variable_set(:@admin_token, 'admin-tok')
+      controller_instance.instance_variable_set(:@instance_name, 'inst-name')
+
+      allow(controller_instance).to receive(:create_instance_go).and_return(
+        'instance_token' => 'tok-from-create',
+        'instance_uuid' => 'uuid-from-create',
+        'data' => {}
+      )
+      allow(controller_instance).to receive(:render)
+    end
+
+    it 'invokes register_webhook_after_create with the freshly created instance_token' do
+      expect(controller_instance).to receive(:register_webhook_after_create).with('http://evo.example.com', 'tok-from-create')
+
+      controller_instance.create
+    end
+  end
+end

--- a/spec/controllers/api/v1/evolution_go/privacy_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/privacy_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Pins that PrivacyController#set_instance_params uses the EvolutionGoConcern
+# credential helper for legacy channels (EVO-984).
+RSpec.describe Api::V1::EvolutionGo::PrivacyController, type: :controller do
+  describe '#set_instance_params (channel branch)' do
+    let(:controller_instance) { described_class.new }
+    let(:channel) do
+      instance_double(
+        Channel::Whatsapp,
+        id: 'chan-uuid',
+        provider_config: { 'api_url' => '', 'admin_token' => '', 'instance_token' => 'inst-tok',
+                           'instance_uuid' => 'inst-uuid', 'instance_name' => 'inst-name' },
+        inbox: instance_double(Inbox)
+      )
+    end
+
+    before do
+      controller_instance.params = ActionController::Parameters.new(id: 'inst-uuid')
+      relation = double('relation')
+      allow(Channel::Whatsapp).to receive(:joins).with(:inbox).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:first).and_return(channel)
+    end
+
+    it 'falls back to GlobalConfig for api_url and admin_token when provider_config is blank' do
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+      controller_instance.send(:set_instance_params)
+
+      expect(controller_instance.instance_variable_get(:@api_url)).to eq('http://global.example.com')
+      expect(controller_instance.instance_variable_get(:@admin_token)).to eq('global-secret')
+      expect(controller_instance.instance_variable_get(:@instance_token)).to eq('inst-tok')
+    end
+  end
+end

--- a/spec/controllers/api/v1/evolution_go/profile_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/profile_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Pins that ProfileController#set_instance_params uses the EvolutionGoConcern
+# credential helper for legacy channels (EVO-984).
+RSpec.describe Api::V1::EvolutionGo::ProfileController, type: :controller do
+  describe '#set_instance_params (channel branch)' do
+    let(:controller_instance) { described_class.new }
+    let(:channel) do
+      instance_double(
+        Channel::Whatsapp,
+        id: 'chan-uuid',
+        provider_config: { 'api_url' => '', 'admin_token' => '', 'instance_token' => 'inst-tok',
+                           'instance_uuid' => 'inst-uuid', 'instance_name' => 'inst-name' },
+        inbox: instance_double(Inbox)
+      )
+    end
+
+    before do
+      controller_instance.params = ActionController::Parameters.new(id: 'inst-uuid')
+      relation = double('relation')
+      allow(Channel::Whatsapp).to receive(:joins).with(:inbox).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:first).and_return(channel)
+    end
+
+    it 'falls back to GlobalConfig for api_url and admin_token when provider_config is blank' do
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+      controller_instance.send(:set_instance_params)
+
+      expect(controller_instance.instance_variable_get(:@api_url)).to eq('http://global.example.com')
+      expect(controller_instance.instance_variable_get(:@admin_token)).to eq('global-secret')
+      expect(controller_instance.instance_variable_get(:@instance_token)).to eq('inst-tok')
+    end
+  end
+end

--- a/spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb
@@ -39,4 +39,57 @@ RSpec.describe Api::V1::EvolutionGo::QrcodesController, type: :controller do
       expect(controller_instance.instance_variable_get(:@instance_name)).to eq('inst-name')
     end
   end
+
+  # POST /qrcodes (refresh) é uma rota plana — não recebe :id. Antes do fix,
+  # #create lia auth_params[:api_url] direto e respondia 400 quando o frontend
+  # mandava só instance_uuid (canal legado pré-EVO-984), repetindo o sintoma da
+  # issue. Estes testes pinam que o método agora resolve credenciais via canal.
+  describe '#create credential resolution' do
+    let(:controller_instance) { described_class.new }
+    let(:channel) do
+      instance_double(
+        Channel::Whatsapp,
+        id: 'chan-uuid',
+        provider_config: { 'api_url' => '', 'instance_token' => 'inst-tok',
+                           'instance_uuid' => 'inst-uuid', 'instance_name' => 'inst-name' },
+        inbox: instance_double(Inbox)
+      )
+    end
+
+    before do
+      relation = double('relation')
+      allow(Channel::Whatsapp).to receive(:joins).with(:inbox).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:first).and_return(channel)
+    end
+
+    it 'falls back to channel + GlobalConfig when payload has only instance_uuid' do
+      controller_instance.params = ActionController::Parameters.new(qrcode: { instance_uuid: 'inst-uuid' })
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+      allow(controller_instance).to receive(:get_qrcode_go).with('http://global.example.com', 'inst-tok').and_return(base64: 'x', code: 'y', connected: false)
+
+      expect(controller_instance).to receive(:render).with(
+        hash_including(json: hash_including(success: true))
+      )
+
+      controller_instance.create
+    end
+
+    it 'still 400s when channel lookup fails and payload is missing credentials' do
+      relation = double('relation')
+      allow(Channel::Whatsapp).to receive(:joins).with(:inbox).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:first).and_return(nil)
+      allow(GlobalConfigService).to receive(:load).and_return('')
+
+      controller_instance.params = ActionController::Parameters.new(qrcode: { instance_uuid: 'unknown-uuid' })
+
+      expect(controller_instance).to receive(:render).with(
+        hash_including(status: :bad_request)
+      )
+
+      controller_instance.create
+    end
+  end
 end

--- a/spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Pins that QrcodesController#set_instance_params resolves credentials through
+# EvolutionGoConcern#evolution_go_credentials_for, so a refactor that drops the
+# concern include or reverts to direct provider_config['api_url'] reads cannot
+# silently regress legacy Evolution Go channels (the EVO-984 root cause).
+RSpec.describe Api::V1::EvolutionGo::QrcodesController, type: :controller do
+  describe '#set_instance_params' do
+    let(:controller_instance) { described_class.new }
+    let(:channel) do
+      instance_double(
+        Channel::Whatsapp,
+        id: 'chan-uuid',
+        provider_config: { 'api_url' => '', 'admin_token' => '', 'instance_token' => 'inst-tok',
+                           'instance_uuid' => 'inst-uuid', 'instance_name' => 'inst-name' },
+        inbox: instance_double(Inbox)
+      )
+    end
+
+    before do
+      controller_instance.params = ActionController::Parameters.new(id: 'inst-name')
+      relation = double('relation')
+      allow(Channel::Whatsapp).to receive(:joins).with(:inbox).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:first).and_return(channel)
+    end
+
+    it 'resolves api_url and admin_token from GlobalConfig when provider_config is empty' do
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+      controller_instance.send(:set_instance_params)
+
+      expect(controller_instance.instance_variable_get(:@api_url)).to eq('http://global.example.com')
+      expect(controller_instance.instance_variable_get(:@instance_token)).to eq('inst-tok')
+      expect(controller_instance.instance_variable_get(:@instance_uuid)).to eq('inst-uuid')
+      expect(controller_instance.instance_variable_get(:@instance_name)).to eq('inst-name')
+    end
+  end
+end

--- a/spec/controllers/api/v1/evolution_go/settings_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/settings_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Pins that SettingsController#set_instance_params uses the EvolutionGoConcern
+# credential helper, so legacy channels with empty provider_config fall back to
+# GlobalConfigService instead of breaking advanced-settings calls (EVO-984).
+RSpec.describe Api::V1::EvolutionGo::SettingsController, type: :controller do
+  describe '#set_instance_params (channel branch)' do
+    let(:controller_instance) { described_class.new }
+    let(:channel) do
+      instance_double(
+        Channel::Whatsapp,
+        id: 'chan-uuid',
+        provider_config: { 'api_url' => '', 'admin_token' => '', 'instance_token' => 'inst-tok',
+                           'instance_uuid' => 'inst-uuid', 'instance_name' => 'inst-name' },
+        inbox: instance_double(Inbox)
+      )
+    end
+
+    before do
+      controller_instance.params = ActionController::Parameters.new(id: 'inst-uuid')
+      relation = double('relation')
+      allow(Channel::Whatsapp).to receive(:joins).with(:inbox).and_return(relation)
+      allow(relation).to receive(:where).and_return(relation)
+      allow(relation).to receive(:first).and_return(channel)
+    end
+
+    it 'falls back to GlobalConfig for api_url and admin_token when provider_config is blank' do
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+      allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+      controller_instance.send(:set_instance_params)
+
+      expect(controller_instance.instance_variable_get(:@api_url)).to eq('http://global.example.com')
+      expect(controller_instance.instance_variable_get(:@admin_token)).to eq('global-secret')
+      expect(controller_instance.instance_variable_get(:@instance_token)).to eq('inst-tok')
+    end
+  end
+end

--- a/spec/controllers/concerns/evolution_go_concern_spec.rb
+++ b/spec/controllers/concerns/evolution_go_concern_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit-level coverage for EvolutionGoConcern's credential resolution. Older
+# Evolution Go channels created before the provider_config persistence fix may
+# still have empty api_url/admin_token in their config — controllers must fall
+# back to GlobalConfigService so QR generation / settings / privacy / profile
+# endpoints stop failing for those channels.
+RSpec.describe EvolutionGoConcern, type: :concern do
+  let(:host_class) do
+    Class.new do
+      include EvolutionGoConcern
+
+      public :evolution_go_credentials_for
+    end
+  end
+
+  let(:host) { host_class.new }
+
+  describe '#evolution_go_credentials_for' do
+    context 'when provider_config has the credentials' do
+      it 'returns the channel values without consulting GlobalConfig' do
+        expect(GlobalConfigService).not_to receive(:load).with('EVOLUTION_GO_API_URL', anything)
+        expect(GlobalConfigService).not_to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', anything)
+
+        channel = instance_double(
+          Channel::Whatsapp,
+          provider_config: {
+            'api_url' => 'http://channel.example.com',
+            'admin_token' => 'channel-token',
+            'instance_token' => 'instance-token',
+            'instance_uuid' => 'uuid-1',
+            'instance_name' => 'instance-name'
+          }
+        )
+
+        creds = host.evolution_go_credentials_for(channel)
+
+        expect(creds[:api_url]).to eq('http://channel.example.com')
+        expect(creds[:admin_token]).to eq('channel-token')
+        expect(creds[:instance_token]).to eq('instance-token')
+        expect(creds[:instance_uuid]).to eq('uuid-1')
+        expect(creds[:instance_name]).to eq('instance-name')
+      end
+    end
+
+    context 'when provider_config is missing api_url and admin_token' do
+      it 'falls back to GlobalConfigService for api_url and admin_token' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+        channel = instance_double(
+          Channel::Whatsapp,
+          provider_config: {
+            'instance_token' => 'instance-token',
+            'instance_uuid' => 'uuid-1'
+          }
+        )
+
+        creds = host.evolution_go_credentials_for(channel)
+
+        expect(creds[:api_url]).to eq('http://global.example.com')
+        expect(creds[:admin_token]).to eq('global-secret')
+        expect(creds[:instance_token]).to eq('instance-token')
+      end
+    end
+
+    context 'when provider_config has values but they are blank strings' do
+      it 'still falls back to GlobalConfigService' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+        allow(Rails.logger).to receive(:warn)
+
+        channel = instance_double(
+          Channel::Whatsapp,
+          id: 'chan-uuid',
+          provider_config: { 'api_url' => '', 'admin_token' => '   ' }
+        )
+
+        creds = host.evolution_go_credentials_for(channel)
+
+        expect(creds[:api_url]).to eq('http://global.example.com')
+        expect(creds[:admin_token]).to eq('global-secret')
+      end
+    end
+
+    context 'when neither provider_config nor GlobalConfig has values' do
+      it 'returns empty strings without raising' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('')
+        allow(Rails.logger).to receive(:warn)
+
+        channel = instance_double(Channel::Whatsapp, id: 'chan-uuid', provider_config: {})
+
+        creds = host.evolution_go_credentials_for(channel)
+
+        expect(creds[:api_url]).to eq('')
+        expect(creds[:admin_token]).to eq('')
+      end
+    end
+
+    context 'when channel is nil' do
+      it 'returns the GlobalConfig values without raising' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+        creds = host.evolution_go_credentials_for(nil)
+
+        expect(creds[:api_url]).to eq('http://global.example.com')
+        expect(creds[:admin_token]).to eq('global-secret')
+        expect(creds[:instance_token]).to be_nil
+      end
+
+      it 'does not warn (no channel to attribute the inconsistency to)' do
+        allow(GlobalConfigService).to receive(:load).and_return('')
+        expect(Rails.logger).not_to receive(:warn)
+
+        host.evolution_go_credentials_for(nil)
+      end
+    end
+
+    context 'when channel is present but instance_token is blank (corrupt channel)' do
+      it 'logs a warning so production occurrences are observable' do
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_API_URL', '').and_return('http://global.example.com')
+        allow(GlobalConfigService).to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', '').and_return('global-secret')
+
+        channel = instance_double(
+          Channel::Whatsapp,
+          id: 'chan-uuid',
+          provider_config: { 'instance_uuid' => 'uuid-1' }
+        )
+
+        expect(Rails.logger).to receive(:warn).with(/channel chan-uuid resolved with missing instance credentials/)
+
+        host.evolution_go_credentials_for(channel)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the two bugs reported in [EVO-984](https://linear.app/evoai/issue/EVO-984):

1. **Legacy Evolution Go channels with empty `provider_config['api_url']`/`['admin_token']` fail every API call.** The 4 controllers that operate on existing channels (`qrcodes`, `settings`, `privacy`, `profile`) read those fields directly with no fallback. Operators see "Erro ao gerar QR Code" and have to recreate the channel from scratch.
2. **On instance creation, the webhook URL is never sent to Evolution Go.** `connect_instance` only fires when the user opens the QR screen — any inbound message between create and QR is dropped.

## Changes

- New `Whatsapp::EvolutionGoConcern#evolution_go_credentials_for(channel)` helper resolves `api_url`/`admin_token` from `provider_config`, falling back to `GlobalConfigService.load('EVOLUTION_GO_API_URL' / '_ADMIN_SECRET')` when blank. Logs `Rails.logger.warn` when the channel is found but `instance_token` is blank, so corrupt-channel cases are observable in production.
- The 4 controllers (`qrcodes`, `settings`, `privacy`, `profile`) now use the helper in `set_instance_params` instead of reading `provider_config` directly. `privacy`/`profile`/`settings` additionally `include EvolutionGoConcern` (`qrcodes` already had it).
- `AuthorizationsController#create` now invokes `register_webhook_after_create(api_url, instance_token)` right after `create_instance_go` succeeds, so the webhook is registered eagerly. Failures are logged and swallowed to avoid regressing channel creation — the QR action also re-runs the same `connect_instance` call later.

## Validation

- `evo-ai-crm-community: bundle exec rspec spec/controllers/concerns/evolution_go_concern_spec.rb spec/controllers/api/v1/evolution_go/` — **16 examples, 0 failures**
- `evo-ai-crm-community: ruby -c` on every changed file — clean
- Manual end-to-end (Rails console + browser):
  - Legacy channel with `update_column(:provider_config, ...empty...)` → Connect generates QR (was "Erro ao gerar QR Code" pré-fix). Fallback resolved via `EVOLUTION_GO_API_URL`/`EVOLUTION_GO_ADMIN_SECRET` from Admin Settings.
  - Fresh channel creation → Evolution Go logs show `Creating instance` + `Connecting instance at .../instance/connect` in the same request, before user opens QR.

## Changed Files

### Backend
- `app/controllers/concerns/evolution_go_concern.rb` — new credential helper + log warn
- `app/controllers/api/v1/evolution_go/authorizations_controller.rb` — eager webhook
- `app/controllers/api/v1/evolution_go/privacy_controller.rb`
- `app/controllers/api/v1/evolution_go/profile_controller.rb`
- `app/controllers/api/v1/evolution_go/qrcodes_controller.rb`
- `app/controllers/api/v1/evolution_go/settings_controller.rb`

### Specs
- `spec/controllers/concerns/evolution_go_concern_spec.rb` (new)
- `spec/controllers/api/v1/evolution_go/authorizations_controller_spec.rb` (new)
- `spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb` (new)
- `spec/controllers/api/v1/evolution_go/settings_controller_spec.rb` (new)
- `spec/controllers/api/v1/evolution_go/privacy_controller_spec.rb` (new)
- `spec/controllers/api/v1/evolution_go/profile_controller_spec.rb` (new)

## Linked Issue

- EVO-984

## Summary by Sourcery

Fix Evolution Go WhatsApp CRM integration to handle missing channel credentials and register webhooks eagerly on instance creation.

Bug Fixes:
- Resolve Evolution Go API URL and admin token for existing WhatsApp channels from global configuration when provider_config values are missing.
- Prevent failures when legacy or corrupt channels lack instance credentials by centralizing resolution and logging diagnostics.
- Ensure the Evolution Go webhook is registered immediately after instance creation so inbound messages are not lost before the QR screen is opened.

Enhancements:
- Introduce a shared helper in EvolutionGoConcern for resolving Evolution Go credentials reused by QR code, settings, privacy, and profile controllers.
- Update Evolution Go controllers to support global-config fallbacks when credentials are supplied via request parameters.
- Add controller and concern specs covering Evolution Go credential resolution and eager webhook registration behavior.

Tests:
- Add specs for Evolution Go controllers and concern to validate credential fallback logic and eager webhook registration.