### PR TITLE
fix(crm): expose conversation uuid in pipeline payload (EVO-1007)

### DIFF
--- a/app/serializers/pipeline_item_serializer.rb
+++ b/app/serializers/pipeline_item_serializer.rb
@@ -58,6 +58,7 @@ module PipelineItemSerializer
         labels_by_title: labels_by_title,
         labels_by_id: labels_by_id
       )
+      result[:conversation]['uuid'] = pipeline_item.conversation.uuid
       if pipeline_item.conversation.association(:contact).loaded? && pipeline_item.conversation.contact
         result[:contact] = ContactSerializer.serialize(pipeline_item.conversation.contact)
       end


### PR DESCRIPTION
## Summary

- Inject `conversation.uuid` into the pipeline item payload so the frontend kanban can navigate from a card to `/conversations/<uuid>`.
- Implemented as a single line inside `PipelineItemSerializer.serialize`, after the call to `ConversationSerializer.serialize`. The global `ConversationSerializer` is intentionally left untouched — adding `:uuid` there changes the chat module's keying behavior (chat reducer keys messages by `uuid || id`, mismatching the read at `selectedConversation.id`) and broke message rendering in `/conversations`. Scoping the change to the pipeline payload avoids that regression.

## Validation

- `ruby -c app/serializers/pipeline_item_serializer.rb`
- `ruby -c app/serializers/conversation_serializer.rb`
- `bundle exec rspec spec/serializers/conversation_serializer_spec.rb` (7 examples, 0 failures)
- `bundle exec rspec spec/models/pipeline_item_spec.rb` reproduces 8 pre-existing failures on `develop` (fixture uses `pipeline_type: 'lead'` which the model rejects). Not introduced by this change.

## Changed Files

- `app/serializers/pipeline_item_serializer.rb`

## Linked Issue

- EVO-1007 — https://linear.app/evoai/issue/EVO-1007

## Related PRs

- Frontend: https://github.com/EvolutionAPI/evo-ai-frontend-community/pull/new/fix/EVO-1007

## Summary by Sourcery

New Features:
- Include the conversation UUID in serialized pipeline item responses for items with an associated conversation.