### PR TITLE
fix(crm): expose evolution health proxy route (EVO-1055)

### DIFF
--- a/app/controllers/api/v1/evolution/health_controller.rb
+++ b/app/controllers/api/v1/evolution/health_controller.rb
@@ -1,0 +1,43 @@
+class Api::V1::Evolution::HealthController < Api::V1::BaseController
+  TIMEOUT_SECONDS = 5
+
+  def show
+    api_url = params[:api_url].to_s
+
+    if api_url.blank?
+      render json: { error: 'api_url is required' }, status: :bad_request
+      return
+    end
+
+    uri = URI.parse("#{api_url.chomp('/')}/")
+
+    unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+      render json: { error: 'invalid api_url' }, status: :bad_request
+      return
+    end
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == 'https')
+    http.open_timeout = TIMEOUT_SECONDS
+    http.read_timeout = TIMEOUT_SECONDS
+
+    request = Net::HTTP::Get.new(uri)
+    request['Accept'] = 'application/json'
+
+    response = http.request(request)
+
+    unless response.is_a?(Net::HTTPSuccess)
+      render json: { status: response.code.to_i, error: 'upstream not healthy' },
+             status: :bad_gateway
+      return
+    end
+
+    render json: JSON.parse(response.body)
+  rescue JSON::ParserError
+    render json: { error: 'invalid response from evolution api' }, status: :bad_gateway
+  rescue URI::InvalidURIError
+    render json: { error: 'invalid api_url' }, status: :bad_request
+  rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED, SocketError => e
+    render json: { error: "evolution api unreachable: #{e.message}" }, status: :bad_gateway
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,7 @@ Rails.application.routes.draw do
       end
 
       scope path: 'evolution', as: 'evolution' do
+        get :health, to: 'evolution/health#show'
         resource :authorization, only: [:create], controller: 'evolution/authorizations'
         resources :qrcodes, only: [:create, :show], controller: 'evolution/qrcodes'
         resources :proxies, only: [:create, :show], controller: 'evolution/proxies'


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/evolution/health` route under the `evolution` scope.
- New `Api::V1::Evolution::HealthController#show` proxies the request to `${api_url}/` and returns the upstream JSON.
- The frontend's `EvolutionService.healthCheck` already calls this route to validate a configured Evolution API URL before creating a WhatsApp channel; without it, every channel creation hit 404 ("Health check falhou. Verifique se a URL da Evolution API está correta e acessível") and could not proceed.
- The controller mirrors the existing `Net::HTTP` pattern from `evolution/authorizations_controller#check_server_status`: 5s open/read timeout; `BadRequest` on missing/invalid `api_url`; `BadGateway` on upstream timeout, refused, non-2xx, or JSON parse failure. Authentication is inherited from `Api::V1::BaseController`.

## Validation

- `ruby -c app/controllers/api/v1/evolution/health_controller.rb` (OK)
- `ruby -c config/routes.rb` (OK)
- `bundle exec rspec spec/serializers/conversation_serializer_spec.rb` (7 examples, 0 failures — sanity, since the touched scope has no controller spec)

## Notes

- No new spec added: the `evolution` namespace controllers (qrcodes, settings, privacy, proxies, instances, profile, authorizations) do not currently have rspec coverage in this repo — kept consistent with the existing pattern. Reasonable follow-up if the team wants to standardize.
- Symmetry note: the `evolution_go` provider does not use this proxy pattern (the frontend `evolutionGoService.healthCheck` fetches `${apiUrl}/server/ok` directly). This PR does not change that asymmetry; it only fills the missing piece on the `evolution` side.

## Linked Issue

- EVO-1055 — https://linear.app/evoai/issue/EVO-1055

## Summary by Sourcery

Expose a new Evolution health check API endpoint that proxies health status from the configured Evolution backend to support WhatsApp channel creation validation.

New Features:
- Add GET /api/v1/evolution/health route under the Evolution API scope.
- Introduce Api::V1::Evolution::HealthController#show to proxy health check requests to a given Evolution API URL and return the upstream JSON response.

Bug Fixes:
- Resolve 404 errors during Evolution WhatsApp channel creation by providing the expected backend health check endpoint used by the frontend.