### PR TITLE
test(crm): regression spec for contact+attachment cascade (EVO-973)

### DIFF
--- a/spec/requests/api/v1/contacts_spec.rb
+++ b/spec/requests/api/v1/contacts_spec.rb
@@ -272,6 +272,37 @@ RSpec.describe 'Api::V1::ContactsController', type: :request do
       end
     end
 
+    context 'when contact has messages with attachments (EVO-973 regression)' do
+      let!(:channel_att) { Channel::Api.create! }
+      let!(:inbox_att) { Inbox.create!(name: 'Attachment Inbox', channel: channel_att) }
+      let!(:contact_inbox_att) { ContactInbox.create!(contact: contact, inbox: inbox_att, source_id: SecureRandom.hex(8)) }
+      let!(:conversation_att) { Conversation.create!(inbox: inbox_att, contact: contact, contact_inbox: contact_inbox_att) }
+      let!(:message_att) do
+        Message.create!(
+          conversation: conversation_att,
+          inbox: inbox_att,
+          content: 'media',
+          message_type: :incoming,
+          sender: contact
+        )
+      end
+      let!(:attachment) do
+        Attachment.create!(
+          attachable: message_att,
+          file_type: :image,
+          external_url: 'https://example.com/test.jpg'
+        )
+      end
+
+      it 'deletes contact and cascades through message attachments without PG::UndefinedColumn' do
+        delete "/api/v1/contacts/#{contact.id}", headers: headers
+
+        expect(response).to have_http_status(:ok)
+        expect(Contact.exists?(contact.id)).to be false
+        expect(Attachment.exists?(attachment.id)).to be false
+      end
+    end
+
     context 'when contact deletion fails due to foreign key constraint' do
       let!(:channel_fk) { Channel::Api.create! }
       let!(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel_fk) }


### PR DESCRIPTION
## Summary

- Adds regression spec for the `cleanup_contact_dependent_records → messages.destroy_all → attachments cascade` path that was the root cause of `PG::UndefinedColumn: attachments.attachable_id does not exist` when deleting a contact with media messages.
- The fix (adding polymorphic columns via migration) was already shipped in PR #3. This spec guards against future regressions.

## How it works

When `DELETE /api/v1/contacts/:id` is called, the controller explicitly calls `contact.messages.destroy_all`. Each `message.destroy` cascades via `has_many :attachments, as: :attachable, dependent: :destroy`, issuing:
```sql
DELETE FROM attachments WHERE attachable_type = 'Message' AND attachable_id = <uuid>
```
Without `attachable_id` in the table, this raises `PG::UndefinedColumn` → 500. The spec creates the full chain (inbox → conversation → message → attachment) and asserts the delete returns 200 and the attachment is destroyed.

## Validation

- `ruby -c spec/requests/api/v1/contacts_spec.rb` → Syntax OK
- `bundle exec rspec spec/requests/api/v1/contacts_spec.rb -e "EVO-973 regression" --format documentation` → **1 example, 0 failures**

## Changed Files

- `spec/requests/api/v1/contacts_spec.rb`

## Linked Issue

- EVO-973

## Summary by Sourcery

Tests:
- Add regression request spec covering contact deletion cascading through messages to attachments, preventing PG::UndefinedColumn errors when attachments are present.