### PR TITLE
fix(contacts): distinguish WhatsApp group contacts from real customer contacts (EVO-1018)

### DIFF
--- a/app/builders/contact_inbox_with_contact_builder.rb
+++ b/app/builders/contact_inbox_with_contact_builder.rb
@@ -108,7 +108,8 @@ class ContactInboxWithContactBuilder
       additional_attributes: contact_attributes[:additional_attributes],
       custom_attributes: contact_attributes[:custom_attributes],
       location: contact_attributes[:location] || '', # Ensure location is never nil
-      country_code: contact_attributes[:country_code] || '' # Ensure country_code is never nil
+      country_code: contact_attributes[:country_code] || '', # Ensure country_code is never nil
+      type: contact_attributes[:type] || 'person'
     )
 
     # Contacts created via inbox/channel flows are usually followed by conversation creation.

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -356,7 +356,11 @@ class Api::V1::ContactsController < Api::V1::BaseController
     contacts_with_name = Contact.all.where("contacts.name IS NOT NULL AND BTRIM(contacts.name) <> ''")
     @listable_contacts = contacts_with_identity.or(contacts_with_name)
 
-    @listable_contacts = @listable_contacts.where(type: params[:type]) if params[:type].present?
+    if params[:type].present?
+      @listable_contacts = @listable_contacts.where(type: params[:type])
+    elsif params[:include_groups] != 'true'
+      @listable_contacts = @listable_contacts.non_groups
+    end
 
     @listable_contacts = @listable_contacts.for_company(params[:company_id]) if params[:company_id].present?
 

--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -443,7 +443,7 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
     # Get contacts that are NOT already in THIS specific pipeline
     contacts_in_current_pipeline = @pipeline.pipeline_items.where.not(contact_id: nil).select(:contact_id)
 
-    current_contacts = Contact.all
+    current_contacts = Contact.non_groups
                        .includes(avatar_attachment: :blob)
                        .where.not(contacts: { id: contacts_in_current_pipeline })
                        .order(name: :desc)

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -46,7 +46,7 @@ class Contact < ApplicationRecord
   self.inheritance_column = :_type_disabled
   attr_accessor :skip_default_pipeline_assignment
 
-  TYPES = %w[person company].freeze
+  TYPES = %w[person company group].freeze
 
   validates :type, presence: true, inclusion: { in: TYPES }
   validates :email, allow_blank: true, uniqueness: { case_sensitive: false },
@@ -85,6 +85,8 @@ class Contact < ApplicationRecord
 
   scope :persons, -> { where(type: 'person') }
   scope :companies, -> { where(type: 'company') }
+  scope :groups, -> { where(type: 'group') }
+  scope :non_groups, -> { where.not(type: 'group') }
   scope :for_company, ->(company_id) { joins(:contact_companies).where(contact_companies: { company_id: company_id }) }
 
   scope :order_on_last_activity_at, lambda { |direction|
@@ -220,6 +222,10 @@ class Contact < ApplicationRecord
 
   def person?
     type == 'person'
+  end
+
+  def whatsapp_group?
+    type == 'group'
   end
 
   private
@@ -383,6 +389,7 @@ class Contact < ApplicationRecord
 
   def assign_to_default_pipeline
     return if skip_default_pipeline_assignment
+    return if whatsapp_group?
 
     default_pipeline = Pipeline.default.first
     return unless default_pipeline

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -224,7 +224,7 @@ class Contact < ApplicationRecord
     type == 'person'
   end
 
-  def whatsapp_group?
+  def group?
     type == 'group'
   end
 
@@ -389,7 +389,7 @@ class Contact < ApplicationRecord
 
   def assign_to_default_pipeline
     return if skip_default_pipeline_assignment
-    return if whatsapp_group?
+    return if group?
 
     default_pipeline = Pipeline.default.first
     return unless default_pipeline

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -85,7 +85,8 @@ class SearchService
   end
 
   def filter_contacts
-    @contacts = Contact.non_groups.where(
+    base = params[:include_groups] == 'true' ? Contact.all : Contact.non_groups
+    @contacts = base.where(
       "name ILIKE :search OR email ILIKE :search OR phone_number
       ILIKE :search OR identifier ILIKE :search", search: "%#{search_query}%"
     ).resolved_contacts.order_on_last_activity_at('desc').page(params[:page]).per(15)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -85,7 +85,7 @@ class SearchService
   end
 
   def filter_contacts
-    @contacts = Contact.where(
+    @contacts = Contact.non_groups.where(
       "name ILIKE :search OR email ILIKE :search OR phone_number
       ILIKE :search OR identifier ILIKE :search", search: "%#{search_query}%"
     ).resolved_contacts.order_on_last_activity_at('desc').page(params[:page]).per(15)

--- a/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
@@ -44,7 +44,7 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
-    @contact.update!(type: 'group') unless @contact.whatsapp_group?
+    @contact.update_columns(type: 'group') unless @contact.group?
     update_group_name_if_safe
 
     Rails.logger.debug { "Evolution Go API: Group contact set - ID: #{@contact.id}, Name: #{@contact.name}, Identifier: #{@contact.identifier}, Source ID: #{@contact_inbox.source_id}" }

--- a/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
@@ -36,13 +36,15 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
       inbox: inbox,
       contact_attributes: {
         name: group_subject,
-        identifier: group_jid
+        identifier: group_jid,
+        type: 'group'
       }
     ).perform
 
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
+    @contact.update!(type: 'group') unless @contact.whatsapp_group?
     update_group_name_if_safe
 
     Rails.logger.debug { "Evolution Go API: Group contact set - ID: #{@contact.id}, Name: #{@contact.name}, Identifier: #{@contact.identifier}, Source ID: #{@contact_inbox.source_id}" }

--- a/app/services/whatsapp/evolution_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_handlers/messages_upsert.rb
@@ -76,7 +76,7 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
-    @contact.update!(type: 'group') unless @contact.whatsapp_group?
+    @contact.update_columns(type: 'group') unless @contact.group?
     update_group_name_if_safe(subject)
   end
 

--- a/app/services/whatsapp/evolution_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_handlers/messages_upsert.rb
@@ -68,13 +68,15 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
       inbox: inbox,
       contact_attributes: {
         name: subject,
-        identifier: group_jid
+        identifier: group_jid,
+        type: 'group'
       }
     ).perform
 
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
+    @contact.update!(type: 'group') unless @contact.whatsapp_group?
     update_group_name_if_safe(subject)
   end
 

--- a/db/migrate/20260507154544_add_group_to_contact_type_enum.rb
+++ b/db/migrate/20260507154544_add_group_to_contact_type_enum.rb
@@ -1,0 +1,23 @@
+class AddGroupToContactTypeEnum < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<-SQL
+      ALTER TYPE contact_type_enum ADD VALUE IF NOT EXISTS 'group';
+    SQL
+
+    # ALTER TYPE ADD VALUE cannot be used inside a transaction in PostgreSQL.
+    # disable_ddl_transaction! runs this migration outside a transaction, so the
+    # new enum value is committed before the UPDATE below tries to use it.
+    execute <<-SQL
+      UPDATE contacts SET type = 'group'
+      WHERE type = 'person' AND identifier ILIKE '%@g.us';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      UPDATE contacts SET type = 'person' WHERE type = 'group';
+    SQL
+  end
+end

--- a/db/migrate/20260513120000_clean_group_pipeline_items.rb
+++ b/db/migrate/20260513120000_clean_group_pipeline_items.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CleanGroupPipelineItems < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      DELETE FROM pipeline_items
+      WHERE contact_id IN (
+        SELECT id FROM contacts WHERE type = 'group'
+      )
+      AND conversation_id IS NULL;
+    SQL
+  end
+
+  def down
+    # Intentionally irreversible: removed pipeline associations for group contacts cannot be recovered.
+  end
+end

--- a/db/migrate/20260513120001_add_index_to_contacts_type.rb
+++ b/db/migrate/20260513120001_add_index_to_contacts_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexToContactsType < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :contacts, :type,
+              name: 'index_contacts_on_type',
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 9025_08_19_224901) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "contact_type_enum", ["person", "company"]
+  create_enum "contact_type_enum", ["person", "company", "group"]
 
   create_table "access_tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", limit: 255, null: false

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contact, type: :model do
+  let(:person_contact)  { Contact.create!(name: 'Alice', email: 'alice@example.com', type: 'person') }
+  let(:company_contact) { Contact.create!(name: 'Acme Corp', type: 'company') }
+  let(:group_contact)   { Contact.create!(name: 'Almoço BH', identifier: '12345-9876@g.us', type: 'group') }
+
+  describe '#group?' do
+    it 'returns true for type=group' do
+      expect(group_contact.group?).to be true
+    end
+
+    it 'returns false for type=person' do
+      expect(person_contact.group?).to be false
+    end
+
+    it 'returns false for type=company' do
+      expect(company_contact.group?).to be false
+    end
+  end
+
+  describe '.non_groups scope' do
+    before { person_contact; company_contact; group_contact }
+
+    it 'excludes contacts with type=group' do
+      ids = Contact.non_groups.pluck(:id)
+      expect(ids).not_to include(group_contact.id)
+    end
+
+    it 'includes person and company contacts' do
+      ids = Contact.non_groups.pluck(:id)
+      expect(ids).to include(person_contact.id, company_contact.id)
+    end
+  end
+
+  describe '#assign_to_default_pipeline' do
+    let!(:pipeline) { Pipeline.create!(name: 'Default', pipeline_type: 'sales', is_default: true, created_by: User.create!(email: 'dev@example.com', name: 'Dev')) }
+
+    it 'skips pipeline assignment for group contacts' do
+      expect { group_contact }.not_to change(PipelineItem, :count)
+    end
+
+    it 'creates a pipeline item for person contacts when a default pipeline exists' do
+      expect { person_contact }.to change(PipelineItem, :count).by(1)
+    end
+  end
+end

--- a/spec/requests/api/v1/contacts_groups_spec.rb
+++ b/spec/requests/api/v1/contacts_groups_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Contacts group filtering', type: :request do
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+  after  { ENV.delete('EVOAI_CRM_API_TOKEN'); Current.reset }
+
+  let!(:person)  { Contact.create!(name: 'Maria da Silva', email: 'maria@example.com', type: 'person') }
+  let!(:company) { Contact.create!(name: 'Acme Corp', type: 'company') }
+  let!(:group)   { Contact.create!(name: 'Almoço BH', identifier: '12345-9876@g.us', type: 'group') }
+
+  def response_names
+    JSON.parse(response.body).dig('data', 'payload')&.map { |c| c['name'] } ||
+      JSON.parse(response.body)['data']&.map { |c| c['name'] } || []
+  end
+
+  describe 'GET /api/v1/contacts' do
+    it 'excludes group contacts by default' do
+      get '/api/v1/contacts', headers: headers
+      expect(response).to have_http_status(:ok)
+      names = response_names
+      expect(names).to include('Maria da Silva', 'Acme Corp')
+      expect(names).not_to include('Almoço BH')
+    end
+
+    it 'includes group contacts when include_groups=true' do
+      get '/api/v1/contacts', params: { include_groups: 'true' }, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response_names).to include('Almoço BH')
+    end
+
+    it 'returns only group contacts when type=group' do
+      get '/api/v1/contacts', params: { type: 'group' }, headers: headers
+      expect(response).to have_http_status(:ok)
+      names = response_names
+      expect(names).to include('Almoço BH')
+      expect(names).not_to include('Maria da Silva', 'Acme Corp')
+    end
+  end
+
+  describe 'GET /api/v1/contacts/search' do
+    it 'excludes group contacts from search results by default' do
+      get '/api/v1/contacts/search', params: { q: 'Almoço' }, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response_names).not_to include('Almoço BH')
+    end
+
+    it 'includes group contacts in search when include_groups=true' do
+      get '/api/v1/contacts/search', params: { q: 'Almoço', include_groups: 'true' }, headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(response_names).to include('Almoço BH')
+    end
+  end
+end

--- a/spec/services/whatsapp/incoming_message_evolution_go_service_groups_spec.rb
+++ b/spec/services/whatsapp/incoming_message_evolution_go_service_groups_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Whatsapp::IncomingMessageEvolutionGoService do
   let(:channel) { instance_double(Channel::Whatsapp, provider: 'evolution_go') }
   let(:inbox) { instance_double(Inbox, id: 1, channel: channel) }
-  let(:contact) { instance_double(Contact, id: 99, name: 'My Squad', identifier: '12345-9876@g.us', update!: true) }
+  let(:contact) { instance_double(Contact, id: 99, name: 'My Squad', identifier: '12345-9876@g.us', update!: true, group?: true) }
   let(:contact_inbox) { instance_double(ContactInbox, id: 7, contact: contact, source_id: '12345-9876@g.us') }
   let(:builder) { instance_double(ContactInboxWithContactBuilder, perform: contact_inbox) }
 
@@ -152,6 +152,26 @@ RSpec.describe Whatsapp::IncomingMessageEvolutionGoService do
       allow(contact).to receive(:name).and_return('Renomeado pelo operador')
       expect(contact).not_to receive(:update!)
       service.send(:update_group_name_if_safe)
+    end
+  end
+
+  describe '#set_contact — retrofit pre-existing contact without type=group' do
+    let(:pre_existing_contact) do
+      instance_double(Contact, id: 42, name: 'My Squad', identifier: '12345-9876@g.us',
+                               update!: true, update_columns: true, group?: false)
+    end
+    let(:contact_inbox_for_pre_existing) { instance_double(ContactInbox, id: 8, contact: pre_existing_contact, source_id: '12345-9876@g.us') }
+    let(:builder_for_pre_existing) { instance_double(ContactInboxWithContactBuilder, perform: contact_inbox_for_pre_existing) }
+
+    before do
+      service.instance_variable_set(:@evolution_go_info, group_info)
+      service.instance_variable_set(:@evolution_go_data, group_data)
+      allow(ContactInboxWithContactBuilder).to receive(:new).and_return(builder_for_pre_existing)
+    end
+
+    it 'calls update_columns(type: group) to retrofit a pre-existing contact that lacks the group type' do
+      expect(pre_existing_contact).to receive(:update_columns).with(type: 'group')
+      service.send(:set_contact)
     end
   end
 end

--- a/spec/services/whatsapp/incoming_message_evolution_service_groups_spec.rb
+++ b/spec/services/whatsapp/incoming_message_evolution_service_groups_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Whatsapp::IncomingMessageEvolutionService do
   let(:channel) { instance_double(Channel::Whatsapp, provider: 'evolution', provider_service: provider_service) }
   let(:inbox) { instance_double(Inbox, id: 1, channel: channel) }
   let(:contact) do
-    instance_double(Contact, id: 99, name: 'WhatsApp Group 99876', identifier: '12345-9876@g.us', update!: true).tap do |c|
+    instance_double(Contact, id: 99, name: 'WhatsApp Group 99876', identifier: '12345-9876@g.us', update!: true, group?: true).tap do |c|
       allow(c).to receive(:name).and_return('WhatsApp Group 99876')
     end
   end
@@ -193,6 +193,28 @@ RSpec.describe Whatsapp::IncomingMessageEvolutionService do
     it 'is a no-op when subject is blank' do
       expect(contact).not_to receive(:update!)
       service.send(:update_group_name_if_safe, nil)
+    end
+  end
+
+  describe '#set_contact — retrofit pre-existing contact without type=group' do
+    let(:pre_existing_contact) do
+      instance_double(Contact, id: 42, name: 'WhatsApp Group 42', identifier: '12345-9876@g.us',
+                               update!: true, update_columns: true, group?: false).tap do |c|
+        allow(c).to receive(:name).and_return('WhatsApp Group 42')
+      end
+    end
+    let(:contact_inbox_for_pre_existing) { instance_double(ContactInbox, id: 8, contact: pre_existing_contact, source_id: '12345-9876@g.us') }
+    let(:builder_for_pre_existing) { instance_double(ContactInboxWithContactBuilder, perform: contact_inbox_for_pre_existing) }
+
+    before do
+      service.instance_variable_set(:@raw_message, group_message_payload)
+      allow(ContactInboxWithContactBuilder).to receive(:new).and_return(builder_for_pre_existing)
+      allow(provider_service).to receive(:fetch_group_subject).and_return(nil)
+    end
+
+    it 'calls update_columns(type: group) to retrofit a pre-existing contact that lacks the group type' do
+      expect(pre_existing_contact).to receive(:update_columns).with(type: 'group')
+      service.send(:set_contact)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `group` value to `contact_type_enum` with migration and backfill (contacts with `identifier ILIKE '%@g.us'`)
- Set `type='group'` in `set_group_contact` for both Evolution API and Evolution Go handlers; retrofit existing group contacts on next message arrival
- Add `non_groups` scope and `whatsapp_group?` helper to `Contact` model as single documented discriminator
- Exclude group contacts from `listable_contacts` by default (opt-in via `include_groups=true`)
- Exclude groups from `SearchService#filter_contacts` (global search)
- Exclude groups from `PipelineItemsController#available_contacts` (pipeline item picker)
- Skip default pipeline assignment for group contacts

## Validation

- `ruby -c` on all modified Ruby files — ✅ Syntax OK
- Migration ran successfully in Docker: 8 existing group contacts backfilled

## Deploy note

⚠️ This PR includes a migration. Run `bundle exec rails db:migrate` after deploying.

## Related PRs

- Frontend: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/new/fix/EVO-1018

## Linked Issue

- EVO-1018

## Summary by Sourcery

Distinguish WhatsApp group chats from individual customer contacts and prevent groups from flowing into CRM and pipeline flows by default.

New Features:
- Introduce a new 'group' contact type in the contact_type_enum and apply it to WhatsApp group contacts.

Bug Fixes:
- Ensure WhatsApp group chats are no longer treated as regular customer contacts across listings, search, and pipeline assignment.

Enhancements:
- Add Contact scopes and helpers to consistently filter or detect group contacts.
- Default newly created contacts to 'person' while allowing explicit creation of 'group' contacts from WhatsApp handlers.
- Exclude group contacts from listable contacts, global contact search, and pipeline available-contacts unless explicitly requested.