### PR TITLE
fix(crm): add notificame verify endpoint (EVO-986)

### DIFF
--- a/app/controllers/api/v1/channels/notificame_channels_controller.rb
+++ b/app/controllers/api/v1/channels/notificame_channels_controller.rb
@@ -1,0 +1,68 @@
+class Api::V1::Channels::NotificameChannelsController < Api::V1::BaseController
+  skip_before_action :authenticate_user!, :authenticate_access_token!, :set_current_user, raise: false
+
+  def verify
+    missing = missing_params
+    return missing_params_response(missing) if missing.any?
+
+    channels = Whatsapp::Providers::NotificameService.list_channels(verify_params[:api_token])
+    return list_failed_response if channels.blank?
+
+    return channel_not_found_response unless channel_matches?(channels, verify_params[:channel_id])
+
+    success_response(
+      data: { success: true, channels: channels },
+      message: 'Notificame connection verified successfully'
+    )
+  rescue StandardError => e
+    Rails.logger.error "Notificame verify error: #{e.class} - #{e.message}"
+    error_response(ApiErrorCodes::EXTERNAL_SERVICE_ERROR, e.message, status: :unprocessable_entity)
+  end
+
+  private
+
+  def verify_params
+    @verify_params ||= {
+      api_token: params[:api_token].to_s.strip,
+      channel_id: params[:channel_id].to_s.strip,
+      phone_number: params[:phone_number].to_s.strip
+    }
+  end
+
+  def missing_params
+    verify_params.select { |_k, v| v.blank? }.keys.map(&:to_s)
+  end
+
+  def missing_params_response(missing)
+    error_response(
+      ApiErrorCodes::MISSING_REQUIRED_FIELD,
+      "Missing required parameters: #{missing.join(', ')}",
+      status: :bad_request
+    )
+  end
+
+  def list_failed_response
+    error_response(
+      ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
+      'Could not list Notificame channels. Verify the API Token.',
+      status: :unprocessable_entity
+    )
+  end
+
+  def channel_not_found_response
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      "Channel ID '#{verify_params[:channel_id]}' was not found for the provided API Token.",
+      status: :unprocessable_entity
+    )
+  end
+
+  def channel_matches?(channels, channel_id)
+    channels.any? do |entry|
+      next false unless entry.is_a?(Hash)
+
+      [entry['id'], entry['channel_id'], entry['channelId'], entry['uuid']]
+        .compact.map(&:to_s).include?(channel_id)
+    end
+  end
+end

--- a/app/controllers/api/v1/channels/notificame_channels_controller.rb
+++ b/app/controllers/api/v1/channels/notificame_channels_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Channels::NotificameChannelsController < Api::V1::BaseController
-  skip_before_action :authenticate_user!, :authenticate_access_token!, :set_current_user, raise: false
+  before_action :authorize_request
 
   def verify
     missing = missing_params
@@ -8,18 +8,32 @@ class Api::V1::Channels::NotificameChannelsController < Api::V1::BaseController
     channels = Whatsapp::Providers::NotificameService.list_channels(verify_params[:api_token])
     return list_failed_response if channels.blank?
 
-    return channel_not_found_response unless channel_matches?(channels, verify_params[:channel_id])
+    matched_channel = find_channel(channels, verify_params[:channel_id])
+    return channel_not_found_response unless matched_channel
+    return phone_mismatch_response unless phone_number_matches?(matched_channel, verify_params[:phone_number])
 
     success_response(
-      data: { success: true, channels: channels },
+      data: { channels: channels },
       message: 'Notificame connection verified successfully'
     )
   rescue StandardError => e
     Rails.logger.error "Notificame verify error: #{e.class} - #{e.message}"
-    error_response(ApiErrorCodes::EXTERNAL_SERVICE_ERROR, e.message, status: :unprocessable_entity)
+    # Generic message: e.message can carry HTTP body fragments or internal
+    # data we don't want exposed to clients. Keep a friendly 422 for the
+    # common case (invalid token / Notificame unreachable); the global
+    # handle_internal_error filters details in production for true 500s.
+    error_response(
+      ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
+      'Could not verify Notificame connection. Please check the API token and try again.',
+      status: :unprocessable_entity
+    )
   end
 
   private
+
+  def authorize_request
+    authorize ::Inbox, :create?
+  end
 
   def verify_params
     @verify_params ||= {
@@ -57,12 +71,34 @@ class Api::V1::Channels::NotificameChannelsController < Api::V1::BaseController
     )
   end
 
-  def channel_matches?(channels, channel_id)
-    channels.any? do |entry|
+  def phone_mismatch_response
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      "Phone number does not match channel '#{verify_params[:channel_id]}'.",
+      status: :unprocessable_entity
+    )
+  end
+
+  def find_channel(channels, channel_id)
+    target = channel_id.to_s.strip.downcase
+    channels.find do |entry|
       next false unless entry.is_a?(Hash)
 
       [entry['id'], entry['channel_id'], entry['channelId'], entry['uuid']]
-        .compact.map(&:to_s).include?(channel_id)
+        .compact
+        .map { |v| v.to_s.strip.downcase }
+        .include?(target)
     end
+  end
+
+  # Compare digits-only to ignore E.164 `+` prefix and any formatting
+  # punctuation the operator may have typed.
+  def phone_number_matches?(channel, expected_phone)
+    candidates = [channel['phone'], channel['phone_number'], channel['phoneNumber'], channel['msisdn']]
+                 .compact.map { |v| v.to_s.gsub(/\D/, '') }
+    expected = expected_phone.to_s.gsub(/\D/, '')
+    return false if expected.blank?
+
+    candidates.include?(expected)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -317,6 +317,7 @@ Rails.application.routes.draw do
 
       scope path: 'channels', as: 'channels' do
         resource :twilio_channel, only: [:create], controller: 'channels/twilio_channels'
+        post 'notificame/verify', to: 'channels/notificame_channels#verify', as: :notificame_verify
       end
 
       scope path: 'notificame', as: 'notificame' do

--- a/spec/requests/api/v1/channels/notificame_channels_spec.rb
+++ b/spec/requests/api/v1/channels/notificame_channels_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe 'Api::V1::Channels::NotificameChannelsController', type: :request do
+  let(:base_url) { 'http://auth.test' }
+  let(:validate_url) { "#{base_url}/api/v1/auth/validate" }
+  let(:token) { 'test-bearer-token' }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+  let!(:user) { User.create!(name: 'Test User', email: "notificame-test-#{SecureRandom.hex(4)}@example.com") }
+
+  let(:notificame_channels) do
+    [
+      { 'id' => 'channel-abc', 'phone' => '+5511999999999', 'name' => 'Sales' },
+      { 'id' => 'channel-xyz', 'phone' => '+5511888888888', 'name' => 'Support' }
+    ]
+  end
+
+  let(:valid_params) do
+    {
+      api_token: 'notif-test-token',
+      channel_id: 'channel-abc',
+      phone_number: '+5511999999999'
+    }
+  end
+
+  around do |example|
+    original_base_url = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+    ENV['EVO_AUTH_SERVICE_URL'] = base_url
+    Rails.cache.clear
+    Current.reset
+    example.run
+    Rails.cache.clear
+    Current.reset
+    ENV['EVO_AUTH_SERVICE_URL'] = original_base_url
+  end
+
+  before do
+    stub_request(:post, validate_url)
+      .with(headers: { 'Authorization' => "Bearer #{token}" })
+      .to_return(
+        status: 200,
+        body: { success: true, data: { user: { id: user.id, email: user.email } } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    permission_check_url = "#{base_url}/api/v1/users/#{user.id}/check_permission"
+    stub_request(:post, permission_check_url)
+      .to_return(
+        status: 200,
+        body: { success: true, data: { has_permission: true } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+
+    Current.user = user
+  end
+
+  describe 'POST /api/v1/channels/notificame/verify' do
+    context 'with valid params' do
+      before do
+        allow(Whatsapp::Providers::NotificameService).to receive(:list_channels).and_return(notificame_channels)
+      end
+
+      it 'returns 200 and the channels list' do
+        post '/api/v1/channels/notificame/verify', params: valid_params, headers: headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+        parsed = response.parsed_body
+        expect(parsed['data']['channels']).to eq(notificame_channels.map(&:stringify_keys))
+      end
+
+      it 'does not duplicate the success envelope in the response payload' do
+        post '/api/v1/channels/notificame/verify', params: valid_params, headers: headers, as: :json
+
+        parsed = response.parsed_body
+        # `success` should appear once at the top of the envelope, not nested under data.
+        expect(parsed['data']).not_to have_key('success')
+      end
+    end
+
+    context 'with mismatched phone number' do
+      before do
+        allow(Whatsapp::Providers::NotificameService).to receive(:list_channels).and_return(notificame_channels)
+      end
+
+      it 'returns 422 with a phone-mismatch error' do
+        post '/api/v1/channels/notificame/verify',
+             params: valid_params.merge(phone_number: '+5500000000000'),
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']['message']).to match(/phone number/i)
+      end
+    end
+
+    context 'with channel_id not in the list' do
+      before do
+        allow(Whatsapp::Providers::NotificameService).to receive(:list_channels).and_return(notificame_channels)
+      end
+
+      it 'returns 422 with channel-not-found error' do
+        post '/api/v1/channels/notificame/verify',
+             params: valid_params.merge(channel_id: 'channel-missing'),
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']['message']).to match(/was not found/i)
+      end
+    end
+
+    context 'when the Notificame token is invalid (empty list)' do
+      before do
+        allow(Whatsapp::Providers::NotificameService).to receive(:list_channels).and_return([])
+      end
+
+      it 'returns 422 asking the operator to verify the token' do
+        post '/api/v1/channels/notificame/verify', params: valid_params, headers: headers, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']['message']).to match(/verify the api token/i)
+      end
+    end
+
+    context 'with missing required params' do
+      it 'returns 400 listing the missing fields' do
+        post '/api/v1/channels/notificame/verify',
+             params: { api_token: 'something' },
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body['error']['message']).to include('channel_id', 'phone_number')
+      end
+    end
+
+    context 'when the Notificame service raises' do
+      before do
+        allow(Whatsapp::Providers::NotificameService)
+          .to receive(:list_channels).and_raise(StandardError.new('connect timeout on https://internal.notificame.invalid'))
+      end
+
+      it 'returns a generic 422 and does not echo the raw exception message' do
+        post '/api/v1/channels/notificame/verify', params: valid_params, headers: headers, as: :json
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        body = response.parsed_body
+        expect(body['error']['message']).to match(/please check the api token/i)
+        expect(body['error']['message']).not_to include('internal.notificame.invalid')
+      end
+    end
+
+    context 'when the API response contains whitespace and case noise in channel ids' do
+      let(:noisy_channels) do
+        [{ 'id' => '  Channel-ABC  ', 'phone' => '+5511999999999' }]
+      end
+
+      before do
+        allow(Whatsapp::Providers::NotificameService).to receive(:list_channels).and_return(noisy_channels)
+      end
+
+      it 'still matches when API returns whitespace and uppercase' do
+        post '/api/v1/channels/notificame/verify', params: valid_params, headers: headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/channels/notificame/verify` so the Notificame channel-creation flow stops 404'ing.
- The new endpoint validates `api_token` + `channel_id` against Notificame Hub via `Whatsapp::Providers::NotificameService.list_channels`, returning a clear 4xx with the offending field when invalid.

## Validation
- `ruby -c app/controllers/api/v1/channels/notificame_channels_controller.rb`
- `ruby -c config/routes.rb`
- `bundle exec rubocop app/controllers/api/v1/channels/notificame_channels_controller.rb` (no offenses)

## Linked Issue
- https://linear.app/evoai/issue/EVO-986

## Related PRs
- Frontend payload fix: see companion PR on `evo-ai-frontend-community` `fix/EVO-986`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Notificame channel verification endpoint to validate credentials with the external Notificame service.

New Features:
- Introduce POST /api/v1/channels/notificame/verify to validate Notificame channel configuration via the Notificame service.

Bug Fixes:
- Prevent 404 errors during Notificame channel creation by providing a dedicated verification endpoint with clear validation errors.

Enhancements:
- Return structured error responses for missing parameters, invalid API tokens, and unknown channel IDs when verifying Notificame channels.