### PR TITLE
fix(crm): surface macro webhook delivery failures (EVO-1041)

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -1,6 +1,9 @@
 class WebhookJob < ApplicationJob
   queue_as :medium
-  #  There are 3 types of webhooks, account, inbox and agent_bot
+  # Webhook types: :account_webhook (default), :inbox_webhook, :agent_bot,
+  # :api_inbox_webhook, :macro_webhook. Only :macro_webhook re-raises on
+  # failure so Sidekiq surfaces the error; others swallow-and-warn per the
+  # legacy contract (see lib/webhooks/trigger.rb#execute).
   def perform(url, payload, webhook_type = :account_webhook)
     Webhooks::Trigger.execute(url, payload, webhook_type)
   end

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Macros::ExecutionService < ActionService
   def initialize(macro, conversation, user)
     super(conversation)
@@ -90,6 +92,10 @@ class Macros::ExecutionService < ActionService
     raise e
   end
 
+  # `webhook_url` comes from the macro JSON `action_params`. Historically the
+  # field is stored as `[url_string]`, but defensive handling for nil / bare
+  # string is kept so a malformed macro entry does not crash the whole
+  # execution loop.
   def send_webhook_event(webhook_url)
     clean_url = Array(webhook_url).first.to_s.strip
     if clean_url.blank?
@@ -98,7 +104,7 @@ class Macros::ExecutionService < ActionService
     end
 
     payload = @conversation.webhook_data.merge(event: 'macro.executed')
-    Rails.logger.info "Macro #{@macro.id}: enqueuing webhook event url=#{clean_url}"
-    WebhookJob.perform_later(clean_url, payload)
+    Rails.logger.info "Macro #{@macro.id}: enqueuing webhook event"
+    WebhookJob.perform_later(clean_url, payload, :macro_webhook)
   end
 end

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -91,9 +91,14 @@ class Macros::ExecutionService < ActionService
   end
 
   def send_webhook_event(webhook_url)
+    clean_url = Array(webhook_url).first.to_s.strip
+    if clean_url.blank?
+      Rails.logger.warn "Macro #{@macro.id}: skipping send_webhook_event — empty URL"
+      return
+    end
+
     payload = @conversation.webhook_data.merge(event: 'macro.executed')
-    # Sanitize the webhook URL to remove any leading/trailing whitespace or tabs
-    clean_url = webhook_url.first.to_s.strip
+    Rails.logger.info "Macro #{@macro.id}: enqueuing webhook event url=#{clean_url}"
     WebhookJob.perform_later(clean_url, payload)
   end
 end

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -15,15 +15,19 @@ class Webhooks::Trigger
     perform_request
   rescue StandardError => e
     handle_error(e)
+    # Keep the legacy "Exception: Invalid webhook URL" prefix so existing
+    # Loki/Sentry/Grafana alerts grepping for it keep matching; structured
+    # context follows.
     Rails.logger.warn(
-      "Webhook delivery failed: type=#{@webhook_type} event=#{@payload[:event]} url=#{@url} error=#{e.class}: #{e.message}"
+      "Exception: Invalid webhook URL #{loggable_url} : #{e.message} " \
+      "(type=#{@webhook_type} event=#{@payload[:event]} error=#{e.class})"
     )
-    # Re-raise for non api_inbox webhooks so Sidekiq retries the job and the
-    # failure becomes visible in queue/error tracking instead of being silent.
-    # api_inbox webhook errors are intentionally swallowed because the message
-    # status is already updated by handle_error and we don't want to retry user
-    # message dispatches on every transient hiccup.
-    raise unless @webhook_type == :api_inbox_webhook
+    # Re-raise ONLY for macro webhooks so Sidekiq surfaces the failure in
+    # queue/error tracking. Other webhook types (account, inbox, agent_bot,
+    # api_inbox) keep their legacy swallow-and-warn behaviour — re-raising
+    # them would trigger the default ActiveJob retry policy (25 attempts
+    # over ~21 days) across every listener that dispatches webhooks.
+    raise if @webhook_type == :macro_webhook
   end
 
   private
@@ -46,7 +50,23 @@ class Webhooks::Trigger
   end
 
   def should_handle_error?
-    @webhook_type == :api_inbox_webhook && SUPPORTED_ERROR_HANDLE_EVENTS.include?(@payload[:event])
+    api_inbox_webhook? && SUPPORTED_ERROR_HANDLE_EVENTS.include?(@payload[:event])
+  end
+
+  def api_inbox_webhook?
+    @webhook_type == :api_inbox_webhook
+  end
+
+  # Strip query string before logging. Account webhooks frequently carry
+  # auth tokens in the query (`?token=...`); leaking those into Loki/Sentry
+  # is a real risk. Path + host is enough to identify the destination.
+  def loggable_url
+    uri = URI.parse(@url.to_s)
+    return @url.to_s if uri.host.blank?
+
+    [uri.scheme, '://', uri.host, uri.path].join
+  rescue URI::InvalidURIError
+    '<unparseable>'
   end
 
   def update_message_status(error)

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -15,7 +15,15 @@ class Webhooks::Trigger
     perform_request
   rescue StandardError => e
     handle_error(e)
-    Rails.logger.warn "Exception: Invalid webhook URL #{@url} : #{e.message}"
+    Rails.logger.warn(
+      "Webhook delivery failed: type=#{@webhook_type} event=#{@payload[:event]} url=#{@url} error=#{e.class}: #{e.message}"
+    )
+    # Re-raise for non api_inbox webhooks so Sidekiq retries the job and the
+    # failure becomes visible in queue/error tracking instead of being silent.
+    # api_inbox webhook errors are intentionally swallowed because the message
+    # status is already updated by handle_error and we don't want to retry user
+    # message dispatches on every transient hiccup.
+    raise unless @webhook_type == :api_inbox_webhook
   end
 
   private

--- a/spec/lib/webhooks/trigger_spec.rb
+++ b/spec/lib/webhooks/trigger_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Trigger do
+  let(:url)     { 'https://example.test/hook' }
+  let(:payload) { { event: 'macro.executed', conversation: { id: 42 } } }
+
+  before do
+    allow(RestClient::Request).to receive(:execute).and_raise(RestClient::Exceptions::ReadTimeout)
+  end
+
+  describe '.execute (webhook type behaviour)' do
+    it 're-raises for :macro_webhook so Sidekiq surfaces the failure' do
+      expect do
+        described_class.execute(url, payload, :macro_webhook)
+      end.to raise_error(RestClient::Exceptions::ReadTimeout)
+    end
+
+    it 'swallows for :api_inbox_webhook (legacy contract preserved)' do
+      expect do
+        described_class.execute(url, payload, :api_inbox_webhook)
+      end.not_to raise_error
+    end
+
+    it 'swallows for :account_webhook (legacy contract preserved)' do
+      expect do
+        described_class.execute(url, payload, :account_webhook)
+      end.not_to raise_error
+    end
+
+    it 'swallows for :inbox_webhook (legacy contract preserved)' do
+      expect do
+        described_class.execute(url, payload, :inbox_webhook)
+      end.not_to raise_error
+    end
+
+    it 'swallows for :agent_bot (legacy contract preserved)' do
+      expect do
+        described_class.execute(url, payload, :agent_bot)
+      end.not_to raise_error
+    end
+  end
+
+  describe '.execute (log format)' do
+    it 'keeps the legacy "Exception: Invalid webhook URL" prefix for grep compatibility' do
+      logger = instance_double(Logger, warn: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+
+      described_class.execute(url, payload, :account_webhook)
+
+      expect(logger).to have_received(:warn).with(/Exception: Invalid webhook URL/)
+    end
+
+    it 'redacts query string from the logged URL' do
+      logger = instance_double(Logger, warn: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+      sensitive_url = 'https://example.test/hook?token=secret123&other=foo'
+
+      described_class.execute(sensitive_url, payload, :account_webhook)
+
+      expect(logger).to have_received(:warn).with(satisfy { |msg|
+        msg.include?('https://example.test/hook') && msg.exclude?('token=secret123')
+      })
+    end
+
+    it 'falls back to <unparseable> for malformed URLs without crashing' do
+      logger = instance_double(Logger, warn: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+
+      expect do
+        described_class.execute('not a url at all', payload, :account_webhook)
+      end.not_to raise_error
+
+      expect(logger).to have_received(:warn).with(/Exception: Invalid webhook URL/)
+    end
+
+    it 'includes structured context (type, event, error class) after the legacy prefix' do
+      logger = instance_double(Logger, warn: nil)
+      allow(Rails).to receive(:logger).and_return(logger)
+
+      begin
+        described_class.execute(url, payload, :macro_webhook)
+      rescue RestClient::Exceptions::ReadTimeout
+        # expected — macro_webhook re-raises
+      end
+
+      expect(logger).to have_received(:warn).with(satisfy { |msg|
+        msg.include?('type=macro_webhook') &&
+          msg.include?('event=macro.executed') &&
+          msg.include?('error=RestClient::Exceptions::ReadTimeout')
+      })
+    end
+  end
+end

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -3,22 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Macros::ExecutionService do
-  let(:macro)        { instance_double(Macro, id: 'macro-123') }
-  let(:webhook_data) { { conversation: { id: 42 } } }
-  let(:conversation) { instance_double(Conversation, webhook_data: webhook_data) }
-  let(:user)         { instance_double(User, id: 'user-1') }
-
-  before do
-    allow(conversation).to receive(:reload).and_return(conversation)
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:macro) do
+    Macro.create!(
+      name: 'Test macro',
+      created_by: user,
+      updated_by: user,
+      actions: [{ 'action_name' => 'send_webhook_event', 'action_params' => ['https://webhook.site/abc'] }]
+    )
   end
 
   describe '#send_webhook_event' do
     let(:service) { described_class.new(macro, conversation, user) }
 
-    it 'enqueues WebhookJob with the stripped URL and macro.executed payload' do
+    it 'enqueues WebhookJob with the stripped URL, macro.executed payload, and :macro_webhook type' do
       expect(WebhookJob).to receive(:perform_later).with(
         'https://webhook.site/abc',
-        hash_including(event: 'macro.executed')
+        hash_including(event: 'macro.executed'),
+        :macro_webhook
       )
 
       service.send(:send_webhook_event, ["  https://webhook.site/abc  \t"])

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Macros::ExecutionService do
+  let(:macro)        { instance_double(Macro, id: 'macro-123') }
+  let(:webhook_data) { { conversation: { id: 42 } } }
+  let(:conversation) { instance_double(Conversation, webhook_data: webhook_data) }
+  let(:user)         { instance_double(User, id: 'user-1') }
+
+  before do
+    allow(conversation).to receive(:reload).and_return(conversation)
+  end
+
+  describe '#send_webhook_event' do
+    let(:service) { described_class.new(macro, conversation, user) }
+
+    it 'enqueues WebhookJob with the stripped URL and macro.executed payload' do
+      expect(WebhookJob).to receive(:perform_later).with(
+        'https://webhook.site/abc',
+        hash_including(event: 'macro.executed')
+      )
+
+      service.send(:send_webhook_event, ["  https://webhook.site/abc  \t"])
+    end
+
+    it 'skips enqueue and warns when the URL is blank' do
+      expect(WebhookJob).not_to receive(:perform_later)
+      expect(Rails.logger).to receive(:warn).with(/skipping send_webhook_event/)
+
+      service.send(:send_webhook_event, ['   '])
+    end
+
+    it 'skips enqueue when params is nil' do
+      expect(WebhookJob).not_to receive(:perform_later)
+      service.send(:send_webhook_event, nil)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Macro webhook actions silently swallowed delivery failures. `Webhooks::Trigger` rescued every `StandardError` and only emitted a warn log, while `Macros::ExecutionService#send_webhook_event` enqueued the job without validating the URL. The UI reported success even when nothing reached the destination.

- `lib/webhooks/trigger.rb`: re-raise for non `:api_inbox_webhook` types so Sidekiq logs/retries the failure, and enrich the warn log with `webhook_type`, `event`, `url` and `error` class. `:api_inbox_webhook` continues to swallow errors silently because `handle_error` already updates the message status and we don't want to retry user message dispatches on every transient hiccup.
- `app/services/macros/execution_service.rb`: skip enqueue when the URL is blank after stripping, log enqueue with `url` for traceability, and accept `nil` params safely.

## Validation

- `ruby -c app/services/macros/execution_service.rb`
- `ruby -c lib/webhooks/trigger.rb`
- `ruby -c spec/services/macros/execution_service_spec.rb`
- `bundle exec rspec spec/services/macros/execution_service_spec.rb` — 3 examples, 0 failures
- `bundle exec rspec spec/requests/api/v1/macros_spec.rb` — 1 example, 0 failures (regression check)
- `bundle exec rubocop lib/webhooks/trigger.rb spec/services/macros/execution_service_spec.rb` — clean

## Changed Files

- `lib/webhooks/trigger.rb`
- `app/services/macros/execution_service.rb`
- `spec/services/macros/execution_service_spec.rb`

## Linked Issue

- EVO-1041: https://linear.app/evoai/issue/EVO-1041/macro-webhook-action-ui-reports-success-but-webhook-destination-never

## Summary by Sourcery

Improve reliability and observability of macro webhook deliveries by surfacing invalid or failing webhook calls instead of silently swallowing them.

Bug Fixes:
- Ensure macro webhook jobs are not enqueued when the configured URL is blank or consists only of whitespace, preventing no-op deliveries that previously appeared successful.

Enhancements:
- Enrich webhook delivery failure logging with webhook type, event, URL, and error class, and re-raise non inbox webhook errors so they are retried and visible in Sidekiq and error tracking.
- Add logging around macro webhook enqueueing to trace which URLs are targeted and when sends are skipped due to invalid configuration.

Tests:
- Add service specs for macro webhook execution to cover URL sanitization, empty URL handling, and webhook job enqueue behavior.