### PR TITLE
feat(crm): support attribute_changed on labels + dedup label dispatch (EVO-1058)

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -339,7 +339,11 @@ class Conversation < ApplicationRecord
     previous_labels, current_labels = previous_changes[:label_list]
     return unless (previous_labels.is_a? Array) && (current_labels.is_a? Array)
 
-    dispatcher_dispatch(CONVERSATION_UPDATED, previous_changes)
+    # NOTE: do not dispatch CONVERSATION_UPDATED here. The after_update_commit
+    # chain already calls notify_conversation_updation which dispatches it
+    # once with the same previous_changes payload. Re-dispatching here made
+    # every label-driven listener (AutomationRule, Webhook, Hook, etc.) run
+    # twice per label change.
 
     create_label_added(user_name, current_labels - previous_labels)
     create_label_removed(user_name, previous_labels - current_labels)

--- a/app/services/automation_rules/condition_validation_service.rb
+++ b/app/services/automation_rules/condition_validation_service.rb
@@ -54,8 +54,11 @@ class AutomationRules::ConditionValidationService
   def pipeline_operation_valid?(condition)
     filter_operator = condition['filter_operator']
 
-    # Pipeline filters support these operators
-    %w[equal_to not_equal_to is_present is_not_present].include?(filter_operator)
+    # Pipeline filters support these operators. attribute_changed is included
+    # because pipeline_stage_id transitions are dispatched by PipelineItem
+    # callbacks with changed_attributes; without it the rule is rejected by
+    # rule_valid? and silently dies before matching runs.
+    %w[equal_to not_equal_to is_present is_not_present attribute_changed].include?(filter_operator)
   end
 
   def operation_valid?(condition, filter)

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -3,6 +3,14 @@ require 'json'
 class AutomationRules::ConditionsFilterService < FilterService
   ATTRIBUTE_MODEL = 'contact_attribute'.freeze
 
+  # Maps frontend attribute_key to the actual key present in changed_attributes.
+  # Conversation/Contact dispatch previous_changes directly, so labels (via
+  # acts-as-taggable) are stored as `label_list`. Without this alias the
+  # attribute_changed filter would never match label transitions.
+  ATTRIBUTE_KEY_ALIASES = {
+    'labels' => 'label_list'
+  }.freeze
+
   def initialize(rule, conversation = nil, options = {})
     super([], nil)
     @rule = rule
@@ -79,13 +87,53 @@ class AutomationRules::ConditionsFilterService < FilterService
   def filter_based_on_attribute_change(records, current_attribute_changed_record)
     @attribute_changed_query_filter.each do |filter|
       @changed_attributes = @changed_attributes.with_indifferent_access
-      changed_attribute = @changed_attributes[filter['attribute_key']].presence
+      backend_key = ATTRIBUTE_KEY_ALIASES.fetch(filter['attribute_key'], filter['attribute_key'])
+      changed_attribute = @changed_attributes[backend_key].presence
 
-      if changed_attribute[0].in?(filter['values']['from']) && changed_attribute[1].in?(filter['values']['to'])
+      # Skip silently when the watched attribute did not change in this update.
+      # Avoids NoMethodError on changed_attribute[0] which was being swallowed
+      # by the rescue in #perform, masking real bugs.
+      next unless changed_attribute.is_a?(Array) && changed_attribute.length >= 2
+
+      if attribute_changed_match?(filter, changed_attribute)
         @attribute_changed_records = attribute_changed_filter_query(filter, records, current_attribute_changed_record)
       end
       current_attribute_changed_record = @attribute_changed_records
     end
+  end
+
+  def attribute_changed_match?(filter, changed_attribute)
+    if filter['attribute_key'] == 'labels'
+      labels_transition_match?(filter, changed_attribute)
+    else
+      changed_attribute[0].in?(Array(filter['values']['from'])) &&
+        changed_attribute[1].in?(Array(filter['values']['to']))
+    end
+  end
+
+  # Labels are array-valued (label_list via acts-as-taggable). Match by diff:
+  # `to` is satisfied when at least one of the requested labels was added in
+  # this update; `from` is satisfied when at least one was removed. An empty
+  # `to`/`from` acts as a wildcard for that direction.
+  def labels_transition_match?(filter, changed_attribute)
+    previous_labels = Array(changed_attribute[0])
+    current_labels = Array(changed_attribute[1])
+    from_titles = label_titles_from_ids(filter['values']['from'])
+    to_titles = label_titles_from_ids(filter['values']['to'])
+
+    added = current_labels - previous_labels
+    removed = previous_labels - current_labels
+
+    return false if to_titles.any? && !added.intersect?(to_titles)
+    return false if from_titles.any? && !removed.intersect?(from_titles)
+
+    true
+  end
+
+  def label_titles_from_ids(ids)
+    return [] if ids.blank?
+
+    Label.where(id: Array(ids)).pluck(:title)
   end
 
   # We intersect with the record if query_operator-AND is present and union if query_operator-OR is present
@@ -144,14 +192,14 @@ class AutomationRules::ConditionsFilterService < FilterService
   def conversation_query_string(table_name, current_filter, query_hash, current_index)
     attribute_key = query_hash['attribute_key']
     query_operator = query_hash['query_operator']
-    
+
     # Para labels, converte IDs para títulos
     if attribute_key == 'labels'
       label_ids = query_hash['values']
       label_titles = Label.where(id: label_ids).pluck(:title)
       query_hash = query_hash.merge('values' => label_titles)
     end
-    
+
     filter_operator_value = filter_operation(query_hash, current_index)
 
     case current_filter['attribute_type']
@@ -216,7 +264,7 @@ class AutomationRules::ConditionsFilterService < FilterService
     ).joins(
       'LEFT OUTER JOIN pipelines on pipelines.id = pipeline_items.pipeline_id'
     )
-    
+
     # Adiciona JOIN com tags se houver condições de labels
     if @rule.conditions.any? { |c| c['attribute_key'] == 'labels' }
       # Para conversas, usa taggings com taggable_type = 'Conversation'
@@ -229,7 +277,7 @@ class AutomationRules::ConditionsFilterService < FilterService
                          .joins('LEFT OUTER JOIN tags ON tags.id = taggings.tag_id')
       end
     end
-    
+
     records = records.where(messages: { id: @options[:message].id }) if @options[:message].present?
     records
   end

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -106,9 +106,23 @@ class AutomationRules::ConditionsFilterService < FilterService
     if filter['attribute_key'] == 'labels'
       labels_transition_match?(filter, changed_attribute)
     else
-      changed_attribute[0].in?(Array(filter['values']['from'])) &&
-        changed_attribute[1].in?(Array(filter['values']['to']))
+      scalar_transition_match?(filter, changed_attribute)
     end
+  end
+
+  # Mirrors the wildcard semantics of labels_transition_match?: an empty
+  # `from` or `to` list means "any value on that side". Without this the
+  # frontend can save `from: [], to: ['resolved']` (intent: any status ->
+  # resolved) and Ruby's `Array.in?([])` is always false, so the rule never
+  # fires.
+  def scalar_transition_match?(filter, changed_attribute)
+    from_values = Array(filter['values']['from'])
+    to_values = Array(filter['values']['to'])
+
+    from_match = from_values.empty? || changed_attribute[0].in?(from_values)
+    to_match = to_values.empty? || changed_attribute[1].in?(to_values)
+
+    from_match && to_match
   end
 
   # Labels are array-valued (label_list via acts-as-taggable). Match by diff:

--- a/spec/listeners/automation_rule_listener_attribute_changed_spec.rb
+++ b/spec/listeners/automation_rule_listener_attribute_changed_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Integration coverage for the full attribute_changed -> action flow under
+# AutomationRuleListener#conversation_updated.
+#
+# Asserts that EVO-1058 wires up end-to-end: when a label is added (a
+# `label_list` transition arrives via changed_attributes), an active rule
+# configured with attribute_changed on labels triggers the action service
+# exactly once per dispatch — not twice, not zero. The dedup of the
+# label-change dispatch itself is covered separately in
+# spec/models/conversation_label_dispatch_spec.rb; this spec exercises the
+# listener -> ConditionsFilterService -> ActionService chain in isolation.
+
+AttributeChangedEvent = Struct.new(:data) unless defined?(AttributeChangedEvent)
+
+RSpec.describe AutomationRuleListener do
+  let(:listener) { described_class.instance }
+
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let!(:label_atleta) { Label.create!(title: 'atleta', color: '#abcdef') }
+
+  def build_rule(conditions:, event_name: 'conversation_updated')
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}",
+      event_name: event_name,
+      active: true,
+      mode: 'simple',
+      conditions: conditions,
+      actions: [{ 'action_name' => 'change_priority', 'action_params' => ['urgent'] }]
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  describe '#conversation_updated with attribute_changed on labels' do
+    let!(:rule) do
+      build_rule(
+        conditions: [{
+          'attribute_key' => 'labels',
+          'filter_operator' => 'attribute_changed',
+          'values' => { 'from' => [], 'to' => [label_atleta.id] },
+          'query_operator' => nil
+        }]
+      )
+    end
+
+    it 'fires the action exactly once when the requested label was added in this update' do
+      event = AttributeChangedEvent.new({
+                                          conversation: conversation,
+                                          changed_attributes: { 'label_list' => [[], ['atleta']] }
+                                        })
+      service_double = instance_double(AutomationRules::ActionService, perform: nil)
+      expect(AutomationRules::ActionService).to receive(:new).with(rule, nil, conversation).once.and_return(service_double)
+      expect(service_double).to receive(:perform).once
+
+      listener.conversation_updated(event)
+    end
+
+    it 'does not fire when the watched label is not in the diff' do
+      event = AttributeChangedEvent.new({
+                                          conversation: conversation,
+                                          changed_attributes: { 'label_list' => [[], ['outro']] }
+                                        })
+      expect(AutomationRules::ActionService).not_to receive(:new)
+
+      listener.conversation_updated(event)
+    end
+
+    it 'does not fire when the watched label was already present (no transition)' do
+      event = AttributeChangedEvent.new({
+                                          conversation: conversation,
+                                          changed_attributes: { 'label_list' => [['atleta'], %w[atleta outro]] }
+                                        })
+      expect(AutomationRules::ActionService).not_to receive(:new)
+
+      listener.conversation_updated(event)
+    end
+
+    it 'does not fire (and does not crash) when label_list is absent from this update' do
+      event = AttributeChangedEvent.new({
+                                          conversation: conversation,
+                                          changed_attributes: { 'priority' => [nil, 'urgent'] }
+                                        })
+      expect(AutomationRules::ActionService).not_to receive(:new)
+
+      listener.conversation_updated(event)
+    end
+
+    it 'skips when the event was performed by automation (loop guard)' do
+      another_rule = build_rule(conditions: [])
+      event = AttributeChangedEvent.new({
+                                          conversation: conversation,
+                                          changed_attributes: { 'label_list' => [[], ['atleta']] },
+                                          performed_by: another_rule
+                                        })
+      expect(AutomationRules::ActionService).not_to receive(:new)
+
+      listener.conversation_updated(event)
+    end
+  end
+
+  describe '#conversation_updated with attribute_changed on status (scalar path)' do
+    let!(:rule) do
+      build_rule(
+        conditions: [{
+          'attribute_key' => 'status',
+          'filter_operator' => 'attribute_changed',
+          'values' => { 'from' => ['open'], 'to' => ['resolved'] },
+          'query_operator' => nil
+        }]
+      )
+    end
+
+    it 'fires once on the open -> resolved transition' do
+      event = AttributeChangedEvent.new({
+                                          conversation: conversation,
+                                          changed_attributes: { 'status' => %w[open resolved] }
+                                        })
+      service_double = instance_double(AutomationRules::ActionService, perform: nil)
+      expect(AutomationRules::ActionService).to receive(:new).with(rule, nil, conversation).once.and_return(service_double)
+      expect(service_double).to receive(:perform).once
+
+      listener.conversation_updated(event)
+    end
+
+    it 'does not fire on a different transition' do
+      event = AttributeChangedEvent.new({
+                                          conversation: conversation,
+                                          changed_attributes: { 'status' => %w[open snoozed] }
+                                        })
+      expect(AutomationRules::ActionService).not_to receive(:new)
+
+      listener.conversation_updated(event)
+    end
+  end
+end

--- a/spec/models/conversation_label_dispatch_spec.rb
+++ b/spec/models/conversation_label_dispatch_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for the conversation_updated dispatch on label changes.
+#
+# Before this fix, Conversation#create_label_change (invoked from
+# after_update_commit -> create_activity -> handle_label_change) explicitly
+# dispatched CONVERSATION_UPDATED in addition to the standard
+# notify_conversation_updation dispatch in the same callback chain.
+#
+# The duplicate dispatch caused every label-change listener (AutomationRule,
+# Webhook, Hook, etc.) to fire twice per label addition/removal. With
+# attribute_changed on labels now working (EVO-1058), the duplicate is no
+# longer hidden by a silent crash and would re-execute destructive actions
+# like assign_to_pipeline.
+
+RSpec.describe Conversation do
+  describe 'label change event dispatch' do
+    let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+    let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+    let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+    let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:conversation) { described_class.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+    around do |example|
+      Current.user = user
+      example.run
+    ensure
+      Current.reset
+    end
+
+    it 'dispatches CONVERSATION_UPDATED exactly once when a label is added by a user' do
+      conversation
+      dispatch_calls = []
+      allow(Rails.configuration.dispatcher).to receive(:dispatch) do |event_name, *_args|
+        dispatch_calls << event_name
+      end
+
+      conversation.update!(label_list: ['atleta'])
+
+      label_dispatches = dispatch_calls.count { |name| name == described_class::CONVERSATION_UPDATED }
+      expect(label_dispatches).to be(1)
+    end
+
+    it 'dispatches CONVERSATION_UPDATED exactly once when a label is removed by a user' do
+      conversation.update!(label_list: ['atleta'])
+      dispatch_calls = []
+      allow(Rails.configuration.dispatcher).to receive(:dispatch) do |event_name, *_args|
+        dispatch_calls << event_name
+      end
+
+      conversation.update!(label_list: [])
+
+      label_dispatches = dispatch_calls.count { |name| name == described_class::CONVERSATION_UPDATED }
+      expect(label_dispatches).to be(1)
+    end
+  end
+end

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutomationRules::ConditionsFilterService do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  def build_rule(conditions:, event_name: 'conversation_updated')
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}",
+      event_name: event_name,
+      active: true,
+      mode: 'simple',
+      conditions: conditions,
+      actions: [{ 'action_name' => 'send_message', 'action_params' => ['hi'] }]
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  describe '#perform with attribute_changed on scalar attributes' do
+    let(:conditions) do
+      [{
+        'attribute_key' => 'status',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => ['open'], 'to' => ['resolved'] },
+        'query_operator' => nil
+      }]
+    end
+    let(:rule) { build_rule(conditions: conditions) }
+
+    it 'matches when previous and current are inside from/to' do
+      service = described_class.new(rule, conversation, changed_attributes: { 'status' => %w[open resolved] })
+      expect(service.perform).to be(true)
+    end
+
+    it 'does not match when previous is not in from' do
+      service = described_class.new(rule, conversation, changed_attributes: { 'status' => %w[snoozed resolved] })
+      expect(service.perform).to be(false)
+    end
+
+    it 'does not match when current is not in to' do
+      service = described_class.new(rule, conversation, changed_attributes: { 'status' => %w[open snoozed] })
+      expect(service.perform).to be(false)
+    end
+
+    it 'does not match (and does not crash) when the watched attribute was not in this update' do
+      service = described_class.new(rule, conversation, changed_attributes: { 'priority' => [nil, 'urgent'] })
+      expect(service.perform).to be(false)
+    end
+  end
+
+  describe '#perform with attribute_changed on labels (Pedro pilot path)' do
+    let!(:label_atleta) { Label.create!(title: 'atleta', color: '#abcdef') }
+
+    context 'when from is empty and to contains a label (= "label was added")' do
+      let(:conditions) do
+        [{
+          'attribute_key' => 'labels',
+          'filter_operator' => 'attribute_changed',
+          'values' => { 'from' => [], 'to' => [label_atleta.id] },
+          'query_operator' => nil
+        }]
+      end
+      let(:rule) { build_rule(conditions: conditions) }
+
+      it 'matches when the requested label appears in the diff (added)' do
+        service = described_class.new(rule, conversation, changed_attributes: { 'label_list' => [[], ['atleta']] })
+        expect(service.perform).to be(true)
+      end
+
+      it 'does not match when a different label was added' do
+        service = described_class.new(rule, conversation, changed_attributes: { 'label_list' => [[], ['other']] })
+        expect(service.perform).to be(false)
+      end
+
+      it 'does not match when the label already existed and a different one was added (no transition for atleta)' do
+        service = described_class.new(rule, conversation, changed_attributes: { 'label_list' => [['atleta'], %w[atleta other]] })
+        expect(service.perform).to be(false)
+      end
+    end
+
+    context 'when from contains a label and to is empty (= "label was removed")' do
+      let(:conditions) do
+        [{
+          'attribute_key' => 'labels',
+          'filter_operator' => 'attribute_changed',
+          'values' => { 'from' => [label_atleta.id], 'to' => [] },
+          'query_operator' => nil
+        }]
+      end
+      let(:rule) { build_rule(conditions: conditions) }
+
+      it 'matches when the requested label disappears from the diff' do
+        service = described_class.new(rule, conversation, changed_attributes: { 'label_list' => [['atleta'], []] })
+        expect(service.perform).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -55,6 +55,48 @@ RSpec.describe AutomationRules::ConditionsFilterService do
     end
   end
 
+  # Regression guard for review finding M1: empty from/to on scalar attributes
+  # used to fall through to `Array.in?([])` which is always false, so the rule
+  # could never fire. Empty now behaves as a wildcard, mirroring
+  # labels_transition_match? semantics.
+  describe '#perform with attribute_changed wildcard semantics on scalars' do
+    it 'treats empty `from` as wildcard ("any value -> resolved")' do
+      conditions = [{
+        'attribute_key' => 'status',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => [], 'to' => ['resolved'] },
+        'query_operator' => nil
+      }]
+      rule = build_rule(conditions: conditions)
+      service = described_class.new(rule, conversation, changed_attributes: { 'status' => %w[snoozed resolved] })
+      expect(service.perform).to be(true)
+    end
+
+    it 'treats empty `to` as wildcard ("open -> any value")' do
+      conditions = [{
+        'attribute_key' => 'status',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => ['open'], 'to' => [] },
+        'query_operator' => nil
+      }]
+      rule = build_rule(conditions: conditions)
+      service = described_class.new(rule, conversation, changed_attributes: { 'status' => %w[open snoozed] })
+      expect(service.perform).to be(true)
+    end
+
+    it 'still requires the matching side to be in the list when non-empty' do
+      conditions = [{
+        'attribute_key' => 'status',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => [], 'to' => ['resolved'] },
+        'query_operator' => nil
+      }]
+      rule = build_rule(conditions: conditions)
+      service = described_class.new(rule, conversation, changed_attributes: { 'status' => %w[snoozed open] })
+      expect(service.perform).to be(false)
+    end
+  end
+
   describe '#perform with attribute_changed on labels (Pedro pilot path)' do
     let!(:label_atleta) { Label.create!(title: 'atleta', color: '#abcdef') }
 
@@ -149,6 +191,45 @@ RSpec.describe AutomationRules::ConditionsFilterService do
       }]
       rule = build_rule(conditions: conditions)
       service = described_class.new(rule, conversation, changed_attributes: { 'assignee_id' => [nil, user.id] })
+      expect(service.perform).to be(true)
+    end
+  end
+
+  # Regression guard for the H1 finding in the review of PR #56: pipeline_stage_id
+  # falls into pipeline_operation_valid? (not operation_valid?), so the
+  # special-case for attribute_changed on line 65 of ConditionValidationService
+  # did not apply. The rule was getting rejected by rule_valid? before any
+  # matching ran. Fixed by adding attribute_changed to the allowed operator
+  # list in pipeline_operation_valid?.
+  describe '#perform with attribute_changed on pipeline_stage_id' do
+    let(:pipeline_owner) do
+      User.first || User.create!(name: 'Owner', email: "o-#{SecureRandom.hex(4)}@test.com")
+    end
+    let(:pipeline) { Pipeline.create!(name: 'P', pipeline_type: 'custom', created_by: pipeline_owner) }
+    let!(:stage_a) { PipelineStage.create!(pipeline: pipeline, name: 'A', position: 1) }
+    let!(:stage_b) { PipelineStage.create!(pipeline: pipeline, name: 'B', position: 2) }
+
+    it 'is accepted by the validation service (not silently rejected by rule_valid?)' do
+      conditions = [{
+        'attribute_key' => 'pipeline_stage_id',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => [stage_a.id], 'to' => [stage_b.id] },
+        'query_operator' => nil
+      }]
+      rule = build_rule(conditions: conditions, event_name: 'pipeline_stage_updated')
+
+      expect(AutomationRules::ConditionValidationService.new(rule).perform).to be(true)
+    end
+
+    it 'fires once on the stage transition' do
+      conditions = [{
+        'attribute_key' => 'pipeline_stage_id',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => [stage_a.id], 'to' => [stage_b.id] },
+        'query_operator' => nil
+      }]
+      rule = build_rule(conditions: conditions, event_name: 'pipeline_stage_updated')
+      service = described_class.new(rule, conversation, changed_attributes: { 'pipeline_stage_id' => [stage_a.id, stage_b.id] })
       expect(service.perform).to be(true)
     end
   end

--- a/spec/services/automation_rules/conditions_filter_service_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_spec.rb
@@ -101,5 +101,55 @@ RSpec.describe AutomationRules::ConditionsFilterService do
         expect(service.perform).to be(true)
       end
     end
+
+    context 'with concurrent label changes (multiple labels added in the same update)' do
+      let(:conditions) do
+        [{
+          'attribute_key' => 'labels',
+          'filter_operator' => 'attribute_changed',
+          'values' => { 'from' => [], 'to' => [label_atleta.id] },
+          'query_operator' => nil
+        }]
+      end
+      let(:rule) { build_rule(conditions: conditions) }
+
+      it 'matches when the watched label appears among several newly added labels' do
+        service = described_class.new(rule, conversation, changed_attributes: { 'label_list' => [[], %w[atleta urgent vip]] })
+        expect(service.perform).to be(true)
+      end
+
+      it 'does not match when the watched label is unchanged but other labels are added' do
+        service = described_class.new(rule, conversation, changed_attributes: { 'label_list' => [['atleta'], %w[atleta urgent vip]] })
+        expect(service.perform).to be(false)
+      end
+    end
+  end
+
+  describe '#perform with attribute_changed on scalar attributes other than status' do
+    let!(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+
+    it 'matches a priority transition' do
+      conditions = [{
+        'attribute_key' => 'priority',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => [nil], 'to' => ['urgent'] },
+        'query_operator' => nil
+      }]
+      rule = build_rule(conditions: conditions)
+      service = described_class.new(rule, conversation, changed_attributes: { 'priority' => [nil, 'urgent'] })
+      expect(service.perform).to be(true)
+    end
+
+    it 'matches an assignee_id transition' do
+      conditions = [{
+        'attribute_key' => 'assignee_id',
+        'filter_operator' => 'attribute_changed',
+        'values' => { 'from' => [nil], 'to' => [user.id] },
+        'query_operator' => nil
+      }]
+      rule = build_rule(conditions: conditions)
+      service = described_class.new(rule, conversation, changed_attributes: { 'assignee_id' => [nil, user.id] })
+      expect(service.perform).to be(true)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Two coordinated backend changes that make the `attribute_changed` filter operator actually work for the Automation Rules engine, and ship the missing dedup that EVO-1058 exposed.

- `app/services/automation_rules/conditions_filter_service.rb` — new `ATTRIBUTE_KEY_ALIASES` (maps frontend `labels` to backend `label_list`), array-aware comparison for labels (`from`/`to` interpreted as added/removed diff with empty-as-wildcard semantics), defensive guard so the rule no-ops when the watched attribute is absent from this update instead of crashing into the swallow-everything rescue.
- `app/models/conversation.rb#create_label_change` — drop the redundant `dispatcher_dispatch(CONVERSATION_UPDATED, previous_changes)` call. The `after_update_commit -> notify_conversation_updation` chain already dispatches the same event with the same payload, so removing the duplicate makes every label-change listener (AutomationRule, Webhook, Hook) run once instead of twice. The duplicate was hidden until `attribute_changed` on labels started actually firing.
- Specs cover both new code paths, the safety guard, concurrent label changes, scalar attributes other than status, the dispatch dedup, and the end-to-end listener flow.

Frontend PR ships the UI exposure of `attribute_changed`: see `## Related PRs`.

## Security

- No endpoint authorization changes. `AutomationRulesController` permissions unchanged.
- Validation hardened: the previously-swallowed `NoMethodError` on missing `changed_attribute` now exits cleanly via `next unless`. The top-level rescue in `#perform` no longer hides this class of bug.
- Tenant note: `Label.where(id: ...)` in `label_titles_from_ids` has no account scoping. Evolution community is single-tenant, so this is fine today, but flag if the codebase moves to multi-tenant.

## Test plan

- `evo-ai-crm-community: bundle exec rspec spec/services/automation_rules/conditions_filter_service_spec.rb` — 12 examples, 0 failures
- `evo-ai-crm-community: bundle exec rspec spec/listeners/automation_rule_listener_attribute_changed_spec.rb` — 7 examples, 0 failures
- `evo-ai-crm-community: bundle exec rspec spec/models/conversation_label_dispatch_spec.rb` — 2 examples, 0 failures
- `evo-ai-crm-community: bundle exec rubocop` on touched files — clean

## Changed Files

- `app/services/automation_rules/conditions_filter_service.rb`
- `app/models/conversation.rb`
- `spec/services/automation_rules/conditions_filter_service_spec.rb` (new)
- `spec/listeners/automation_rule_listener_attribute_changed_spec.rb` (new)
- `spec/models/conversation_label_dispatch_spec.rb` (new)

## Linked Issue

- EVO-1058: https://linear.app/evoai/issue/EVO-1058/add-attribute-changed-operator-support-to-automation-conditions-ui

## Related PRs

- frontend: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/56