### PR TITLE
fix(bulk-actions): return per-item success/failed ids (EVO-1011)

### DIFF
--- a/app/controllers/api/v1/bulk_actions_controller.rb
+++ b/app/controllers/api/v1/bulk_actions_controller.rb
@@ -3,13 +3,13 @@ class Api::V1::BulkActionsController < Api::V1::BaseController
 
   def create
     if type_matches?
-      ::BulkActionsJob.perform_now(
+      result = ::BulkActionsJob.perform_now(
         user: current_user,
         params: permitted_params
       )
-      
+
       success_response(
-        data: nil,
+        data: result,
         message: 'Bulk action completed successfully',
         status: :created
       )

--- a/app/jobs/bulk_actions_job.rb
+++ b/app/jobs/bulk_actions_job.rb
@@ -18,6 +18,7 @@ class BulkActionsJob < ApplicationJob
   def bulk_update
     if @params[:type] == 'Contact'
       bulk_contact_update
+      { success_ids: [], failed_ids: [] }
     else
       bulk_remove_labels
       bulk_conversation_update
@@ -35,11 +36,19 @@ class BulkActionsJob < ApplicationJob
 
   def bulk_conversation_update
     params = available_params(@params)
+    success_ids = []
+    failed_ids = []
+
     records.each do |conversation|
       bulk_add_labels(conversation)
       bulk_snoozed_until(conversation)
       conversation.update!(params) if params
+      success_ids << conversation.display_id
+    rescue StandardError
+      failed_ids << conversation.display_id
     end
+
+    { success_ids: success_ids, failed_ids: failed_ids }
   end
 
   def bulk_remove_labels


### PR DESCRIPTION
## Summary
- `BulkActionsJob#bulk_conversation_update` now collects `success_ids` and `failed_ids` per conversation using a rescue clause inside the iteration
- `BulkActionsController#create` captures the job result and includes it in the API response payload
- Frontend can now show accurate per-item failure toasts (e.g., "8 resolved, 2 failed")

## Validation
- `evo-ai-crm-community: bundle exec ruby -c app/jobs/bulk_actions_job.rb`
- `evo-ai-crm-community: bundle exec ruby -c app/controllers/api/v1/bulk_actions_controller.rb`

## Changed Files
- `app/jobs/bulk_actions_job.rb`
- `app/controllers/api/v1/bulk_actions_controller.rb`

## Related PRs
- Frontend: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/50

## Linked Issue
- EVO-1011

## Summary by Sourcery

Report per-item success and failure IDs from bulk conversation updates and expose them in the bulk actions API response.

New Features:
- Return success and failure conversation IDs from bulk conversation updates in the bulk actions job.
- Include bulk action result metadata (success and failure IDs) in the bulk actions create API response payload.