### PR TITLE
fix: Evolution Go/API — GlobalConfig fallback, rollback auth, interactive messages

### DIFF
--- a/app/controllers/api/v1/evolution/health_controller.rb
+++ b/app/controllers/api/v1/evolution/health_controller.rb
@@ -2,10 +2,10 @@ class Api::V1::Evolution::HealthController < Api::V1::BaseController
   TIMEOUT_SECONDS = 5
 
   def show
-    api_url = params[:api_url].to_s
+    api_url = params[:api_url].presence || GlobalConfigService.load('EVOLUTION_API_URL', '').to_s.strip
 
     if api_url.blank?
-      render json: { error: 'api_url is required' }, status: :bad_request
+      render json: { error: 'api_url is required. Provide it in the request or configure EVOLUTION_API_URL globally.' }, status: :bad_request
       return
     end
 

--- a/app/controllers/api/v1/evolution/proxies_controller.rb
+++ b/app/controllers/api/v1/evolution/proxies_controller.rb
@@ -32,10 +32,12 @@ class Api::V1::Evolution::ProxiesController < Api::V1::BaseController
     begin
       # Extract parameters
       proxy_params = params[:proxy] || params
-      api_url = proxy_params[:api_url]
-      api_hash = proxy_params[:api_hash]
       instance_name = proxy_params[:instance_name]
       proxy_settings = proxy_params[:proxy_settings]
+
+      # Resolve credentials with GlobalConfig fallback for legacy channels
+      channel = find_whatsapp_channel_by_instance_name(instance_name)
+      api_url, api_hash = resolve_evolution_credentials(channel, proxy_params)
 
       Rails.logger.info "Evolution API: Setting proxy for instance #{instance_name}"
 

--- a/app/controllers/api/v1/evolution/qrcodes_controller.rb
+++ b/app/controllers/api/v1/evolution/qrcodes_controller.rb
@@ -32,9 +32,11 @@ class Api::V1::Evolution::QrcodesController < Api::V1::BaseController
     begin
       # Extract parameters
       auth_params = params[:qrcode] || params
-      api_url = auth_params[:api_url]
-      api_hash = auth_params[:api_hash]
       instance_name = auth_params[:instance_name]
+
+      # Resolve credentials with GlobalConfig fallback for legacy channels
+      channel = find_whatsapp_channel_by_instance_name(instance_name)
+      api_url, api_hash = resolve_evolution_credentials(channel, auth_params)
 
       Rails.logger.info "Evolution API: Refreshing QR code for instance #{instance_name}"
 

--- a/app/controllers/api/v1/evolution/settings_controller.rb
+++ b/app/controllers/api/v1/evolution/settings_controller.rb
@@ -32,10 +32,12 @@ class Api::V1::Evolution::SettingsController < Api::V1::BaseController
     begin
       # Extract parameters
       settings_params = params[:settings] || params
-      api_url = settings_params[:api_url]
-      api_hash = settings_params[:api_hash]
       instance_name = settings_params[:instance_name]
       instance_settings = settings_params[:instance_settings]
+
+      # Resolve credentials with GlobalConfig fallback for legacy channels
+      channel = find_whatsapp_channel_by_instance_name(instance_name)
+      api_url, api_hash = resolve_evolution_credentials(channel, settings_params)
 
       Rails.logger.info "Evolution API: Setting instance settings for #{instance_name}"
 

--- a/app/controllers/api/v1/evolution_go/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution_go/authorizations_controller.rb
@@ -196,8 +196,26 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
   def delete_instance
     Rails.logger.info "Evolution Go API: Deleting instance #{@instance_uuid}"
 
+    if @api_url.blank? || @instance_uuid.blank?
+      return render json: {
+        error: 'Missing required parameters: api_url and instanceId'
+      }, status: :bad_request
+    end
+
+    # Evolution Go DELETE /instance/delete/:id is an AuthAdmin route — it requires
+    # the global API key (admin_token), NOT the per-instance token. During rollback
+    # the channel was never persisted so instance_token is unavailable; fall back to
+    # admin_token which is always resolvable via GlobalConfig.
+    auth_token = @instance_token.presence || @admin_token
+
+    if auth_token.blank?
+      return render json: {
+        error: 'Missing credentials: instance_token or admin_token required to delete instance'
+      }, status: :bad_request
+    end
+
     begin
-      delete_instance_go(@api_url, @instance_token, @instance_uuid)
+      delete_instance_go(@api_url, auth_token, @instance_uuid)
 
       render json: {
         success: true,

--- a/app/controllers/concerns/evolution_concern.rb
+++ b/app/controllers/concerns/evolution_concern.rb
@@ -32,6 +32,26 @@ module EvolutionConcern
     token.presence
   end
 
+  # Resolve credentials for create actions where the channel may not exist yet.
+  # Prefers channel-based lookup (with GlobalConfig fallback), falls back to
+  # raw request params for pre-creation flows (QR code refresh, proxy set, etc.).
+  def resolve_evolution_credentials(channel, raw_params)
+    if channel
+      evolution_credentials_for!(channel)
+    else
+      api_url = raw_params[:api_url].presence || GlobalConfigService.load('EVOLUTION_API_URL', '').to_s.strip
+      api_hash = raw_params[:api_hash].presence || GlobalConfigService.load('EVOLUTION_ADMIN_SECRET', '').to_s.strip
+
+      if api_url.blank? || api_hash.blank?
+        raise StandardError,
+              'Evolution API not configured. Provide api_url + api_hash in the request ' \
+              'or configure EVOLUTION_API_URL + EVOLUTION_ADMIN_SECRET globally.'
+      end
+
+      [api_url, api_hash]
+    end
+  end
+
   # Raise if either credential is missing — the message tells the operator
   # exactly what to configure rather than leaking a `nil.chomp` stack trace.
   def evolution_credentials_for!(channel)

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -7,6 +7,8 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
 
     if message.attachments.present?
       send_attachment_message(phone_number, message)
+    elsif message.content_type == 'input_select'
+      send_interactive_message(phone_number, message)
     elsif message.content.present?
       send_text_message(phone_number, message)
     else
@@ -202,6 +204,80 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
 
   def instance_name
     whatsapp_channel.provider_config['instance_name']
+  end
+
+  def send_interactive_message(phone_number, message)
+    clean_number = phone_number.delete('+')
+    items = message.content_attributes&.dig('items') || []
+
+    if items.empty?
+      Rails.logger.warn "[Evolution Go] Interactive message has no items, falling back to text"
+      return send_text_message(phone_number, message)
+    end
+
+    # Evolution Go /send/button supports max 3 reply buttons;
+    # /send/list supports more via sections.
+    if items.length <= 3
+      send_button_message(clean_number, message, items)
+    else
+      send_list_message(clean_number, message, items)
+    end
+  end
+
+  def send_button_message(clean_number, message, items)
+    buttons = items.map do |item|
+      { type: 'reply', reply: { id: item['value'].to_s, title: item['title'].to_s.truncate(20) } }
+    end
+
+    body = {
+      number: clean_number,
+      title: '',
+      description: html_to_whatsapp(message.content.to_s),
+      buttons: buttons,
+      delay: 0
+    }
+
+    quoted_info = build_quoted_info(message)
+    body[:quoted] = quoted_info if quoted_info.present?
+
+    Rails.logger.info "[Evolution Go] Sending button message to #{clean_number} with #{buttons.length} buttons"
+
+    response = HTTParty.post(
+      "#{api_base_path}/send/button",
+      headers: instance_headers,
+      body: body.to_json
+    )
+
+    process_evolution_go_response(response)
+  end
+
+  def send_list_message(clean_number, message, items)
+    rows = items.map do |item|
+      { id: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
+    end
+
+    body = {
+      number: clean_number,
+      title: '',
+      description: html_to_whatsapp(message.content.to_s),
+      buttonText: 'Menu',
+      footerText: '',
+      sections: [{ title: 'Options', rows: rows }],
+      delay: 0
+    }
+
+    quoted_info = build_quoted_info(message)
+    body[:quoted] = quoted_info if quoted_info.present?
+
+    Rails.logger.info "[Evolution Go] Sending list message to #{clean_number} with #{rows.length} rows"
+
+    response = HTTParty.post(
+      "#{api_base_path}/send/list",
+      headers: instance_headers,
+      body: body.to_json
+    )
+
+    process_evolution_go_response(response)
   end
 
   def send_text_message(phone_number, message)

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -7,6 +7,8 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
 
     if message.attachments.present?
       send_attachment_message(phone_number, message)
+    elsif message.content_type == 'input_select'
+      send_interactive_message(phone_number, message)
     elsif message.content.present?
       send_text_message(phone_number, message)
     else
@@ -293,6 +295,70 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
 
   def instance_name
     whatsapp_channel.provider_config['instance_name']
+  end
+
+  def send_interactive_message(phone_number, message)
+    clean_number = phone_number.delete('+')
+    items = message.content_attributes&.dig('items') || []
+
+    if items.empty?
+      Rails.logger.warn "[Evolution] Interactive message has no items, falling back to text"
+      return send_text_message(phone_number, message)
+    end
+
+    if items.length <= 3
+      send_button_message(clean_number, message, items)
+    else
+      send_list_message(clean_number, message, items)
+    end
+  end
+
+  def send_button_message(clean_number, message, items)
+    buttons = items.map do |item|
+      { type: 'reply', reply: { id: item['value'].to_s, title: item['title'].to_s.truncate(20) } }
+    end
+
+    body = {
+      number: clean_number,
+      title: '',
+      description: html_to_whatsapp(message.content.to_s),
+      buttons: buttons
+    }
+
+    Rails.logger.info "[Evolution] Sending button message to #{clean_number} with #{buttons.length} buttons"
+
+    response = HTTParty.post(
+      "#{api_base_path}/message/sendButtons/#{instance_name}",
+      headers: api_headers,
+      body: body.to_json
+    )
+
+    process_response(response)
+  end
+
+  def send_list_message(clean_number, message, items)
+    rows = items.map do |item|
+      { id: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
+    end
+
+    body = {
+      number: clean_number,
+      title: '',
+      description: html_to_whatsapp(message.content.to_s),
+      buttonText: 'Menu',
+      footerText: '',
+      sections: [{ title: 'Options', rows: rows }]
+    }
+
+    Rails.logger.info "[Evolution] Sending list message to #{clean_number} with #{rows.length} rows"
+
+    response = HTTParty.post(
+      "#{api_base_path}/message/sendList/#{instance_name}",
+      headers: api_headers,
+      body: body.to_json
+    )
+
+    process_response(response)
   end
 
   def send_text_message(phone_number, message)


### PR DESCRIPTION
## Summary

- **EVO-1045**: Evolution API controllers now fall back to GlobalConfig for legacy channels with empty provider_config
- **EVO-1043**: `delete_instance` rollback uses `admin_token` fallback, preventing orphan instances
- **EVO-980**: Added interactive message support (buttons/lists) for Evolution Go and Evolution API

## Changes

### EVO-1045 — GlobalConfig fallback for Evolution API
- Added `resolve_evolution_credentials()` to `EvolutionConcern` for DRY credential resolution
- Fixed `create` actions in `proxies_controller`, `qrcodes_controller`, `settings_controller`
- Fixed `health_controller` to fall back to `EVOLUTION_API_URL`

### EVO-1043 — Rollback auth fix
- `delete_instance` uses `admin_token` as fallback when `instance_token` is nil (rollback path)
- Added guard clauses for missing parameters

### EVO-980 — Interactive messages (buttons/lists)
- `EvolutionGoService`: dispatches to `/send/button` (≤3 items) or `/send/list` (>3 items)
- `EvolutionService`: dispatches to `/message/sendButtons` and `/message/sendList`
- `content_type='input_select'` now sends interactive payloads instead of `unsupported`

## Test plan

- [x] Create Evolution Go channel with GlobalConfig fallback (empty api_url/admin_token)
- [x] Verify QR code generation and instance connection works
- [ ] Force channel creation failure → verify rollback deletes orphan instance
- [ ] Send bot message with `input_select` → verify buttons/list on WhatsApp

## Summary by Sourcery

Add interactive WhatsApp input_select support for Evolution providers and improve Evolution API credential resolution and rollback safety.

New Features:
- Support sending interactive input_select messages as buttons or lists via Evolution Go and Evolution API providers.
- Allow automation rules to trigger on conversation_resolved and conversation_status_changed events.

Bug Fixes:
- Ensure Evolution API health checks and controller create actions fall back to GlobalConfig when api_url or admin credentials are omitted.
- Fix Evolution Go delete_instance rollback by falling back to admin_token when instance_token is unavailable and validating required parameters.

Enhancements:
- Centralize Evolution credential resolution for create flows with a helper that prefers channel config and falls back to global settings.
- Improve error messages for missing Evolution configuration in health checks and credential resolution.
- Update project README and contributing links to the new evolution-foundation GitHub organization.

Documentation:
- Update README and CONTRIBUTING links and clone instructions to point to the evolution-foundation GitHub repositories.