### PR TITLE
fix(crm): use valid pipeline_type in pipeline_item_spec fixture (EVO-1047)

### DIFF
--- a/spec/models/pipeline_item_spec.rb
+++ b/spec/models/pipeline_item_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PipelineItem, type: :model do
-  let(:pipeline) { Pipeline.create!(name: 'Test Pipeline', pipeline_type: 'lead', created_by: User.create!(email: 'test@example.com', name: 'Test User')) }
+  let(:pipeline) { Pipeline.create!(name: 'Test Pipeline', pipeline_type: 'sales', created_by: User.create!(email: 'test@example.com', name: 'Test User')) }
   let(:pipeline_stage) { PipelineStage.create!(pipeline: pipeline, name: 'Stage 1', position: 1) }
   let(:contact) { Contact.create!(name: 'Test Contact', email: 'contact@example.com') }
 


### PR DESCRIPTION
## Summary
- Replace `pipeline_type: 'lead'` (rejected by the `Pipeline` inclusion validator) with `'sales'` in the shared `let(:pipeline)` fixture at `spec/models/pipeline_item_spec.rb:6`.
- Unblocks 3 of 8 examples in the file. Remaining 5 failures are **not** caused by this fixture and are out of EVO-1047's literal scope (which forbids rewriting the spec).

## Why this is a partial fix (intentional)

The original intake for EVO-1047 assumed all 8 failures shared the same cause because the shared `let(:pipeline)` is lazy and explodes first in every example. Once the fixture is valid, 5 examples reveal pre-existing bugs in the spec itself:

- **3 examples** fail at `Inbox.create!(name: 'Test Inbox')` — `Inbox` requires the polymorphic `channel` association; the spec predates that contract.
- **2 examples** fail at `contact.destroy` with `PG::ForeignKeyViolation` on `pipeline_items.contact_id` — the spec tries to manufacture an orphan card directly, bypassing the cleanup path introduced by EVO-460.

The spec file has not been touched since 31/Mar/2026 (`Refactor account-related references in specs to remove dependency on Account model`) and has not kept up with EVO-460 (Feb — orphan cleanup contract), EVO-989/PR #44 (05/May — new `dispatch_initial_stage_event` callback), or EVO-1109 (13/May — Product Catalog touching `pipeline_item`).

A follow-up card covering the rewrite will be opened separately so this PR stays inside EVO-1047's literal scope (`out of scope: rewriting the spec; expanding test coverage`).

## Validation
- `evo-ai-crm-community: ruby -c spec/models/pipeline_item_spec.rb` → Syntax OK
- `evo-ai-crm-community: bundle exec rspec spec/models/pipeline_item_spec.rb` → 8 examples, **5 failures** (down from 8/8 on `develop`). The 3 fixed examples are the ones the spec literally covers (validator behaviour for `conversation_id` / `contact_id` mutual-exclusion baseline).

## Changed Files
- `spec/models/pipeline_item_spec.rb`

## Linked Issue
- EVO-1047

## Summary by Sourcery

Bug Fixes:
- Correct pipeline_type value in the shared pipeline fixture so it passes Pipeline inclusion validation in pipeline_item_spec.