### PR TITLE
fix: Evolution Go/API — dedup, clear config, GlobalConfig fallback, interactive messages

### DIFF
--- a/app/controllers/api/v1/admin/app_configs_controller.rb
+++ b/app/controllers/api/v1/admin/app_configs_controller.rb
@@ -66,6 +66,19 @@ module Api
           success_response(data: { config_type: config_type, configs: configs }, message: 'Configuration updated successfully')
         end
 
+        def destroy
+          config_type = params[:config_type]
+          allowed_keys = CONFIG_TYPES[config_type]
+          return config_type_not_found unless allowed_keys
+
+          ActiveRecord::Base.transaction do
+            InstallationConfig.where(name: allowed_keys).destroy_all
+            allowed_keys.each { |key| GlobalConfig.clear_cache }
+          end
+
+          success_response(data: { config_type: config_type }, message: 'Configuration cleared successfully')
+        end
+
         def test_connection
           config_type = params[:config_type]
           allowed_keys = CONFIG_TYPES[config_type]

--- a/app/services/whatsapp/evolution_go_handlers/helpers.rb
+++ b/app/services/whatsapp/evolution_go_handlers/helpers.rb
@@ -155,6 +155,13 @@ module Whatsapp::EvolutionGoHandlers::Helpers
     return false if raw_message_id.blank?
     return false unless message_content.present? || @evolution_go_message.present?
 
+    # Dedup: skip if message already exists in the database (prevents duplicates
+    # when Sidekiq retries or webhooks arrive twice)
+    if inbox.messages.exists?(source_id: raw_message_id)
+      Rails.logger.info "Evolution Go API: Skipping duplicate message #{raw_message_id}"
+      return false
+    end
+
     true
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
         get 'app_configs/:config_type', to: 'app_configs#show', as: :app_config
         post 'app_configs/:config_type', to: 'app_configs#create', as: :app_configs
         post 'app_configs/:config_type/test_connection', to: 'app_configs#test_connection', as: :test_app_config_connection
+        delete 'app_configs/:config_type', to: 'app_configs#destroy', as: :destroy_app_config
       end
 
       resource :global_config, controller: 'global_config', only: [:show]


### PR DESCRIPTION
## Summary

Batch of fixes for Evolution Go and Evolution API integration issues.

### EVO-1045: GlobalConfig fallback for Evolution API controllers
- `resolve_evolution_credentials()` in EvolutionConcern for DRY credential resolution
- proxies, qrcodes, settings, health controllers now fall back to GlobalConfig

### EVO-1043: Fix delete_instance rollback leaving orphan instances
- Uses admin_token as fallback when instance_token unavailable during rollback

### EVO-980: Interactive message support (buttons/lists)
- EvolutionGoService: /send/button (<=3 items) and /send/list (>3 items)
- EvolutionService: /message/sendButtons and /message/sendList

### EVO-1051: Clear Configuration action for Admin Settings
- DELETE /api/v1/admin/app_configs/:config_type endpoint
- Removes all InstallationConfig rows for the config type and clears cache

### Duplicate messages fix
- Evolution Go `message_processable?` was missing dedup check
- Added `inbox.messages.exists?(source_id:)` guard to prevent duplicates on Sidekiq retry

## Test plan

- [x] Create channel with GlobalConfig fallback
- [x] QR code generation works on legacy channels
- [x] Login works after SetupSurveyResponse model fix
- [x] Weak password returns 422 with structured errors
- [x] Messages no longer duplicate in chat
- [ ] Clear Configuration button resets config on Admin Settings screens

## Summary by Sourcery

Add an admin API endpoint to clear app configuration and prevent duplicate Evolution Go messages from being processed.

New Features:
- Expose DELETE /api/v1/admin/app_configs/:config_type to clear stored configuration for a given config type.

Bug Fixes:
- Skip processing Evolution Go messages that have already been stored to avoid duplicate messages on retries or duplicate webhooks.

Enhancements:
- Wire the new configuration clear action into the admin routes with a dedicated named route.