### PR TITLE
refactor(EVO-1113): consolidate credential resolution in EvolutionConcern

### DIFF
--- a/app/controllers/concerns/evolution_concern.rb
+++ b/app/controllers/concerns/evolution_concern.rb
@@ -4,66 +4,45 @@ module EvolutionConcern
   private
 
   # Resolve `api_url` for an Evolution channel, falling back to the global
-  # admin config when the channel itself was created with an empty
-  # `provider_config['api_url']`.
+  # admin config (EVOLUTION_API_URL) when the channel has an empty
+  # `provider_config['api_url']` or when channel is nil (pre-creation flows).
   #
-  # Why this exists: the Admin Settings page lets the operator configure the
-  # Evolution API URL once (saved into GlobalConfig as `EVOLUTION_API_URL`).
-  # Channels created afterwards leave `provider_config['api_url']` blank,
-  # relying on the backend to fall through to the global. `Whatsapp::Providers::
-  # EvolutionService` already does this fallback (see `validate_provider_config?`),
-  # but several REST controllers were calling `provider_config['api_url'].chomp('/')`
-  # directly and crashing with `undefined method 'chomp' for nil` whenever an
-  # operator used the global flow. Using this helper everywhere keeps the
-  # fallback consistent and surfaces a clear error when truly missing.
-  def evolution_api_url_for(channel)
-    return nil if channel.nil?
-
-    url = channel.provider_config&.dig('api_url').presence ||
+  # Accepts optional raw_params to check request params before GlobalConfig
+  # (used in create actions where the channel may not exist yet).
+  def evolution_api_url_for(channel, raw_params = {})
+    url = channel&.provider_config&.dig('api_url').presence ||
+          raw_params[:api_url].presence ||
           GlobalConfigService.load('EVOLUTION_API_URL', '').to_s.strip
     url.presence
   end
 
-  def evolution_admin_token_for(channel)
-    return nil if channel.nil?
-
-    token = channel.provider_config&.dig('admin_token').presence ||
+  def evolution_admin_token_for(channel, raw_params = {})
+    token = channel&.provider_config&.dig('admin_token').presence ||
+            raw_params[:api_hash].presence ||
             GlobalConfigService.load('EVOLUTION_ADMIN_SECRET', '').to_s.strip
     token.presence
   end
 
-  # Resolve credentials for create actions where the channel may not exist yet.
-  # Prefers channel-based lookup (with GlobalConfig fallback), falls back to
-  # raw request params for pre-creation flows (QR code refresh, proxy set, etc.).
-  def resolve_evolution_credentials(channel, raw_params)
-    if channel
-      evolution_credentials_for!(channel)
-    else
-      api_url = raw_params[:api_url].presence || GlobalConfigService.load('EVOLUTION_API_URL', '').to_s.strip
-      api_hash = raw_params[:api_hash].presence || GlobalConfigService.load('EVOLUTION_ADMIN_SECRET', '').to_s.strip
-
-      if api_url.blank? || api_hash.blank?
-        raise StandardError,
-              'Evolution API not configured. Provide api_url + api_hash in the request ' \
-              'or configure EVOLUTION_API_URL + EVOLUTION_ADMIN_SECRET globally.'
-      end
-
-      [api_url, api_hash]
-    end
-  end
-
-  # Raise if either credential is missing — the message tells the operator
-  # exactly what to configure rather than leaking a `nil.chomp` stack trace.
-  def evolution_credentials_for!(channel)
-    api_url = evolution_api_url_for(channel)
-    api_hash = evolution_admin_token_for(channel)
+  # Resolve credentials with GlobalConfig fallback. Works for both:
+  # - Existing channels (reads provider_config, falls back to GlobalConfig)
+  # - Pre-creation flows where channel is nil (reads raw_params, falls back to GlobalConfig)
+  #
+  # Raises with a clear message when credentials are missing from all sources.
+  def evolution_credentials_for!(channel, raw_params = {})
+    api_url = evolution_api_url_for(channel, raw_params)
+    api_hash = evolution_admin_token_for(channel, raw_params)
 
     if api_url.blank? || api_hash.blank?
       raise StandardError,
-            'Evolution API not configured. Set api_url + admin_token on the channel ' \
-            'or configure EVOLUTION_API_URL + EVOLUTION_ADMIN_SECRET globally.'
+            'Evolution API not configured. Set api_url + admin_token on the channel, ' \
+            'provide them in the request, or configure EVOLUTION_API_URL + EVOLUTION_ADMIN_SECRET globally.'
     end
 
     [api_url, api_hash]
+  end
+
+  # Convenience alias for controllers that pass raw_params in create actions.
+  def resolve_evolution_credentials(channel, raw_params)
+    evolution_credentials_for!(channel, raw_params)
   end
 end


### PR DESCRIPTION
## Summary

Eliminates duplicated credential resolution logic in `EvolutionConcern`. Before this change, there were two separate code paths with different error messages and duplicated `GlobalConfigService.load()` calls.

---

### Problem

`evolution_concern.rb` had two methods that resolved credentials differently:

1. **`evolution_credentials_for!(channel)`** — called `evolution_api_url_for(channel)` which did `return nil if channel.nil?`. When channel was nil (pre-creation flows), it returned nil instead of falling back to GlobalConfig. This forced controllers to use a different method.

2. **`resolve_evolution_credentials(channel, raw_params)`** — duplicated the `GlobalConfigService.load()` calls in a separate `else` branch when channel was nil. Error message said "api_hash" while the other method said "admin_token" — inconsistent vocabulary for the same credential.

### What was refactored

**File:** `app/controllers/concerns/evolution_concern.rb` (-46 +25 lines, net -21)

**Before (3 methods, 2 code paths):**
```ruby
def evolution_api_url_for(channel)
  return nil if channel.nil?  # ← blocked GlobalConfig fallback
  channel.provider_config&.dig('api_url').presence ||
    GlobalConfigService.load('EVOLUTION_API_URL', '').to_s.strip
end

def resolve_evolution_credentials(channel, raw_params)
  if channel
    evolution_credentials_for!(channel)
  else
    # ← duplicated GlobalConfigService.load() calls here
    api_url = raw_params[:api_url].presence || GlobalConfigService.load(...)
    # ← different error message ("api_hash" vs "admin_token")
  end
end
```

**After (single unified path):**
```ruby
def evolution_api_url_for(channel, raw_params = {})
  channel&.provider_config&.dig('api_url').presence ||
    raw_params[:api_url].presence ||
    GlobalConfigService.load('EVOLUTION_API_URL', '').to_s.strip
end

def evolution_credentials_for!(channel, raw_params = {})
  # single entry point, one error message
end

def resolve_evolution_credentials(channel, raw_params)
  evolution_credentials_for!(channel, raw_params)  # alias
end
```

**Resolution priority (same for api_url and admin_token):**
1. `channel.provider_config['api_url']` (if channel present)
2. `raw_params[:api_url]` (if provided in request)
3. `GlobalConfigService.load('EVOLUTION_API_URL')`
4. Raise with unified error message

**Backward compatibility:** `resolve_evolution_credentials` is now a one-line alias — no controller changes needed. Existing call sites in proxies, qrcodes, settings controllers continue working.

---

## Test plan

- [x] `ruby -c` syntax check on concern: OK
- [x] `ruby -c` syntax check on all 4 consumer controllers (proxies, qrcodes, settings, health): OK
- [x] Channel Configuration tab loads correctly (manually verified)
- [x] `resolve_evolution_credentials` remains backward-compatible alias
- [x] 1 file changed, clean scope, branch based on latest develop

## Summary by Sourcery

Unify Evolution API credential resolution in the EvolutionConcern to support both existing channels and pre-creation flows via a single code path.

Enhancements:
- Allow Evolution API URL and admin token to be resolved from channel provider_config, request parameters, or global config with a consistent precedence order.
- Standardize the error messaging for missing Evolution credentials across all controller usages and eliminate duplicated GlobalConfig lookups.
- Expose resolve_evolution_credentials as a thin alias to the unified evolution_credentials_for! helper for backward-compatible controller integrations.