### PR TITLE
fix(crm): apply storage provider from admin UI at runtime [EVO-1050]

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,12 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = (GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')) rescue ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')).to_sym
+  config.active_storage.service = begin
+    GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local'))
+  rescue StandardError => e
+    warn "[ActiveStorage] GlobalConfigService unavailable at boot (#{e.message}); falling back to ENV"
+    ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')
+  end.to_sym
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = ActiveModel::Type::Boolean.new.cast(ENV.fetch('FORCE_SSL', false))

--- a/config/initializers/active_storage_dynamic_service.rb
+++ b/config/initializers/active_storage_dynamic_service.rb
@@ -7,6 +7,9 @@
 # (Redis-cached, invalidated on save via GlobalConfig.set).  Web workers and
 # Sidekiq jobs both call through this path, so they converge within one cache
 # cycle after the admin switches providers.
+#
+# Caveat: S3 credentials are still read at boot from config/storage.yml ERB —
+# changing them in the UI requires a service restart.
 Rails.application.config.after_initialize do
   ActiveStorage::Blob.class_eval do
     class << self
@@ -18,8 +21,13 @@ Rails.application.config.after_initialize do
           ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')
         ).presence || 'local'
         key = service_name.to_sym
-        (respond_to?(:services) && services[key]) || _static_service
-      rescue StandardError
+        resolved = respond_to?(:services) && services[key]
+        unless resolved
+          Rails.logger.warn("[ActiveStorage] service '#{service_name}' not registered (built at boot); falling back to boot-time default")
+        end
+        resolved || _static_service
+      rescue StandardError => e
+        Rails.logger.warn("[ActiveStorage] failed to resolve dynamic service: #{e.message}; falling back to boot-time default")
         _static_service
       end
     end

--- a/config/initializers/active_storage_dynamic_service.rb
+++ b/config/initializers/active_storage_dynamic_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Overrides ActiveStorage::Blob.service so the storage provider chosen in Admin
+# Settings → Storage is honoured at request time, not only at boot.
+#
+# GlobalConfigService.load reads from installation_configs via GlobalConfig
+# (Redis-cached, invalidated on save via GlobalConfig.set).  Web workers and
+# Sidekiq jobs both call through this path, so they converge within one cache
+# cycle after the admin switches providers.
+Rails.application.config.after_initialize do
+  ActiveStorage::Blob.class_eval do
+    class << self
+      alias_method :_static_service, :service
+
+      def service
+        service_name = GlobalConfigService.load(
+          'ACTIVE_STORAGE_SERVICE',
+          ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')
+        ).presence || 'local'
+        key = service_name.to_sym
+        (respond_to?(:services) && services[key]) || _static_service
+      rescue StandardError
+        _static_service
+      end
+    end
+  end
+end

--- a/config/initializers/active_storage_dynamic_service.rb
+++ b/config/initializers/active_storage_dynamic_service.rb
@@ -11,6 +11,8 @@
 # Caveat: S3 credentials are still read at boot from config/storage.yml ERB —
 # changing them in the UI requires a service restart.
 Rails.application.config.after_initialize do
+  next if ActiveStorage::Blob.respond_to?(:_static_service)
+
   ActiveStorage::Blob.class_eval do
     class << self
       alias_method :_static_service, :service


### PR DESCRIPTION
Applies the storage provider chosen in Admin Settings → Storage at runtime in the CRM service, without requiring a process restart.

## What changed

- **`config/initializers/active_storage_dynamic_service.rb`**: Overrides `ActiveStorage::Blob.service` via `class_eval` + `alias_method` so the service is resolved dynamically from `GlobalConfigService` on every call instead of being fixed at boot. Guard added (`next if respond_to?(:_static_service)`) to prevent infinite recursion on initializer double-load (dev reload, Zeitwerk, class-cache restart without process reboot).
- **`config/environments/production.rb`**: Boot-time fallback refactored from inline rescue to explicit `begin/rescue` block with `warn` log so failures at startup are traceable.

## Operational notes

- **S3 credentials** (access key, secret, region, endpoint) are still read at boot from `config/storage.yml` ERB — changing them via the UI requires restarting the service and its Sidekiq workers.
- **Provider changes** (Local ↔ S3 ↔ S3-Compatible) take effect immediately after save (cache invalidated via `GlobalConfig.set`). Auth converges within **60 seconds** (passive TTL); there is a window of up to 60 s where auth and CRM may use different providers — the storage UI banner communicates this to operators.
- **Existing blobs** remain on the original provider; only new uploads use the updated configuration. Migration/re-attachment is explicitly out of scope.
- ENV vars remain a valid override/fallback for infra-as-code installs (AC #3).

## Validation

- `ruby -c config/initializers/active_storage_dynamic_service.rb` ✅
- `ruby -c config/environments/production.rb` ✅

## Linked Issue

- EVO-1050