### PR TITLE
fix(crm): fix outbound media delivery failures (EVO-1151)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts must always use LF line endings (Docker entrypoints break with CRLF)
+docker/entrypoints/**     text eol=lf
+docker/entrypoints/*.sh   text eol=lf
+*.sh                      text eol=lf
+*.rb                      text eol=lf

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,8 +139,8 @@ GEM
       uniform_notifier (~> 1.11)
     bundle-audit (0.1.0)
       bundler-audit
-    bundler-audit (0.9.1)
-      bundler (>= 1.2.0, < 3)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
       thor (~> 1.0)
     byebug (11.1.3)
     chunky_png (1.4.0)
@@ -408,6 +408,7 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     mock_redis (0.36.0)
       ruby2_keywords
@@ -436,6 +437,9 @@ GEM
     newrelic_rpm (9.6.0)
       base64
     nio4r (2.7.3)
+    nokogiri (1.18.8)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
@@ -956,6 +960,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-24
+  ruby
   x86_64-darwin-18
   x86_64-darwin-20
   x86_64-darwin-21
@@ -1093,7 +1098,7 @@ DEPENDENCIES
   working_hours
 
 RUBY VERSION
-   ruby 3.4.4p34
+  ruby 3.4.4p34
 
 BUNDLED WITH
-   2.7.2
+  4.0.9

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -22,6 +22,9 @@ class SendReplyJob < ApplicationJob
     else
       services[channel_name].new(message: message).perform if services[channel_name].present?
     end
+  rescue StandardError => e
+    Rails.logger.error "[SendReplyJob] Delivery failed for message #{message_id}: #{e.message}"
+    message&.update(status: :failed, external_error: e.message.to_s.truncate(1000))
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -369,9 +369,9 @@ class Message < ApplicationRecord
   end
 
   def send_reply
-    # FIXME: Giving it few seconds for the attachment to be uploaded to the service
-    # active storage attaches the file only after commit
-    attachments.blank? ? ::SendReplyJob.perform_later(id) : ::SendReplyJob.set(wait: 2.seconds).perform_later(id)
+    # Active Storage attaches the file only after commit; wait gives storage provider time to make it available.
+    # 5 s is safer than 2 s for large files (video/PDF) on slower storage backends.
+    attachments.blank? ? ::SendReplyJob.perform_later(id) : ::SendReplyJob.set(wait: 5.seconds).perform_later(id)
   end
 
   def reopen_conversation

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -314,7 +314,11 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
 
   def send_attachment_message(phone_number, message)
     attachment = message.attachments.first
-    return unless attachment
+
+    unless attachment
+      Rails.logger.error "[Evolution Go] No attachment found for message #{message.id}"
+      return false
+    end
 
     Rails.logger.info "[Evolution Go] Sending #{attachment.file_type} message to #{phone_number}"
 
@@ -360,12 +364,12 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
         return message_id
       else
         Rails.logger.warn "[Evolution Go] Message sent but no ID returned: #{parsed_response}"
-        return true
+        return nil
       end
     end
 
     Rails.logger.error "[Evolution Go] Send failed: #{response.code} - #{response.body}"
-    false
+    raise "[Evolution Go] HTTP #{response.code}: #{response.body.to_s.truncate(300)}"
   end
 
   def map_file_type_to_evolution_go(file_type)
@@ -386,24 +390,31 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
   def generate_direct_s3_url(attachment)
     return attachment.file_url unless attachment.file.attached?
 
-    # Always return the signed URL, never the bare object URL.
+    # Always use a signed URL — never the bare object URL.
     #
-    # Why: stripping the AWS signing parameters only works when the S3 bucket
-    # is publicly readable. Real-world deployments (Cloudflare R2, S3 with
-    # restricted ACLs, MinIO with private buckets) return XML error responses
-    # to unauthenticated GETs, and Evolution Go (which downloads the URL on
-    # behalf of WhatsApp) rejects the upload with:
-    #   "Invalid file format: 'text/xml; charset=utf-8'. Only image/jpeg,
-    #   image/png and image/webp are accepted"
+    # Private buckets (Cloudflare R2, S3 restricted ACLs, MinIO) return an XML
+    # error to unauthenticated GETs; Evolution Go then rejects the upload with
+    # "Invalid file format: 'text/xml; charset=utf-8'".
     #
-    # The signed URL has a short TTL (5 minutes by default) which is enough
-    # for Evolution Go to fetch the media before forwarding it to WhatsApp,
-    # and it carries response-content-type so the upstream sees the right
-    # MIME type. Public buckets remain compatible because the signature is
-    # ignored when the object is anonymously readable.
-    signed_url = attachment.download_url
+    # TTL is set to 15 minutes instead of the Rails default of 5 minutes because
+    # Evolution Go may take several minutes to fetch large video/PDF files under
+    # provider load. A 5-minute window is too tight and causes silent delivery
+    # failures when the provider is slow.
+    #
+    # ACTIVE_STORAGE_URL overrides the host used in DiskService signed URLs so
+    # that external containers (Evolution Go) can actually reach the file.
+    # Without it, localhost:3000 resolves to the caller's container, not the CRM.
+    url_options = Rails.application.routes.default_url_options.dup
+    if ENV['ACTIVE_STORAGE_URL'].present?
+      storage_uri = URI.parse(ENV['ACTIVE_STORAGE_URL'])
+      url_options[:host] = storage_uri.host
+      url_options[:port] = storage_uri.port
+      url_options[:protocol] = storage_uri.scheme
+    end
+    ActiveStorage::Current.url_options = url_options if ActiveStorage::Current.url_options.blank?
+    signed_url = attachment.file.blob.url(expires_in: 15.minutes)
 
-    Rails.logger.info "[Evolution Go S3] Using signed URL (works for both public and private buckets)"
+    Rails.logger.info "[Evolution Go S3] Using signed URL with 15-minute TTL (host: #{url_options[:host]})"
     signed_url
   end
 

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -378,7 +378,11 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
 
   def send_attachment_message(phone_number, message)
     attachment = message.attachments.first
-    return unless attachment
+
+    unless attachment
+      Rails.logger.error "[Evolution] No attachment found for message #{message.id}"
+      return false
+    end
 
     case attachment.file_type
     when 'image'
@@ -463,13 +467,27 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
   def generate_direct_s3_url(attachment)
     return attachment.file_url unless attachment.file.attached?
 
-    # Always return the signed URL — see the matching method in
-    # evolution_go_service.rb for the full rationale. Stripping the AWS
-    # signing parameters only works on public buckets; on Cloudflare R2,
-    # private S3 buckets and MinIO, the upstream provider gets a `text/xml`
-    # error body back and rejects the upload.
-    signed_url = attachment.download_url
-    Rails.logger.info "[Evolution S3] Using signed URL (works for both public and private buckets)"
+    # Always use a signed URL — never the bare object URL.
+    # Private buckets (Cloudflare R2, S3 restricted ACLs, MinIO) return an XML
+    # error to unauthenticated GETs; Evolution API then rejects with a MIME-type
+    # error. TTL is 15 minutes (instead of the Rails default of 5 minutes) so
+    # slow providers have enough time to fetch large video/PDF files.
+    #
+    # ACTIVE_STORAGE_URL overrides the host used in DiskService signed URLs so
+    # that external containers (Evolution API, Evolution Go) can actually reach
+    # the file. Without it, localhost:3000 resolves to the caller's container,
+    # not the CRM Rails app.
+    url_options = Rails.application.routes.default_url_options.dup
+    if ENV['ACTIVE_STORAGE_URL'].present?
+      storage_uri = URI.parse(ENV['ACTIVE_STORAGE_URL'])
+      url_options[:host] = storage_uri.host
+      url_options[:port] = storage_uri.port
+      url_options[:protocol] = storage_uri.scheme
+    end
+    ActiveStorage::Current.url_options = url_options if ActiveStorage::Current.url_options.blank?
+    signed_url = attachment.file.blob.url(expires_in: 15.minutes)
+
+    Rails.logger.info "[Evolution S3] Using signed URL with 15-minute TTL (host: #{url_options[:host]})"
     signed_url
   end
 

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -34,7 +34,13 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          lang_code: lang_code,
                                          parameters: processed_parameters
                                        })
-    message.update!(source_id: message_id) if message_id.present?
+
+    if message_id == false
+      Rails.logger.error "[WhatsApp] Template delivery failed for message #{message.id} — provider returned error"
+      message.update!(status: :failed, external_error: 'Template delivery failed: provider returned an error response')
+    elsif message_id.is_a?(String) && message_id.present?
+      message.update!(source_id: message_id)
+    end
   end
 
   def processable_channel_message_template
@@ -128,7 +134,13 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     Rails.logger.info "WhatsApp Send: Using number #{target_number} for contact #{message.conversation.contact.id} (identifier: #{message.conversation.contact.identifier}, source_id: #{message.conversation.contact_inbox.source_id})"
 
     message_id = channel.send_message(target_number, message)
-    message.update!(source_id: message_id) if message_id.present?
+
+    if message_id == false
+      Rails.logger.error "[WhatsApp] Delivery failed for message #{message.id} — provider returned error"
+      message.update!(status: :failed, external_error: 'Delivery failed: provider returned an error response')
+    elsif message_id.is_a?(String) && message_id.present?
+      message.update!(source_id: message_id)
+    end
   end
 
   def determine_target_number_for_sending
@@ -164,7 +176,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
         Rails.logger.info "WhatsApp Send: Using identifier #{contact.identifier}"
         contact.identifier
       # If contact_inbox source_id is an identifier (e.g., 96426461769841@lid), use it
-      elsif contact_inbox.source_id.include?('@lid')
+      elsif contact_inbox.source_id&.include?('@lid')
         Rails.logger.info "WhatsApp Send: Using source_id identifier #{contact_inbox.source_id}"
         contact_inbox.source_id
       # Fallback to contact's phone number if available


### PR DESCRIPTION
## Summary
- Surface silent failures in `SendReplyJob` via `rescue StandardError` + `external_error` field
- Delay attachment jobs by 5 s so Active Storage finishes writing before dispatch
- Fix `ACTIVE_STORAGE_URL` host in `generate_direct_s3_url`: `localhost:3000` was unreachable from Evolution API / Evolution Go containers — media was silently dropped on every send
- Raise on HTTP failure in `process_evolution_go_response` so provider errors propagate to `external_error`
- Return `nil` (not `true`) in Evolution Go when no message ID in response; only persist `source_id` when it is a String
- Add nil-safe guard on `contact_inbox.source_id&.include?('@lid')`
- Enforce LF line endings for Docker entrypoints via `.gitattributes` to prevent shebang breakage on Windows hosts

## Validation
- `evo-ai-crm-community: ruby -c app/jobs/send_reply_job.rb` — Syntax OK
- `evo-ai-crm-community: ruby -c app/models/message.rb` — Syntax OK
- `evo-ai-crm-community: ruby -c app/services/whatsapp/providers/evolution_service.rb` — Syntax OK
- `evo-ai-crm-community: ruby -c app/services/whatsapp/providers/evolution_go_service.rb` — Syntax OK
- `evo-ai-crm-community: ruby -c app/services/whatsapp/send_on_whatsapp_service.rb` — Syntax OK
- Sidekiq container restarted with `ACTIVE_STORAGE_URL=http://host.docker.internal:3000`, confirmed reachable (HTTP 200) from both Sidekiq and Evolution API containers
- Text, image, and video messages confirmed delivered end-to-end

## Changed Files
- `app/jobs/send_reply_job.rb`
- `app/models/message.rb`
- `app/services/whatsapp/providers/evolution_go_service.rb`
- `app/services/whatsapp/providers/evolution_service.rb`
- `app/services/whatsapp/send_on_whatsapp_service.rb`
- `.gitattributes`
- `Gemfile.lock`

## Linked Issue
- EVO-1151

## Summary by Sourcery

Improve reliability and observability of WhatsApp outbound message delivery and media handling across Evolution providers.

Bug Fixes:
- Prevent silent failures when sending WhatsApp replies by marking messages as failed and recording external_error on exceptions in SendReplyJob.
- Avoid treating missing attachments as successful sends in Evolution and Evolution Go providers, logging errors and returning failure instead.
- Fix media delivery from private or containerized storage by generating reachable signed Active Storage URLs with configurable host and longer TTL, and by increasing the delay before dispatching attachment messages so uploads complete.
- Ensure WhatsApp send and template flows correctly interpret provider responses, only persisting valid string message IDs and marking messages as failed when the provider signals an error.
- Guard against nil contact_inbox.source_id when checking for @lid identifiers to avoid runtime errors.
- Surface HTTP errors from Evolution Go as raised exceptions instead of silent false responses to propagate provider failures.

Enhancements:
- Standardize logging around WhatsApp delivery, attachment handling, and S3 URL generation for easier debugging of outbound issues.

Build:
- Enforce LF line endings for Docker entrypoint scripts via .gitattributes to keep shebangs working on Windows hosts.