### PR TITLE
fix(EVO-1115): corrigir payload de buttons/lists para formato Evolution Go + paridade

### DIFF
--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -225,14 +225,19 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
   end
 
   def send_button_message(clean_number, message, items)
+    # Formato Evolution Go /send/button: { type, displayText, id }
+    # WhatsApp reply button displayText limit: 20 caracteres
     buttons = items.map do |item|
-      { type: 'reply', reply: { id: item['value'].to_s, title: item['title'].to_s.truncate(20) } }
+      { type: 'reply', displayText: item['title'].to_s.truncate(20), id: item['value'].to_s }
     end
+
+    content = html_to_whatsapp(message.content.to_s)
 
     body = {
       number: clean_number,
-      title: '',
-      description: html_to_whatsapp(message.content.to_s),
+      title: content.truncate(60),
+      description: content,
+      footer: 'Evo CRM',
       buttons: buttons,
       delay: 0
     }
@@ -252,17 +257,21 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
   end
 
   def send_list_message(clean_number, message, items)
+    # Formato Evolution Go /send/list: { rowId, title, description }
+    # WhatsApp list row title limit: 24 caracteres
     rows = items.map do |item|
-      { id: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
+      { rowId: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
     end
+
+    content = html_to_whatsapp(message.content.to_s)
 
     body = {
       number: clean_number,
-      title: '',
-      description: html_to_whatsapp(message.content.to_s),
-      buttonText: 'Menu',
-      footerText: '',
-      sections: [{ title: 'Options', rows: rows }],
+      title: content.truncate(60),
+      description: content,
+      buttonText: I18n.t('whatsapp.interactive.list_button', default: 'Menu'),
+      footerText: 'Evo CRM',
+      sections: [{ title: I18n.t('whatsapp.interactive.list_section', default: 'Options'), rows: rows }],
       delay: 0
     }
 

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -314,14 +314,19 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
   end
 
   def send_button_message(clean_number, message, items)
+    # Formato Evolution API /message/sendButtons: { type, displayText, id }
+    # WhatsApp reply button displayText limit: 20 caracteres
     buttons = items.map do |item|
-      { type: 'reply', reply: { id: item['value'].to_s, title: item['title'].to_s.truncate(20) } }
+      { type: 'reply', displayText: item['title'].to_s.truncate(20), id: item['value'].to_s }
     end
+
+    content = html_to_whatsapp(message.content.to_s)
 
     body = {
       number: clean_number,
-      title: '',
-      description: html_to_whatsapp(message.content.to_s),
+      title: content.truncate(60),
+      description: content,
+      footer: 'Evo CRM',
       buttons: buttons
     }
 
@@ -337,17 +342,21 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
   end
 
   def send_list_message(clean_number, message, items)
+    # Formato Evolution API /message/sendList: { rowId, title, description }
+    # WhatsApp list row title limit: 24 caracteres
     rows = items.map do |item|
-      { id: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
+      { rowId: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
     end
+
+    content = html_to_whatsapp(message.content.to_s)
 
     body = {
       number: clean_number,
-      title: '',
-      description: html_to_whatsapp(message.content.to_s),
-      buttonText: 'Menu',
-      footerText: '',
-      sections: [{ title: 'Options', rows: rows }]
+      title: content.truncate(60),
+      description: content,
+      buttonText: I18n.t('whatsapp.interactive.list_button', default: 'Menu'),
+      footerText: 'Evo CRM',
+      sections: [{ title: I18n.t('whatsapp.interactive.list_section', default: 'Options'), rows: rows }]
     }
 
     Rails.logger.info "[Evolution] Sending list message to #{clean_number} with #{rows.length} rows"


### PR DESCRIPTION
## Resumo

O payload enviado pelo CRM para os endpoints `/send/button` e `/send/list` do Evolution Go estava incompatível com o formato esperado pelo servidor, resultando em erro HTTP 400 `"title is required"`. Esta PR corrige o formato do payload e equaliza ambos os providers (Evolution Go e Evolution API).

---

### Problemas identificados e corrigidos

**1. Campos `title` e `footer` vazios (400 Bad Request)**

O handler do Evolution Go (`send_handler.go:538-551`) valida `title`, `description` e `footer` como obrigatórios — strings vazias são rejeitadas. O CRM enviava `title: ''` e `footer: ''`.

Correção: `title` usa `content.truncate(60)` e `footer` usa `'Evo CRM'`.

**2. Formato dos buttons incompatível**

Evolution Go espera `{ type: 'reply', displayText: 'texto', id: 'id' }` conforme documentação (`API-INTERACTIVE-DOCS.txt:43-49`). O CRM enviava `{ type: 'reply', reply: { id: 'id', title: 'texto' } }` (formato WhatsApp Cloud API, não Evolution Go).

Correção: Formato alinhado com a especificação da API.

**3. Formato das list rows incompatível**

Evolution Go espera `{ rowId, title, description }`. O CRM enviava `{ id, title, description }`.

Correção: Campo renomeado para `rowId`.

**4. Paridade EvolutionService**

Mesmas correções aplicadas ao `EvolutionService` para `/message/sendButtons` e `/message/sendList` da Evolution API.

**5. i18n para strings do menu**

`buttonText` usa `I18n.t('whatsapp.interactive.list_button', default: 'Menu')` e section title usa `I18n.t('whatsapp.interactive.list_section', default: 'Options')`.

---

## Arquivos

- `app/services/whatsapp/providers/evolution_go_service.rb` (+18/-9)
- `app/services/whatsapp/providers/evolution_service.rb` (+18/-9)

## Plano de testes

- [x] `ruby -c` syntax check em ambos services: OK
- [x] Envio direto via API do Evolution Go `/send/button` → 200 (botões recebidos no WhatsApp)
- [x] Envio direto via API do Evolution Go `/send/list` → 200 (lista com menu recebida no WhatsApp)
- [x] Envio via CRM API → Sidekiq → EvolutionGoService → Evolution Go → WhatsApp: 200 em ambos cenários
- [x] Confirmado recebimento pelo usuário em 2 números distintos
- [x] 2 arquivos, branch dedicada, escopo EVO-1115

## Summary by Sourcery

Align WhatsApp interactive button and list payloads with the expected formats for Evolution Go and Evolution API providers to prevent 400 errors and standardize behavior.

Bug Fixes:
- Correct button payload structure for Evolution Go and Evolution API to use top-level displayText and id fields as required by their endpoints.
- Update list message rows to use rowId instead of id so list payloads are accepted by Evolution Go and Evolution API.
- Populate required title and footer fields in interactive messages to satisfy provider validation and avoid empty-string rejections.

Enhancements:
- Reuse converted message content for both title and description with length limits to better fit WhatsApp constraints.
- Localize list button label and section title via i18n with sensible defaults for interactive list menus across providers.