### PR TITLE
feat(EVO-1373): add carousel message support for Evolution Go

### DIFF
--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -9,6 +9,8 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
       send_attachment_message(phone_number, message)
     elsif message.content_type == 'input_select'
       send_interactive_message(phone_number, message)
+    elsif message.content_type == 'cards'
+      send_carousel_message(phone_number, message)
     elsif message.content.present?
       send_text_message(phone_number, message)
     else
@@ -282,6 +284,70 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
 
     response = HTTParty.post(
       "#{api_base_path}/send/list",
+      headers: instance_headers,
+      body: body.to_json
+    )
+
+    process_evolution_go_response(response)
+  end
+
+  def send_carousel_message(phone_number, message)
+    clean_number = phone_number.delete('+')
+
+    # CRM armazena cards em content_attributes.items (validado por ContentAttributeValidator)
+    # Cada item segue o schema: { title, description, media_url, actions: [{ text, type, payload, uri }] }
+    items = message.content_attributes&.dig('items') || message.items || []
+
+    if items.empty?
+      Rails.logger.warn "[Evolution Go] Carousel message has no items, falling back to text"
+      return send_text_message(phone_number, message)
+    end
+
+    # Transforma formato CRM (items) para formato Evolution Go /send/carousel
+    cards = items.map do |item|
+      item = item.with_indifferent_access
+      actions = item[:actions] || []
+
+      {
+        header: {
+          title: (item[:title] || '').to_s.truncate(60),
+          imageUrl: item[:media_url].to_s
+        },
+        body: {
+          text: (item[:description] || '').to_s.truncate(1024)
+        },
+        footer: 'Evo CRM',
+        buttons: actions.map do |action|
+          action = action.with_indifferent_access
+          btn_type = (action[:type] || 'reply').to_s.upcase
+          btn = {
+            type: btn_type,
+            displayText: (action[:text] || '').to_s.truncate(20),
+            id: (action[:payload] || action[:uri] || '').to_s
+          }
+          btn[:copyCode] = action[:payload].to_s if btn_type == 'COPY'
+          btn.compact
+        end
+      }
+    end
+
+    content = html_to_whatsapp(message.content.to_s)
+
+    body = {
+      number: clean_number,
+      body: content.presence || '',
+      footer: 'Evo CRM',
+      cards: cards,
+      delay: 0
+    }
+
+    quoted_info = build_quoted_info(message)
+    body[:quoted] = quoted_info if quoted_info.present?
+
+    Rails.logger.info "[Evolution Go] Sending carousel with #{cards.length} cards to #{clean_number}"
+
+    response = HTTParty.post(
+      "#{api_base_path}/send/carousel",
       headers: instance_headers,
       body: body.to_json
     )


### PR DESCRIPTION
## Summary

- Add `send_carousel_message` to `EvolutionGoService` for sending WhatsApp carousel messages via Evolution Go `/send/carousel`
- Add `cards` content_type dispatch in `send_message` router
- Transform CRM item schema (`title/description/media_url/actions`) into Evolution Go carousel payload (`header/body/footer/buttons`)

## Root cause

`EvolutionGoService#send_message` had no handler for `content_type == 'cards'`, so carousel messages fell through to the text fallback or were marked as unsupported.

## Changes

**`app/services/whatsapp/providers/evolution_go_service.rb`**

| What | Detail |
|------|--------|
| Dispatch | Added `elsif message.content_type == 'cards'` → `send_carousel_message` in `send_message` |
| `send_carousel_message` | Reads `content_attributes.items` (CRM schema validated by `ContentAttributeValidator`), maps each item to Evolution Go card format |
| Card mapping | `title` → `header.title`, `media_url` → `header.imageUrl`, `description` → `body.text`, actions → `buttons` with type REPLY/URL/CALL/COPY |
| Limits | Title truncated to 60 chars, body to 1024, button displayText to 20 (WhatsApp limits) |
| Extras | Supports quoted replies via `build_quoted_info`, text fallback when items array is empty |

## Test checklist

- [x] `ruby -c` syntax check passed
- [x] Direct Evolution Go API test: `POST /send/carousel` with 2 cards → received on WhatsApp with images and buttons
- [x] End-to-end CRM test: `POST /api/v1/conversations/:id/messages` with `content_type: cards` + items → Sidekiq processed → Evolution Go sent → WhatsApp delivered → receipt webhook → status updated to `delivered`
- [x] ActionCable broadcast confirmed: `message.created` and `message.updated` events with `content_type: cards`
- [x] Empty items fallback: falls back to text message
- [ ] Manual: verify carousel renders in CRM chat (frontend — EVO-1374)

## API payload example

```json
{
  "content": "Confira nossos produtos!",
  "content_type": "cards",
  "content_attributes": {
    "items": [
      {
        "title": "Produto 1",
        "description": "Descrição do produto",
        "media_url": "https://example.com/image.jpg",
        "actions": [
          { "text": "Comprar", "type": "reply", "payload": "buy_1" }
        ]
      }
    ]
  }
}
```

## Summary by Sourcery

Add support for sending WhatsApp carousel messages via Evolution Go when messages use the cards content type.

New Features:
- Route cards content_type messages through a new send_carousel_message handler in EvolutionGoService.
- Map CRM card items into Evolution Go carousel payloads, including headers, bodies, footers, and buttons, and send them via the /send/carousel endpoint.

Enhancements:
- Gracefully fall back to text messages when carousel items are empty and support quoted replies for carousel messages.