### PR TITLE
feat(crm): lib/evo_extension_points/ with 5 no-op modules (EVO-1286)

### DIFF
--- a/config/initializers/evo_extension_points.rb
+++ b/config/initializers/evo_extension_points.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Smoke-load the public extension contract so the host application crashes
+# loud at boot if the entry point is broken. No overrides are registered
+# here — community ships with no-op defaults. See lib/evo_extension_points.rb
+# and EXTENSION_POINTS.md at the repo root.
+require 'evo_extension_points'
+
+Rails.application.config.after_initialize do
+  EvoExtensionPoints::PluginLoader.load_all
+end

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Public extension contract of evo-ai-crm-community. See EXTENSION_POINTS.md
+# at the repository root for the full contract. The five sub-modules below
+# ship no-op defaults; an external consumer overrides a specific extension
+# point at process start via EvoExtensionPoints.replace(:name, &block) or via
+# the per-module register* / replace* APIs.
+
+require_relative 'evo_extension_points/feature_gate'
+require_relative 'evo_extension_points/tenant_context'
+require_relative 'evo_extension_points/plugin_loader'
+require_relative 'evo_extension_points/theme_tokens'
+require_relative 'evo_extension_points/data_export'
+
+module EvoExtensionPoints
+  KNOWN_KEYS = %i[
+    feature_gate
+    tenant_context_current_id
+    tenant_context_with_tenant
+    theme_tokens
+  ].freeze
+
+  class UnknownExtensionPoint < ArgumentError; end
+
+  class << self
+    def replace(key, &block)
+      raise ArgumentError, 'block required' unless block
+      raise UnknownExtensionPoint, "unknown extension point: #{key.inspect}" unless KNOWN_KEYS.include?(key)
+
+      overrides[key] = block
+      block
+    end
+
+    def impl_for(key)
+      overrides[key]
+    end
+
+    def reset!
+      @overrides = nil
+      PluginLoader.reset!
+      DataExport.reset!
+    end
+
+    private
+
+    def overrides
+      @overrides ||= {}
+    end
+  end
+end

--- a/lib/evo_extension_points/data_export.rb
+++ b/lib/evo_extension_points/data_export.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Data export extension point. The community release does not declare any
+  # exportable tables on its own — DataExport.exportable_tables_for_tenant
+  # returns []. An external consumer (e.g. an enterprise gem providing
+  # tenant-scoped data export) registers exportable tables via
+  # DataExport.register(name:, &scope_block) at boot, and the registry is
+  # consulted at runtime.
+  #
+  # The "scope block" receives a tenant_id and must return an Enumerable of
+  # records or a query-like object the caller can iterate. The community
+  # never reaches into community tables on behalf of the consumer; the block
+  # is the consumer's responsibility.
+  module DataExport
+    Entry = Struct.new(:name, :scope_block, keyword_init: true)
+
+    class << self
+      def register(name:, &scope_block)
+        raise ArgumentError, 'scope_block is required' unless scope_block
+
+        sym = name.to_sym
+        registry[sym] = Entry.new(name: sym, scope_block: scope_block)
+        sym
+      end
+
+      def exportable_tables_for_tenant(tenant_id)
+        registry.values.map do |entry|
+          { name: entry.name, records: entry.scope_block.call(tenant_id) }
+        end
+      end
+
+      def registered_names
+        registry.keys.dup
+      end
+
+      def reset!
+        @registry = nil
+      end
+
+      private
+
+      def registry
+        @registry ||= {}
+      end
+    end
+  end
+end

--- a/lib/evo_extension_points/feature_gate.rb
+++ b/lib/evo_extension_points/feature_gate.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Feature gating extension point. Community default: every flag is enabled.
+  # An external consumer (e.g. an enterprise licensing gem) can replace this
+  # implementation via EvoExtensionPoints.replace(:feature_gate) { |flag, **ctx| ... }
+  # without patching community source. See EXTENSION_POINTS.md at the repo root.
+  module FeatureGate
+    DEFAULT_IMPL = ->(_flag, **_context) { true }
+
+    class << self
+      def feature_enabled?(flag, **context)
+        impl = EvoExtensionPoints.impl_for(:feature_gate) || DEFAULT_IMPL
+        impl.call(flag, **context)
+      end
+    end
+  end
+end

--- a/lib/evo_extension_points/plugin_loader.rb
+++ b/lib/evo_extension_points/plugin_loader.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Plugin loader extension point. Community default: an in-memory registry
+  # that accepts registrations and invokes on_boot callbacks, but ships with
+  # zero registered plugins. See EXTENSION_POINTS.md.
+  module PluginLoader
+    class PluginRegistration
+      attr_reader :id
+
+      def initialize(id)
+        @id = id
+        @on_boot_callbacks = []
+        @routes_callbacks = []
+      end
+
+      def on_boot(&block)
+        @on_boot_callbacks << block if block
+        self
+      end
+
+      def routes(&block)
+        @routes_callbacks << block if block
+        self
+      end
+
+      def invoke_on_boot!
+        @on_boot_callbacks.each(&:call)
+      end
+
+      def routes_callbacks
+        @routes_callbacks.dup
+      end
+    end
+
+    class << self
+      def register_plugin(name)
+        sym = name.to_sym
+        registration = PluginRegistration.new(sym)
+        yield(registration) if block_given?
+        registry[sym] = registration
+        registration
+      end
+
+      def plugins
+        registry.keys.dup
+      end
+
+      def registration(name)
+        registry[name.to_sym]
+      end
+
+      def load_all
+        registry.each_value(&:invoke_on_boot!)
+        nil
+      end
+
+      def reset!
+        @registry = nil
+      end
+
+      private
+
+      def registry
+        @registry ||= {}
+      end
+    end
+  end
+end

--- a/lib/evo_extension_points/tenant_context.rb
+++ b/lib/evo_extension_points/tenant_context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Tenant context extension point. Community default: single-tenant mode —
+  # current_tenant_id is always nil and with_tenant is a pass-through.
+  # See EXTENSION_POINTS.md.
+  module TenantContext
+    DEFAULT_CURRENT_ID = -> {}
+    DEFAULT_WITH_TENANT = ->(_id, &block) { block&.call }
+
+    class << self
+      def current_tenant_id
+        impl = EvoExtensionPoints.impl_for(:tenant_context_current_id) || DEFAULT_CURRENT_ID
+        impl.call
+      end
+
+      def with_tenant(id, &)
+        impl = EvoExtensionPoints.impl_for(:tenant_context_with_tenant) || DEFAULT_WITH_TENANT
+        impl.call(id, &)
+      end
+    end
+  end
+end

--- a/lib/evo_extension_points/theme_tokens.rb
+++ b/lib/evo_extension_points/theme_tokens.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Theme tokens extension point. Community default: the canonical Evolution
+  # palette and typography tokens. Token keys mirror the public CSS variable
+  # contract declared in EXTENSION_POINTS.md of the React frontend
+  # (story 0.3); keep both in sync.
+  module ThemeTokens
+    DEFAULT_TOKENS = {
+      '--evo-color-primary-500' => '#00ffa7',
+      '--evo-color-primary-foreground' => '#0b0f14',
+      '--evo-color-accent-500' => '#00ffa7',
+      '--evo-color-background' => '#0b0f14',
+      '--evo-color-foreground' => '#e6f1ec',
+      '--evo-font-sans' => 'Inter, system-ui, sans-serif'
+    }.freeze
+
+    DEFAULT_IMPL = ->(_scope) { DEFAULT_TOKENS.dup }
+
+    class << self
+      def defaults(scope: :default)
+        impl = EvoExtensionPoints.impl_for(:theme_tokens) || DEFAULT_IMPL
+        impl.call(scope)
+      end
+    end
+  end
+end

--- a/spec/lib/email_configuration_spec.rb
+++ b/spec/lib/email_configuration_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe 'Email Configuration (Story 2.1)' do
   before do
     ENV['ENCRYPTION_KEY'] = 'test-encryption-key-for-fernet!!'
     InstallationConfig.reset_encryption_key_cache!
+    # Wipe configs that this spec asserts on so pre-seeded rows in the test
+    # DB don't collide with `create!` calls inside the examples.
+    InstallationConfig.where(name: %w[
+      MAILER_TYPE SMTP_ADDRESS SMTP_PORT SMTP_USERNAME SMTP_PASSWORD_SECRET
+      MAILER_SENDER_EMAIL RESEND_API_SECRET BMS_API_SECRET
+    ]).delete_all
     # Stub Redis to avoid cache pollution between tests
     redis_double = double('redis')
     allow($alfred).to receive(:with).and_yield(redis_double)
@@ -125,6 +131,11 @@ RSpec.describe 'Email Configuration (Story 2.1)' do
     end
 
     context 'when neither DB nor ENV has a value' do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('SMTP_ADDRESS', anything) { |_, default| default }
+      end
+
       it 'returns default value' do
         result = GlobalConfigService.load('SMTP_ADDRESS', 'default-smtp')
         expect(result).to eq('default-smtp')
@@ -264,29 +275,32 @@ RSpec.describe 'Email Configuration (Story 2.1)' do
         mailer.send(:apply_dynamic_delivery_settings)
       end
 
-      it 'calls message.delivery_method with SMTP settings' do
+      it 'calls message.delivery_method with the SMTP delivery class and settings' do
         smtp_opts = { address: 'smtp.example.com', port: 587 }
         mailer.instance_variable_set(:@dynamic_delivery_method, :smtp)
         mailer.instance_variable_set(:@dynamic_delivery_options, smtp_opts)
 
-        expect(mock_message).to receive(:delivery_method).with(:smtp, smtp_opts)
+        expected_class = ApplicationMailer.delivery_methods[:smtp]
+        expect(mock_message).to receive(:delivery_method).with(expected_class, smtp_opts)
         mailer.send(:apply_dynamic_delivery_settings)
       end
 
-      it 'calls message.delivery_method with BMS and empty options' do
+      it 'calls message.delivery_method with the BMS delivery class and empty options' do
         mailer.instance_variable_set(:@dynamic_delivery_method, :bms)
         mailer.instance_variable_set(:@dynamic_delivery_options, {})
 
-        expect(mock_message).to receive(:delivery_method).with(:bms, {})
+        expected_class = ApplicationMailer.delivery_methods[:bms]
+        expect(mock_message).to receive(:delivery_method).with(expected_class, {})
         mailer.send(:apply_dynamic_delivery_settings)
       end
 
-      it 'passes api_key in options and calls message.delivery_method for resend' do
+      it 'passes api_key in options and calls message.delivery_method with the Resend delivery class' do
         mailer.instance_variable_set(:@dynamic_delivery_method, :resend)
         mailer.instance_variable_set(:@dynamic_delivery_options, {})
         mailer.instance_variable_set(:@dynamic_resend_api_key, 'my-resend-key')
 
-        expect(mock_message).to receive(:delivery_method).with(:resend, { api_key: 'my-resend-key' })
+        expected_class = ApplicationMailer.delivery_methods[:resend]
+        expect(mock_message).to receive(:delivery_method).with(expected_class, { api_key: 'my-resend-key' })
         mailer.send(:apply_dynamic_delivery_settings)
       end
     end

--- a/spec/lib/evo_extension_points_spec.rb
+++ b/spec/lib/evo_extension_points_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'evo_extension_points'
+
+RSpec.describe EvoExtensionPoints do
+  # Always reset the top-level EvoExtensionPoints between examples, even when
+  # nested describe blocks change described_class to a submodule that does not
+  # implement reset!.
+  after { EvoExtensionPoints.reset! } # rubocop:disable RSpec/DescribedClass
+
+  describe '.replace' do
+    it 'rejects unknown extension point keys' do
+      expect { described_class.replace(:not_a_thing) { :noop } }
+        .to raise_error(described_class::UnknownExtensionPoint)
+    end
+
+    it 'requires a block' do
+      expect { described_class.replace(:feature_gate) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe EvoExtensionPoints::FeatureGate do
+    it 'returns true for any flag in the community default' do
+      expect(described_class.feature_enabled?(:anything)).to be true
+      expect(described_class.feature_enabled?(:paid_feature, account: 'x')).to be true
+    end
+
+    it 'honors a replace override' do
+      EvoExtensionPoints.replace(:feature_gate) { |flag, **_ctx| flag == :paid_feature }
+      expect(described_class.feature_enabled?(:paid_feature)).to be true
+      expect(described_class.feature_enabled?(:other)).to be false
+    end
+  end
+
+  describe EvoExtensionPoints::TenantContext do
+    it 'returns nil for current_tenant_id in the community default' do
+      expect(described_class.current_tenant_id).to be_nil
+    end
+
+    it 'passes through with_tenant yielding without binding state' do
+      yielded = false
+      result = described_class.with_tenant('any-id') do
+        yielded = true
+        :payload
+      end
+      expect(yielded).to be true
+      expect(result).to eq(:payload)
+      expect(described_class.current_tenant_id).to be_nil
+    end
+
+    it 'honors a replace override on current_tenant_id' do
+      EvoExtensionPoints.replace(:tenant_context_current_id) { 'tenant-42' }
+      expect(described_class.current_tenant_id).to eq('tenant-42')
+    end
+  end
+
+  describe EvoExtensionPoints::PluginLoader do
+    it 'returns an empty list of plugins by default' do
+      expect(described_class.plugins).to eq([])
+    end
+
+    it 'load_all is a no-op when nothing is registered' do
+      expect { described_class.load_all }.not_to raise_error
+      expect(described_class.plugins).to eq([])
+    end
+
+    it 'records registered plugins and invokes on_boot callbacks' do
+      booted = []
+      described_class.register_plugin(:demo) do |plugin|
+        plugin.on_boot { booted << :demo }
+      end
+      expect(described_class.plugins).to eq([:demo])
+      described_class.load_all
+      expect(booted).to eq([:demo])
+    end
+  end
+
+  describe EvoExtensionPoints::ThemeTokens do
+    it 'returns the canonical Evolution token set by default' do
+      tokens = described_class.defaults
+      expect(tokens).to include(
+        '--evo-color-primary-500' => '#00ffa7',
+        '--evo-color-background' => '#0b0f14'
+      )
+    end
+
+    it 'returns a fresh copy so callers can mutate without poisoning the default' do
+      first = described_class.defaults
+      first['--evo-color-primary-500'] = '#000000'
+      expect(described_class.defaults['--evo-color-primary-500']).to eq('#00ffa7')
+    end
+
+    it 'honors a replace override scoped by argument' do
+      EvoExtensionPoints.replace(:theme_tokens) { |scope| { 'scope' => scope.to_s } }
+      expect(described_class.defaults(scope: :consumer)).to eq('scope' => 'consumer')
+    end
+  end
+
+  describe EvoExtensionPoints::DataExport do
+    it 'returns an empty list by default (community registers nothing)' do
+      expect(described_class.exportable_tables_for_tenant('any')).to eq([])
+      expect(described_class.registered_names).to eq([])
+    end
+
+    it 'invokes registered scope blocks with the tenant id' do
+      described_class.register(name: :widgets) { |tenant_id| ["widget-#{tenant_id}"] }
+      result = described_class.exportable_tables_for_tenant('tenant-7')
+      expect(result).to eq([{ name: :widgets, records: ['widget-tenant-7'] }])
+    end
+
+    it 'rejects registration without a scope block' do
+      expect { described_class.register(name: :empty) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implement the public extension contract declared in `EXTENSION_POINTS.md` (story 0.2 — PR #73) as loadable Ruby modules under `EvoExtensionPoints` with community no-op defaults.

Five extension points:

- `FeatureGate.feature_enabled?(flag, **context)` → `true`
- `TenantContext.current_tenant_id` → `nil`; `TenantContext.with_tenant(id) { ... }` → pass-through yield
- `PluginLoader.register_plugin(name) { |p| p.on_boot { ... } }`; `plugins` → `[]`; `load_all` → no-op
- `ThemeTokens.defaults(scope:)` → canonical Evolution palette / typography hash
- `DataExport.register(name:, &scope_block)` + `exportable_tables_for_tenant(tenant_id)` → `[]` (community registers nothing)

Override API at the top-level: `EvoExtensionPoints.replace(:key, &block)`. Unknown keys raise `EvoExtensionPoints::UnknownExtensionPoint`. An external consumer (e.g. an enterprise licensing gem) swaps a default at process start without patching community source.

`lib/` is already in `config.eager_load_paths`; no autoload change required. `config/initializers/evo_extension_points.rb` requires the entry point at boot and triggers `PluginLoader.load_all` in `after_initialize`.

The story scope was expanded on 2026-05-17 to include `DataExport` (consumed by the rewritten story 3.11) and to formalize the `replace` override API. `AuthBridge` (also raised in the audit) lives in a separate story 0.8 (EVO-1375) in the `evo-auth-service-community` repo, not here.

Includes a separate commit fixing 16 pre-existing failures in `spec/lib/email_configuration_spec.rb` (unrelated to this story but needed to keep the CI suite green); see the commit message of `42ae50c` for the root cause breakdown.

## Security

- Pure Ruby modules with frozen-literal defaults and in-memory override registry. No DB writes, no network calls, no env reads.
- `EvoExtensionPoints.replace` validates the key against a fixed allow-list (`KNOWN_KEYS`) and raises on unknown — consumers can't inject arbitrary keys.
- `ThemeTokens.defaults` returns a `dup` of the default hash so callers can mutate without poisoning subsequent reads.
- `DataExport.register` requires a scope block (`ArgumentError` otherwise); the block is the consumer's responsibility, community never reaches into consumer-owned tables.
- No external URLs, no secrets, no env vars introduced.

## Test plan

- [x] `bundle exec rspec spec/lib/evo_extension_points_spec.rb` — 16 examples, 0 failures
- [x] `bundle exec rspec spec/lib` — 59 examples, 0 failures (after the email config spec fix in the second commit)
- [x] `bundle exec rubocop lib/evo_extension_points.rb lib/evo_extension_points/ config/initializers/evo_extension_points.rb spec/lib/evo_extension_points_spec.rb` — 0 offenses
- [ ] CI confirms full suite stays green after the email-config spec fix (untouched code paths everywhere else)

## Changed Files

- `lib/evo_extension_points.rb` (new — entry point + override API)
- `lib/evo_extension_points/feature_gate.rb` (new)
- `lib/evo_extension_points/tenant_context.rb` (new)
- `lib/evo_extension_points/plugin_loader.rb` (new)
- `lib/evo_extension_points/theme_tokens.rb` (new)
- `lib/evo_extension_points/data_export.rb` (new)
- `config/initializers/evo_extension_points.rb` (new — boot smoke-load + `PluginLoader.load_all` in `after_initialize`)
- `spec/lib/evo_extension_points_spec.rb` (new — 16 examples)
- `spec/lib/email_configuration_spec.rb` (fix pre-existing failures — separate commit)

## Linked Issue

- [EVO-1286](https://linear.app/evoai/issue/EVO-1286)

## Related PRs

- [EVO-1283 / PR #73](https://github.com/evolution-foundation/evo-ai-crm-community/pull/73) — the EXTENSION_POINTS.md contract this story implements