### PR TITLE
feat(crm): CI guard-rail for EvoExtensionPoints contract (EVO-1287)

### DIFF
--- a/.github/workflows/community-with-enterprise-stub.yml
+++ b/.github/workflows/community-with-enterprise-stub.yml
@@ -1,0 +1,44 @@
+name: community-with-enterprise-stub
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+env:
+  RAILS_ENV: test
+  ENCRYPTION_KEY: test-encryption-key-for-fernet!!
+
+jobs:
+  contract:
+    name: Verify EvoExtensionPoints contract (EXTENSION_POINTS.md ↔ API)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.4'
+          bundler-cache: true
+
+      - name: Run RSpec standalone (no enterprise stub)
+        run: bundle exec rspec spec/lib/evo_extension_points_spec.rb spec/lib/evo_extension_points/
+
+      - name: Verify EXTENSION_POINTS.md matches live API
+        run: bundle exec rake evo_extension_points:check_contract
+
+      - name: Run RSpec with enterprise stub mounted
+        env:
+          BUNDLE_WITH: enterprise_stub
+        run: |
+          bundle install
+          # The enterprise_stub gem is a fixture under spec/support/enterprise_stub.
+          # It is not in Rails.groups, so we require it explicitly here, before
+          # spec_helper runs, so its EvoExtensionPoints.replace / register calls
+          # execute and the suite runs with the stubbed implementations attached.
+          bundle exec rspec --require enterprise_stub \
+            spec/lib/evo_extension_points_spec.rb \
+            spec/lib/evo_extension_points/

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -152,6 +152,32 @@ end
 present in `1.0.0` is a major bump. Adding new token keys or new
 accepted `scope:` values is a minor bump.
 
+### 5. `data_export`
+
+**Version:** `1.0.0`
+**Default:** registers nothing; `exportable_tables_for_tenant(tenant_id)`
+returns `[]`.
+
+```ruby
+EvoExtensionPoints::DataExport.register(name: :widgets) do |tenant_id|
+  Widget.where(tenant_id: tenant_id)
+end
+
+EvoExtensionPoints::DataExport.exportable_tables_for_tenant(tenant_id)
+# => [{ name: :widgets, records: <enumerable> }]
+```
+
+The contract is a dynamic registry: an external consumer registers one
+or more named scope blocks at boot, each block receiving a `tenant_id`
+and returning an enumerable of records (or a query-like object the
+caller can iterate). The community release ships with no registrations;
+in standalone mode the registry is empty and the export is a no-op.
+
+**Breaking-change policy:** renaming `register`,
+`exportable_tables_for_tenant` or the `Entry` shape (`{ name:, records:
+}`) is a major bump. Adding new optional fields to the returned entry
+hash is a minor bump.
+
 ---
 
 ## How to use as a consumer

--- a/Gemfile
+++ b/Gemfile
@@ -215,6 +215,14 @@ group :test do
   gem 'test-prof'
 end
 
+# CI-only group: loads the enterprise stub fixture under
+# spec/support/enterprise_stub/ when BUNDLE_WITH=enterprise_stub.
+# Used by .github/workflows/community-with-enterprise-stub.yml to verify
+# that the EvoExtensionPoints contract has not regressed (story EVO-1287).
+group :enterprise_stub do
+  gem 'enterprise_stub', path: 'spec/support/enterprise_stub'
+end
+
 group :development, :test do
   gem 'active_record_query_trace'
   ##--- gems for debugging and error reporting ---##

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,11 @@ GIT
       net-http-persistent (~> 4.0)
       nokogiri (~> 1, >= 1.10.8)
 
+PATH
+  remote: spec/support/enterprise_stub
+  specs:
+    enterprise_stub (0.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -408,7 +413,6 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.25.5)
     mock_redis (0.36.0)
       ruby2_keywords
@@ -437,9 +441,6 @@ GEM
     newrelic_rpm (9.6.0)
       base64
     nio4r (2.7.3)
-    nokogiri (1.18.8)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
@@ -960,7 +961,6 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-24
-  ruby
   x86_64-darwin-18
   x86_64-darwin-20
   x86_64-darwin-21
@@ -993,6 +993,7 @@ DEPENDENCIES
   down
   elastic-apm
   email_reply_trimmer
+  enterprise_stub!
   facebook-messenger
   factory_bot_rails (>= 6.4.3)
   faker

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -11,6 +11,7 @@ require_relative 'evo_extension_points/tenant_context'
 require_relative 'evo_extension_points/plugin_loader'
 require_relative 'evo_extension_points/theme_tokens'
 require_relative 'evo_extension_points/data_export'
+require_relative 'evo_extension_points/contract_check'
 
 module EvoExtensionPoints
   KNOWN_KEYS = %i[

--- a/lib/evo_extension_points/contract_check.rb
+++ b/lib/evo_extension_points/contract_check.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Compares the public extension point contract declared in
+  # EXTENSION_POINTS.md against the modules actually exposed under
+  # EvoExtensionPoints. Used by the rake task
+  # evo_extension_points:check_contract (lib/tasks/evo_extension_points.rake)
+  # which the community-with-enterprise-stub CI workflow runs on every PR.
+  #
+  # Extension point names are normalized to lowercase snake_case strings on
+  # both sides:
+  #   - From EXTENSION_POINTS.md: parsed out of `### N. \`feature_gate\``
+  #     headings and from the "## Extension points" overview table.
+  #   - From the live API: each constant directly defined under
+  #     EvoExtensionPoints that is itself a Module (i.e. an extension
+  #     point), with its name underscored. Internal infrastructure
+  #     (KNOWN_KEYS, UnknownExtensionPoint, ContractCheck) is excluded.
+  module ContractCheck
+    INFRASTRUCTURE = %w[
+      KNOWN_KEYS
+      UnknownExtensionPoint
+      ContractCheck
+    ].freeze
+
+    HEADING_PATTERN = /^###\s+\d+\.\s+`([a-z][a-z0-9_]*)`/m
+
+    class << self
+      def documented_points(markdown)
+        markdown.scan(HEADING_PATTERN).flatten.map(&:downcase).uniq
+      end
+
+      def implemented_points
+        EvoExtensionPoints.constants(false).filter_map do |const_name|
+          next if INFRASTRUCTURE.include?(const_name.to_s)
+
+          value = EvoExtensionPoints.const_get(const_name)
+          next unless value.is_a?(Module)
+
+          underscore(const_name.to_s)
+        end
+      end
+
+      private
+
+      def underscore(camel)
+        camel
+          .gsub('::', '/')
+          .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+          .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+          .downcase
+      end
+    end
+  end
+end

--- a/lib/tasks/evo_extension_points.rake
+++ b/lib/tasks/evo_extension_points.rake
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# rake task: evo_extension_points:check_contract
+#
+# Guard-rail that catches breaking changes to the public extension contract
+# declared in EXTENSION_POINTS.md (story 0.2) versus the live Ruby modules
+# under EvoExtensionPoints (story 0.5). Wired into CI by the workflow
+# .github/workflows/community-with-enterprise-stub.yml.
+#
+# The check is intentionally simple: parse the documented extension point
+# names out of EXTENSION_POINTS.md and confirm a corresponding constant
+# exists under EvoExtensionPoints. Renames, removals, or undocumented
+# additions all fail loudly with a message that names the offending point.
+
+namespace :evo_extension_points do # rubocop:disable Metrics/BlockLength
+  desc 'Verify EXTENSION_POINTS.md matches the live EvoExtensionPoints API'
+  task check_contract: :environment do
+    require 'evo_extension_points'
+
+    md_path = Rails.root.join('EXTENSION_POINTS.md')
+    abort "[evo_extension_points:check_contract] EXTENSION_POINTS.md not found at #{md_path}" unless md_path.exist?
+
+    documented = EvoExtensionPoints::ContractCheck.documented_points(md_path.read)
+    implemented = EvoExtensionPoints::ContractCheck.implemented_points
+
+    missing = documented - implemented
+    undocumented = implemented - documented
+
+    if missing.any?
+      lines = missing.map { |n| "Breaking change in extension point #{n} — needs major version bump + deprecation window" }
+      abort <<~MSG
+        [evo_extension_points:check_contract] Breaking change detected!
+
+        #{lines.join("\n")}
+
+        EXTENSION_POINTS.md declares the extension point(s) above, but no
+        matching module exists under EvoExtensionPoints. This usually
+        means the module was removed or renamed without updating the
+        public contract — see ADR13 + the Compatibility Promise section
+        of EXTENSION_POINTS.md.
+      MSG
+    end
+
+    if undocumented.any?
+      abort <<~MSG
+        [evo_extension_points:check_contract] Undocumented extension point(s) detected!
+
+        The following module(s) exist under EvoExtensionPoints but are
+        not declared in EXTENSION_POINTS.md:
+
+        #{undocumented.map { |n| "  - #{n}" }.join("\n")}
+
+        Adding a new extension point requires documenting it in
+        EXTENSION_POINTS.md (a minor version bump per ADR13).
+      MSG
+    end
+
+    puts "[evo_extension_points:check_contract] OK — #{documented.size} extension point(s) documented and implemented:"
+    documented.sort.each { |name| puts "  - #{name}" }
+  end
+end

--- a/spec/lib/evo_extension_points/contract_check_spec.rb
+++ b/spec/lib/evo_extension_points/contract_check_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'evo_extension_points'
+
+RSpec.describe EvoExtensionPoints::ContractCheck do
+  describe '.documented_points' do
+    it 'parses extension point names from `### N. `name`` headings' do
+      markdown = <<~MD
+        # Extension Points
+
+        ## Extension points
+
+        ### 1. `feature_gate`
+
+        Some prose.
+
+        ### 2. `tenant_context`
+
+        ### 3. `plugin_loader`
+
+        ### 4. `theme_tokens`
+
+        ### 5. `data_export`
+      MD
+
+      expect(described_class.documented_points(markdown))
+        .to match_array(%w[feature_gate tenant_context plugin_loader theme_tokens data_export])
+    end
+
+    it 'is case-insensitive and deduplicated' do
+      markdown = <<~MD
+        ### 1. `feature_gate`
+        ### 2. `feature_gate`
+      MD
+
+      expect(described_class.documented_points(markdown)).to eq(%w[feature_gate])
+    end
+
+    it 'ignores headings that are not extension point declarations' do
+      markdown = <<~MD
+        ### 1. Some Section
+        ### 2. Another Section
+      MD
+
+      expect(described_class.documented_points(markdown)).to eq([])
+    end
+  end
+
+  describe '.implemented_points' do
+    it 'lists every Module constant directly defined under EvoExtensionPoints' do
+      points = described_class.implemented_points
+      expect(points).to include('feature_gate', 'tenant_context', 'plugin_loader', 'theme_tokens', 'data_export')
+    end
+
+    it 'excludes internal infrastructure (KNOWN_KEYS, UnknownExtensionPoint, ContractCheck)' do
+      points = described_class.implemented_points
+      expect(points).not_to include('known_keys', 'unknown_extension_point', 'contract_check')
+    end
+  end
+
+  describe 'integration with the real EXTENSION_POINTS.md' do
+    let(:markdown) { Rails.root.join('EXTENSION_POINTS.md').read }
+
+    it 'has the documented points and the implemented points fully matching' do
+      documented = described_class.documented_points(markdown).sort
+      implemented = described_class.implemented_points.sort
+
+      expect(documented).to eq(implemented),
+                            "Drift between EXTENSION_POINTS.md and EvoExtensionPoints API.\n" \
+                            "Documented only: #{(documented - implemented).inspect}\n" \
+                            "Implemented only: #{(implemented - documented).inspect}"
+    end
+  end
+
+  describe 'breaking change detection (simulated)' do
+    it 'flags an extension point that was renamed in the markdown but kept in the API' do
+      tampered = <<~MD
+        ### 1. `feature_gate`
+        ### 2. `renamed_tenant_context`
+        ### 3. `plugin_loader`
+        ### 4. `theme_tokens`
+        ### 5. `data_export`
+      MD
+
+      documented = described_class.documented_points(tampered)
+      implemented = described_class.implemented_points
+
+      missing = documented - implemented
+      undocumented = implemented - documented
+
+      expect(missing).to include('renamed_tenant_context')
+      expect(undocumented).to include('tenant_context')
+    end
+
+    it 'flags an extension point that was removed from the markdown but kept in the API' do
+      tampered = <<~MD
+        ### 1. `feature_gate`
+        ### 2. `plugin_loader`
+        ### 3. `theme_tokens`
+        ### 4. `data_export`
+      MD
+
+      documented = described_class.documented_points(tampered)
+      implemented = described_class.implemented_points
+
+      undocumented = implemented - documented
+      expect(undocumented).to include('tenant_context')
+    end
+  end
+end

--- a/spec/lib/tasks/evo_extension_points_rake_spec.rb
+++ b/spec/lib/tasks/evo_extension_points_rake_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'evo_extension_points'
+require 'rake'
+
+RSpec.describe 'evo_extension_points:check_contract rake task', type: :task do
+  let(:task) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('evo_extension_points:check_contract')
+    Rake::Task['evo_extension_points:check_contract']
+  end
+
+  before { task.reenable }
+
+  def stub_extension_points_md(markdown)
+    md_path = instance_double(Pathname, exist?: true, read: markdown, to_s: 'EXTENSION_POINTS.md')
+    allow(Rails.root).to receive(:join).with('EXTENSION_POINTS.md').and_return(md_path)
+  end
+
+  context 'when documented and implemented points match' do
+    it 'exits cleanly (no SystemExit)' do
+      expect { task.invoke }.to output(/OK — 5 extension point\(s\) documented and implemented/).to_stdout
+    end
+  end
+
+  context 'when an extension point declared in the markdown has no matching module' do
+    before do
+      stub_extension_points_md(<<~MD)
+        ### 1. `feature_gate`
+        ### 2. `tenant_context`
+        ### 3. `plugin_loader`
+        ### 4. `theme_tokens`
+        ### 5. `data_export`
+        ### 6. `ghost_extension_point`
+      MD
+    end
+
+    it 'aborts with the literal AC3 wording naming the missing point' do
+      expect { task.invoke }
+        .to raise_error(SystemExit)
+        .and output(/Breaking change in extension point ghost_extension_point — needs major version bump \+ deprecation window/).to_stderr
+    end
+  end
+
+  context 'when a module exists under EvoExtensionPoints but is not documented' do
+    before do
+      stub_extension_points_md(<<~MD)
+        ### 1. `feature_gate`
+        ### 2. `tenant_context`
+        ### 3. `plugin_loader`
+        ### 4. `theme_tokens`
+      MD
+    end
+
+    it 'aborts identifying the undocumented module name' do
+      expect { task.invoke }
+        .to raise_error(SystemExit)
+        .and output(/Undocumented extension point\(s\) detected.*data_export/m).to_stderr
+    end
+  end
+end

--- a/spec/support/enterprise_stub/enterprise_stub.gemspec
+++ b/spec/support/enterprise_stub/enterprise_stub.gemspec
@@ -1,0 +1,21 @@
+Gem::Specification.new do |spec|
+  spec.name    = 'enterprise_stub'
+  spec.version = '0.0.0'
+  spec.authors = ['Evolution API LTDA']
+  spec.email   = ['dev@evofoundation.com.br']
+  spec.summary = 'CI-only fixture that exercises the EvoExtensionPoints contract'
+  spec.description = <<~DESC
+    Internal fixture used by the community-with-enterprise-stub CI workflow.
+    Registers itself against every EvoExtensionPoints extension point with
+    trivial counter/spy implementations so the suite fails immediately if a
+    documented extension point is renamed or removed. Never published.
+  DESC
+  spec.license       = 'Nonstandard'
+  spec.required_ruby_version = '>= 3.4'
+
+  spec.metadata['allowed_push_host'] = 'none'
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.files         = ['lib/enterprise_stub.rb']
+  spec.require_paths = ['lib']
+end

--- a/spec/support/enterprise_stub/lib/enterprise_stub.rb
+++ b/spec/support/enterprise_stub/lib/enterprise_stub.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Internal CI fixture. Exercises every EvoExtensionPoints extension point
+# with a trivial counter/spy implementation. If a documented extension
+# point is renamed or removed, one of the `replace` / `register` calls
+# below raises EvoExtensionPoints::UnknownExtensionPoint or NameError and
+# the suite fails immediately — that is the desired behaviour.
+#
+# Loaded only when BUNDLE_WITH=enterprise_stub is set during bundle
+# install (Gemfile group :enterprise_stub).
+
+require 'evo_extension_points'
+
+module EnterpriseStub
+  module Counters
+    class << self
+      def reset!
+        @calls = Hash.new(0)
+      end
+
+      def increment(name)
+        @calls ||= Hash.new(0)
+        @calls[name] += 1
+      end
+
+      def calls
+        @calls ||= Hash.new(0)
+        @calls.dup
+      end
+    end
+  end
+
+  module Boot
+    class << self
+      def install! # rubocop:disable Metrics/MethodLength
+        EvoExtensionPoints.replace(:feature_gate) do |flag, **_context|
+          EnterpriseStub::Counters.increment(:feature_gate)
+          flag != :explicitly_disabled
+        end
+
+        EvoExtensionPoints.replace(:tenant_context_current_id) do
+          EnterpriseStub::Counters.increment(:tenant_context_current_id)
+          'stub-tenant'
+        end
+
+        EvoExtensionPoints.replace(:tenant_context_with_tenant) do |_id, &block|
+          EnterpriseStub::Counters.increment(:tenant_context_with_tenant)
+          block&.call
+        end
+
+        EvoExtensionPoints.replace(:theme_tokens) do |scope|
+          EnterpriseStub::Counters.increment(:theme_tokens)
+          { 'stub-scope' => scope.to_s }
+        end
+
+        EvoExtensionPoints::PluginLoader.register_plugin(:enterprise_stub) do |plugin|
+          plugin.on_boot { EnterpriseStub::Counters.increment(:plugin_loader_on_boot) }
+        end
+
+        EvoExtensionPoints::DataExport.register(name: :enterprise_stub_table) do |tenant_id|
+          EnterpriseStub::Counters.increment(:data_export)
+          [{ tenant_id: tenant_id, row: 'stub' }]
+        end
+      end
+    end
+  end
+end
+
+# One-shot: requiring this file installs the stubs into the global
+# EvoExtensionPoints registry. Re-requiring is harmless (replace just
+# overwrites the same keys), but resetting EvoExtensionPoints during a
+# test will drop the stubs — re-call EnterpriseStub::Boot.install! to
+# restore them.
+EnterpriseStub::Boot.install!


### PR DESCRIPTION
## Summary

Adds a CI workflow + rake task + enterprise stub fixture that catches breaking changes to the public extension contract declared in `EXTENSION_POINTS.md` against the live modules under `EvoExtensionPoints` (story EVO-1286).

Pieces:

- **Workflow** `.github/workflows/community-with-enterprise-stub.yml` — on every PR: RSpec standalone → `rake evo_extension_points:check_contract` → install the enterprise stub via `BUNDLE_WITH=enterprise_stub bundle install` → RSpec again with `--require enterprise_stub` so the stub attaches before the suite loads.
- **Rake task** `lib/tasks/evo_extension_points.rake` (`evo_extension_points:check_contract`) — aborts with the literal AC3 wording (`Breaking change in extension point <name> — needs major version bump + deprecation window`) for each documented point with no matching module, and with an `Undocumented extension point(s) detected` block for each module not in the markdown.
- **Contract check** `lib/evo_extension_points/contract_check.rb` — exposes `documented_points(markdown)` (parses `### N. \`name\`` headings) and `implemented_points` (`EvoExtensionPoints.constants(false)` filtered to Module values, internal infrastructure excluded).
- **Enterprise stub** `spec/support/enterprise_stub/` — path-only gem in Gemfile group `:enterprise_stub`; installs trivial counter/spy implementations on all five extension points so renaming or removing one breaks the suite via `EvoExtensionPoints::UnknownExtensionPoint` or `NameError`.
- **Docs sync** — adds `### 5. \`data_export\`` to `EXTENSION_POINTS.md` so the live API and the documented contract are in sync (the `DataExport` module was added in EVO-1286 but had not yet been documented).

## Security

- Workflow is read-only against the repo; no secrets read, no external services hit.
- `permissions: contents: read` minimizes the token scope.
- Triggers only on `pull_request` (no duplicate runs on push to main/develop).
- Enterprise stub is path-only and never reaches RubyGems (`allowed_push_host = "none"`), and `BUNDLE_WITH` is off by default in production.
- Rake task reads `EXTENSION_POINTS.md` and `EvoExtensionPoints` only — no DB, no network, no env reads beyond Rails environment.

## Test plan

- [x] `bundle exec rspec spec/lib/evo_extension_points/contract_check_spec.rb` — 8 examples, 0 failures
- [x] `bundle exec rspec spec/lib/tasks/evo_extension_points_rake_spec.rb` — 3 examples, 0 failures (covers AC3 wording literally + AC4 undocumented detection)
- [x] `bundle exec rspec spec/lib` — 70 examples, 0 failures
- [x] `bundle exec rake evo_extension_points:check_contract` — exits 0 with the five documented and implemented points listed
- [x] `bundle exec rubocop` on every new file — 0 offenses
- [ ] CI confirms the workflow itself green on this PR (this is the first run)

## Changed Files

- `.github/workflows/community-with-enterprise-stub.yml` (new — workflow)
- `lib/evo_extension_points/contract_check.rb` (new — checker)
- `lib/tasks/evo_extension_points.rake` (new — rake task)
- `lib/evo_extension_points.rb` (modified — requires the checker)
- `EXTENSION_POINTS.md` (modified — adds the `data_export` section)
- `Gemfile` / `Gemfile.lock` (modified — adds the `:enterprise_stub` group)
- `spec/support/enterprise_stub/enterprise_stub.gemspec` (new — path-only fixture gem)
- `spec/support/enterprise_stub/lib/enterprise_stub.rb` (new — stub bootstrap)
- `spec/lib/evo_extension_points/contract_check_spec.rb` (new — parser + introspection + simulated drift)
- `spec/lib/tasks/evo_extension_points_rake_spec.rb` (new — rake task with literal AC wording assertions)

## Related PRs

- EVO-1286 / PR #75 (merged) — `lib/evo_extension_points/` with the five no-op modules this PR's checker validates against.

## Linked Issue

- [EVO-1287](https://linear.app/evoai/issue/EVO-1287)