### PR TITLE
fix(EVO-1372): hardening de mensagens interativas com validacao, truncate e fallback

### DIFF
--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -210,25 +210,24 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
 
   def send_interactive_message(phone_number, message)
     clean_number = phone_number.delete('+')
-    items = message.content_attributes&.dig('items') || []
+    items = filter_valid_items(message.content_attributes&.dig('items') || [])
 
     if items.empty?
-      Rails.logger.warn "[Evolution Go] Interactive message has no items, falling back to text"
+      Rails.logger.warn "[Evolution Go] Interactive message has no valid items, falling back to text"
       return send_text_message(phone_number, message)
     end
 
-    # Evolution Go /send/button supports max 3 reply buttons;
-    # /send/list supports more via sections.
     if items.length <= 3
       send_button_message(clean_number, message, items)
     else
       send_list_message(clean_number, message, items)
     end
+  rescue StandardError => e
+    Rails.logger.error "[Evolution Go] Interactive message failed (#{e.message}), falling back to text"
+    send_text_message(phone_number, message)
   end
 
   def send_button_message(clean_number, message, items)
-    # Formato Evolution Go /send/button: { type, displayText, id }
-    # WhatsApp reply button displayText limit: 20 caracteres
     buttons = items.map do |item|
       { type: 'reply', displayText: item['title'].to_s.truncate(20), id: item['value'].to_s }
     end
@@ -259,10 +258,12 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
   end
 
   def send_list_message(clean_number, message, items)
-    # Formato Evolution Go /send/list: { rowId, title, description }
-    # WhatsApp list row title limit: 24 caracteres
-    rows = items.map do |item|
+    rows = items.first(10).map do |item|
       { rowId: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
+    end
+
+    if items.length > 10
+      Rails.logger.warn "[Evolution Go] List truncated from #{items.length} to 10 rows (WhatsApp limit)"
     end
 
     content = interactive_body_text(message)
@@ -295,7 +296,6 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
     clean_number = phone_number.delete('+')
 
     # CRM armazena cards em content_attributes.items (validado por ContentAttributeValidator)
-    # Cada item segue o schema: { title, description, media_url, actions: [{ text, type, payload, uri }] }
     items = message.content_attributes&.dig('items') || message.items || []
 
     if items.empty?
@@ -303,7 +303,6 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
       return send_text_message(phone_number, message)
     end
 
-    # Transforma formato CRM (items) para formato Evolution Go /send/carousel
     cards = items.map do |item|
       item = item.with_indifferent_access
       actions = item[:actions] || []
@@ -353,6 +352,16 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
     )
 
     process_evolution_go_response(response)
+  end
+
+  def filter_valid_items(items)
+    return [] unless items.is_a?(Array)
+
+    valid, rejected = items.partition { |item| item['title'].present? && item['value'].present? }
+    if rejected.any?
+      Rails.logger.warn "[Evolution Go] Filtered #{rejected.length} items missing title or value"
+    end
+    valid
   end
 
   def send_text_message(phone_number, message)

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -299,10 +299,10 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
 
   def send_interactive_message(phone_number, message)
     clean_number = phone_number.delete('+')
-    items = message.content_attributes&.dig('items') || []
+    items = filter_valid_items(message.content_attributes&.dig('items') || [])
 
     if items.empty?
-      Rails.logger.warn "[Evolution] Interactive message has no items, falling back to text"
+      Rails.logger.warn "[Evolution] Interactive message has no valid items, falling back to text"
       return send_text_message(phone_number, message)
     end
 
@@ -311,11 +311,12 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     else
       send_list_message(clean_number, message, items)
     end
+  rescue StandardError => e
+    Rails.logger.error "[Evolution] Interactive message failed (#{e.message}), falling back to text"
+    send_text_message(phone_number, message)
   end
 
   def send_button_message(clean_number, message, items)
-    # Formato Evolution API /message/sendButtons: { type, displayText, id }
-    # WhatsApp reply button displayText limit: 20 caracteres
     buttons = items.map do |item|
       { type: 'reply', displayText: item['title'].to_s.truncate(20), id: item['value'].to_s }
     end
@@ -342,10 +343,12 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
   end
 
   def send_list_message(clean_number, message, items)
-    # Formato Evolution API /message/sendList: { rowId, title, description }
-    # WhatsApp list row title limit: 24 caracteres
-    rows = items.map do |item|
+    rows = items.first(10).map do |item|
       { rowId: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
+    end
+
+    if items.length > 10
+      Rails.logger.warn "[Evolution] List truncated from #{items.length} to 10 rows (WhatsApp limit)"
     end
 
     content = interactive_body_text(message)
@@ -368,6 +371,16 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     )
 
     process_response(response)
+  end
+
+  def filter_valid_items(items)
+    return [] unless items.is_a?(Array)
+
+    valid, rejected = items.partition { |item| item['title'].present? && item['value'].present? }
+    if rejected.any?
+      Rails.logger.warn "[Evolution] Filtered #{rejected.length} items missing title or value"
+    end
+    valid
   end
 
   def send_text_message(phone_number, message)


### PR DESCRIPTION
## Summary

- Filtrar items sem `title` ou `value` antes do envio de mensagens interativas (com log warning)
- Truncar list rows ao limite de 10 por section do WhatsApp (com log warning)
- Rescue de erros da API com fallback graceful para texto plano
- Aplicado em ambos `EvolutionGoService` e `EvolutionService`

## Root cause

PR #59 (EVO-980) implementou buttons/lists sem validacao defensiva. Code review de 16/05/2026 identificou 3 gaps MEDIUM:

1. Sem fallback quando API rejeita payload interativo (mensagem perdida)
2. Items com `title`/`value` vazio passam direto -> WhatsApp rejeita mensagem inteira
3. Listas com >10 rows violam limite do WhatsApp -> API rejeita payload

## Changes

| Fix | evolution_go_service.rb | evolution_service.rb |
|-----|------------------------|---------------------|
| `filter_valid_items` | Particiona items, rejeita sem `title`/`value`, log warning | Mesmo |
| `send_list_message` | `items.first(10)` + warning log quando trunca | Mesmo |
| `send_interactive_message` | `rescue StandardError` -> fallback `send_text_message` | Mesmo |

## Test checklist

- [x] `ruby -c` syntax check — ambos OK
- [x] Botoes validos (2 items): entregue como ButtonMessage, status read no WhatsApp
- [x] Items invalidos (title vazio/null/ausente): filtrados -> fallback texto, entregue e lido
- [x] Lista 12 items: truncada a 10 rows, enviada como ListMessage, entregue e lida
- [x] Log `"truncated from 12 to 10"` confirmado
- [x] Todos os 3 testes confirmados manualmente no WhatsApp

## Related

- EVO-980 (origem — code review fresh de 16/05/2026)
- PR #59 (implementacao original de buttons/lists)