### PR TITLE
feat(EVO-590): permitir re-pipeline para contatos com jornada completada

### DIFF
--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -48,11 +48,11 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
         return
       end
 
-      # Check if conversation is already in THIS specific pipeline
-      if @pipeline.pipeline_items.exists?(conversation: conversation)
+      # Check if conversation has an ACTIVE (not completed) item in this pipeline
+      if @pipeline.pipeline_items.where(conversation: conversation, completed_at: nil).exists?
         error_response(
           ApiErrorCodes::BUSINESS_RULE_VIOLATION,
-          'Item is already in this pipeline'
+          'Item already has an active journey in this pipeline'
         )
         return
       end
@@ -69,11 +69,11 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
         return
       end
 
-      # Check if contact is already in THIS specific pipeline
-      if @pipeline.pipeline_items.exists?(contact: contact)
+      # Check if contact has an ACTIVE (not completed) item in this pipeline
+      if @pipeline.pipeline_items.where(contact: contact, completed_at: nil).exists?
         error_response(
           ApiErrorCodes::BUSINESS_RULE_VIOLATION,
-          'Contact is already in this pipeline'
+          'Contact already has an active journey in this pipeline'
         )
         return
       end
@@ -93,13 +93,13 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
     pipeline_stage = @pipeline.pipeline_stages.find(stage_id)
 
     if conversation.present?
-      # Check if conversation already exists in this pipeline
-      existing_pc = @pipeline.pipeline_items.find_by(conversation: conversation)
+      # Check if conversation already has an ACTIVE journey in this pipeline
+      existing_pc = @pipeline.pipeline_items.find_by(conversation: conversation, completed_at: nil)
 
       if existing_pc
         error_response(
           ApiErrorCodes::BUSINESS_RULE_VIOLATION,
-          "Item already exists in this pipeline in stage '#{existing_pc.pipeline_stage.name}'",
+          "Item already has an active journey in this pipeline in stage '#{existing_pc.pipeline_stage.name}'",
           details: {
             existing_stage: existing_pc.pipeline_stage.name,
             existing_stage_id: existing_pc.pipeline_stage_id
@@ -592,6 +592,16 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
   end
 
   def apply_filters
+    # By default show only active items; pass status=completed to see completed, status=all for everything
+    case params[:status]
+    when 'completed'
+      @pipeline_items = @pipeline_items.where.not(completed_at: nil)
+    when 'all'
+      # no filter
+    else
+      @pipeline_items = @pipeline_items.where(completed_at: nil)
+    end
+
     @pipeline_items = filter_by_stage if params[:stage_id].present?
     @pipeline_items = search_conversations if params[:search].present?
   end

--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -592,7 +592,7 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
   end
 
   def apply_filters
-    # By default show only active items; pass status=completed to see completed, status=all for everything
+    # Status filter: active (default), completed, all
     case params[:status]
     when 'completed'
       @pipeline_items = @pipeline_items.where.not(completed_at: nil)
@@ -602,8 +602,50 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
       @pipeline_items = @pipeline_items.where(completed_at: nil)
     end
 
+    # Temporal filters for completed/lost items
+    # completed_after: ISO8601 date — items completed after this date
+    # completed_before: ISO8601 date — items completed before this date
+    # completed_period: last_7d, last_30d, last_90d, last_year, this_month, this_year
+    if params[:completed_period].present?
+      range = temporal_range(params[:completed_period])
+      @pipeline_items = @pipeline_items.where(completed_at: range) if range
+    else
+      if params[:completed_after].present?
+        @pipeline_items = @pipeline_items.where('completed_at >= ?', Time.zone.parse(params[:completed_after]))
+      end
+      if params[:completed_before].present?
+        @pipeline_items = @pipeline_items.where('completed_at <= ?', Time.zone.parse(params[:completed_before]))
+      end
+    end
+
+    # Entered date filters
+    if params[:entered_after].present?
+      @pipeline_items = @pipeline_items.where('entered_at >= ?', Time.zone.parse(params[:entered_after]))
+    end
+    if params[:entered_before].present?
+      @pipeline_items = @pipeline_items.where('entered_at <= ?', Time.zone.parse(params[:entered_before]))
+    end
+
     @pipeline_items = filter_by_stage if params[:stage_id].present?
     @pipeline_items = search_conversations if params[:search].present?
+  end
+
+  def temporal_range(period)
+    now = Time.current
+    case period
+    when 'last_7d'
+      7.days.ago..now
+    when 'last_30d'
+      30.days.ago..now
+    when 'last_90d'
+      90.days.ago..now
+    when 'last_year'
+      1.year.ago..now
+    when 'this_month'
+      now.beginning_of_month..now
+    when 'this_year'
+      now.beginning_of_year..now
+    end
   end
 
   def apply_sorting

--- a/app/models/pipeline_item.rb
+++ b/app/models/pipeline_item.rb
@@ -45,8 +45,10 @@ class PipelineItem < ApplicationRecord
   has_many :products, through: :pipeline_item_products
   has_many :product_variants, through: :pipeline_item_products
 
-  validates :conversation_id, uniqueness: { scope: :pipeline_id }, allow_nil: true
-  validates :contact_id, uniqueness: { scope: :pipeline_id }, allow_nil: true
+  validates :conversation_id, uniqueness: { scope: :pipeline_id, conditions: -> { where(completed_at: nil) },
+                                            message: 'already has an active journey in this pipeline' }, allow_nil: true
+  validates :contact_id, uniqueness: { scope: :pipeline_id, conditions: -> { where(completed_at: nil) },
+                                       message: 'already has an active journey in this pipeline' }, allow_nil: true
   validate :must_have_conversation_or_contact
   validate :validate_custom_fields_structure
 

--- a/app/models/pipeline_item.rb
+++ b/app/models/pipeline_item.rb
@@ -62,6 +62,8 @@ class PipelineItem < ApplicationRecord
   after_destroy :publish_pipeline_item_deleted
 
   scope :in_stage, ->(stage) { where(pipeline_stage: stage) }
+  scope :active, -> { where(completed_at: nil) }
+  scope :completed, -> { where.not(completed_at: nil) }
 
   def move_to_stage(new_stage, _moved_by = nil)
     return false if new_stage.pipeline != pipeline

--- a/app/serializers/pipeline_serializer.rb
+++ b/app/serializers/pipeline_serializer.rb
@@ -54,8 +54,9 @@ module PipelineSerializer
           labels_by_id ||= all_labels.index_by { |label| label.id.to_s }
         end
 
-        # Serialize all items with full details
-        serialized_items = pipeline.pipeline_items.map do |item|
+        # Serialize only active items (completed journeys are accessible via pipeline_items endpoint with status=completed)
+        active_items = pipeline.pipeline_items.select { |item| item.completed_at.nil? }
+        serialized_items = active_items.map do |item|
           PipelineItemSerializer.serialize(
             item,
             include_entity: true,

--- a/app/services/pipelines/conversation_service.rb
+++ b/app/services/pipelines/conversation_service.rb
@@ -86,11 +86,13 @@ class Pipelines::ConversationService
   def prepare_conversation_for_pipeline(conversation)
     conversation.reload
 
-    existing_pipeline_items = conversation.pipeline_items.reload
-    return unless existing_pipeline_items.exists?
+    # Only remove active items from OTHER pipelines (not this one)
+    # This preserves completed journey history in the current pipeline
+    other_pipeline_items = conversation.pipeline_items.where.not(pipeline_id: @pipeline.id)
+    return unless other_pipeline_items.exists?
 
-    Rails.logger.info "Pipeline Service: Conversation #{conversation.id} already has pipeline conversations, destroying them first"
-    existing_pipeline_items.destroy_all
+    Rails.logger.info "Pipeline Service: Removing conversation #{conversation.id} from #{other_pipeline_items.count} other pipeline(s)"
+    other_pipeline_items.destroy_all
     conversation.reload
   end
 

--- a/db/migrate/20260517000001_allow_re_pipeline_for_completed_items.rb
+++ b/db/migrate/20260517000001_allow_re_pipeline_for_completed_items.rb
@@ -1,0 +1,34 @@
+class AllowRePipelineForCompletedItems < ActiveRecord::Migration[7.0]
+  def up
+    # Remove old unique indexes that prevent re-entry after completion
+    remove_index :pipeline_items, name: :index_pipeline_items_on_conversation_id_and_pipeline_id, if_exists: true
+    remove_index :pipeline_items, name: :index_pipeline_items_on_contact_id_and_pipeline_id, if_exists: true
+
+    # Add new partial unique indexes: uniqueness only for ACTIVE items (completed_at IS NULL)
+    # This allows a contact/conversation to have multiple completed journeys + one active
+    add_index :pipeline_items, [:conversation_id, :pipeline_id],
+              unique: true,
+              where: 'conversation_id IS NOT NULL AND completed_at IS NULL',
+              name: :idx_pipeline_items_active_conversation_per_pipeline
+
+    add_index :pipeline_items, [:contact_id, :pipeline_id],
+              unique: true,
+              where: 'conversation_id IS NULL AND completed_at IS NULL',
+              name: :idx_pipeline_items_active_contact_per_pipeline
+  end
+
+  def down
+    remove_index :pipeline_items, name: :idx_pipeline_items_active_conversation_per_pipeline, if_exists: true
+    remove_index :pipeline_items, name: :idx_pipeline_items_active_contact_per_pipeline, if_exists: true
+
+    add_index :pipeline_items, [:conversation_id, :pipeline_id],
+              unique: true,
+              where: 'conversation_id IS NOT NULL',
+              name: :index_pipeline_items_on_conversation_id_and_pipeline_id
+
+    add_index :pipeline_items, [:contact_id, :pipeline_id],
+              unique: true,
+              where: 'conversation_id IS NULL',
+              name: :index_pipeline_items_on_contact_id_and_pipeline_id
+  end
+end


### PR DESCRIPTION
## Summary

Permitir que contatos/conversas re-entrem no pipeline apos completar uma jornada anterior, mantendo historico completo de jornadas passadas com filtros temporais.

## Root cause

Unique indexes (`conversation_id, pipeline_id` e `contact_id, pipeline_id`) e validacoes de model impediam qualquer contato de ter mais de 1 pipeline_item por pipeline, mesmo apos `completed_at` ser preenchido. Usuarios com vendas recorrentes (consultorios, assinaturas anuais) nao conseguiam reiniciar o ciclo de vendas.

## Changes

| Arquivo | O que mudou |
|---------|-------------|
| `pipeline_item.rb` | Uniqueness validation com `conditions: -> { where(completed_at: nil) }` — unicidade apenas para items ativos |
| `pipeline_items_controller.rb` | Checks de duplicata apenas para items ativos. Filtro `status` (active/completed/all). Filtros temporais: `completed_period`, `completed_after/before`, `entered_after/before` |
| `conversation_service.rb` | `prepare_conversation_for_pipeline` preserva historico do pipeline atual, remove items de outros pipelines |
| Migration `20260517000001` | Substitui unique indexes por partial indexes com `WHERE completed_at IS NULL` |

## API — novos query params no GET /pipeline_items

| Param | Tipo | Descricao |
|-------|------|-----------|
| `status` | string | `active` (default), `completed`, `all` |
| `completed_period` | string | `last_7d`, `last_30d`, `last_90d`, `last_year`, `this_month`, `this_year` |
| `completed_after` | ISO8601 | Items completados apos esta data |
| `completed_before` | ISO8601 | Items completados antes desta data |
| `entered_after` | ISO8601 | Items que entraram no pipeline apos esta data |
| `entered_before` | ISO8601 | Items que entraram antes desta data |

## Test checklist

- [x] `ruby -c` — todos os arquivos OK
- [x] Adicionar contato ao pipeline — funciona
- [x] Completar jornada — `completed_at` preenchido
- [x] Re-pipeline apos completar — nova jornada criada, historico preservado
- [x] Duplicar jornada ativa — bloqueado ("Contact already has an active journey")
- [x] API default — retorna apenas items ativos (1)
- [x] API `status=all` — retorna todos (2)
- [x] API `status=completed` — retorna apenas completados (1)
- [x] API `completed_period=last_7d` — 0 (item completado ha 10 dias, fora do range)
- [x] API `completed_period=last_30d` — 1 (10 dias dentro de 30)
- [x] API `completed_period=last_90d` — 1
- [x] Frontend pipeline — mostra 1 contato por jornada ativa

## Criterios de aceite da issue

- [x] Possivel criar nova jornada para contato que ja completou
- [x] Historico de jornadas mantido e acessivel
- [x] Filtros temporais na lista de concluidos/perdidos
- [x] Validacao: nao permite duplicar jornada aberta
- [x] Testado em desenvolvimento e staging