### PR TITLE
fix(crm): render-side label-UUID guard in activity messages (EVO-1190)

### DIFF
--- a/app/models/concerns/label_activity_message_handler.rb
+++ b/app/models/concerns/label_activity_message_handler.rb
@@ -1,6 +1,8 @@
 module LabelActivityMessageHandler
   extend ActiveSupport::Concern
 
+  UUID_LABEL_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
   private
 
   def create_label_added(user_name, labels = [])
@@ -14,7 +16,33 @@ module LabelActivityMessageHandler
   def create_label_change_activity(change_type, user_name, labels = [])
     return unless labels.size.positive?
 
-    content = I18n.t("conversations.activity.labels.#{change_type}", user_name: user_name, labels: labels.join(', '))
+    resolved = resolve_label_titles_for_activity(labels)
+    content = I18n.t("conversations.activity.labels.#{change_type}", user_name: user_name, labels: resolved.join(', '))
     ::Conversations::ActivityMessageJob.perform_later(self, activity_message_params(content)) if content
+  end
+
+  # Defense-in-depth at the render boundary. The primary write paths that fed
+  # UUIDs into `tags.name` were closed by EVO-1001 (`LabelConcern`, 2026-04-24)
+  # and the automation flow (`ActionService#add_label` + StageAutomationService,
+  # 2026-05-12). Several callers still skip those resolvers and can leak UUIDs
+  # into `previous_changes[:label_list]`:
+  #   * `BulkActionsJob#bulk_add_labels` and `#remove_labels` — bulk-action
+  #     payloads carry UUIDs straight to `Labelable#add_labels`/`update!`.
+  #   * `ActionService#remove_label` — operates on the conversation's existing
+  #     `label_list`; if that list still contains legacy UUIDs the diff keeps
+  #     them.
+  #   * Direct writes in `app/controllers/api/v1/contacts_controller.rb`.
+  #   * Legacy data persisted before the upstream fixes (orphan UUID-shaped
+  #     `tags.name` rows survive a tagging removal).
+  # Resolving here guarantees the activity message always shows a human-readable
+  # title regardless of how the write reached `label_list`. If the label has
+  # been deleted the original value is preserved so the message still renders.
+  def resolve_label_titles_for_activity(labels)
+    values = Array(labels).map(&:to_s).reject(&:empty?)
+    uuids = values.grep(UUID_LABEL_REGEX)
+    return values if uuids.empty?
+
+    titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h.transform_keys(&:to_s)
+    values.map { |v| titles_by_id[v] || v }
   end
 end

--- a/spec/models/concerns/label_activity_message_handler_spec.rb
+++ b/spec/models/concerns/label_activity_message_handler_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Coverage for EVO-1190 — defense-in-depth at the activity-message render
+# boundary. The upstream resolvers (LabelConcern, ActionService#add_label,
+# StageAutomationService) keep UUIDs out of `tags.name` for their own write
+# paths, but BulkActionsJob, ActionService#remove_label and a few direct
+# writers can still leak UUIDs into `previous_changes[:label_list]`. This spec
+# locks in two layers: the helper resolves UUIDs in isolation, and a bypass
+# write through `update!(label_list: [uuid])` still produces an activity
+# message with the title (not the UUID).
+
+RSpec.describe LabelActivityMessageHandler do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:label) { Label.create!(title: "hot-lead-#{SecureRandom.hex(2)}") }
+
+  around do |example|
+    Current.user = user
+    example.run
+  ensure
+    Current.reset
+  end
+
+  def captured_activity_contents
+    contents = []
+    allow(Conversations::ActivityMessageJob).to receive(:perform_later) do |_record, params|
+      contents << params[:content]
+    end
+    contents
+  end
+
+  describe '#create_label_added' do
+    it 'renders the label title when a UUID is dispatched (regression of EVO-1001)' do
+      contents = captured_activity_contents
+      conversation.send(:create_label_added, user.name, [label.id])
+
+      expect(contents).to include(a_string_matching(/#{Regexp.escape(label.title)}/))
+      expect(contents).not_to include(a_string_matching(/#{Regexp.escape(label.id)}/))
+    end
+
+    it 'passes plain titles through unchanged' do
+      contents = captured_activity_contents
+      conversation.send(:create_label_added, user.name, ['hot-lead'])
+
+      expect(contents.last).to include('hot-lead')
+    end
+
+    it 'resolves a mixed array of UUID and title in a single activity message' do
+      other_label = Label.create!(title: "vip-#{SecureRandom.hex(2)}")
+      contents = captured_activity_contents
+
+      conversation.send(:create_label_added, user.name, [label.id, other_label.title])
+
+      expect(contents.last).to include(label.title)
+      expect(contents.last).to include(other_label.title)
+      expect(contents.last).not_to include(label.id)
+    end
+
+    it 'falls back to the raw UUID when the label no longer exists (graceful degradation)' do
+      orphan_uuid = SecureRandom.uuid
+      contents = captured_activity_contents
+
+      conversation.send(:create_label_added, user.name, [orphan_uuid])
+
+      expect(contents.last).to include(orphan_uuid)
+    end
+
+    it 'does not enqueue an activity message when the labels array is empty' do
+      expect(Conversations::ActivityMessageJob).not_to receive(:perform_later)
+      conversation.send(:create_label_added, user.name, [])
+    end
+  end
+
+  describe '#create_label_removed' do
+    it 'renders the label title when a UUID is dispatched' do
+      contents = captured_activity_contents
+      conversation.send(:create_label_removed, user.name, [label.id])
+
+      expect(contents.last).to include(label.title)
+      expect(contents.last).not_to include(label.id)
+    end
+  end
+
+  describe 'callback chain on a bypass write (update!(label_list: [uuid]))' do
+    # Simulates the BulkActionsJob path: a caller writes `label_list` with a
+    # raw UUID, skipping LabelConcern's resolver. The activity message must
+    # still render the title because of the render-time guard.
+    it 'preserves the title in the resulting activity message when adding' do
+      conversation
+      contents = captured_activity_contents
+
+      conversation.update!(label_list: [label.id])
+
+      label_activity = contents.find { |c| c&.include?('added') }
+      expect(label_activity).to be_present
+      expect(label_activity).to include(label.title)
+      expect(label_activity).not_to include(label.id)
+    end
+
+    it 'preserves the title in the resulting activity message when removing' do
+      conversation.update!(label_list: [label.id])
+      contents = captured_activity_contents
+
+      conversation.update!(label_list: [])
+
+      label_activity = contents.find { |c| c&.include?('removed') }
+      expect(label_activity).to be_present
+      expect(label_activity).to include(label.title)
+      expect(label_activity).not_to include(label.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add a render-time guard in `LabelActivityMessageHandler` so the conversation activity message never shows a UUID in place of a `Label#title`, regardless of how the label landed in `label_list`.

EVO-1190 was filed as a regression of EVO-1001, but the diagnosis (orphan UUID-named tags + `Automation System added <uuid>` activity messages dated 2026-05-06 → 2026-05-11) shows the bug was actually introduced by EVO-989 (per-stage automation rules, 6a3a926, 2026-05-05) and the primary write path was already fixed by 87d700a on 2026-05-12. This PR adds defense-in-depth for the **remaining** write paths that still skip the upstream resolvers:

- `BulkActionsJob#bulk_add_labels` and `#remove_labels` — bulk-action payload carries UUIDs straight to `Labelable`.
- `ActionService#remove_label` — operates on the existing `label_list`, so any legacy UUID stays in the diff.
- Direct writes in `app/controllers/api/v1/contacts_controller.rb` (lines 441/454).
- Legacy data persisted before EVO-1001 (orphan UUID-shaped `tags.name` rows observed in dev DB).

## Behaviour

- UUID-shaped entries are resolved to `Label#title` at activity-message compose time.
- Plain titles pass through unchanged.
- A UUID for a deleted label falls back to the raw value so the message still renders.

## Validation

- `evo-ai-crm-community: ruby -c app/models/concerns/label_activity_message_handler.rb` → Syntax OK
- `evo-ai-crm-community: bundle exec rspec spec/models/concerns/label_activity_message_handler_spec.rb spec/models/conversation_label_dispatch_spec.rb` → 10 examples, 0 failures (includes 2 E2E examples that exercise the bypass path via `conv.update!(label_list: [uuid])`)
- `evo-ai-crm-community: bundle exec rubocop app/models/concerns/label_activity_message_handler.rb spec/models/concerns/label_activity_message_handler_spec.rb` → 0 offenses

## Changed Files

- `app/models/concerns/label_activity_message_handler.rb`
- `spec/models/concerns/label_activity_message_handler_spec.rb`

## Follow-up (out of scope here)

Sanitising at the model boundary (`Labelable#update_labels` / `#add_labels`) would close the bypass class permanently and unify the four UUID-resolver copies that live across `LabelConcern`, `ActionService`, `StageAutomationService` and now `LabelActivityMessageHandler`. Worth a dedicated card.

## Linked Issue

- EVO-1190 — https://linear.app/evoai/issue/EVO-1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure conversation label activity messages always display human-readable label titles instead of raw UUIDs by resolving labels at render time.

Bug Fixes:
- Prevent UUID-shaped label identifiers from appearing in conversation activity messages by resolving them to the corresponding label titles at render time, with a safe fallback when labels have been deleted.

Tests:
- Add specs covering label activity message rendering for UUID-based labels, plain-title labels, mixed cases, and deleted-label fallbacks.