### PR TITLE
feat(agent-bot): render Typebot choice blocks as interactive buttons

### DIFF
--- a/app/controllers/webhooks/bot_runtime_controller.rb
+++ b/app/controllers/webhooks/bot_runtime_controller.rb
@@ -22,7 +22,20 @@ class Webhooks::BotRuntimeController < ActionController::API
       return
     end
 
-    message = AgentBots::MessageCreator.new(agent_bot).create_bot_reply(content, conversation)
+    content_type = params[:content_type].presence || 'text'
+    raw_items    = params[:items]
+    content_attributes = nil
+
+    if content_type == 'input_select' && raw_items.present?
+      items = raw_items.map { |item| { title: item[:title].to_s, value: item[:value].to_s } }
+      content_attributes = { items: items }
+    end
+
+    message = AgentBots::MessageCreator.new(agent_bot).create_bot_reply(
+      content, conversation,
+      content_type: content_type,
+      content_attributes: content_attributes
+    )
 
     if message
       Rails.logger.info "[BotRuntime::Postback] Message created: #{message.id} conversation=#{conversation.display_id}"

--- a/app/services/agent_bots/message_creator.rb
+++ b/app/services/agent_bots/message_creator.rb
@@ -3,7 +3,7 @@ class AgentBots::MessageCreator
     @agent_bot = agent_bot
   end
 
-  def create_bot_reply(content, conversation, force: false)
+  def create_bot_reply(content, conversation, force: false, content_type: 'text', content_attributes: nil)
     return if content.blank?
 
     # If force is true, skip eligibility check (e.g., for final response after transfer)
@@ -18,7 +18,7 @@ class AgentBots::MessageCreator
     end
 
     Rails.logger.info "[AgentBot HTTP] Creating bot reply in conversation #{conversation.id}"
-    create_message_with_fallback(content, conversation)
+    create_message_with_fallback(content, conversation, content_type: content_type, content_attributes: content_attributes)
   end
 
   private
@@ -53,22 +53,25 @@ class AgentBots::MessageCreator
     eligible
   end
 
-  def create_message_with_fallback(content, conversation)
-    create_direct_message(content, conversation)
+  def create_message_with_fallback(content, conversation, content_type:, content_attributes:)
+    create_direct_message(content, conversation, content_type: content_type, content_attributes: content_attributes)
   rescue StandardError => e
     log_creation_error(e)
-    create_message_with_builder(content, conversation)
+    create_message_with_builder(content, conversation, content_type: content_type, content_attributes: content_attributes)
   end
 
-  def create_direct_message(content, conversation)
+  def create_direct_message(content, conversation, content_type:, content_attributes:)
     message_attributes = {
       inbox: conversation.inbox,
       conversation: conversation,
       content: content,
       message_type: 'outgoing',
       sender: @agent_bot,
-      content_type: 'text'
+      content_type: content_type
     }
+
+    merged_content_attributes = {}
+    merged_content_attributes.merge!(content_attributes) if content_attributes.present?
 
     # Check if send_as_reply is enabled in bot_config
     send_as_reply = @agent_bot.bot_config&.dig('send_as_reply') == true
@@ -77,8 +80,10 @@ class AgentBots::MessageCreator
     # OR if send_as_reply is enabled in bot_config
     if conversation.post_conversation? || send_as_reply
       reply_attributes = build_reply_attributes(conversation)
-      message_attributes[:content_attributes] = reply_attributes if reply_attributes.present?
+      merged_content_attributes.merge!(reply_attributes) if reply_attributes.present?
     end
+
+    message_attributes[:content_attributes] = merged_content_attributes if merged_content_attributes.present?
 
     message = Message.create!(message_attributes)
 
@@ -94,8 +99,11 @@ class AgentBots::MessageCreator
     Rails.logger.info '[AgentBot HTTP] Trying with MessageBuilder as fallback'
   end
 
-  def create_message_with_builder(content, conversation)
-    message_params = { content: content, message_type: 'outgoing' }
+  def create_message_with_builder(content, conversation, content_type:, content_attributes:)
+    message_params = { content: content, message_type: 'outgoing', content_type: content_type }
+
+    merged_content_attributes = {}
+    merged_content_attributes.merge!(content_attributes) if content_attributes.present?
 
     # Check if send_as_reply is enabled in bot_config
     send_as_reply = @agent_bot.bot_config&.dig('send_as_reply') == true
@@ -104,8 +112,10 @@ class AgentBots::MessageCreator
     # OR if send_as_reply is enabled in bot_config
     if conversation.post_conversation? || send_as_reply
       reply_attributes = build_reply_attributes(conversation)
-      message_params[:content_attributes] = reply_attributes if reply_attributes.present?
+      merged_content_attributes.merge!(reply_attributes) if reply_attributes.present?
     end
+
+    message_params[:content_attributes] = merged_content_attributes if merged_content_attributes.present?
 
     message = Messages::MessageBuilder.new(@agent_bot, conversation, message_params).perform
     Rails.logger.info "[AgentBot HTTP] MessageBuilder fallback successful: #{message.id}"

--- a/app/services/agent_bots/response_processor.rb
+++ b/app/services/agent_bots/response_processor.rb
@@ -43,14 +43,18 @@ class AgentBots::ResponseProcessor
     artifacts = extract_artifacts(parsed_response)
     return unless artifacts
 
-    text_content = extract_text_from_artifacts(artifacts)
+    extracted = extract_content_from_artifacts(artifacts)
+    text_content = extracted[:text]
     return unless text_content
 
     conversation = AgentBots::ConversationFinder.new(@agent_bot, @payload).find_conversation
     return unless conversation
 
+    select_part = extracted[:select]
+    select_items = select_part&.dig('items')
+
     # Check if text segmentation is enabled for this agent bot
-    if @agent_bot.text_segmentation_enabled && ['evo_ai_provider', 'n8n_provider'].include?(@agent_bot.bot_provider)
+    if select_items.blank? && @agent_bot.text_segmentation_enabled && ['evo_ai_provider', 'n8n_provider'].include?(@agent_bot.bot_provider)
       process_segmented_response(text_content, conversation)
     else
       # Process as a single message with signature
@@ -59,13 +63,15 @@ class AgentBots::ResponseProcessor
       
       # Try to create message normally first
       message_creator = AgentBots::MessageCreator.new(@agent_bot)
-      message = message_creator.create_bot_reply(final_content, conversation)
+      content_type = select_items.present? ? 'input_select' : 'text'
+      content_attributes = select_items.present? ? { items: select_items } : nil
+      message = message_creator.create_bot_reply(final_content, conversation, content_type: content_type, content_attributes: content_attributes)
       
       # If message creation failed (conversation not eligible, e.g., after transfer),
       # try to force create it anyway (for final responses after transfer)
       unless message
         Rails.logger.info "[AgentBot HTTP] Message creation failed (conversation not eligible), attempting force create..."
-        message = message_creator.create_bot_reply(final_content, conversation, force: true)
+        message = message_creator.create_bot_reply(final_content, conversation, force: true, content_type: content_type, content_attributes: content_attributes)
       end
       
       message
@@ -79,12 +85,27 @@ class AgentBots::ResponseProcessor
     artifacts
   end
 
-  def extract_text_from_artifacts(artifacts)
-    artifact = artifacts.first
-    return unless artifact['parts']&.any?
+  def extract_content_from_artifacts(artifacts)
+    text = nil
+    select = nil
 
-    text_part = artifact['parts'].find { |p| p['type'] == 'text' }
-    text_part&.dig('text')
+    artifacts.each do |artifact|
+      next unless artifact.is_a?(Hash) && artifact['parts'].is_a?(Array)
+
+      artifact['parts'].each do |part|
+        next unless part.is_a?(Hash)
+
+        if text.nil? && part['type'] == 'text' && part['text'].present?
+          text = part['text']
+        end
+
+        if select.nil? && part['type'] == 'select'
+          select = part
+        end
+      end
+    end
+
+    { text: text, select: select }
   end
 
   def process_segmented_response(text_content, conversation)

--- a/app/services/whatsapp/providers/base_service.rb
+++ b/app/services/whatsapp/providers/base_service.rb
@@ -114,10 +114,27 @@ class Whatsapp::Providers::BaseService
     end
   end
 
+  def interactive_body_text(message)
+    content = html_to_whatsapp(message.content.to_s)
+    return content if content.blank?
+
+    lines = content.split("\n")
+    removed_any = false
+
+    while lines.any? && lines.last.strip.match?(/^\d+\.\s+\S/)
+      lines.pop
+      removed_any = true
+    end
+
+    pruned = lines.join("\n").strip
+    return content unless removed_any
+    pruned.presence || content
+  end
+
   def create_button_payload(message)
     buttons = create_buttons(message.content_attributes['items'])
     json_hash = { 'buttons' => buttons }
-    create_payload('button', message.content, JSON.generate(json_hash))
+    create_payload('button', interactive_body_text(message), JSON.generate(json_hash))
   end
 
   def create_list_payload(message)
@@ -125,6 +142,6 @@ class Whatsapp::Providers::BaseService
     section1 = { 'rows' => rows }
     sections = [section1]
     json_hash = { :button => 'Choose an item', 'sections' => sections }
-    create_payload('list', message.content, JSON.generate(json_hash))
+    create_payload('list', interactive_body_text(message), JSON.generate(json_hash))
   end
 end

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -208,6 +208,23 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
     whatsapp_channel.provider_config['instance_name']
   end
 
+  def interactive_body_text(message)
+    content = html_to_whatsapp(message.content.to_s)
+    return content if content.blank?
+
+    lines = content.split("\n")
+    removed_any = false
+
+    while lines.any? && lines.last.strip.match?(/^\d+\.\s+\S/)
+      lines.pop
+      removed_any = true
+    end
+
+    pruned = lines.join("\n").strip
+    return content unless removed_any
+    pruned.presence || content
+  end
+
   def send_interactive_message(phone_number, message)
     clean_number = phone_number.delete('+')
     items = message.content_attributes&.dig('items') || []
@@ -233,7 +250,7 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
       { type: 'reply', displayText: item['title'].to_s.truncate(20), id: item['value'].to_s }
     end
 
-    content = html_to_whatsapp(message.content.to_s)
+    content = interactive_body_text(message)
 
     body = {
       number: clean_number,
@@ -265,7 +282,7 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
       { rowId: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
     end
 
-    content = html_to_whatsapp(message.content.to_s)
+    content = interactive_body_text(message)
 
     body = {
       number: clean_number,

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -208,23 +208,6 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
     whatsapp_channel.provider_config['instance_name']
   end
 
-  def interactive_body_text(message)
-    content = html_to_whatsapp(message.content.to_s)
-    return content if content.blank?
-
-    lines = content.split("\n")
-    removed_any = false
-
-    while lines.any? && lines.last.strip.match?(/^\d+\.\s+\S/)
-      lines.pop
-      removed_any = true
-    end
-
-    pruned = lines.join("\n").strip
-    return content unless removed_any
-    pruned.presence || content
-  end
-
   def send_interactive_message(phone_number, message)
     clean_number = phone_number.delete('+')
     items = message.content_attributes&.dig('items') || []

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -297,23 +297,6 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     whatsapp_channel.provider_config['instance_name']
   end
 
-  def interactive_body_text(message)
-    content = html_to_whatsapp(message.content.to_s)
-    return content if content.blank?
-
-    lines = content.split("\n")
-    removed_any = false
-
-    while lines.any? && lines.last.strip.match?(/^\d+\.\s+\S/)
-      lines.pop
-      removed_any = true
-    end
-
-    pruned = lines.join("\n").strip
-    return content unless removed_any
-    pruned.presence || content
-  end
-
   def send_interactive_message(phone_number, message)
     clean_number = phone_number.delete('+')
     items = message.content_attributes&.dig('items') || []

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -297,6 +297,23 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     whatsapp_channel.provider_config['instance_name']
   end
 
+  def interactive_body_text(message)
+    content = html_to_whatsapp(message.content.to_s)
+    return content if content.blank?
+
+    lines = content.split("\n")
+    removed_any = false
+
+    while lines.any? && lines.last.strip.match?(/^\d+\.\s+\S/)
+      lines.pop
+      removed_any = true
+    end
+
+    pruned = lines.join("\n").strip
+    return content unless removed_any
+    pruned.presence || content
+  end
+
   def send_interactive_message(phone_number, message)
     clean_number = phone_number.delete('+')
     items = message.content_attributes&.dig('items') || []
@@ -320,7 +337,7 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
       { type: 'reply', displayText: item['title'].to_s.truncate(20), id: item['value'].to_s }
     end
 
-    content = html_to_whatsapp(message.content.to_s)
+    content = interactive_body_text(message)
 
     body = {
       number: clean_number,
@@ -348,7 +365,7 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
       { rowId: item['value'].to_s, title: item['title'].to_s.truncate(24), description: '' }
     end
 
-    content = html_to_whatsapp(message.content.to_s)
+    content = interactive_body_text(message)
 
     body = {
       number: clean_number,


### PR DESCRIPTION
## Summary

Handles structured `input_select` messages from the bot runtime to create
interactive button/list messages in the CRM. The chat widget renders them as
clickable buttons and WhatsApp receives them as interactive list messages.

## Dependencies

> Requires evolution-foundation/evo-bot-runtime#2 to be merged first
> (provides `content_type` and `items` in the postback payload).

## Changes

### [app/controllers/webhooks/bot_runtime_controller.rb](evo-crm-community/evo-ai-crm-community/app/controllers/webhooks/bot_runtime_controller.rb:0:0-0:0)
- Reads `content_type` and `items` params from the runtime postback.
- Builds `content_attributes: {items: [...]}` and passes it to the service
  when `content_type == "input_select"`.
- Falls back to the existing plain-text flow when params are absent.

### `app/services/agent_bots/response_processor.rb`
- `extract_text_from_artifacts` now returns `{text:, select:}` instead of a
  plain string, scanning all artifact parts for both `text` and `select` types.

### [app/services/agent_bots/message_creator.rb](evo-crm-community/evo-ai-crm-community/app/services/agent_bots/message_creator.rb:0:0-0:0)
- Creates messages with `content_type: "input_select"` and
  `content_attributes: {items: [...]}` when structured select data is present.

### `app/services/whatsapp/providers/base_service.rb`
- New `interactive_body_text(message)` helper: strips trailing numbered-list
  lines (e.g. `1. Option`) from the message body before building WhatsApp
  button/list payloads, avoiding duplication of options in both text and
  buttons.
- `create_button_payload` and `create_list_payload` use the new helper.

### `app/services/whatsapp/providers/evolution_go_service.rb`
- Overrides `interactive_body_text` with the same stripping logic.
- `send_interactive_message` uses it for both button and list paths.

### `app/services/whatsapp/providers/evolution_service.rb`
- Same changes as `evolution_go_service.rb` for provider consistency.

## Notes

- `db/schema.rb` is intentionally excluded (auto-generated file).
- Backward-compatible: when no `content_type` is provided by the runtime, the
  controller falls back to the existing plain-text message creation flow.

## Summary by Sourcery

Handle structured select responses from the bot runtime by creating input_select messages with selectable items and improving WhatsApp interactive message bodies.

New Features:
- Support creating input_select messages with structured items from bot runtime postbacks and agent bot responses.
- Enable WhatsApp providers to send interactive button and list messages using cleaned-up body text derived from bot messages.

Enhancements:
- Refine agent bot response processing to extract both text and select artifacts from bot responses and disable text segmentation when select items are present.
- Extend message creation logic to propagate content_type and content_attributes, merging them with reply metadata when applicable.
- Normalize WhatsApp interactive message body text by stripping trailing numbered option lines to avoid duplicating options in both text and buttons/lists.