### PR TITLE
feat(crm): EvoFlow module foundation — client + payload + worker (EVO-1238)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -257,6 +257,15 @@ USE_OPTIMIZED_CONVERSATION_FINDER=false
 # Internal API token for secure communication between EvoAI services
 EVOAI_CRM_API_TOKEN=
 
+# EvoFlow Integration (event tracking → evo-flow)
+# Base URL INCLUDING the /api/v1 prefix
+EVO_FLOW_API_URL=http://evo-flow:3000/api/v1
+# Shared service-to-service key; MUST equal evo-flow's AUTH_APIKEY_INTEGRATION_LOCAL (no default)
+AUTH_APIKEY_INTEGRATION_LOCAL=
+# In production the client refuses to send the key over plain http. Set to
+# 'true' ONLY when evo-flow is reached over a trusted private network.
+EVO_FLOW_ALLOW_INSECURE=
+
 # Fernet encryption key for sensitive configuration values (e.g., API keys stored in installation_configs)
 # Must be a Fernet-compatible base64-encoded 256-bit key
 # Generate with: ruby -e "require 'securerandom'; require 'base64'; puts Base64.urlsafe_encode64(SecureRandom.random_bytes(32))"

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -1,0 +1,102 @@
+module EvoFlow
+  # Raised on any non-2xx evo-flow response, an unparseable body, or a network
+  # failure. Mirrors Crm::Hubspot::Api::BaseClient::ApiError (code + response).
+  class HTTPError < StandardError
+    attr_reader :code, :response
+
+    def initialize(message = nil, code = nil, response = nil)
+      @code = code
+      @response = response
+      super(message)
+    end
+  end
+
+  # Raised at construction time for an unusable configuration (missing key, or
+  # cleartext transport in production). Fails fast instead of emitting a
+  # request that is guaranteed to 401 or that leaks the shared key in cleartext.
+  class ConfigurationError < StandardError; end
+
+  # Instance-based (DI-friendly) authenticated HTTP client for evo-flow.
+  # Pattern mirrors app/services/crm/hubspot/api/base_client.rb (HTTParty +
+  # custom error + handle_response).
+  class Client
+    include HTTParty
+
+    DEFAULT_API_URL = 'http://evo-flow:3000/api/v1'.freeze
+    REDACTED_BODY = '[redacted: auth failure]'.freeze
+    MAX_LOGGED_BODY = 500
+
+    def initialize(api_url: ENV.fetch('EVO_FLOW_API_URL', DEFAULT_API_URL),
+                   api_key: ENV.fetch('AUTH_APIKEY_INTEGRATION_LOCAL', nil),
+                   timeout: 10)
+      @api_url = api_url
+      @api_key = api_key
+      @timeout = timeout
+      validate_config!
+    end
+
+    def post(path, payload)
+      response = self.class.post(join(@api_url, path),
+                                 body: payload.to_json,
+                                 headers: request_headers,
+                                 timeout: @timeout)
+      handle_response(response)
+    rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError => e
+      raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
+    end
+
+    private
+
+    def validate_config!
+      raise ConfigurationError, 'AUTH_APIKEY_INTEGRATION_LOCAL is not set' if @api_key.to_s.strip.empty?
+      return if URI(@api_url).scheme == 'https'
+      return unless Rails.env.production?
+      return if ENV.fetch('EVO_FLOW_ALLOW_INSECURE', nil) == 'true'
+
+      raise ConfigurationError,
+            "refusing to send the API key over cleartext (#{@api_url}); use https " \
+            'or set EVO_FLOW_ALLOW_INSECURE=true only on a trusted private network'
+    end
+
+    # URI.join drops the /api/v1 prefix when path starts with '/' (a leading
+    # slash resets to root). A *relative* join (base ends with '/', path has
+    # no leading slash) preserves the prefix and normalises the boundary.
+    def join(base, path)
+      URI.join("#{base.chomp('/')}/", path.to_s.sub(%r{\A/+}, '')).to_s
+    end
+
+    def request_headers
+      { 'Content-Type' => 'application/json', 'X-Integration-API-Key' => @api_key }
+    end
+
+    def handle_response(response)
+      raise_api_error(response) unless (200..299).cover?(response.code)
+
+      parse_body(response)
+    end
+
+    def parse_body(response)
+      response.parsed_response
+    rescue JSON::ParserError, TypeError => e
+      raise EvoFlow::HTTPError.new("evo-flow returned an unparseable body: #{e.message}",
+                                   response.code, response)
+    end
+
+    def raise_api_error(response)
+      msg = "evo-flow API error: #{response.code} - #{safe_body(response)}"
+      Rails.logger.error(msg)
+      # error.response still carries the full HTTParty response for programmatic
+      # use; only the logged/message form is redacted/bounded.
+      raise EvoFlow::HTTPError.new(msg, response.code, response)
+    end
+
+    # Auth-rejection bodies frequently echo the offending key/context, so they
+    # are never logged. Other bodies are length-bounded to keep logs sane.
+    def safe_body(response)
+      return REDACTED_BODY if [401, 403].include?(response.code)
+
+      body = response.body.to_s
+      body.length > MAX_LOGGED_BODY ? "#{body[0, MAX_LOGGED_BODY]}... (truncated)" : body
+    end
+  end
+end

--- a/app/services/evo_flow/payload_builder.rb
+++ b/app/services/evo_flow/payload_builder.rb
@@ -1,0 +1,44 @@
+module EvoFlow
+  # Shapes the real evo-flow DTOs (camelCase, single-tenant: NO accountId).
+  # track  -> TrackEventDto    (uses `event`)
+  # identify -> IdentifyEventDto (uses `eventName`)
+  # See evo-flow/src/modules/events/dto/*.
+  class PayloadBuilder
+    # Exactly 5 kwargs (RuboCop ParameterLists max 5 — do not add a 6th).
+    def self.build_track(event_name:, contact_id:, properties:, occurred_at:, message_id:)
+      {
+        messageId: message_id,
+        contactId: contact_id.to_s,
+        event: event_name,
+        properties: properties || {},
+        timestamp: iso8601(occurred_at)
+      }
+    end
+
+    def self.build_identify(event_name:, contact_id:, traits:, occurred_at:, message_id:)
+      {
+        messageId: message_id,
+        contactId: contact_id.to_s,
+        eventName: event_name,
+        traits: traits || {},
+        timestamp: iso8601(occurred_at)
+      }
+    end
+
+    # Deterministic, forward-looking idempotency key. NOTE: evo-flow has no
+    # consumer-side dedup yet (clickhouse contact_events is MergeTree); Sidekiq
+    # retries currently still duplicate downstream. Tracked separately.
+    def self.message_id_for(event_name, contact_id, source_event_uuid)
+      Digest::SHA256.hexdigest("#{event_name}|#{contact_id}|#{source_event_uuid}")
+    end
+
+    # Always emits UTC ISO-8601. A String is validated by re-parsing (fail
+    # fast with ArgumentError rather than shipping an unparseable timestamp
+    # that evo-flow would silently misread/reject downstream).
+    def self.iso8601(time)
+      return Time.iso8601(time).utc.iso8601 if time.is_a?(String)
+
+      (time || Time.current).utc.iso8601
+    end
+  end
+end

--- a/app/workers/evo_flow/publish_event_worker.rb
+++ b/app/workers/evo_flow/publish_event_worker.rb
@@ -1,0 +1,76 @@
+module EvoFlow
+  # Pure Sidekiq worker (repo convention: include Sidekiq::Worker, lives in
+  # app/workers/). retry: 5 overrides the global sidekiq.yml max_retries: 3.
+  #
+  # On retry exhaustion the sidekiq_retries_exhausted hook fires and the job
+  # lands in the (default-on) Dead Set, broadcasting Wisper
+  # :evo_flow_publish_failed for downstream handling (listener wired later).
+  # Honest caveat: this hook runs in-process on the final attempt; if that
+  # process is hard-killed (OOM/SIGKILL) the hook does not run — terminal
+  # alerting then relies on Dead Set monitoring, not this broadcast.
+  #
+  # Signature is perform(path, payload) — Client#post needs the target path;
+  # documented divergence from EVO-1238's perform(payload).
+  class PublishEventWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :integrations, retry: 5
+
+    # Event content may carry PII (contact traits/properties). It is redacted
+    # before being persisted as Sidekiq job args / Dead Set / Wisper payload;
+    # only identifiers needed for triage and replay decisions are kept.
+    PII_KEYS = %w[properties traits].freeze
+
+    # Wisper 2.0.0 exposes NO `Wisper.publish`; global listeners registered via
+    # `Wisper.subscribe` (config/initializers/contact_company_listeners.rb) are
+    # notified by any Wisper::Publisher#broadcast. `publish` is private, so
+    # wrap it. Mirrors the repo idiom in Contacts::BulkTransferService.
+    class FailureBroadcaster
+      include Wisper::Publisher
+
+      def broadcast_failed(path:, payload:, error:)
+        publish('evo_flow_publish_failed', data: { path: path, payload: payload, error: error })
+      end
+    end
+
+    def self.sanitize_payload(payload)
+      return payload unless payload.is_a?(Hash)
+
+      payload.each_with_object({}) do |(key, value), acc|
+        acc[key] = PII_KEYS.include?(key.to_s) ? '[redacted]' : value
+      end
+    end
+
+    sidekiq_retries_exhausted do |job, ex|
+      args = job['args'] || []
+      path = args[0]
+      safe_payload = EvoFlow::PublishEventWorker.sanitize_payload(args[1])
+      Rails.logger.error("[EvoFlow] terminal failure path=#{path} msg=#{ex.message}")
+      FailureBroadcaster.new.broadcast_failed(path: path, payload: safe_payload, error: ex.message)
+    end
+
+    def perform(path, payload)
+      EvoFlow::Client.new.post(path, payload)
+      Rails.logger.info("[EvoFlow] published path=#{path} messageId=#{message_id(payload)}")
+    rescue EvoFlow::HTTPError => e
+      Rails.logger.warn(
+        "[EvoFlow] publish failed (will retry) path=#{path} code=#{e.code} msg=#{e.message}"
+      )
+      raise
+    rescue StandardError => e
+      # Any other failure (unparseable body, bad args, config error) must also
+      # count as a Sidekiq retry and reach the exhaustion path uniformly.
+      Rails.logger.warn("[EvoFlow] publish errored (will retry) path=#{path} msg=#{e.message}")
+      raise
+    end
+
+    private
+
+    # Sidekiq JSON-serialises args → string keys for enqueued jobs; tolerate
+    # symbol keys too (in-process / console invocation with builder output).
+    def message_id(payload)
+      return unless payload.is_a?(Hash)
+
+      payload['messageId'] || payload[:messageId]
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,16 @@ module Evolution
     config.api_only = true
 
     config.eager_load_paths << Rails.root.join('lib')
+
+    # EvoFlow::EVENT_NAMES is grouped with Events::Types under lib/events/ but
+    # its constant name does not match the Zeitwerk path. The ignore must be
+    # configured before the autoloader is set up (an initializer would run too
+    # late), so it lives here. The file is required explicitly so the constant
+    # is always available and production eager_load does not raise NameError.
+    evo_flow_event_names = Rails.root.join('lib/events/evo_flow_event_names.rb')
+    Rails.autoloaders.main.ignore(evo_flow_event_names)
+    require evo_flow_event_names.to_s
+
     # MCP resources/tools don't follow standard Rails naming patterns
     # Don't add to eager_load_paths - let them be loaded on-demand by Zeitwerk
     # config.eager_load_paths << Rails.root.join('app/mcp')

--- a/lib/events/evo_flow_event_names.rb
+++ b/lib/events/evo_flow_event_names.rb
@@ -1,0 +1,13 @@
+module EvoFlow
+  # Canonical list of event names CRM emits to evo-flow.
+  # Story 7.3 (EVO-1238) foundation: declaration only — hard validation
+  # (raise EvoFlow::InvalidEventName) is story 7.5 (EVO-1241).
+  # Dot-notation matches the Events::Types convention (lib/events/types.rb).
+  EVENT_NAMES = %w[
+    contact.created contact.updated contact.deleted
+    contact.label.added contact.label.removed contact.custom_attribute.changed
+    conversation.created conversation.resolved
+    message.created message.delivered message.read message.failed
+    campaign.triggered campaign.message.sent campaign.message.opened campaign.message.clicked
+  ].freeze
+end

--- a/spec/lib/events/evo_flow_event_names_spec.rb
+++ b/spec/lib/events/evo_flow_event_names_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+# F6/F7: EvoFlow::EVENT_NAMES lives in lib/events/ with a constant name that
+# does not match the Zeitwerk path; loading is handled by an ignore + explicit
+# require in config/application.rb. This spec is the regression guard: if a
+# future refactor breaks that wiring (or production eager_load), it fails here
+# instead of only at deploy time.
+RSpec.describe 'EvoFlow::EVENT_NAMES' do
+  it 'is a frozen Array<String> of exactly the 16 events (AC6)' do
+    expect(EvoFlow::EVENT_NAMES).to be_frozen
+    expect(EvoFlow::EVENT_NAMES).to all(be_a(String))
+    expect(EvoFlow::EVENT_NAMES).to contain_exactly(
+      'contact.created', 'contact.updated', 'contact.deleted',
+      'contact.label.added', 'contact.label.removed', 'contact.custom_attribute.changed',
+      'conversation.created', 'conversation.resolved',
+      'message.created', 'message.delivered', 'message.read', 'message.failed',
+      'campaign.triggered', 'campaign.message.sent',
+      'campaign.message.opened', 'campaign.message.clicked'
+    )
+  end
+
+  it 'production-style eager_load does not raise (Zeitwerk wiring intact)' do
+    expect { Rails.application.eager_load! }.not_to raise_error
+  end
+
+  it 'autoloads the EvoFlow:: app classes alongside the lib constant' do
+    expect(EvoFlow::Client).to be < Object
+    expect(EvoFlow::PayloadBuilder).to be < Object
+    expect(EvoFlow::PublishEventWorker).to be < Object
+    expect(EvoFlow::HTTPError).to be < StandardError
+    expect(EvoFlow::ConfigurationError).to be < StandardError
+  end
+end

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe EvoFlow::Client do
+  let(:api_url) { 'http://evo-flow:3000/api/v1' }
+  let(:api_key) { 'xyz' }
+  let(:client) { described_class.new(api_url: api_url, api_key: api_key, timeout: 5) }
+  let(:track_url) { "#{api_url}/events/track" }
+  let(:payload) { { event: 'contact.created', contactId: '42' } }
+
+  describe '#post' do
+    it 'POSTs to the full /api/v1 URL with auth + json headers (AC1)' do
+      stub = stub_request(:post, track_url)
+             .with(
+               body: payload.to_json,
+               headers: {
+                 'X-Integration-API-Key' => api_key,
+                 'Content-Type' => 'application/json'
+               }
+             )
+             .to_return(
+               status: 200,
+               body: { messageId: 'm-1', status: 'queued' }.to_json,
+               headers: { 'Content-Type' => 'application/json' }
+             )
+
+      result = client.post('/events/track', payload)
+
+      expect(stub).to have_been_requested
+      expect(result).to include('messageId' => 'm-1', 'status' => 'queued')
+    end
+
+    it 'keeps the /api/v1 prefix and never hits the bare root (F8)' do
+      good = stub_request(:post, track_url).to_return(status: 200, body: '{}')
+      root = stub_request(:post, 'http://evo-flow:3000/events/track')
+
+      client.post('/events/track', payload)
+      client.post('events/track', payload)       # no leading slash
+      client.post('//events/track', payload)     # doubled leading slash
+
+      expect(good).to have_been_requested.times(3)
+      expect(root).not_to have_been_requested
+    end
+
+    it 'raises EvoFlow::HTTPError with #code and #response on HTTP 500 (AC2)' do
+      stub_request(:post, track_url).to_return(status: 500, body: 'boom')
+
+      expect { client.post('/events/track', payload) }
+        .to raise_error(EvoFlow::HTTPError) { |error|
+          expect(error.code).to eq(500)
+          expect(error.response).to be_present
+          expect(error.response.body).to eq('boom')
+        }
+    end
+
+    it 'raises EvoFlow::HTTPError with nil code on a refused connection (AC2b)' do
+      stub_request(:post, track_url).to_raise(Errno::ECONNREFUSED)
+
+      expect { client.post('/events/track', payload) }
+        .to raise_error(EvoFlow::HTTPError) { |error|
+          expect(error.code).to be_nil
+          expect(error.message).to include('evo-flow request failed')
+        }
+    end
+
+    it 'raises EvoFlow::HTTPError with nil code on a timeout (AC2b)' do
+      stub_request(:post, track_url).to_timeout
+
+      expect { client.post('/events/track', payload) }
+        .to raise_error(EvoFlow::HTTPError) { |error| expect(error.code).to be_nil }
+    end
+
+    it 'raises EvoFlow::HTTPError on an unparseable 2xx body (F2)' do
+      stub_request(:post, track_url)
+        .to_return(status: 200, body: '{not-json', headers: { 'Content-Type' => 'application/json' })
+
+      expect { client.post('/events/track', payload) }
+        .to raise_error(EvoFlow::HTTPError) { |error|
+          expect(error.code).to eq(200)
+          expect(error.message).to include('unparseable')
+        }
+    end
+
+    it 'never logs an auth-rejection body (may echo the key) (F3)' do
+      stub_request(:post, track_url).to_return(status: 401, body: 'token=xyz leaked')
+      logged = []
+      allow(Rails.logger).to receive(:error) { |m| logged << m }
+
+      expect { client.post('/events/track', payload) }.to raise_error(EvoFlow::HTTPError) { |error|
+        expect(error.message).to include('[redacted: auth failure]')
+        expect(error.message).not_to include('xyz leaked')
+      }
+      expect(logged.join).to include('[redacted: auth failure]')
+      expect(logged.join).not_to include('xyz leaked')
+    end
+  end
+
+  describe 'configuration safety' do
+    it 'raises ConfigurationError when the API key is blank (F13)' do
+      expect { described_class.new(api_url: api_url, api_key: '') }
+        .to raise_error(EvoFlow::ConfigurationError, /not set/)
+      expect { described_class.new(api_url: api_url, api_key: nil) }
+        .to raise_error(EvoFlow::ConfigurationError)
+    end
+
+    context 'when in production' do
+      before { allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production')) }
+
+      it 'refuses cleartext http without an explicit opt-out (F1)' do
+        expect { described_class.new(api_url: 'http://evo-flow:3000/api/v1', api_key: 'k') }
+          .to raise_error(EvoFlow::ConfigurationError, /cleartext/)
+      end
+
+      it 'allows https' do
+        expect { described_class.new(api_url: 'https://evo-flow/api/v1', api_key: 'k') }
+          .not_to raise_error
+      end
+
+      it 'allows http only with the explicit insecure opt-out' do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('EVO_FLOW_ALLOW_INSECURE', nil).and_return('true')
+        expect { described_class.new(api_url: 'http://evo-flow:3000/api/v1', api_key: 'k') }
+          .not_to raise_error
+      end
+    end
+  end
+
+  describe 'ENV defaults (F9 — consistent ENV.fetch)' do
+    it 'falls back to the documented default base URL' do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch)
+        .with('EVO_FLOW_API_URL', described_class::DEFAULT_API_URL)
+        .and_return(described_class::DEFAULT_API_URL)
+      allow(ENV).to receive(:fetch).with('AUTH_APIKEY_INTEGRATION_LOCAL', nil).and_return('k')
+
+      stub = stub_request(:post, 'http://evo-flow:3000/api/v1/events/track')
+             .to_return(status: 200, body: '{}')
+
+      described_class.new.post('/events/track', payload)
+
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/services/evo_flow/payload_builder_spec.rb
+++ b/spec/services/evo_flow/payload_builder_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe EvoFlow::PayloadBuilder do
+  let(:occurred_at) { Time.zone.parse('2026-05-19T12:00:00Z') }
+
+  describe '.build_track (real TrackEventDto)' do
+    subject(:payload) do
+      described_class.build_track(
+        event_name: 'contact.created',
+        contact_id: 42,
+        properties: { a: 1 },
+        occurred_at: occurred_at,
+        message_id: 'sha'
+      )
+    end
+
+    it 'matches the real evo-flow track DTO (AC5)' do
+      expect(payload).to eq(
+        messageId: 'sha',
+        contactId: '42',
+        event: 'contact.created',
+        properties: { a: 1 },
+        timestamp: occurred_at.utc.iso8601
+      )
+    end
+
+    it 'has no accountId and no eventType keys (single-tenant, AC5)' do
+      expect(payload).not_to have_key(:accountId)
+      expect(payload).not_to have_key(:eventType)
+      expect(payload).not_to have_key(:eventName)
+    end
+
+    it 'stringifies contactId and defaults nil properties to {}' do
+      built = described_class.build_track(
+        event_name: 'contact.created', contact_id: 7,
+        properties: nil, occurred_at: occurred_at, message_id: 'x'
+      )
+      expect(built[:contactId]).to eq('7')
+      expect(built[:properties]).to eq({})
+    end
+  end
+
+  describe '.build_identify (real IdentifyEventDto)' do
+    subject(:payload) do
+      described_class.build_identify(
+        event_name: 'contact.updated',
+        contact_id: 42,
+        traits: { email: 'x' },
+        occurred_at: occurred_at,
+        message_id: 'sha'
+      )
+    end
+
+    it 'matches the real evo-flow identify DTO (AC5b)' do
+      expect(payload).to eq(
+        messageId: 'sha',
+        contactId: '42',
+        eventName: 'contact.updated',
+        traits: { email: 'x' },
+        timestamp: occurred_at.utc.iso8601
+      )
+    end
+
+    it 'has no accountId/eventType and no track-only `event` key (AC5b)' do
+      expect(payload).not_to have_key(:accountId)
+      expect(payload).not_to have_key(:eventType)
+      expect(payload).not_to have_key(:event)
+    end
+  end
+
+  describe '.message_id_for' do
+    it 'is deterministic and equals SHA256(event|contact|uuid) (AC3)' do
+      first = described_class.message_id_for('message.delivered', 42, 'abc')
+      second = described_class.message_id_for('message.delivered', 42, 'abc')
+
+      expect(first).to eq(second)
+      expect(first).to eq(Digest::SHA256.hexdigest('message.delivered|42|abc'))
+    end
+
+    it 'differs when any component differs' do
+      base = described_class.message_id_for('message.delivered', 42, 'abc')
+      expect(described_class.message_id_for('message.read', 42, 'abc')).not_to eq(base)
+      expect(described_class.message_id_for('message.delivered', 43, 'abc')).not_to eq(base)
+      expect(described_class.message_id_for('message.delivered', 42, 'xyz')).not_to eq(base)
+    end
+  end
+
+  describe '.iso8601' do
+    it 'normalises a valid string to UTC ISO-8601' do
+      expect(described_class.iso8601('2026-05-19T09:00:00-03:00')).to eq('2026-05-19T12:00:00Z')
+      expect(described_class.iso8601('2026-05-19T12:00:00Z')).to eq('2026-05-19T12:00:00Z')
+    end
+
+    it 'fails fast on an unparseable string (no silent bad data) (F11)' do
+      expect { described_class.iso8601('not-a-timestamp') }.to raise_error(ArgumentError)
+    end
+
+    it 'formats Time as UTC and falls back to Time.current when nil' do
+      expect(described_class.iso8601(occurred_at)).to eq(occurred_at.utc.iso8601)
+      expect { Time.iso8601(described_class.iso8601(nil)) }.not_to raise_error
+    end
+  end
+end

--- a/spec/workers/evo_flow/publish_event_integration_spec.rb
+++ b/spec/workers/evo_flow/publish_event_integration_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+# F10/F5: exercises the real data path PayloadBuilder -> PublishEventWorker ->
+# Client -> evo-flow wire, with nothing mocked but the HTTP boundary. Catches
+# DTO-shape and symbol/string-key regressions the over-mocked unit specs miss.
+RSpec.describe 'EvoFlow publish integration', type: :job do
+  let(:message_id) { EvoFlow::PayloadBuilder.message_id_for('contact.created', 42, 'evt-uuid') }
+  let(:payload) do
+    EvoFlow::PayloadBuilder.build_track(
+      event_name: 'contact.created', contact_id: 42, properties: { plan: 'pro' },
+      occurred_at: Time.zone.parse('2026-05-19T12:00:00Z'), message_id: message_id
+    )
+  end
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch)
+      .with('EVO_FLOW_API_URL', EvoFlow::Client::DEFAULT_API_URL)
+      .and_return('http://evo-flow:3000/api/v1')
+    allow(ENV).to receive(:fetch)
+      .with('AUTH_APIKEY_INTEGRATION_LOCAL', nil).and_return('integration-key')
+  end
+
+  def real_track_dto?(request)
+    body = JSON.parse(request.body)
+    body['messageId'] == message_id && body['contactId'] == '42' &&
+      body['event'] == 'contact.created' && body['properties'] == { 'plan' => 'pro' } &&
+      body['timestamp'] == '2026-05-19T12:00:00Z' &&
+      !body.key?('accountId') && !body.key?('eventType')
+  end
+
+  it 'sends the real built track DTO over the wire and logs the messageId' do
+    stub = stub_request(:post, 'http://evo-flow:3000/api/v1/events/track')
+           .with(headers: { 'X-Integration-API-Key' => 'integration-key',
+                            'Content-Type' => 'application/json' }) { |req| real_track_dto?(req) }
+           .to_return(status: 200, body: { messageId: message_id, status: 'queued' }.to_json,
+                      headers: { 'Content-Type' => 'application/json' })
+    expect(Rails.logger).to receive(:info).with(/messageId=#{message_id}/)
+
+    EvoFlow::PublishEventWorker.new.perform('/events/track', payload)
+
+    expect(stub).to have_been_requested
+  end
+end

--- a/spec/workers/evo_flow/publish_event_worker_spec.rb
+++ b/spec/workers/evo_flow/publish_event_worker_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe EvoFlow::PublishEventWorker, type: :job do
+  let(:client) { instance_double(EvoFlow::Client) }
+  let(:path) { '/events/track' }
+  let(:payload) do
+    { 'messageId' => 'm-1', 'contactId' => '42', 'event' => 'contact.created',
+      'properties' => { 'email' => 'pii@example.com' } }
+  end
+
+  before { allow(EvoFlow::Client).to receive(:new).and_return(client) }
+
+  describe '#perform' do
+    it 'forwards path + payload to EvoFlow::Client#post (happy path)' do
+      allow(client).to receive(:post).and_return('messageId' => 'm-1', 'status' => 'queued')
+
+      described_class.new.perform(path, payload)
+
+      expect(client).to have_received(:post).with(path, payload)
+    end
+
+    it 're-raises EvoFlow::HTTPError so Sidekiq counts the retry' do
+      allow(client).to receive(:post).and_raise(EvoFlow::HTTPError.new('500', 500, nil))
+
+      expect { described_class.new.perform(path, payload) }
+        .to raise_error(EvoFlow::HTTPError)
+    end
+
+    it 're-raises non-HTTPError too so every failure path counts as a retry (F4)' do
+      allow(client).to receive(:post).and_raise(ArgumentError, 'bad args')
+
+      expect { described_class.new.perform(path, payload) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe '.sanitize_payload (F3)' do
+    it 'redacts PII-bearing fields, keeps identifiers, tolerates symbol keys' do
+      expect(described_class.sanitize_payload(payload)).to eq(
+        'messageId' => 'm-1', 'contactId' => '42', 'event' => 'contact.created',
+        'properties' => '[redacted]'
+      )
+      expect(described_class.sanitize_payload(traits: { email: 'x' }, contactId: '7'))
+        .to eq(traits: '[redacted]', contactId: '7')
+    end
+
+    it 'passes non-hash payloads through untouched' do
+      expect(described_class.sanitize_payload('raw')).to eq('raw')
+    end
+  end
+
+  describe 'sidekiq configuration' do
+    it 'uses the integrations queue and retry: 5 (overrides global 3)' do
+      expect(described_class.sidekiq_options['queue']).to eq(:integrations)
+      expect(described_class.sidekiq_options['retry']).to eq(5)
+    end
+  end
+
+  describe 'retries exhausted -> Wisper :evo_flow_publish_failed (AC4)' do
+    let(:listener) do
+      Class.new do
+        attr_reader :received
+
+        def evo_flow_publish_failed(args)
+          @received = args
+        end
+      end.new
+    end
+
+    it 'broadcasts with path + error and a PII-redacted payload (AC4 + F3)' do
+      job = { 'args' => [path, payload], 'class' => described_class.name }
+      exception = EvoFlow::HTTPError.new('boom', 500, nil)
+
+      Wisper.subscribe(listener) do
+        described_class.sidekiq_retries_exhausted_block.call(job, exception)
+      end
+
+      expect(listener.received).to be_present
+      expect(listener.received[:data][:path]).to eq(path)
+      expect(listener.received[:data][:error]).to eq('boom')
+      expect(listener.received[:data][:payload]['properties']).to eq('[redacted]')
+      expect(listener.received[:data][:payload]['messageId']).to eq('m-1')
+    end
+  end
+end


### PR DESCRIPTION
## EVO-1238 — EvoFlow Module Foundation

### What's in
- **`EvoFlow::Client`** (`app/services/evo_flow/client.rb`) — instance/DI HTTParty client, `X-Integration-API-Key`, configurable timeout, relative-URI join (keeps `/api/v1`), parse-safe, redacted auth logs. `+ EvoFlow::HTTPError / EvoFlow::ConfigurationError`.
- **`EvoFlow::PayloadBuilder`** — real evo-flow DTOs (camelCase, single-tenant: no `accountId`/`eventType`), deterministic `message_id_for` (SHA256), UTC ISO-8601 with validation.
- **`EvoFlow::PublishEventWorker`** — pure Sidekiq (`queue: :integrations, retry: 5`), `sidekiq_retries_exhausted` → Wisper `:evo_flow_publish_failed`, PII (`properties`/`traits`) redacted before Redis/Dead Set/broadcast.
- **`lib/events/evo_flow_event_names.rb`** — frozen `EvoFlow::EVENT_NAMES` (16 events) + Zeitwerk ignore/require wiring in `config/application.rb` (constant name ≠ path).
- **`.env.example`** — `EVO_FLOW_API_URL`, `AUTH_APIKEY_INTEGRATION_LOCAL`, `EVO_FLOW_ALLOW_INSECURE`.

### Documented divergences
- `Wisper.publish` does not exist in Wisper 2.0.0 → internal `FailureBroadcaster` (`include Wisper::Publisher`), same event/payload, repo idiom.
- `AUTH_APIKEY_INTEGRATION_LOCAL` is **created** here; worker is `EvoFlow::PublishEventWorker` in `app/workers/`; `/api/v1` lives in `EVO_FLOW_API_URL`; payload uses real DTO; `perform(path, payload)`.

### Quality
- Adversarial review: **13/13 findings resolved** (TLS guard, parse-safety, log/PII redaction, uniform retry path, ENV consistency, URL-join hardening, ISO-8601 validation, blank-key fail-fast, integration + eager-load regression specs).
- RuboCop clean (EvoFlow files). **RSpec 33/33**. `zeitwerk:check` OK. `Rails.application.eager_load!` OK.

### Known caveat (non-blocking, pre-existing in spec)
evo-flow has no consumer-side dedup yet (`contact_events` MergeTree); Sidekiq retries still duplicate downstream until a future evo-flow story. `message_id_for` is the correct forward-looking foundation.

## Summary by Sourcery

Introduce the foundational EvoFlow CRM integration with a dedicated HTTP client, payload builder, Sidekiq worker, and canonical event name list, wired into Rails autoloading.

New Features:
- Add EvoFlow::Client service for authenticated, parse-safe HTTP communication with the evo-flow API, including configuration validation and secure error handling.
- Add EvoFlow::PayloadBuilder to construct evo-flow track and identify payloads with deterministic message IDs and normalized timestamps.
- Add EvoFlow::PublishEventWorker Sidekiq worker to enqueue EvoFlow publishing jobs with retries, logging, and Wisper-based failure broadcasting.
- Define EvoFlow::EVENT_NAMES as the canonical list of CRM events emitted to evo-flow.

Enhancements:
- Configure Rails autoloader to ignore and explicitly require the EvoFlow event names file so the constant is always available and eager loading remains stable.

Tests:
- Add unit and integration specs for the EvoFlow client, payload builder, event names, and publish event worker to validate behaviour, retries, and error handling.