### PR TITLE
fix(crm): EvoFlow hardening — review follow-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -262,8 +262,8 @@ EVOAI_CRM_API_TOKEN=
 EVO_FLOW_API_URL=http://evo-flow:3000/api/v1
 # Shared service-to-service key; MUST equal evo-flow's AUTH_APIKEY_INTEGRATION_LOCAL (no default)
 AUTH_APIKEY_INTEGRATION_LOCAL=
-# In production the client refuses to send the key over plain http. Set to
-# 'true' ONLY when evo-flow is reached over a trusted private network.
+# In production the client refuses to send the key over plain http. Accepts
+# any of true/1/yes/on (case-insensitive); ONLY enable on a trusted private network.
 EVO_FLOW_ALLOW_INSECURE=
 
 # Fernet encryption key for sensitive configuration values (e.g., API keys stored in installation_configs)

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -11,9 +11,10 @@ module EvoFlow
     end
   end
 
-  # Raised at construction time for an unusable configuration (missing key, or
-  # cleartext transport in production). Fails fast instead of emitting a
-  # request that is guaranteed to 401 or that leaks the shared key in cleartext.
+  # Raised at construction time for an unusable configuration (missing key,
+  # invalid scheme, or cleartext transport in production). Fails fast instead
+  # of emitting a request that is guaranteed to 401 or that leaks the shared
+  # key over cleartext.
   class ConfigurationError < StandardError; end
 
   # Instance-based (DI-friendly) authenticated HTTP client for evo-flow.
@@ -23,8 +24,11 @@ module EvoFlow
     include HTTParty
 
     DEFAULT_API_URL = 'http://evo-flow:3000/api/v1'.freeze
-    REDACTED_BODY = '[redacted: auth failure]'.freeze
+    REDACTED_4XX = '[redacted: 4xx body]'.freeze
     MAX_LOGGED_BODY = 500
+    VALID_SCHEMES = %w[http https].freeze
+    # Accepted truthy values for EVO_FLOW_ALLOW_INSECURE (case-insensitive).
+    INSECURE_TRUTHY = %w[true 1 yes on].freeze
 
     def initialize(api_url: ENV.fetch('EVO_FLOW_API_URL', DEFAULT_API_URL),
                    api_key: ENV.fetch('AUTH_APIKEY_INTEGRATION_LOCAL', nil),
@@ -41,7 +45,10 @@ module EvoFlow
                                  headers: request_headers,
                                  timeout: @timeout)
       handle_response(response)
-    rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError => e
+    # Net::OpenTimeout/Net::ReadTimeout already inherit from Timeout::Error.
+    # OpenSSL::SSL::SSLError is its own hierarchy and must be listed explicitly.
+    rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError,
+           OpenSSL::SSL::SSLError => e
       raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
     end
 
@@ -49,13 +56,24 @@ module EvoFlow
 
     def validate_config!
       raise ConfigurationError, 'AUTH_APIKEY_INTEGRATION_LOCAL is not set' if @api_key.to_s.strip.empty?
-      return if URI(@api_url).scheme == 'https'
+
+      scheme = URI(@api_url).scheme
+      unless VALID_SCHEMES.include?(scheme)
+        raise ConfigurationError,
+              "EVO_FLOW_API_URL has invalid or missing scheme (#{scheme.inspect}); " \
+              "expected one of #{VALID_SCHEMES.inspect}"
+      end
+      return if scheme == 'https'
       return unless Rails.env.production?
-      return if ENV.fetch('EVO_FLOW_ALLOW_INSECURE', nil) == 'true'
+      return if insecure_allowed?
 
       raise ConfigurationError,
             "refusing to send the API key over cleartext (#{@api_url}); use https " \
-            'or set EVO_FLOW_ALLOW_INSECURE=true only on a trusted private network'
+            'or set EVO_FLOW_ALLOW_INSECURE=<true|1|yes|on> only on a trusted private network'
+    end
+
+    def insecure_allowed?
+      INSECURE_TRUTHY.include?(ENV.fetch('EVO_FLOW_ALLOW_INSECURE', '').to_s.downcase)
     end
 
     # URI.join drops the /api/v1 prefix when path starts with '/' (a leading
@@ -85,15 +103,14 @@ module EvoFlow
     def raise_api_error(response)
       msg = "evo-flow API error: #{response.code} - #{safe_body(response)}"
       Rails.logger.error(msg)
-      # error.response still carries the full HTTParty response for programmatic
-      # use; only the logged/message form is redacted/bounded.
       raise EvoFlow::HTTPError.new(msg, response.code, response)
     end
 
-    # Auth-rejection bodies frequently echo the offending key/context, so they
-    # are never logged. Other bodies are length-bounded to keep logs sane.
+    # 4xx bodies frequently reflect client input (auth tokens on 401/403,
+    # validation echoes on 400/422, etc.), so the whole 4xx class is redacted.
+    # 5xx bodies are length-bounded; other classes pass through.
     def safe_body(response)
-      return REDACTED_BODY if [401, 403].include?(response.code)
+      return REDACTED_4XX if (400..499).cover?(response.code)
 
       body = response.body.to_s
       body.length > MAX_LOGGED_BODY ? "#{body[0, MAX_LOGGED_BODY]}... (truncated)" : body

--- a/app/services/evo_flow/payload_builder.rb
+++ b/app/services/evo_flow/payload_builder.rb
@@ -34,11 +34,14 @@ module EvoFlow
 
     # Always emits UTC ISO-8601. A String is validated by re-parsing (fail
     # fast with ArgumentError rather than shipping an unparseable timestamp
-    # that evo-flow would silently misread/reject downstream).
+    # that evo-flow would silently misread/reject downstream). nil is also
+    # rejected — the caller must be explicit about the event timestamp so a
+    # missing occurred_at never silently becomes "now".
     def self.iso8601(time)
+      raise ArgumentError, 'occurred_at is required (no implicit Time.current fallback)' if time.nil?
       return Time.iso8601(time).utc.iso8601 if time.is_a?(String)
 
-      (time || Time.current).utc.iso8601
+      time.utc.iso8601
     end
   end
 end

--- a/app/workers/evo_flow/publish_event_worker.rb
+++ b/app/workers/evo_flow/publish_event_worker.rb
@@ -19,6 +19,11 @@ module EvoFlow
     # before being persisted as Sidekiq job args / Dead Set / Wisper payload;
     # only identifiers needed for triage and replay decisions are kept.
     PII_KEYS = %w[properties traits].freeze
+    MAX_ERROR_MESSAGE = 500
+    # Heuristic redaction for likely secrets/tokens embedded in error messages
+    # (>=32 hex/base64 chars). Conservative: catches API keys, JWTs, SHA256
+    # hex digests, etc., without touching short human-readable text.
+    LIKELY_SECRET = %r{[A-Za-z0-9+/_=-]{32,}}
 
     # Wisper 2.0.0 exposes NO `Wisper.publish`; global listeners registered via
     # `Wisper.subscribe` (config/initializers/contact_company_listeners.rb) are
@@ -40,12 +45,22 @@ module EvoFlow
       end
     end
 
+    # For EvoFlow::HTTPError the message is already passed through Client#safe_body;
+    # for JSON::ParserError / ArgumentError / TLS errors it may still echo a
+    # response snippet. Bound length and redact long token-looking substrings.
+    # Idempotent.
+    def self.sanitize_error(error)
+      msg = error.message.to_s.gsub(LIKELY_SECRET, '[redacted]')
+      msg.length > MAX_ERROR_MESSAGE ? "#{msg[0, MAX_ERROR_MESSAGE]}... (truncated)" : msg
+    end
+
     sidekiq_retries_exhausted do |job, ex|
       args = job['args'] || []
       path = args[0]
       safe_payload = EvoFlow::PublishEventWorker.sanitize_payload(args[1])
-      Rails.logger.error("[EvoFlow] terminal failure path=#{path} msg=#{ex.message}")
-      FailureBroadcaster.new.broadcast_failed(path: path, payload: safe_payload, error: ex.message)
+      safe_error = EvoFlow::PublishEventWorker.sanitize_error(ex)
+      Rails.logger.error("[EvoFlow] terminal failure path=#{path} msg=#{safe_error}")
+      FailureBroadcaster.new.broadcast_failed(path: path, payload: safe_payload, error: safe_error)
     end
 
     def perform(path, payload)
@@ -59,7 +74,9 @@ module EvoFlow
     rescue StandardError => e
       # Any other failure (unparseable body, bad args, config error) must also
       # count as a Sidekiq retry and reach the exhaustion path uniformly.
-      Rails.logger.warn("[EvoFlow] publish errored (will retry) path=#{path} msg=#{e.message}")
+      Rails.logger.warn(
+        "[EvoFlow] publish errored (will retry) path=#{path} msg=#{self.class.sanitize_error(e)}"
+      )
       raise
     end
 
@@ -67,10 +84,11 @@ module EvoFlow
 
     # Sidekiq JSON-serialises args → string keys for enqueued jobs; tolerate
     # symbol keys too (in-process / console invocation with builder output).
+    # Returns '<missing>' (not '') when absent, so logs are greppable.
     def message_id(payload)
-      return unless payload.is_a?(Hash)
+      return '<missing>' unless payload.is_a?(Hash)
 
-      payload['messageId'] || payload[:messageId]
+      payload['messageId'] || payload[:messageId] || '<missing>'
     end
   end
 end

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -81,17 +81,28 @@ RSpec.describe EvoFlow::Client do
         }
     end
 
-    it 'never logs an auth-rejection body (may echo the key) (F3)' do
-      stub_request(:post, track_url).to_return(status: 401, body: 'token=xyz leaked')
+    it 'redacts any 4xx body (auth + validation echoes) (L2)' do
       logged = []
       allow(Rails.logger).to receive(:error) { |m| logged << m }
 
-      expect { client.post('/events/track', payload) }.to raise_error(EvoFlow::HTTPError) { |error|
-        expect(error.message).to include('[redacted: auth failure]')
-        expect(error.message).not_to include('xyz leaked')
-      }
-      expect(logged.join).to include('[redacted: auth failure]')
-      expect(logged.join).not_to include('xyz leaked')
+      [400, 401, 403, 422, 429].each do |code|
+        stub_request(:post, track_url).to_return(status: code, body: "echo-input-#{code} secret=xyz")
+        expect { client.post('/events/track', payload) }.to raise_error(EvoFlow::HTTPError) { |error|
+          expect(error.message).to include('[redacted: 4xx body]')
+          expect(error.message).not_to include('echo-input')
+        }
+      end
+      expect(logged.join).not_to include('echo-input')
+    end
+
+    it 'wraps OpenSSL::SSL::SSLError as HTTPError with nil code (L4)' do
+      stub_request(:post, track_url).to_raise(OpenSSL::SSL::SSLError.new('handshake failed'))
+
+      expect { client.post('/events/track', payload) }
+        .to raise_error(EvoFlow::HTTPError) { |error|
+          expect(error.code).to be_nil
+          expect(error.message).to include('evo-flow request failed')
+        }
     end
   end
 
@@ -101,6 +112,15 @@ RSpec.describe EvoFlow::Client do
         .to raise_error(EvoFlow::ConfigurationError, /not set/)
       expect { described_class.new(api_url: api_url, api_key: nil) }
         .to raise_error(EvoFlow::ConfigurationError)
+    end
+
+    it 'rejects an invalid/missing scheme in any environment (M2)' do
+      # Reproduces the EVO_FLOW_API_URL=evo-flow:3000 typo: URI parses 'evo-flow'
+      # as the scheme. Must fail fast even in development/test.
+      expect { described_class.new(api_url: 'evo-flow:3000/api/v1', api_key: 'k') }
+        .to raise_error(EvoFlow::ConfigurationError, /invalid or missing scheme/)
+      expect { described_class.new(api_url: 'ftp://evo-flow/api/v1', api_key: 'k') }
+        .to raise_error(EvoFlow::ConfigurationError, /invalid or missing scheme/)
     end
 
     context 'when in production' do
@@ -116,11 +136,24 @@ RSpec.describe EvoFlow::Client do
           .not_to raise_error
       end
 
-      it 'allows http only with the explicit insecure opt-out' do
+      it 'accepts EVO_FLOW_ALLOW_INSECURE in any of true/1/yes/on (case-insensitive) (L1)' do
         allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with('EVO_FLOW_ALLOW_INSECURE', nil).and_return('true')
-        expect { described_class.new(api_url: 'http://evo-flow:3000/api/v1', api_key: 'k') }
-          .not_to raise_error
+
+        %w[true TRUE True 1 yes YES on On].each do |val|
+          allow(ENV).to receive(:fetch).with('EVO_FLOW_ALLOW_INSECURE', '').and_return(val)
+          expect { described_class.new(api_url: 'http://evo-flow:3000/api/v1', api_key: 'k') }
+            .not_to raise_error
+        end
+      end
+
+      it 'rejects non-truthy values for EVO_FLOW_ALLOW_INSECURE' do
+        allow(ENV).to receive(:fetch).and_call_original
+
+        ['', 'maybe', '0', 'false'].each do |val|
+          allow(ENV).to receive(:fetch).with('EVO_FLOW_ALLOW_INSECURE', '').and_return(val)
+          expect { described_class.new(api_url: 'http://evo-flow:3000/api/v1', api_key: 'k') }
+            .to raise_error(EvoFlow::ConfigurationError, /cleartext/)
+        end
       end
     end
   end

--- a/spec/services/evo_flow/payload_builder_spec.rb
+++ b/spec/services/evo_flow/payload_builder_spec.rb
@@ -95,9 +95,13 @@ RSpec.describe EvoFlow::PayloadBuilder do
       expect { described_class.iso8601('not-a-timestamp') }.to raise_error(ArgumentError)
     end
 
-    it 'formats Time as UTC and falls back to Time.current when nil' do
+    it 'formats Time as UTC' do
       expect(described_class.iso8601(occurred_at)).to eq(occurred_at.utc.iso8601)
-      expect { Time.iso8601(described_class.iso8601(nil)) }.not_to raise_error
+    end
+
+    it 'raises ArgumentError on nil — no implicit Time.current fallback (L3)' do
+      expect { described_class.iso8601(nil) }
+        .to raise_error(ArgumentError, /occurred_at is required/)
     end
   end
 end

--- a/spec/workers/evo_flow/publish_event_worker_spec.rb
+++ b/spec/workers/evo_flow/publish_event_worker_spec.rb
@@ -81,5 +81,54 @@ RSpec.describe EvoFlow::PublishEventWorker, type: :job do
       expect(listener.received[:data][:payload]['properties']).to eq('[redacted]')
       expect(listener.received[:data][:payload]['messageId']).to eq('m-1')
     end
+
+    it 'redacts long secret-like tokens out of ex.message before broadcast/log (M1)' do
+      job = { 'args' => [path, payload], 'class' => described_class.name }
+      leaked_token = 'a' * 40
+      exception = ArgumentError.new("upstream said token=#{leaked_token} go away")
+      logged = []
+      allow(Rails.logger).to receive(:error) { |m| logged << m }
+
+      Wisper.subscribe(listener) do
+        described_class.sidekiq_retries_exhausted_block.call(job, exception)
+      end
+
+      expect(listener.received[:data][:error]).not_to include(leaked_token)
+      expect(listener.received[:data][:error]).to include('[redacted]')
+      expect(logged.join).not_to include(leaked_token)
+    end
+  end
+
+  describe '.sanitize_error (M1)' do
+    it 'redacts likely secrets (>=32 hex/base64) and is length-bounded' do
+      ex = StandardError.new("hex=#{'f' * 64} long body: #{'x' * 600}")
+      out = described_class.sanitize_error(ex)
+      expect(out).to include('[redacted]')
+      expect(out).not_to include('f' * 64)
+      expect(out.length).to be <= 530 # 500 + '... (truncated)' suffix
+    end
+
+    it 'is idempotent (calling twice yields the same string)' do
+      ex = StandardError.new("token=#{'a' * 50}")
+      first = described_class.sanitize_error(ex)
+      expect(described_class.sanitize_error(ex)).to eq(first)
+    end
+
+    it 'leaves short, token-free messages untouched' do
+      expect(described_class.sanitize_error(StandardError.new('boom'))).to eq('boom')
+    end
+  end
+
+  describe 'happy-path log when messageId is absent (L6)' do
+    it 'logs messageId=<missing> instead of an empty value' do
+      allow(client).to receive(:post).and_return({})
+      logged = []
+      allow(Rails.logger).to receive(:info) { |m| logged << m }
+
+      described_class.new.perform(path, {}) # payload with no messageId
+      described_class.new.perform(path, nil) # not even a hash
+
+      expect(logged).to all(include('messageId=<missing>'))
+    end
   end
 end


### PR DESCRIPTION
## EVO-1416 — EvoFlow hardening (follow-up do review do PR #87)

### MEDIUM
- **M1** — `sanitize_error(ex)` helper (length-bound + redação de tokens ≥32 hex/base64), aplicado em `Rails.logger.error` **e** no broadcast Wisper do `sidekiq_retries_exhausted`. Cobre `ex.message` de `JSON::ParserError` / `ArgumentError` / futuros TLS errors (para `HTTPError` o `safe_body` já cuida do body, mas a mensagem da exceção podia escapar).
- **M2** — `validate_config!` rejeita scheme inválido em **qualquer** `Rails.env` (não só produção). Typo `EVO_FLOW_API_URL=evo-flow:3000` (sem `http://`) agora falha no boot com `ConfigurationError` clara, em vez de quebrar feio no primeiro request.

### LOW
- **L1** — `EVO_FLOW_ALLOW_INSECURE` aceita `true`/`1`/`yes`/`on` (case-insensitive). Comentário no `.env.example` atualizado.
- **L2** — `safe_body` redige **todo 4xx** (`400`/`422`/`429` também refletem input do cliente), não só `401`/`403`. Constante renomeada `REDACTED_4XX`.
- **L3 (opcional)** — `PayloadBuilder.iso8601(nil)` levanta `ArgumentError` em vez de cair em `Time.current`. Elimina o risco de mascarar `occurred_at` faltando. Story 7.4 vai ser o primeiro caller real; melhor strict desde já.
- **L4** — rescue em `Client#post` cobre `OpenSSL::SSL::SSLError`. `Net::OpenTimeout` já é coberto por herança de `Timeout::Error`; documentado no comentário do rescue.
- **L6** — `message_id(payload)` loga `<missing>` (em vez de string vazia) quando nem `'messageId'` nem `:messageId` existem. Facilita grep por publicações sem identificador.

### Contratos preservados
- AC4 do EVO-1238 (shape Wisper `{path,payload,error}`) intacto — só o conteúdo do `error` passa por `sanitize_error`.
- AC6 (path + constante `EvoFlow::EVENT_NAMES`) intacto.
- Zeitwerk wiring não tocado.

### Validação
- RuboCop **limpo** nos 9 arquivos EvoFlow.
- RSpec **42/42** (era 33 — `+9` testes cobrindo M1, M2, L1, L2, L3, L4, L6).
- `zeitwerk:check` OK; `Rails.application.eager_load!` OK (spec de regressão).

## Summary by Sourcery

Harden EvoFlow client and worker error handling and configuration validation to prevent secret leakage and fail fast on misconfiguration.

Bug Fixes:
- Redact sensitive 4xx HTTP response bodies from EvoFlow logs and errors to avoid echoing client input and secrets.
- Sanitize exception messages used in EvoFlow logging and Wisper broadcasts to strip likely secrets and bound message length.
- Treat nil timestamps in EvoFlow payload builder as invalid, raising an error instead of silently defaulting to the current time.
- Ensure EvoFlow client wraps SSL handshake failures in a consistent HTTPError with a nil status code.
- Improve EvoFlow configuration validation to reject invalid or missing URL schemes in all environments.
- Make EVO_FLOW_ALLOW_INSECURE accept only explicit truthy values and reject unclear inputs to avoid accidental cleartext usage.
- Log a placeholder when EvoFlow payloads lack a messageId so missing identifiers are detectable in logs.

Tests:
- Extend EvoFlow client, worker, and payload builder specs to cover new sanitization, configuration, and logging behaviors.