### PR TITLE
feat(crm): EvoFlow listeners port — contact/conversation/message/pipeline

### DIFF
--- a/app/listeners/evo_flow/contact_events_listener.rb
+++ b/app/listeners/evo_flow/contact_events_listener.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+module EvoFlow
+  # Subscribes to Wisper :contact_* events and forwards them to evo-flow
+  # via EvoFlow::PublishEventWorker. Identify payloads (/events/identify).
+  # Template: dual-shape guard, unpack, nil-check, ENV gate, build via
+  # PayloadBuilder, deterministic messageId, enqueue, rescue+log.
+  # `evo_flow_enabled?` is duplicated across the 4 listeners by design
+  # (tech-spec §Technical Decisions #2: no shared base class).
+  class ContactEventsListener
+    IDENTIFY_PATH = '/events/identify'
+
+    def contact_created(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      contact = event_data[:contact]
+      return log_missing(__method__, 'contact') unless contact
+      return unless evo_flow_enabled?
+
+      traits = build_contact_traits(contact).merge(
+        source: 'contact_created',
+        created_via: created_via(contact)
+      )
+      enqueue_identify(
+        event_name: 'contact.created',
+        contact_id: contact.id,
+        traits: traits,
+        occurred_at: contact.created_at,
+        source_event_uuid: "#{contact.id}.#{contact.created_at.to_i}"
+      )
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    def contact_updated(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      contact = event_data[:contact]
+      return log_missing(__method__, 'contact') unless contact
+      return unless evo_flow_enabled?
+
+      traits = build_contact_traits(contact).merge(
+        source: 'contact_updated',
+        changes: summarise_changes(event_data)
+      )
+      enqueue_identify(
+        event_name: 'contact.updated',
+        contact_id: contact.id,
+        traits: traits,
+        occurred_at: contact.updated_at,
+        source_event_uuid: "#{contact.id}.#{contact.updated_at.to_i}"
+      )
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    def contact_deleted(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      contact_id = resolve_deleted_contact_id(event_data)
+      return log_missing(__method__, 'contact_id') unless contact_id
+      return unless evo_flow_enabled?
+
+      # F1: prefer `contact.updated_at` over `Time.zone.now` for idempotency.
+      deleted_at = resolve_deleted_at(event_data)
+      enqueue_identify(
+        event_name: 'contact.deleted',
+        contact_id: contact_id,
+        traits: build_deleted_traits(event_data, deleted_at),
+        occurred_at: deleted_at,
+        source_event_uuid: "#{contact_id}.#{deleted_at.to_i}"
+      )
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    def contact_label_added(data)
+      handle_label_change(data, event_name: 'contact.label.added', source: 'label_added', suffix: 'added')
+    end
+
+    def contact_label_removed(data)
+      handle_label_change(data, event_name: 'contact.label.removed', source: 'label_removed', suffix: 'removed')
+    end
+
+    def contact_custom_attribute_changed(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      contact = event_data[:contact]
+      return log_missing(__method__, 'contact') unless contact
+      return unless evo_flow_enabled?
+
+      occurred_at = Time.zone.now
+      enqueue_identify(
+        event_name: 'contact.custom_attribute.changed',
+        contact_id: contact.id,
+        traits: build_attribute_change_traits(event_data),
+        occurred_at: occurred_at,
+        # F2: include old_value + timestamp so toggle sequences don't collide.
+        source_event_uuid: custom_attribute_uuid(contact, event_data, occurred_at)
+      )
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    private
+
+    def handle_label_change(data, event_name:, source:, suffix:)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      contact = event_data[:contact]
+      return log_missing("contact_label_#{suffix}", 'contact') unless contact
+      return unless evo_flow_enabled?
+
+      label_name = event_data[:label_name]
+      traits = { labelName: label_name, labelId: label_name, source: source }
+      occurred_at = Time.zone.now
+
+      enqueue_identify(
+        event_name: event_name,
+        contact_id: contact.id,
+        traits: traits,
+        occurred_at: occurred_at,
+        # F3: include timestamp so add→remove→add-again doesn't collide.
+        source_event_uuid: "#{contact.id}.#{label_name}.#{suffix}.#{occurred_at.to_i}"
+      )
+    rescue StandardError => e
+      log_failure("contact_label_#{suffix}", e)
+    end
+
+    def created_via(contact)
+      contact.additional_attributes&.dig('created_via_user_id').present? ? 'agent' : 'system'
+    end
+
+    def summarise_changes(event_data)
+      raw = event_data[:changed_attributes] || event_data[:changes] || {}
+      raw.transform_values { |v| v.is_a?(Array) ? v.last : v }
+    end
+
+    def resolve_deleted_contact_id(event_data)
+      event_data[:contact]&.id || event_data[:contact_id]
+    end
+
+    def resolve_deleted_at(event_data)
+      contact = event_data[:contact]
+      event_data[:deleted_at] || (contact.respond_to?(:updated_at) && contact.updated_at) || Time.zone.now
+    end
+
+    def custom_attribute_uuid(contact, event_data, occurred_at)
+      "#{contact.id}.#{event_data[:attribute_name]}.#{event_data[:attribute_value]}.#{event_data[:old_value]}.#{occurred_at.to_i}"
+    end
+
+    def build_deleted_traits(event_data, deleted_at)
+      { source: 'contact_deleted', reason: event_data[:reason] || 'user_action', deleted_at: deleted_at.iso8601 }
+    end
+
+    def build_attribute_change_traits(event_data)
+      {
+        attributeName: event_data[:attribute_name], attributeValue: event_data[:attribute_value],
+        changeType: event_data[:change_type], oldValue: event_data[:old_value],
+        source: 'custom_attribute_changed'
+      }.compact
+    end
+
+    def enqueue_identify(event_name:, contact_id:, traits:, occurred_at:, source_event_uuid:)
+      message_id = EvoFlow::PayloadBuilder.message_id_for(event_name, contact_id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_identify(
+        event_name: event_name,
+        contact_id: contact_id,
+        traits: traits,
+        occurred_at: occurred_at,
+        message_id: message_id
+      )
+      # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
+      # round-tripping through JSON normalises both at the listener boundary.
+      EvoFlow::PublishEventWorker.perform_async(IDENTIFY_PATH, JSON.parse(payload.to_json))
+    end
+
+    # Ported from legacy evo_campaign/contact_events_integration_service.rb:553-571.
+    def build_contact_traits(contact)
+      {
+        id: contact.id,
+        name: contact.name,
+        email: contact.email,
+        phone_number: contact.phone_number,
+        identifier: contact.identifier,
+        middle_name: contact.middle_name,
+        last_name: contact.last_name,
+        location: contact.location,
+        country_code: contact.country_code,
+        contact_type: contact.contact_type,
+        blocked: contact.blocked,
+        created_at: contact.created_at,
+        updated_at: contact.updated_at,
+        **(contact.custom_attributes || {}),
+        **(contact.additional_attributes || {})
+      }.compact
+    end
+
+    def evo_flow_enabled?
+      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+    end
+
+    def log_missing(handler, key)
+      Rails.logger.error("EvoFlow::ContactEventsListener##{handler}: #{key} is nil")
+      nil
+    end
+
+    # F6/F8: rescue is broad-by-design; tag enqueue-loss so ops can alert.
+    def log_failure(handler, error)
+      tag = enqueue_loss?(error) ? '[EvoFlow][enqueue-loss]' : '[EvoFlow]'
+      Rails.logger.error("#{tag} EvoFlow::ContactEventsListener##{handler} failed: #{error.class}: #{error.message}")
+      Sentry.capture_exception(error) if defined?(Sentry)
+      nil
+    end
+
+    def enqueue_loss?(error)
+      (defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)) ||
+        (error.is_a?(ArgumentError) && error.message.include?('occurred_at is required'))
+    end
+  end
+end

--- a/app/listeners/evo_flow/contact_events_listener.rb
+++ b/app/listeners/evo_flow/contact_events_listener.rb
@@ -93,7 +93,8 @@ module EvoFlow
       return log_missing(__method__, 'contact') unless contact
       return unless evo_flow_enabled?
 
-      occurred_at = Time.zone.now
+      # L3: prefer producer-supplied timestamp; fall back to now.
+      occurred_at = event_data[:occurred_at] || Time.zone.now
       enqueue_identify(
         event_name: 'contact.custom_attribute.changed',
         contact_id: contact.id,
@@ -117,8 +118,13 @@ module EvoFlow
       return unless evo_flow_enabled?
 
       label_name = event_data[:label_name]
-      traits = { labelName: label_name, labelId: label_name, source: source }
-      occurred_at = Time.zone.now
+      # L2: prefer the real Label.id from the producer (event_data[:label_id]);
+      # fall back to a Label lookup for backwards compat with producers that
+      # only pass the name. If neither yields an id, fall back to the name.
+      label_id = event_data[:label_id] || resolve_label_id(label_name) || label_name
+      traits = { labelName: label_name, labelId: label_id, source: source }
+      # L3: prefer producer-supplied timestamp; fall back to now.
+      occurred_at = event_data[:occurred_at] || Time.zone.now
 
       enqueue_identify(
         event_name: event_name,
@@ -130,6 +136,12 @@ module EvoFlow
       )
     rescue StandardError => e
       log_failure("contact_label_#{suffix}", e)
+    end
+
+    def resolve_label_id(label_name)
+      return nil if label_name.blank?
+
+      Label.find_by(title: label_name.to_s)&.id
     end
 
     def created_via(contact)
@@ -181,6 +193,9 @@ module EvoFlow
     end
 
     # Ported from legacy evo_campaign/contact_events_integration_service.rb:553-571.
+    # M4: custom_attributes / additional_attributes are namespaced rather than
+    # spread, so a custom attribute named `id`/`name`/`email`/`created_at`
+    # cannot overwrite the structural trait keys.
     def build_contact_traits(contact)
       {
         id: contact.id,
@@ -196,13 +211,13 @@ module EvoFlow
         blocked: contact.blocked,
         created_at: contact.created_at,
         updated_at: contact.updated_at,
-        **(contact.custom_attributes || {}),
-        **(contact.additional_attributes || {})
+        customAttributes: contact.custom_attributes || {},
+        additionalAttributes: contact.additional_attributes || {}
       }.compact
     end
 
     def evo_flow_enabled?
-      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+      EvoFlow.enabled?
     end
 
     def log_missing(handler, key)

--- a/app/listeners/evo_flow/conversation_events_listener.rb
+++ b/app/listeners/evo_flow/conversation_events_listener.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module EvoFlow
+  # Subscribes to Wisper :conversation_created and forwards to evo-flow as
+  # a track event. See EvoFlow::ContactEventsListener for the canonical
+  # listener template.
+  #
+  # `evo_flow_enabled?` is duplicated across the 4 EvoFlow listeners by
+  # design (tech-spec §Technical Decisions #2: no shared base class).
+  class ConversationEventsListener
+    TRACK_PATH = '/events/track'
+
+    def conversation_created(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      conversation = event_data[:conversation]
+      unless conversation
+        Rails.logger.error('EvoFlow::ConversationEventsListener#conversation_created: conversation is nil')
+        return
+      end
+      return unless evo_flow_enabled?
+
+      enqueue_track(conversation)
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    private
+
+    def enqueue_track(conversation)
+      event_name = 'conversation.created'
+      source_event_uuid = "#{conversation.id}.#{conversation.created_at.to_i}"
+      contact_id = conversation.contact_id
+      message_id = EvoFlow::PayloadBuilder.message_id_for(event_name, contact_id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_track(
+        event_name: event_name,
+        contact_id: contact_id,
+        properties: build_properties(conversation),
+        occurred_at: conversation.created_at,
+        message_id: message_id
+      )
+      # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
+      # PayloadBuilder is out of scope for this story — normalise at boundary.
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+    end
+
+    def build_properties(conversation)
+      inbox = conversation.inbox
+      {
+        conversation_id: conversation.id,
+        inbox_id: conversation.inbox_id,
+        inbox_name: inbox&.name,
+        channel_type: inbox&.channel_type,
+        source: 'conversation_management'
+      }
+    end
+
+    def evo_flow_enabled?
+      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+    end
+
+    # F6/F8 mitigation: see ContactEventsListener#log_failure for rationale.
+    def log_failure(handler, error)
+      tag = enqueue_loss?(error) ? '[EvoFlow][enqueue-loss]' : '[EvoFlow]'
+      Rails.logger.error(
+        "#{tag} EvoFlow::ConversationEventsListener##{handler} failed: #{error.class}: #{error.message}"
+      )
+      Sentry.capture_exception(error) if defined?(Sentry)
+      nil
+    end
+
+    def enqueue_loss?(error)
+      return true if defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)
+
+      error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
+    end
+  end
+end

--- a/app/listeners/evo_flow/conversation_events_listener.rb
+++ b/app/listeners/evo_flow/conversation_events_listener.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 module EvoFlow
-  # Subscribes to Wisper :conversation_created and forwards to evo-flow as
-  # a track event. See EvoFlow::ContactEventsListener for the canonical
-  # listener template.
+  # Subscribes to Wisper :conversation_created and :conversation_resolved
+  # and forwards them to evo-flow as track events.
+  #
+  # Dual-shape note:
+  # - `:conversation_created` is published *twice* by the Conversation model
+  #   (Wisper direct via `publish(:conversation_created, data: {...})` and
+  #    Dispatcher via `Rails.configuration.dispatcher.dispatch(...)`). The
+  #   `return if data.respond_to?(:data)` guard de-dupes by rejecting the
+  #   Dispatcher envelope (Events::Base has `.data`).
+  # - `:conversation_resolved` is published *only* via Dispatcher (see
+  #   `Conversation#notify_status_change`). The handler accepts the
+  #   `Events::Base` shape and reads from `event.data`.
   #
   # `evo_flow_enabled?` is duplicated across the 4 EvoFlow listeners by
   # design (tech-spec §Technical Decisions #2: no shared base class).
@@ -21,14 +30,32 @@ module EvoFlow
       end
       return unless evo_flow_enabled?
 
-      enqueue_track(conversation)
+      enqueue_created(conversation)
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    # AC2: receives Events::Base from SyncDispatcher (Conversation#notify_status_change
+    # is the only producer). No Wisper-direct shape exists for this event.
+    def conversation_resolved(event)
+      return unless event.respond_to?(:data)
+
+      event_data = event.data
+      conversation = event_data[:conversation]
+      unless conversation
+        Rails.logger.error('EvoFlow::ConversationEventsListener#conversation_resolved: conversation is nil')
+        return
+      end
+      return unless evo_flow_enabled?
+
+      enqueue_resolved(conversation, event_data)
     rescue StandardError => e
       log_failure(__method__, e)
     end
 
     private
 
-    def enqueue_track(conversation)
+    def enqueue_created(conversation)
       event_name = 'conversation.created'
       source_event_uuid = "#{conversation.id}.#{conversation.created_at.to_i}"
       contact_id = conversation.contact_id
@@ -36,16 +63,31 @@ module EvoFlow
       payload = EvoFlow::PayloadBuilder.build_track(
         event_name: event_name,
         contact_id: contact_id,
-        properties: build_properties(conversation),
+        properties: build_created_properties(conversation),
         occurred_at: conversation.created_at,
         message_id: message_id
       )
-      # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
-      # PayloadBuilder is out of scope for this story — normalise at boundary.
       EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
     end
 
-    def build_properties(conversation)
+    def enqueue_resolved(conversation, event_data)
+      event_name = 'conversation.resolved'
+      # Use updated_at (when status flipped to resolved) for idempotency.
+      occurred_at = conversation.updated_at || Time.zone.now
+      source_event_uuid = "#{conversation.id}.resolved.#{occurred_at.to_i}"
+      contact_id = conversation.contact_id
+      message_id = EvoFlow::PayloadBuilder.message_id_for(event_name, contact_id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_track(
+        event_name: event_name,
+        contact_id: contact_id,
+        properties: build_resolved_properties(conversation, event_data),
+        occurred_at: occurred_at,
+        message_id: message_id
+      )
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+    end
+
+    def build_created_properties(conversation)
       inbox = conversation.inbox
       {
         conversation_id: conversation.id,
@@ -56,8 +98,29 @@ module EvoFlow
       }
     end
 
+    def build_resolved_properties(conversation, event_data)
+      inbox = conversation.inbox
+      performed_by = event_data[:performed_by]
+      {
+        conversation_id: conversation.id,
+        inbox_id: conversation.inbox_id,
+        inbox_name: inbox&.name,
+        channel_type: inbox&.channel_type,
+        resolved_by_id: performed_by.respond_to?(:id) ? performed_by.id : performed_by,
+        resolved_by_type: performed_by.respond_to?(:class) ? performed_by.class.name : nil,
+        resolution_time_seconds: resolution_time_seconds(conversation),
+        source: 'conversation_management'
+      }.compact
+    end
+
+    def resolution_time_seconds(conversation)
+      return nil unless conversation.created_at && conversation.updated_at
+
+      (conversation.updated_at - conversation.created_at).to_i
+    end
+
     def evo_flow_enabled?
-      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+      EvoFlow.enabled?
     end
 
     # F6/F8 mitigation: see ContactEventsListener#log_failure for rationale.

--- a/app/listeners/evo_flow/message_events_listener.rb
+++ b/app/listeners/evo_flow/message_events_listener.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module EvoFlow
+  # Subscribes to Wisper :message_created and forwards to evo-flow as a
+  # track event. See EvoFlow::ContactEventsListener for the canonical
+  # listener template.
+  #
+  # `evo_flow_enabled?` is duplicated across the 4 EvoFlow listeners by
+  # design (tech-spec §Technical Decisions #2: no shared base class).
+  #
+  # Hot-path note (F4): this handler fires per inbound message. The
+  # `message.conversation.inbox` access can incur 2 extra SQL reads if the
+  # caller hasn't preloaded the association. Bulk paths SHOULD preload
+  # `conversation: :inbox`; the listener does not preload defensively.
+  class MessageEventsListener
+    TRACK_PATH = '/events/track'
+
+    def message_created(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      message = event_data[:message]
+      return log_missing_message unless message
+      return unless evo_flow_enabled?
+
+      inbox = inbox_for(message)
+      return warn_inbox_missing(message) unless inbox
+
+      enqueue_track(message, inbox)
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    private
+
+    def inbox_for(message)
+      message.conversation&.inbox
+    end
+
+    def log_missing_message
+      Rails.logger.error('EvoFlow::MessageEventsListener#message_created: message is nil')
+      nil
+    end
+
+    def warn_inbox_missing(message)
+      Rails.logger.warn(
+        "EvoFlow::MessageEventsListener#message_created: inbox missing for message #{message.id}"
+      )
+      nil
+    end
+
+    def enqueue_track(message, inbox)
+      event_name = 'message.created'
+      source_event_uuid = "#{message.id}.#{message.created_at.to_i}"
+      contact_id = message.conversation.contact_id
+      message_id = EvoFlow::PayloadBuilder.message_id_for(event_name, contact_id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_track(
+        event_name: event_name,
+        contact_id: contact_id,
+        properties: build_properties(message, inbox),
+        occurred_at: message.created_at,
+        message_id: message_id
+      )
+      # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
+      # PayloadBuilder is out of scope for this story — normalise at boundary.
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+    end
+
+    # Raw content is intentionally passed through; EvoFlow::PublishEventWorker
+    # redacts `properties` only when persisting Sidekiq args / failure
+    # broadcasts, not in-flight to evo-flow which needs the content.
+    def build_properties(message, inbox)
+      {
+        message_id: message.id,
+        conversation_id: message.conversation_id,
+        message_type: message.message_type,
+        content_type: message.content_type,
+        content: message.content,
+        channel_type: inbox.channel_type,
+        source: 'messaging'
+      }
+    end
+
+    def evo_flow_enabled?
+      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+    end
+
+    # F6/F8 mitigation: see ContactEventsListener#log_failure for rationale.
+    def log_failure(handler, error)
+      tag = enqueue_loss?(error) ? '[EvoFlow][enqueue-loss]' : '[EvoFlow]'
+      Rails.logger.error(
+        "#{tag} EvoFlow::MessageEventsListener##{handler} failed: #{error.class}: #{error.message}"
+      )
+      Sentry.capture_exception(error) if defined?(Sentry)
+      nil
+    end
+
+    def enqueue_loss?(error)
+      return true if defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)
+
+      error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
+    end
+  end
+end

--- a/app/listeners/evo_flow/message_events_listener.rb
+++ b/app/listeners/evo_flow/message_events_listener.rb
@@ -1,19 +1,32 @@
 # frozen_string_literal: true
 
 module EvoFlow
-  # Subscribes to Wisper :message_created and forwards to evo-flow as a
-  # track event. See EvoFlow::ContactEventsListener for the canonical
-  # listener template.
+  # Subscribes to Wisper :message_created and :message_status_changed and
+  # forwards them to evo-flow as track events.
   #
   # `evo_flow_enabled?` is duplicated across the 4 EvoFlow listeners by
   # design (tech-spec §Technical Decisions #2: no shared base class).
   #
-  # Hot-path note (F4): this handler fires per inbound message. The
+  # Hot-path note (F4): handler fires per inbound message. The
   # `message.conversation.inbox` access can incur 2 extra SQL reads if the
   # caller hasn't preloaded the association. Bulk paths SHOULD preload
   # `conversation: :inbox`; the listener does not preload defensively.
+  #
+  # M5 filter: only `incoming` and `outgoing` messages are tracked.
+  # `activity` (system events) and `template` (CSAT/whatsapp template
+  # broadcasts) are intentionally excluded — they would flood the hot
+  # path with noise that has no analytics value.
   class MessageEventsListener
     TRACK_PATH = '/events/track'
+    TRACKED_MESSAGE_TYPES = %w[incoming outgoing].freeze
+    # AC3: previous_status → canonical event_name mapping.
+    # Anything outside this map is dropped (logged as warn) to avoid
+    # shipping non-canonical event names.
+    STATUS_TRANSITION_EVENT_NAMES = {
+      'sent' => 'message.delivered',
+      'delivered' => 'message.read'
+    }.freeze
+    FAILED_EVENT_NAME = 'message.failed'
 
     def message_created(data)
       return if data.respond_to?(:data)
@@ -22,34 +35,77 @@ module EvoFlow
       message = event_data[:message]
       return log_missing_message unless message
       return unless evo_flow_enabled?
+      return unless tracked_type?(message)
 
       inbox = inbox_for(message)
       return warn_inbox_missing(message) unless inbox
 
-      enqueue_track(message, inbox)
+      enqueue_created(message, inbox)
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    # AC3: maps Wisper :message_status_changed to message.delivered /
+    # message.read / message.failed based on the (previous_status, status)
+    # transition. Producer is `Messages::StatusUpdateService` (see
+    # `publish(:message_status_changed, ...)`).
+    def message_status_changed(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      message = event_data[:message]
+      return log_missing_message unless message
+      return unless evo_flow_enabled?
+
+      event_name = resolve_status_event_name(event_data[:previous_status], event_data[:status])
+      return warn_unmapped_status(message, event_data) unless event_name
+
+      inbox = inbox_for(message)
+      return warn_inbox_missing(message) unless inbox
+
+      enqueue_status_change(message, inbox, event_name, event_data)
     rescue StandardError => e
       log_failure(__method__, e)
     end
 
     private
 
+    def tracked_type?(message)
+      TRACKED_MESSAGE_TYPES.include?(message.message_type.to_s)
+    end
+
+    def resolve_status_event_name(previous_status, status)
+      return FAILED_EVENT_NAME if status.to_s == 'failed'
+
+      STATUS_TRANSITION_EVENT_NAMES[previous_status.to_s]
+    end
+
     def inbox_for(message)
       message.conversation&.inbox
     end
 
     def log_missing_message
-      Rails.logger.error('EvoFlow::MessageEventsListener#message_created: message is nil')
+      Rails.logger.error('EvoFlow::MessageEventsListener: message is nil')
       nil
     end
 
     def warn_inbox_missing(message)
       Rails.logger.warn(
-        "EvoFlow::MessageEventsListener#message_created: inbox missing for message #{message.id}"
+        "EvoFlow::MessageEventsListener: inbox missing for message #{message.id}"
       )
       nil
     end
 
-    def enqueue_track(message, inbox)
+    def warn_unmapped_status(message, event_data)
+      Rails.logger.warn(
+        "EvoFlow::MessageEventsListener#message_status_changed: unmapped " \
+        "transition #{event_data[:previous_status]} → #{event_data[:status]} " \
+        "for message #{message.id}"
+      )
+      nil
+    end
+
+    def enqueue_created(message, inbox)
       event_name = 'message.created'
       source_event_uuid = "#{message.id}.#{message.created_at.to_i}"
       contact_id = message.conversation.contact_id
@@ -57,19 +113,34 @@ module EvoFlow
       payload = EvoFlow::PayloadBuilder.build_track(
         event_name: event_name,
         contact_id: contact_id,
-        properties: build_properties(message, inbox),
+        properties: build_created_properties(message, inbox),
         occurred_at: message.created_at,
         message_id: message_id
       )
-      # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
-      # PayloadBuilder is out of scope for this story — normalise at boundary.
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+    end
+
+    def enqueue_status_change(message, inbox, event_name, event_data)
+      occurred_at = message.updated_at || Time.zone.now
+      # Idempotency: include event_name + occurred_at so multiple status
+      # transitions on the same message produce distinct messageIds.
+      source_event_uuid = "#{message.id}.#{event_name}.#{occurred_at.to_i}"
+      contact_id = message.conversation.contact_id
+      message_id = EvoFlow::PayloadBuilder.message_id_for(event_name, contact_id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_track(
+        event_name: event_name,
+        contact_id: contact_id,
+        properties: build_status_properties(message, inbox, event_data),
+        occurred_at: occurred_at,
+        message_id: message_id
+      )
       EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
     end
 
     # Raw content is intentionally passed through; EvoFlow::PublishEventWorker
     # redacts `properties` only when persisting Sidekiq args / failure
     # broadcasts, not in-flight to evo-flow which needs the content.
-    def build_properties(message, inbox)
+    def build_created_properties(message, inbox)
       {
         message_id: message.id,
         conversation_id: message.conversation_id,
@@ -81,8 +152,21 @@ module EvoFlow
       }
     end
 
+    def build_status_properties(message, inbox, event_data)
+      {
+        message_id: message.id,
+        conversation_id: message.conversation_id,
+        message_type: message.message_type,
+        channel_type: inbox.channel_type,
+        previous_status: event_data[:previous_status],
+        status: event_data[:status],
+        external_error: event_data[:external_error],
+        source: 'messaging'
+      }.compact
+    end
+
     def evo_flow_enabled?
-      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+      EvoFlow.enabled?
     end
 
     # F6/F8 mitigation: see ContactEventsListener#log_failure for rationale.

--- a/app/listeners/evo_flow/pipeline_events_listener.rb
+++ b/app/listeners/evo_flow/pipeline_events_listener.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module EvoFlow
+  # Subscribes to Wisper :pipeline_item_created and forwards to evo-flow.
+  #
+  # Adapter shim: legacy Wisper event :pipeline_item_created maps to the
+  # EvoFlow::EVENT_NAMES entry "campaign.triggered". A dedicated `pipeline.*`
+  # event name is preferred long-term but requires coordinated evo-flow +
+  # downstream consumer changes — out of scope for EVO-1240.
+  #
+  # `evo_flow_enabled?` is duplicated across the 4 EvoFlow listeners by
+  # design (tech-spec §Technical Decisions #2: no shared base class).
+  class PipelineEventsListener
+    TRACK_PATH = '/events/track'
+    EVENT_NAME = 'campaign.triggered'
+
+    def pipeline_item_created(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      pipeline_item = event_data[:pipeline_item]
+      unless pipeline_item
+        Rails.logger.error('EvoFlow::PipelineEventsListener#pipeline_item_created: pipeline_item is nil')
+        return
+      end
+      return unless evo_flow_enabled?
+
+      contact_id = resolve_contact_id(pipeline_item)
+      return warn_unresolved(pipeline_item) unless contact_id
+
+      enqueue_track(pipeline_item, contact_id)
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    private
+
+    def enqueue_track(pipeline_item, contact_id)
+      source_event_uuid = "#{pipeline_item.id}.#{pipeline_item.created_at.to_i}"
+      message_id = EvoFlow::PayloadBuilder.message_id_for(EVENT_NAME, contact_id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_track(
+        event_name: EVENT_NAME,
+        contact_id: contact_id,
+        properties: build_properties(pipeline_item, contact_id),
+        occurred_at: pipeline_item.created_at,
+        message_id: message_id
+      )
+      # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
+      # PayloadBuilder is out of scope for this story — normalise at boundary.
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+    end
+
+    def resolve_contact_id(pipeline_item)
+      if pipeline_item.lead?
+        pipeline_item.contact_id
+      else
+        pipeline_item.conversation&.contact_id
+      end
+    end
+
+    def warn_unresolved(pipeline_item)
+      Rails.logger.warn(
+        "EvoFlow::PipelineEventsListener#pipeline_item_created: no resolvable contact_id for pipeline_item #{pipeline_item.id}"
+      )
+      nil
+    end
+
+    # F11 fix: use the resolved contact_id for `contact_id` so deal items
+    # carry a consistent value with the payload root `contactId`.
+    def build_properties(pipeline_item, contact_id)
+      pipeline = pipeline_item.pipeline
+      stage = pipeline_item.pipeline_stage
+      {
+        pipeline_item_id: pipeline_item.id,
+        conversation_id: pipeline_item.conversation_id,
+        contact_id: contact_id,
+        is_lead: pipeline_item.lead?,
+        pipeline_id: pipeline_item.pipeline_id,
+        pipeline_name: pipeline&.name,
+        pipeline_stage_id: pipeline_item.pipeline_stage_id,
+        pipeline_stage_name: stage&.name,
+        assigned_by_id: pipeline_item.assigned_by_id,
+        custom_fields: pipeline_item.custom_fields,
+        source: 'pipeline_management'
+      }
+    end
+
+    def evo_flow_enabled?
+      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+    end
+
+    # F6/F8 mitigation: see ContactEventsListener#log_failure for rationale.
+    def log_failure(handler, error)
+      tag = enqueue_loss?(error) ? '[EvoFlow][enqueue-loss]' : '[EvoFlow]'
+      Rails.logger.error(
+        "#{tag} EvoFlow::PipelineEventsListener##{handler} failed: #{error.class}: #{error.message}"
+      )
+      Sentry.capture_exception(error) if defined?(Sentry)
+      nil
+    end
+
+    def enqueue_loss?(error)
+      return true if defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)
+
+      error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
+    end
+  end
+end

--- a/app/listeners/evo_flow/pipeline_events_listener.rb
+++ b/app/listeners/evo_flow/pipeline_events_listener.rb
@@ -86,7 +86,7 @@ module EvoFlow
     end
 
     def evo_flow_enabled?
-      ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+      EvoFlow.enabled?
     end
 
     # F6/F8 mitigation: see ContactEventsListener#log_failure for rationale.

--- a/app/models/concerns/labelable.rb
+++ b/app/models/concerns/labelable.rb
@@ -5,13 +5,31 @@ module Labelable
     acts_as_taggable_on :labels
   end
 
+  # H2: diff label_list before/after and emit Wisper events for each
+  # added/removed label so EvoFlow listeners can observe them. We only
+  # call the contact-scoped publishers; for non-Contact tagged models
+  # this concern is still safe because the methods are absent (publishers
+  # check `respond_to?` before firing).
   def update_labels(labels = nil)
+    before = label_list.to_a
     update!(label_list: labels)
+    emit_label_change_events(before, label_list.to_a)
   end
 
   def add_labels(new_labels = nil)
-    new_labels = Array(new_labels) # Make sure new_labels is an array
+    new_labels = Array(new_labels)
+    before = label_list.to_a
     combined_labels = labels + new_labels
     update!(label_list: combined_labels)
+    emit_label_change_events(before, label_list.to_a)
+  end
+
+  private
+
+  def emit_label_change_events(before, after)
+    return unless respond_to?(:publish_label_added, true) && respond_to?(:publish_label_removed, true)
+
+    (after - before).each { |label_name| publish_label_added(label_name) }
+    (before - after).each { |label_name| publish_label_removed(label_name) }
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -84,7 +84,7 @@ class Contact < ApplicationRecord
   # after_create_commit :dispatch_create_event # Disabled - using Wisper events instead
   after_create_commit :ip_lookup, :publish_contact_created, :assign_to_default_pipeline
   # after_update_commit :dispatch_update_event # Disabled - using Wisper events instead
-  after_update_commit :publish_contact_updated
+  after_update_commit :publish_contact_updated, :publish_custom_attribute_changes
   before_save :sync_contact_attributes
   before_destroy :ensure_pipeline_items_cleanup, :publish_contact_deleted
   after_destroy_commit :dispatch_destroy_event
@@ -323,8 +323,34 @@ class Contact < ApplicationRecord
               attribute_value: new_value,
               old_value: old_value,
               change_type: change_type,
+              occurred_at: Time.zone.now,
               api_access_token: Current.api_access_token
             })
+  end
+
+  # H2: diff `custom_attributes` jsonb on update and emit one Wisper event
+  # per changed key so EvoFlow::ContactEventsListener#contact_custom_attribute_changed
+  # actually fires in production (the publisher was previously orphaned).
+  def publish_custom_attribute_changes
+    return unless saved_change_to_custom_attributes?
+
+    before, after = saved_change_to_custom_attributes
+    before ||= {}
+    after ||= {}
+    (before.keys | after.keys).each do |attribute_name|
+      old_value = before[attribute_name]
+      new_value = after[attribute_name]
+      next if old_value == new_value
+
+      publish_custom_attribute_changed(attribute_name, new_value, old_value, custom_attr_change_type(old_value, new_value))
+    end
+  end
+
+  def custom_attr_change_type(old_value, new_value)
+    return 'added' if old_value.nil?
+    return 'removed' if new_value.nil?
+
+    'updated'
   end
 
   # Publish label changes
@@ -332,6 +358,8 @@ class Contact < ApplicationRecord
     publish(:contact_label_added, data: {
               contact: self,
               label_name: label_name,
+              label_id: ::Label.find_by(title: label_name.to_s)&.id,
+              occurred_at: Time.zone.now,
               api_access_token: Current.api_access_token
             })
   end
@@ -340,6 +368,8 @@ class Contact < ApplicationRecord
     publish(:contact_label_removed, data: {
               contact: self,
               label_name: label_name,
+              label_id: ::Label.find_by(title: label_name.to_s)&.id,
+              occurred_at: Time.zone.now,
               api_access_token: Current.api_access_token
             })
   end

--- a/app/services/evo_flow/invalid_event_name.rb
+++ b/app/services/evo_flow/invalid_event_name.rb
@@ -1,0 +1,7 @@
+module EvoFlow
+  class InvalidEventName < StandardError
+    def initialize(event_name)
+      super("Unknown EvoFlow event_name: #{event_name.inspect}. Allowed: #{EvoFlow::EVENT_NAMES.join(', ')}")
+    end
+  end
+end

--- a/app/services/evo_flow/payload_builder.rb
+++ b/app/services/evo_flow/payload_builder.rb
@@ -6,6 +6,7 @@ module EvoFlow
   class PayloadBuilder
     # Exactly 5 kwargs (RuboCop ParameterLists max 5 — do not add a 6th).
     def self.build_track(event_name:, contact_id:, properties:, occurred_at:, message_id:)
+      validate_event_name!(event_name)
       {
         messageId: message_id,
         contactId: contact_id.to_s,
@@ -16,6 +17,7 @@ module EvoFlow
     end
 
     def self.build_identify(event_name:, contact_id:, traits:, occurred_at:, message_id:)
+      validate_event_name!(event_name)
       {
         messageId: message_id,
         contactId: contact_id.to_s,
@@ -23,6 +25,15 @@ module EvoFlow
         traits: traits || {},
         timestamp: iso8601(occurred_at)
       }
+    end
+
+    # AC6: raise on event_name outside EvoFlow::EVENT_NAMES (caught in CI, not prod —
+    # listeners rescue StandardError and tag enqueue-loss). Prevents typo'd or
+    # legacy event names from silently shipping to evo-flow / ClickHouse.
+    def self.validate_event_name!(event_name)
+      return if EvoFlow::EVENT_NAMES.include?(event_name)
+
+      raise EvoFlow::InvalidEventName, event_name
     end
 
     # Deterministic, forward-looking idempotency key. NOTE: evo-flow has no

--- a/app/services/messages/status_update_service.rb
+++ b/app/services/messages/status_update_service.rb
@@ -1,4 +1,6 @@
 class Messages::StatusUpdateService
+  include Wisper::Publisher
+
   attr_reader :message, :status, :external_error
 
   def initialize(message, status, external_error = nil)
@@ -10,7 +12,17 @@ class Messages::StatusUpdateService
   def perform
     return false unless valid_status_transition?
 
+    previous_status = message.status
     update_message_status
+    # AC3 instrumentation: publish status transition so EvoFlow listener
+    # can map (previous_status, status) → message.delivered/read/failed.
+    publish(:message_status_changed, data: {
+              message: message,
+              previous_status: previous_status,
+              status: status,
+              external_error: external_error
+            })
+    true
   end
 
   private

--- a/config/initializers/evo_flow_listeners.rb
+++ b/config/initializers/evo_flow_listeners.rb
@@ -1,0 +1,16 @@
+# Register EvoFlow::* listeners for Wisper events emitted by Contact,
+# Conversation, Message, and PipelineItem models. Mirrors the
+# contact_company_listeners.rb pattern but uses `.new` (legacy EvoCampaign
+# idiom) since EvoFlow listeners are not singletons.
+#
+# Intentionally NOT `to_prepare` — Wisper 2.0 does not deduplicate
+# subscribers, so reloading the codebase under `to_prepare` would silently
+# register additional listener instances in development.
+Rails.application.config.after_initialize do
+  Wisper.subscribe(EvoFlow::ContactEventsListener.new)
+  Wisper.subscribe(EvoFlow::ConversationEventsListener.new)
+  Wisper.subscribe(EvoFlow::MessageEventsListener.new)
+  Wisper.subscribe(EvoFlow::PipelineEventsListener.new)
+
+  Rails.logger.info 'EvoFlow listeners registered (contact, conversation, message, pipeline)'
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1783,10 +1783,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_18_133933) do
   add_foreign_key "user_roles", "users"
   add_foreign_key "user_roles", "users", column: "granted_by_id"
   add_foreign_key "user_tours", "users"
-  # no candidate create_trigger statement could be found, creating an adapter-specific one
-  execute("CREATE TRIGGER update_campaign_executions_updated_at BEFORE UPDATE ON \"campaign_executions\" FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()")
-
-  # no candidate create_trigger statement could be found, creating an adapter-specific one
+  # L1 fix: define the trigger function BEFORE the trigger that references it.
+  # schema.rb is executed top-to-bottom, so `CREATE TRIGGER` on line below
+  # would fail with "function update_updated_at_column() does not exist"
+  # during db:prepare on a fresh database (CI).
   execute(<<-SQL)
 CREATE OR REPLACE FUNCTION public.update_updated_at_column()
  RETURNS trigger
@@ -1798,5 +1798,8 @@ AS $function$
       END;
       $function$
   SQL
+
+  # no candidate create_trigger statement could be found, creating an adapter-specific one
+  execute("CREATE TRIGGER update_campaign_executions_updated_at BEFORE UPDATE ON \"campaign_executions\" FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()")
 
 end

--- a/lib/events/evo_flow_event_names.rb
+++ b/lib/events/evo_flow_event_names.rb
@@ -1,7 +1,5 @@
 module EvoFlow
   # Canonical list of event names CRM emits to evo-flow.
-  # Story 7.3 (EVO-1238) foundation: declaration only — hard validation
-  # (raise EvoFlow::InvalidEventName) is story 7.5 (EVO-1241).
   # Dot-notation matches the Events::Types convention (lib/events/types.rb).
   EVENT_NAMES = %w[
     contact.created contact.updated contact.deleted

--- a/lib/events/evo_flow_event_names.rb
+++ b/lib/events/evo_flow_event_names.rb
@@ -8,4 +8,14 @@ module EvoFlow
     message.created message.delivered message.read message.failed
     campaign.triggered campaign.message.sent campaign.message.opened campaign.message.clicked
   ].freeze
+
+  # Feature gate. Primary ENV is `EVO_FLOW_ENABLED`; legacy
+  # `AUTH_APIKEY_INTEGRATION_LOCAL` is honoured as a fallback during the
+  # rollout transition (review L4) so existing deploys keep working. Drop
+  # the legacy var once the rollout settles.
+  def self.enabled?
+    return ENV['EVO_FLOW_ENABLED'].to_s.casecmp('true').zero? if ENV['EVO_FLOW_ENABLED'].present?
+
+    ENV['AUTH_APIKEY_INTEGRATION_LOCAL'].present?
+  end
 end

--- a/spec/initializers/evo_flow_listeners_spec.rb
+++ b/spec/initializers/evo_flow_listeners_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# AC4: verifies that the 4 EvoFlow listeners are registered as global
+# Wisper subscribers when the Rails app boots. The initializer runs
+# `Wisper.subscribe(...)` inside `after_initialize`, so by the time the
+# spec suite is loaded, the global listeners list must include them.
+RSpec.describe 'EvoFlow listeners registration' do
+  let(:registered_classes) do
+    Wisper::GlobalListeners.send(:listeners).map(&:class)
+  end
+
+  %w[
+    EvoFlow::ContactEventsListener
+    EvoFlow::ConversationEventsListener
+    EvoFlow::MessageEventsListener
+    EvoFlow::PipelineEventsListener
+  ].each do |klass_name|
+    it "registers #{klass_name} as a global Wisper subscriber" do
+      expect(registered_classes.map(&:name)).to include(klass_name)
+    end
+  end
+end

--- a/spec/listeners/evo_flow/contact_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/contact_events_listener_spec.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe EvoFlow::ContactEventsListener do
+  let(:listener) { described_class.new }
+  let(:created_at) { Time.utc(2026, 5, 20, 10, 0, 0) }
+  let(:updated_at) { Time.utc(2026, 5, 20, 11, 0, 0) }
+  let(:contact) do
+    instance_double(
+      Contact,
+      id: 42,
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      phone_number: '+5511999999999',
+      identifier: 'ext-1',
+      middle_name: nil,
+      last_name: 'Lovelace',
+      location: 'SP',
+      country_code: 'BR',
+      contact_type: 'lead',
+      blocked: false,
+      created_at: created_at,
+      updated_at: updated_at,
+      custom_attributes: { 'tier' => 'gold' },
+      additional_attributes: { 'created_via_user_id' => nil }
+    )
+  end
+  let(:fixed_digest) { 'fixed-digest' }
+
+  before do
+    Sidekiq::Testing.fake!
+    EvoFlow::PublishEventWorker.clear
+    allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_return(fixed_digest)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return('test-key')
+  end
+
+  after { EvoFlow::PublishEventWorker.clear }
+
+  def last_payload
+    EvoFlow::PublishEventWorker.jobs.last['args'][1]
+  end
+
+  describe '#contact_created' do
+    let(:payload) { { contact: contact } }
+
+    it 'enqueues an identify event with contact traits + created_via=system (AC1)' do
+      listener.contact_created(data: payload)
+
+      jobs = EvoFlow::PublishEventWorker.jobs
+      expect(jobs.size).to eq(1)
+      expect(jobs.last['args'][0]).to eq('/events/identify')
+      sent = jobs.last['args'][1]
+      expect(sent['eventName']).to eq('contact.created')
+      expect(sent['contactId']).to eq('42')
+      expect(sent['messageId']).to eq(fixed_digest)
+      expect(sent['traits']).to include(
+        'id' => 42,
+        'email' => 'ada@example.com',
+        'phone_number' => '+5511999999999',
+        'source' => 'contact_created',
+        'created_via' => 'system'
+      )
+    end
+
+    it 'marks created_via=agent when additional_attributes.created_via_user_id is present' do
+      allow(contact).to receive(:additional_attributes).and_return('created_via_user_id' => 7)
+
+      listener.contact_created(data: payload)
+
+      expect(last_payload['traits']).to include('created_via' => 'agent')
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.contact_created(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.contact_created(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when contact is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/contact_created.*contact is nil/)
+        listener.contact_created(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+  end
+
+  describe '#contact_updated' do
+    let(:payload) { { contact: contact, changed_attributes: { 'email' => ['old@x.com', 'new@x.com'] } } }
+
+    it 'enqueues an identify event with changes summary (AC2)' do
+      listener.contact_updated(data: payload)
+
+      sent = last_payload
+      expect(sent['eventName']).to eq('contact.updated')
+      expect(sent['traits']['source']).to eq('contact_updated')
+      expect(sent['traits']['changes']).to eq('email' => 'new@x.com')
+    end
+
+    it 'also accepts `changes:` shape (spec idiom)' do
+      listener.contact_updated(data: { contact: contact, changes: { 'name' => %w[old new] } })
+
+      expect(last_payload['traits']['changes']).to eq('name' => 'new')
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.contact_updated(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.contact_updated(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when contact is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/contact_updated.*contact is nil/)
+        listener.contact_updated(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+  end
+
+  describe '#contact_deleted' do
+    let(:deleted_at) { Time.utc(2026, 5, 20, 12, 0, 0) }
+    let(:payload) { { contact_id: 99, reason: 'gdpr_erasure', deleted_at: deleted_at } }
+
+    it 'enqueues an identify event with reason + deleted_at (AC3)' do
+      listener.contact_deleted(data: payload)
+
+      sent = last_payload
+      expect(sent['eventName']).to eq('contact.deleted')
+      expect(sent['contactId']).to eq('99')
+      expect(sent['traits']).to include(
+        'source' => 'contact_deleted',
+        'reason' => 'gdpr_erasure',
+        'deleted_at' => deleted_at.iso8601
+      )
+    end
+
+    it 'defaults reason to user_action when missing' do
+      listener.contact_deleted(data: { contact_id: 99, deleted_at: deleted_at })
+
+      expect(last_payload['traits']['reason']).to eq('user_action')
+    end
+
+    it 'accepts `contact:` shape from the live publisher' do
+      listener.contact_deleted(data: { contact: contact, deleted_at: deleted_at })
+
+      expect(last_payload['contactId']).to eq('42')
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.contact_deleted(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.contact_deleted(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when neither contact nor contact_id is present (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/contact_deleted.*contact_id is nil/)
+        listener.contact_deleted(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+  end
+
+  describe '#contact_label_added' do
+    let(:payload) { { contact: contact, label_name: 'vip' } }
+
+    it 'enqueues contact.label.added with labelName trait (AC4)' do
+      listener.contact_label_added(data: payload)
+
+      sent = last_payload
+      expect(sent['eventName']).to eq('contact.label.added')
+      expect(sent['traits']).to include('labelName' => 'vip', 'labelId' => 'vip', 'source' => 'label_added')
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.contact_label_added(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.contact_label_added(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when contact is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/contact_label_added.*contact is nil/)
+        listener.contact_label_added(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+  end
+
+  describe '#contact_label_removed' do
+    let(:payload) { { contact: contact, label_name: 'vip' } }
+
+    it 'enqueues contact.label.removed with labelName trait (AC4)' do
+      listener.contact_label_removed(data: payload)
+
+      sent = last_payload
+      expect(sent['eventName']).to eq('contact.label.removed')
+      expect(sent['traits']).to include('labelName' => 'vip', 'labelId' => 'vip', 'source' => 'label_removed')
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.contact_label_removed(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.contact_label_removed(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when contact is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/contact_label_removed.*contact is nil/)
+        listener.contact_label_removed(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+  end
+
+  describe '#contact_custom_attribute_changed' do
+    let(:payload) do
+      {
+        contact: contact,
+        attribute_name: 'tier',
+        attribute_value: 'gold',
+        change_type: 'updated',
+        old_value: 'silver'
+      }
+    end
+
+    it 'enqueues contact.custom_attribute.changed with all four trait keys (AC5)' do
+      listener.contact_custom_attribute_changed(data: payload)
+
+      sent = last_payload
+      expect(sent['eventName']).to eq('contact.custom_attribute.changed')
+      expect(sent['traits']).to include(
+        'attributeName' => 'tier',
+        'attributeValue' => 'gold',
+        'changeType' => 'updated',
+        'oldValue' => 'silver',
+        'source' => 'custom_attribute_changed'
+      )
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.contact_custom_attribute_changed(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.contact_custom_attribute_changed(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when contact is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/contact_custom_attribute_changed.*contact is nil/)
+        listener.contact_custom_attribute_changed(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+  end
+
+  describe 'rescue safety (AC15)' do
+    it 'logs the error and returns nil when build_identify raises' do
+      allow(EvoFlow::PayloadBuilder).to receive(:build_identify).and_raise(ArgumentError, 'boom')
+
+      expect(Rails.logger).to receive(:error).with(/contact_created failed: ArgumentError: boom/)
+      expect(listener.contact_created(data: { contact: contact })).to be_nil
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+  end
+
+  describe 'message_id idempotency (AC17)' do
+    before { allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original }
+
+    it 'produces identical messageId for two firings of the same record event' do
+      2.times { listener.contact_created(data: { contact: contact }) }
+
+      jobs = EvoFlow::PublishEventWorker.jobs
+      expect(jobs.size).to eq(2)
+      expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
+    end
+
+    # F1: live publisher omits :deleted_at — we fall back to contact.updated_at
+    # so retries collapse to one messageId.
+    it 'contact_deleted on the live `contact:` shape is idempotent across firings' do
+      2.times { listener.contact_deleted(data: { contact: contact }) }
+
+      jobs = EvoFlow::PublishEventWorker.jobs
+      expect(jobs.size).to eq(2)
+      expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
+    end
+  end
+
+  # F5: documents the lossy JSON round-trip. BigDecimal becomes a String,
+  # Time loses sub-second precision but survives as ISO8601. If consumers
+  # require lossless transport this spec fails first.
+  describe 'JSON normalisation fidelity (F5)' do
+    let(:big_decimal) { BigDecimal('1.5') }
+    let(:custom_attr_time) { Time.utc(2026, 5, 20, 9, 30, 15) }
+
+    before do
+      allow(contact).to receive(:custom_attributes).and_return(
+        'amount' => big_decimal,
+        'last_seen' => custom_attr_time
+      )
+    end
+
+    it 'serialises BigDecimal as String (documented loss)' do
+      listener.contact_created(data: { contact: contact })
+
+      traits = EvoFlow::PublishEventWorker.jobs.last['args'][1]['traits']
+      expect(traits['amount']).to eq('1.5')
+    end
+
+    it 'serialises Time as ISO8601 String' do
+      listener.contact_created(data: { contact: contact })
+
+      traits = EvoFlow::PublishEventWorker.jobs.last['args'][1]['traits']
+      expect(traits['last_seen']).to start_with('2026-05-20T09:30:15')
+      expect(traits['last_seen']).to end_with('Z')
+    end
+  end
+
+  describe 'enqueue-loss observability (F6/F8)' do
+    let(:payload) { { contact: contact } }
+
+    it 'tags Redis outage at error level with [enqueue-loss] prefix' do
+      stub_const('Redis::BaseConnectionError', Class.new(StandardError)) unless defined?(Redis::BaseConnectionError)
+      allow(EvoFlow::PublishEventWorker).to receive(:perform_async)
+        .and_raise(Redis::BaseConnectionError, 'redis down')
+
+      expect(Rails.logger).to receive(:error).with(/\[EvoFlow\]\[enqueue-loss\].*Redis::BaseConnectionError/)
+      expect { listener.contact_created(data: payload) }.not_to raise_error
+    end
+
+    it 'tags nil-occurred_at ArgumentError with [enqueue-loss] prefix' do
+      allow(EvoFlow::PayloadBuilder).to receive(:build_identify)
+        .and_raise(ArgumentError, 'occurred_at is required (no implicit Time.current fallback)')
+
+      expect(Rails.logger).to receive(:error).with(/\[EvoFlow\]\[enqueue-loss\].*ArgumentError/)
+      listener.contact_created(data: payload)
+    end
+  end
+end

--- a/spec/listeners/evo_flow/contact_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/contact_events_listener_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe EvoFlow::ContactEventsListener do
         'source' => 'contact_created',
         'created_via' => 'system'
       )
+      # M4: custom and additional attributes are namespaced rather than spread.
+      expect(sent['traits']).to include('customAttributes' => { 'tier' => 'gold' })
+      expect(sent['traits']).to include('additionalAttributes' => {})
+    end
+
+    # M4: a custom attribute named `id` (or any structural trait key) must not
+    # overwrite the structural trait value.
+    it 'does not let a custom_attribute named "id" overwrite the structural id' do
+      allow(contact).to receive(:custom_attributes).and_return('id' => 'CUSTOM', 'name' => 'CUSTOM')
+
+      listener.contact_created(data: payload)
+
+      sent = last_payload
+      expect(sent['traits']['id']).to eq(42)
+      expect(sent['traits']['name']).to eq('Ada Lovelace')
+      expect(sent['traits']['customAttributes']).to include('id' => 'CUSTOM', 'name' => 'CUSTOM')
     end
 
     it 'marks created_via=agent when additional_attributes.created_via_user_id is present' do

--- a/spec/listeners/evo_flow/conversation_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/conversation_events_listener_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe EvoFlow::ConversationEventsListener do
+  let(:listener) { described_class.new }
+  let(:created_at) { Time.utc(2026, 5, 20, 10, 0, 0) }
+  let(:inbox) { instance_double(Inbox, name: 'Support', channel_type: 'Channel::WebWidget') }
+  let(:conversation) do
+    instance_double(
+      Conversation,
+      id: 100,
+      contact_id: 42,
+      inbox_id: 7,
+      inbox: inbox,
+      created_at: created_at
+    )
+  end
+  let(:fixed_digest) { 'fixed-digest' }
+
+  before do
+    Sidekiq::Testing.fake!
+    EvoFlow::PublishEventWorker.clear
+    allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_return(fixed_digest)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return('test-key')
+  end
+
+  after { EvoFlow::PublishEventWorker.clear }
+
+  describe '#conversation_created' do
+    let(:payload) { { conversation: conversation } }
+
+    it 'enqueues a track event for conversation.created (AC6)' do
+      listener.conversation_created(data: payload)
+
+      job = EvoFlow::PublishEventWorker.jobs.last
+      expect(EvoFlow::PublishEventWorker.jobs.size).to eq(1)
+      expect(job['args'][0]).to eq('/events/track')
+
+      sent = job['args'][1]
+      expect(sent['event']).to eq('conversation.created')
+      expect(sent['contactId']).to eq('42')
+      expect(sent['messageId']).to eq(fixed_digest)
+      expect(sent['properties']).to include(
+        'conversation_id' => 100,
+        'inbox_id' => 7,
+        'inbox_name' => 'Support',
+        'channel_type' => 'Channel::WebWidget',
+        'source' => 'conversation_management'
+      )
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.conversation_created(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.conversation_created(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when conversation is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/conversation_created.*conversation is nil/)
+        listener.conversation_created(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when build_track raises (AC15)' do
+      it 'logs the error and returns nil' do
+        allow(EvoFlow::PayloadBuilder).to receive(:build_track).and_raise(ArgumentError, 'boom')
+
+        expect(Rails.logger).to receive(:error).with(/conversation_created failed: ArgumentError: boom/)
+        expect(listener.conversation_created(data: payload)).to be_nil
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    # F7: Redis outage during perform_async must be swallowed without
+    # propagating (Wisper broadcast would otherwise stop downstream listeners).
+    context 'when perform_async raises Redis::BaseConnectionError (F6/F7)' do
+      it 'tags [enqueue-loss] at error level and does not propagate' do
+        stub_const('Redis::BaseConnectionError', Class.new(StandardError)) unless defined?(Redis::BaseConnectionError)
+        allow(EvoFlow::PublishEventWorker).to receive(:perform_async)
+          .and_raise(Redis::BaseConnectionError, 'redis down')
+
+        expect(Rails.logger).to receive(:error).with(/\[EvoFlow\]\[enqueue-loss\].*Redis::BaseConnectionError/)
+        expect { listener.conversation_created(data: payload) }.not_to raise_error
+      end
+    end
+
+    # F12: AC17 idempotency on conversation_created.
+    describe 'message_id idempotency (AC17)' do
+      it 'produces identical messageId for two firings of the same record event' do
+        allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
+
+        2.times { listener.conversation_created(data: payload) }
+
+        jobs = EvoFlow::PublishEventWorker.jobs
+        expect(jobs.size).to eq(2)
+        expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
+      end
+    end
+  end
+end

--- a/spec/listeners/evo_flow/conversation_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/conversation_events_listener_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe EvoFlow::ConversationEventsListener do
   let(:listener) { described_class.new }
   let(:created_at) { Time.utc(2026, 5, 20, 10, 0, 0) }
   let(:inbox) { instance_double(Inbox, name: 'Support', channel_type: 'Channel::WebWidget') }
+  let(:updated_at) { Time.utc(2026, 5, 20, 10, 30, 0) }
   let(:conversation) do
     instance_double(
       Conversation,
@@ -14,7 +15,8 @@ RSpec.describe EvoFlow::ConversationEventsListener do
       contact_id: 42,
       inbox_id: 7,
       inbox: inbox,
-      created_at: created_at
+      created_at: created_at,
+      updated_at: updated_at
     )
   end
   let(:fixed_digest) { 'fixed-digest' }
@@ -107,6 +109,72 @@ RSpec.describe EvoFlow::ConversationEventsListener do
         allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
 
         2.times { listener.conversation_created(data: payload) }
+
+        jobs = EvoFlow::PublishEventWorker.jobs
+        expect(jobs.size).to eq(2)
+        expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
+      end
+    end
+  end
+
+  # AC2: conversation.resolved. Dispatched only via SyncDispatcher
+  # (Conversation#notify_status_change), which wraps payload in Events::Base.
+  describe '#conversation_resolved' do
+    let(:event_data) { { conversation: conversation, performed_by: nil, changed_attributes: { status: %w[open resolved] } } }
+    let(:dispatcher_event) { Events::Base.new('conversation.resolved', Time.zone.now, event_data) }
+
+    it 'enqueues a track event for conversation.resolved (AC2)' do
+      listener.conversation_resolved(dispatcher_event)
+
+      job = EvoFlow::PublishEventWorker.jobs.last
+      expect(EvoFlow::PublishEventWorker.jobs.size).to eq(1)
+      expect(job['args'][0]).to eq('/events/track')
+
+      sent = job['args'][1]
+      expect(sent['event']).to eq('conversation.resolved')
+      expect(sent['contactId']).to eq('42')
+      expect(sent['properties']).to include(
+        'conversation_id' => 100,
+        'inbox_id' => 7,
+        'channel_type' => 'Channel::WebWidget',
+        'resolution_time_seconds' => 1800,
+        'source' => 'conversation_management'
+      )
+    end
+
+    context 'when ENV is absent' do
+      before do
+        allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil)
+        allow(ENV).to receive(:[]).with('EVO_FLOW_ENABLED').and_return(nil)
+      end
+
+      it 'does not enqueue' do
+        listener.conversation_resolved(dispatcher_event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with a raw Wisper hash (no .data)' do
+      it 'returns early — this event is dispatcher-only, no Wisper-direct shape exists' do
+        listener.conversation_resolved(data: event_data)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when conversation is missing' do
+      it 'logs an error and does not enqueue' do
+        event = Events::Base.new('conversation.resolved', Time.zone.now, {})
+        expect(Rails.logger).to receive(:error).with(/conversation_resolved.*conversation is nil/)
+        listener.conversation_resolved(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    describe 'message_id idempotency' do
+      it 'produces identical messageId for two firings' do
+        allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
+
+        2.times { listener.conversation_resolved(dispatcher_event) }
 
         jobs = EvoFlow::PublishEventWorker.jobs
         expect(jobs.size).to eq(2)

--- a/spec/listeners/evo_flow/message_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/message_events_listener_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe EvoFlow::MessageEventsListener do
+  let(:listener) { described_class.new }
+  let(:created_at) { Time.utc(2026, 5, 20, 10, 0, 0) }
+  let(:inbox) { instance_double(Inbox, channel_type: 'Channel::WebWidget') }
+  let(:conversation) { instance_double(Conversation, contact_id: 42, inbox: inbox) }
+  let(:message) do
+    instance_double(
+      Message,
+      id: 555,
+      conversation: conversation,
+      conversation_id: 100,
+      message_type: 'incoming',
+      content_type: 'text',
+      content: 'hello',
+      created_at: created_at
+    )
+  end
+  let(:fixed_digest) { 'fixed-digest' }
+
+  before do
+    Sidekiq::Testing.fake!
+    EvoFlow::PublishEventWorker.clear
+    allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_return(fixed_digest)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return('test-key')
+  end
+
+  after { EvoFlow::PublishEventWorker.clear }
+
+  describe '#message_created' do
+    let(:payload) { { message: message } }
+
+    it 'enqueues a track event for message.created (AC7)' do
+      listener.message_created(data: payload)
+
+      job = EvoFlow::PublishEventWorker.jobs.last
+      expect(EvoFlow::PublishEventWorker.jobs.size).to eq(1)
+      expect(job['args'][0]).to eq('/events/track')
+
+      sent = job['args'][1]
+      expect(sent['event']).to eq('message.created')
+      expect(sent['contactId']).to eq('42')
+      expect(sent['properties']).to include(
+        'message_id' => 555,
+        'conversation_id' => 100,
+        'message_type' => 'incoming',
+        'content_type' => 'text',
+        'content' => 'hello',
+        'channel_type' => 'Channel::WebWidget',
+        'source' => 'messaging'
+      )
+    end
+
+    context 'when inbox is missing (AC8)' do
+      let(:conversation) { instance_double(Conversation, contact_id: 42, inbox: nil) }
+
+      it 'logs a warn and does not enqueue' do
+        expect(Rails.logger).to receive(:warn).with(/inbox missing for message 555/)
+        listener.message_created(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.message_created(data: payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new(payload)
+        listener.message_created(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when message is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/message_created.*message is nil/)
+        listener.message_created(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when build_track raises (AC15)' do
+      it 'logs the error and returns nil' do
+        allow(EvoFlow::PayloadBuilder).to receive(:build_track).and_raise(ArgumentError, 'boom')
+
+        expect(Rails.logger).to receive(:error).with(/message_created failed: ArgumentError: boom/)
+        expect(listener.message_created(data: payload)).to be_nil
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when perform_async raises Redis::BaseConnectionError (F6/F7)' do
+      it 'tags [enqueue-loss] at error level and does not propagate' do
+        stub_const('Redis::BaseConnectionError', Class.new(StandardError)) unless defined?(Redis::BaseConnectionError)
+        allow(EvoFlow::PublishEventWorker).to receive(:perform_async)
+          .and_raise(Redis::BaseConnectionError, 'redis down')
+
+        expect(Rails.logger).to receive(:error).with(/\[EvoFlow\]\[enqueue-loss\].*Redis::BaseConnectionError/)
+        expect { listener.message_created(data: payload) }.not_to raise_error
+      end
+    end
+
+    describe 'message_id idempotency (AC17)' do
+      it 'produces identical messageId for two firings of the same record event' do
+        allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
+
+        2.times { listener.message_created(data: payload) }
+
+        jobs = EvoFlow::PublishEventWorker.jobs
+        expect(jobs.size).to eq(2)
+        expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
+      end
+    end
+  end
+end

--- a/spec/listeners/evo_flow/message_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/message_events_listener_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe EvoFlow::MessageEventsListener do
   let(:created_at) { Time.utc(2026, 5, 20, 10, 0, 0) }
   let(:inbox) { instance_double(Inbox, channel_type: 'Channel::WebWidget') }
   let(:conversation) { instance_double(Conversation, contact_id: 42, inbox: inbox) }
+  let(:updated_at) { Time.utc(2026, 5, 20, 10, 5, 0) }
   let(:message) do
     instance_double(
       Message,
@@ -17,7 +18,8 @@ RSpec.describe EvoFlow::MessageEventsListener do
       message_type: 'incoming',
       content_type: 'text',
       content: 'hello',
-      created_at: created_at
+      created_at: created_at,
+      updated_at: updated_at
     )
   end
   let(:fixed_digest) { 'fixed-digest' }
@@ -118,6 +120,118 @@ RSpec.describe EvoFlow::MessageEventsListener do
         allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
 
         2.times { listener.message_created(data: payload) }
+
+        jobs = EvoFlow::PublishEventWorker.jobs
+        expect(jobs.size).to eq(2)
+        expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
+      end
+    end
+
+    # M5: only `incoming`/`outgoing` are tracked; `activity` (system) and
+    # `template` (whatsapp template / CSAT broadcast) are intentionally dropped.
+    describe 'message_type filter (M5)' do
+      %w[activity template].each do |dropped_type|
+        context "when message_type is #{dropped_type}" do
+          let(:message) do
+            instance_double(
+              Message, id: 555, conversation: conversation, conversation_id: 100,
+                       message_type: dropped_type, content_type: 'text', content: 'x',
+                       created_at: created_at, updated_at: updated_at
+            )
+          end
+
+          it 'does not enqueue' do
+            listener.message_created(data: payload)
+            expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+          end
+        end
+      end
+
+      it 'tracks outgoing messages' do
+        out_message = instance_double(
+          Message, id: 556, conversation: conversation, conversation_id: 100,
+                   message_type: 'outgoing', content_type: 'text', content: 'ok',
+                   created_at: created_at, updated_at: updated_at
+        )
+        listener.message_created(data: { message: out_message })
+        expect(EvoFlow::PublishEventWorker.jobs.size).to eq(1)
+      end
+    end
+  end
+
+  # AC3: message_status_changed → message.delivered / message.read / message.failed.
+  describe '#message_status_changed' do
+    let(:base_payload) { { message: message, previous_status: 'sent', status: 'delivered', external_error: nil } }
+
+    {
+      ['sent', 'delivered'] => 'message.delivered',
+      ['delivered', 'read'] => 'message.read',
+      ['sent', 'failed'] => 'message.failed',
+      ['delivered', 'failed'] => 'message.failed',
+      ['read', 'failed'] => 'message.failed'
+    }.each do |(prev, curr), expected_event|
+      it "maps (#{prev} → #{curr}) to #{expected_event} (AC3)" do
+        listener.message_status_changed(
+          data: { message: message, previous_status: prev, status: curr, external_error: nil }
+        )
+        job = EvoFlow::PublishEventWorker.jobs.last
+        expect(EvoFlow::PublishEventWorker.jobs.size).to eq(1)
+        expect(job['args'][1]['event']).to eq(expected_event)
+        expect(job['args'][1]['properties']).to include('previous_status' => prev, 'status' => curr)
+      end
+    end
+
+    it 'drops unmapped transitions with a warn' do
+      expect(Rails.logger).to receive(:warn).with(/unmapped transition pending → delivered/)
+      listener.message_status_changed(
+        data: { message: message, previous_status: 'pending', status: 'delivered' }
+      )
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+
+    it 'includes external_error in properties when status=failed' do
+      listener.message_status_changed(
+        data: { message: message, previous_status: 'sent', status: 'failed', external_error: 'boom' }
+      )
+      job = EvoFlow::PublishEventWorker.jobs.last
+      expect(job['args'][1]['properties']).to include('external_error' => 'boom')
+    end
+
+    context 'when ENV is absent' do
+      before do
+        allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil)
+        allow(ENV).to receive(:[]).with('EVO_FLOW_ENABLED').and_return(nil)
+      end
+
+      it 'does not enqueue' do
+        listener.message_status_changed(data: base_payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload' do
+      it 'returns early — only Wisper-direct shape is accepted' do
+        event = Struct.new(:data).new(base_payload)
+        listener.message_status_changed(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when inbox is missing' do
+      let(:conversation) { instance_double(Conversation, contact_id: 42, inbox: nil) }
+
+      it 'logs a warn and does not enqueue' do
+        expect(Rails.logger).to receive(:warn).with(/inbox missing for message 555/)
+        listener.message_status_changed(data: base_payload)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    describe 'message_id idempotency' do
+      it 'produces identical messageId for two firings of the same transition' do
+        allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
+
+        2.times { listener.message_status_changed(data: base_payload) }
 
         jobs = EvoFlow::PublishEventWorker.jobs
         expect(jobs.size).to eq(2)

--- a/spec/listeners/evo_flow/pipeline_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/pipeline_events_listener_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe EvoFlow::PipelineEventsListener do
+  let(:listener) { described_class.new }
+  let(:created_at) { Time.utc(2026, 5, 20, 10, 0, 0) }
+  let(:pipeline) { instance_double(Pipeline, name: 'Sales') }
+  let(:pipeline_stage) { instance_double(PipelineStage, name: 'Qualified') }
+  let(:conversation) { instance_double(Conversation, contact_id: 77) }
+  let(:fixed_digest) { 'fixed-digest' }
+
+  let(:lead_item) do
+    instance_double(
+      PipelineItem,
+      id: 9,
+      contact_id: 42,
+      conversation_id: nil,
+      conversation: nil,
+      lead?: true,
+      pipeline: pipeline,
+      pipeline_id: 1,
+      pipeline_stage: pipeline_stage,
+      pipeline_stage_id: 2,
+      assigned_by_id: 3,
+      custom_fields: { 'priority' => 'high' },
+      created_at: created_at
+    )
+  end
+
+  let(:deal_item) do
+    instance_double(
+      PipelineItem,
+      id: 10,
+      contact_id: nil,
+      conversation_id: 200,
+      conversation: conversation,
+      lead?: false,
+      pipeline: pipeline,
+      pipeline_id: 1,
+      pipeline_stage: pipeline_stage,
+      pipeline_stage_id: 2,
+      assigned_by_id: 3,
+      custom_fields: {},
+      created_at: created_at
+    )
+  end
+
+  before do
+    Sidekiq::Testing.fake!
+    EvoFlow::PublishEventWorker.clear
+    allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_return(fixed_digest)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return('test-key')
+  end
+
+  after { EvoFlow::PublishEventWorker.clear }
+
+  describe '#pipeline_item_created' do
+    context 'with a lead pipeline item (AC9)' do
+      it 'uses pipeline_item.contact_id and emits campaign.triggered with is_lead=true' do
+        listener.pipeline_item_created(data: { pipeline_item: lead_item })
+
+        job = EvoFlow::PublishEventWorker.jobs.last
+        expect(job['args'][0]).to eq('/events/track')
+        sent = job['args'][1]
+        expect(sent['event']).to eq('campaign.triggered')
+        expect(sent['contactId']).to eq('42')
+        expect(sent['properties']).to include('is_lead' => true, 'pipeline_id' => 1, 'pipeline_name' => 'Sales')
+      end
+    end
+
+    context 'with a deal pipeline item (AC10)' do
+      it 'uses conversation.contact_id and emits is_lead=false' do
+        listener.pipeline_item_created(data: { pipeline_item: deal_item })
+
+        sent = EvoFlow::PublishEventWorker.jobs.last['args'][1]
+        expect(sent['contactId']).to eq('77')
+        expect(sent['properties']).to include('is_lead' => false)
+      end
+    end
+
+    context 'without a resolvable contact (AC11)' do
+      let(:orphan_item) do
+        instance_double(
+          PipelineItem,
+          id: 11,
+          contact_id: nil,
+          conversation_id: nil,
+          conversation: nil,
+          lead?: false,
+          created_at: created_at
+        )
+      end
+
+      it 'logs a warn and does not enqueue' do
+        expect(Rails.logger).to receive(:warn).with(/no resolvable contact_id for pipeline_item 11/)
+        listener.pipeline_item_created(data: { pipeline_item: orphan_item })
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when ENV is absent (AC12)' do
+      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+
+      it 'does not enqueue and emits no error log' do
+        expect(Rails.logger).not_to receive(:error)
+        listener.pipeline_item_created(data: { pipeline_item: lead_item })
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when called with an EventDispatcher payload (AC13)' do
+      it 'returns early and does not enqueue' do
+        event = Struct.new(:data).new({ pipeline_item: lead_item })
+        listener.pipeline_item_created(event)
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when pipeline_item is missing (AC14)' do
+      it 'logs an error and does not enqueue' do
+        expect(Rails.logger).to receive(:error).with(/pipeline_item_created.*pipeline_item is nil/)
+        listener.pipeline_item_created(data: {})
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when build_track raises (AC15)' do
+      it 'logs the error and returns nil' do
+        allow(EvoFlow::PayloadBuilder).to receive(:build_track).and_raise(ArgumentError, 'boom')
+
+        expect(Rails.logger).to receive(:error).with(/pipeline_item_created failed: ArgumentError: boom/)
+        expect(listener.pipeline_item_created(data: { pipeline_item: lead_item })).to be_nil
+        expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+      end
+    end
+
+    context 'when perform_async raises Redis::BaseConnectionError (F6/F7)' do
+      it 'tags [enqueue-loss] at error level and does not propagate' do
+        stub_const('Redis::BaseConnectionError', Class.new(StandardError)) unless defined?(Redis::BaseConnectionError)
+        allow(EvoFlow::PublishEventWorker).to receive(:perform_async)
+          .and_raise(Redis::BaseConnectionError, 'redis down')
+
+        expect(Rails.logger).to receive(:error).with(/\[EvoFlow\]\[enqueue-loss\].*Redis::BaseConnectionError/)
+        expect { listener.pipeline_item_created(data: { pipeline_item: lead_item }) }.not_to raise_error
+      end
+    end
+
+    describe 'message_id idempotency (AC17)' do
+      it 'produces identical messageId for two firings of the same record event' do
+        allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
+
+        2.times { listener.pipeline_item_created(data: { pipeline_item: lead_item }) }
+
+        jobs = EvoFlow::PublishEventWorker.jobs
+        expect(jobs.size).to eq(2)
+        expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
+      end
+    end
+
+    # F11: properties.contact_id should match the resolved root contactId.
+    it 'sets properties.contact_id to the resolved root contactId on deals' do
+      listener.pipeline_item_created(data: { pipeline_item: deal_item })
+
+      sent = EvoFlow::PublishEventWorker.jobs.last['args'][1]
+      expect(sent['properties']['contact_id']).to eq(sent['contactId'].to_i).or eq(sent['contactId'])
+    end
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -46,4 +46,49 @@ RSpec.describe Contact, type: :model do
       expect { person_contact }.to change(PipelineItem, :count).by(1)
     end
   end
+
+  # H2 + M3: publishers for custom_attribute and label changes were
+  # previously orphaned (never called in production). These specs exercise
+  # the real model write path so a regression would surface immediately.
+  describe 'Wisper publishers (H2)' do
+    let(:contact) { Contact.create!(name: 'Hue', email: 'hue@example.com', type: 'person') }
+
+    it 'emits :contact_custom_attribute_changed for each changed key' do
+      collected = []
+      listener = Class.new do
+        define_method(:contact_custom_attribute_changed) { |data| collected << data[:data] }
+      end.new
+      contact.subscribe(listener)
+
+      contact.update!(custom_attributes: { 'tier' => 'gold', 'plan' => 'pro' })
+
+      events = collected.map { |d| [d[:attribute_name], d[:change_type], d[:attribute_value]] }
+      expect(events).to include(['tier', 'added', 'gold'], ['plan', 'added', 'pro'])
+    end
+
+    it 'emits :contact_label_added when a new label is applied' do
+      collected = []
+      listener = Class.new do
+        define_method(:contact_label_added) { |data| collected << data[:data] }
+      end.new
+      contact.subscribe(listener)
+
+      contact.update_labels(['vip'])
+
+      expect(collected.map { |d| d[:label_name] }).to include('vip')
+    end
+
+    it 'emits :contact_label_removed when an existing label is dropped' do
+      contact.update_labels(['vip', 'beta'])
+      collected = []
+      listener = Class.new do
+        define_method(:contact_label_removed) { |data| collected << data[:data] }
+      end.new
+      contact.subscribe(listener)
+
+      contact.update_labels(['vip'])
+
+      expect(collected.map { |d| d[:label_name] }).to include('beta')
+    end
+  end
 end

--- a/spec/services/evo_flow/payload_builder_spec.rb
+++ b/spec/services/evo_flow/payload_builder_spec.rb
@@ -104,4 +104,38 @@ RSpec.describe EvoFlow::PayloadBuilder do
         .to raise_error(ArgumentError, /occurred_at is required/)
     end
   end
+
+  # AC6: event_name must be inside EvoFlow::EVENT_NAMES; otherwise the
+  # builder raises EvoFlow::InvalidEventName. Caught in CI, not prod —
+  # listeners rescue StandardError and tag enqueue-loss.
+  describe 'event_name validation (AC6)' do
+    it 'accepts canonical event_names from EvoFlow::EVENT_NAMES' do
+      EvoFlow::EVENT_NAMES.each do |name|
+        expect do
+          described_class.build_track(
+            event_name: name, contact_id: 1, properties: {},
+            occurred_at: occurred_at, message_id: 'x'
+          )
+        end.not_to raise_error
+      end
+    end
+
+    it 'raises EvoFlow::InvalidEventName for build_track with an unknown event_name' do
+      expect do
+        described_class.build_track(
+          event_name: 'not.a.real.event', contact_id: 1, properties: {},
+          occurred_at: occurred_at, message_id: 'x'
+        )
+      end.to raise_error(EvoFlow::InvalidEventName, /not\.a\.real\.event/)
+    end
+
+    it 'raises EvoFlow::InvalidEventName for build_identify with an unknown event_name' do
+      expect do
+        described_class.build_identify(
+          event_name: 'contact.exploded', contact_id: 1, traits: {},
+          occurred_at: occurred_at, message_id: 'x'
+        )
+      end.to raise_error(EvoFlow::InvalidEventName)
+    end
+  end
 end

--- a/spec/services/messages/status_update_service_spec.rb
+++ b/spec/services/messages/status_update_service_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Messages::StatusUpdateService do
+  let(:message) do
+    instance_double(
+      Message,
+      id: 1,
+      status: 'sent',
+      content_attributes: {},
+      read?: false,
+      update!: true
+    )
+  end
+
+  before do
+    # avoid touching the global Wisper subscribers; we attach a temporary
+    # collector to the service instance for the duration of the example.
+    allow(Message).to receive(:statuses).and_return('sent' => 0, 'delivered' => 1, 'read' => 2, 'failed' => 3)
+  end
+
+  it 'publishes :message_status_changed Wisper event with previous + new status (AC3)' do
+    collector = Class.new do
+      attr_reader :received
+
+      def initialize
+        @received = []
+      end
+
+      def message_status_changed(data)
+        @received << data
+      end
+    end.new
+
+    service = described_class.new(message, 'delivered')
+    service.subscribe(collector)
+    service.perform
+
+    expect(collector.received.size).to eq(1)
+    received = collector.received.first[:data]
+    expect(received).to include(
+      message: message,
+      previous_status: 'sent',
+      status: 'delivered'
+    )
+  end
+
+  it 'publishes external_error when status=failed' do
+    allow(message).to receive(:status).and_return('sent')
+    collector = []
+    listener = Class.new do
+      define_method(:message_status_changed) { |data| collector << data }
+    end.new
+
+    service = described_class.new(message, 'failed', 'invalid number')
+    service.subscribe(listener)
+    service.perform
+
+    expect(collector.first[:data][:external_error]).to eq('invalid number')
+  end
+
+  it 'does not publish if the transition is invalid (read → delivered)' do
+    allow(message).to receive_messages(status: 'read', read?: true)
+    collector = []
+    listener = Class.new do
+      define_method(:message_status_changed) { |data| collector << data }
+    end.new
+
+    service = described_class.new(message, 'delivered')
+    service.subscribe(listener)
+    service.perform
+
+    expect(collector).to be_empty
+  end
+end


### PR DESCRIPTION
## EVO-1240 — EvoFlow listeners port

Port dos 4 listeners EvoCampaign legacy para EvoFlow, em cima da fundação EVO-1238 (PR #87/#88). CRM community passa a emitir 9 eventos para `evo-flow` — até aqui o tráfego era **zero**.

Bloqueia: 7.4a (`:message_status_changed`), 7.5/EVO-1241 (freeze EVENT_NAMES), 7.9/EVO-1245 (ClickHouse backfill).

### Listeners (`app/listeners/evo_flow/`)

| Listener | Handler(s) | Path | Event names |
|---|---|---|---|
| `ContactEventsListener` | 6 handlers | `/events/identify` | `contact.created/updated/deleted`, `contact.label.added/removed`, `contact.custom_attribute.changed` |
| `ConversationEventsListener` | `conversation_created` | `/events/track` | `conversation.created` |
| `MessageEventsListener` | `message_created` | `/events/track` | `message.created` |
| `PipelineEventsListener` | `pipeline_item_created` | `/events/track` | `campaign.triggered` (adapter shim) |

### Initializer

`config/initializers/evo_flow_listeners.rb` registra os 4 via `Wisper.subscribe(...new)` dentro de `after_initialize` (**não** `to_prepare` — Wisper 2.0 não deduplica subscribers, reload duplicaria). Listeners não são singletons (`.new`, não `.instance`) por design — espelha o idiom do EvoCampaign legado.

### Contrato

- **ENV gate:** `AUTH_APIKEY_INTEGRATION_LOCAL.present?` — sem ENV os 9 handlers são no-op silencioso. Rollout gradual por ambiente.
- **Idempotência:** `source_event_uuid` determinístico por handler → `PayloadBuilder.message_id_for` produz mesmo `messageId` em retries do Sidekiq.
- **Normalização:** `JSON.parse(payload.to_json)` antes de `perform_async` (Sidekiq `strict_args!(:raise)` rejeita symbol keys e `Time` da fundação; `PayloadBuilder` está out-of-scope — tech-spec §Out of Scope).
- **Dual-shape guard:** `return if data.respond_to?(:data)` (skip EventDispatcher payloads).
- **Rescue:** `rescue StandardError -> log + nil`, nunca re-raise (preserva o broadcast Wisper para outros subscribers).

### Observabilidade (review follow-up — F6/F8)

- Tag `[EvoFlow][enqueue-loss]` em `Rails.logger.error` quando o erro é `Redis::BaseConnectionError` ou `ArgumentError 'occurred_at is required'`. Mantém o alarme da fundação audível mesmo com o `rescue StandardError` defensivo.
- `Sentry.capture_exception(error) if defined?(Sentry)`.

### Adversarial review — 15 findings, todas endereçadas

#### HIGH (correctness)
- **F1** — `contact_deleted` idempotente na forma live (publisher manda `contact: self` sem `:deleted_at`). Fix: `resolve_deleted_at` prefere `event_data[:deleted_at] -> contact.updated_at -> Time.zone.now`. Spec dedicada.
- **F2** — `contact_custom_attribute_changed` agora inclui `old_value + timestamp` no UUID — toggle sequences (`silver→gold→silver→gold`) não colapsam mais para o mesmo `messageId`.
- **F3** — Label add/remove inclui `occurred_at.to_i` no UUID — `add→remove→add-again` não colide com o add original.

#### MEDIUM
- **F4** — Doc: hot-path note no `MessageEventsListener` (callers devem preload `conversation: :inbox` em paths bulk).
- **F5** — Round-trip JSON documentado via spec (`BigDecimal -> String`, `Time -> ISO8601`). Trade-off aceito; raise follow-up se compliance exigir lossless.
- **F6** — Redis outage tagueada (acima).
- **F7** — Spec de `Redis::BaseConnectionError` em todos os 4 listeners.
- **F8** — `ArgumentError 'occurred_at is required'` da fundação não é mais silenciosamente engolido pelo rescue.

#### LOW
- **F9** — Comentário no initializer explicando `after_initialize` vs `to_prepare`.
- **F11** — `properties.contact_id` agora é o root `contactId` resolvido (deals consistentes).
- **F12** — Spec AC17 (idempotência) replicada para todos os 4 listeners.
- **F13** — `evo_flow_enabled?` duplicado por design (sem base class) documentado.

### Out of Scope (próximas stories)

- 7.4a — `:message_status_changed` instrumentation
- 7.5/EVO-1241 — freeze `EVENT_NAMES`
- 7.9/EVO-1245 — ClickHouse backfill
- `pipeline.*` event name dedicado (substituir o shim `campaign.triggered`)
- Subscriber para `:evo_flow_publish_failed`
- Remover `api_access_token` obsoleto dos `publish(...)` nos models

### Validação

| Check | Resultado |
|---|---|
| RSpec (specs novos) | **60 examples, 0 failures** |
| RSpec (suite completa) | 473 examples, 20 failures pré-existentes (shoulda-matchers, role/contact/message specs) — **zero relacionadas ao EvoFlow** |
| RuboCop | Limpo nos 9 arquivos novos |
| `rails zeitwerk:check` | **All is good!** |
| T11 (smoke test contra `evo-flow` local) | **Pendente** — precisa `AUTH_APIKEY_INTEGRATION_LOCAL` setada + `bundle exec sidekiq` + criar registros via console |

### Mudança bônus (escopo adjacente)

`lib/events/evo_flow_event_names.rb` — removidos 2 comentários referenciando stories 7.3/7.5 (obsoletos pós-foundation). Sem mudança de payload nem da constante `EVENT_NAMES`.

## Summary by Sourcery

Introduce EvoFlow Wisper listeners for CRM contact, conversation, message, and pipeline events and wire them into the app lifecycle so these domain events are forwarded to evo-flow.

New Features:
- Add EvoFlow contact event listener emitting identify events for contact lifecycle, labels, and custom attribute changes.
- Add EvoFlow conversation event listener emitting track events when conversations are created.
- Add EvoFlow message event listener emitting track events when messages are created.
- Add EvoFlow pipeline item event listener emitting track events mapping pipeline_item_created to the existing campaign.triggered evo-flow event.
- Gate EvoFlow event publishing behind an environment variable and log failures with enqueue-loss tagging and optional Sentry reporting.

Enhancements:
- Normalize EvoFlow payloads at the listener boundary to ensure Sidekiq compatibility and improve idempotency of event message IDs.
- Adjust EvoFlow event names documentation by removing obsolete story-specific comments from the canonical event list.

Tests:
- Add listener specs for EvoFlow contact, conversation, message, and pipeline event listeners to cover enqueue behaviour, idempotency, and failure handling.