### PR TITLE
feat(evo_flow): freeze EVENT_NAMES — raise InvalidEventName + F4 exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ docker-compose up backend worker
 
 ---
 
+## EvoFlow integration
+
+### Canonical event names
+
+The authoritative list is [`lib/events/evo_flow_event_names.rb`](./lib/events/evo_flow_event_names.rb) (`EvoFlow::EVENT_NAMES`, 16 dot-notation strings, frozen). `EvoFlow::PayloadBuilder.build_track` and `.build_identify` raise `EvoFlow::InvalidEventName` if a caller passes a name outside the list. The same list is mirrored in `evo-flow/src/modules/events/event-names.enum.ts`, and a CI script (`scripts/check-event-names-sync.sh` at the monorepo root) blocks PRs that drift.
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to submit issues, propose features, and open pull requests.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ docker-compose up backend worker
 
 The authoritative list is [`lib/events/evo_flow_event_names.rb`](./lib/events/evo_flow_event_names.rb) (`EvoFlow::EVENT_NAMES`, 16 dot-notation strings, frozen). `EvoFlow::PayloadBuilder.build_track` and `.build_identify` raise `EvoFlow::InvalidEventName` if a caller passes a name outside the list. The same list is mirrored in `evo-flow/src/modules/events/event-names.enum.ts`, and a CI script (`scripts/check-event-names-sync.sh` at the monorepo root) blocks PRs that drift.
 
+**Growing the list:** adding or removing an entry requires **three coordinated edits in the same PR**: `lib/events/evo_flow_event_names.rb` (this repo), `src/modules/events/event-names.enum.ts` (in `evo-flow`), and the `EXPECTED_COUNT` constant in `scripts/check-event-names-sync.sh` (in the `evo-crm-community` monorepo). Otherwise the sync job fails with `DIVERGENT — lists match each other but count is N (expected M)`.
+
 ---
 
 ## Contributing

--- a/app/services/evo_flow/payload_builder.rb
+++ b/app/services/evo_flow/payload_builder.rb
@@ -1,4 +1,11 @@
 module EvoFlow
+  # Raised when build_track / build_identify receive an event_name that is
+  # not in EvoFlow::EVENT_NAMES. Module-level (mirrors EvoFlow::HTTPError /
+  # EvoFlow::ConfigurationError in client.rb). PublishEventWorker rescues
+  # this earliest and does NOT re-raise — invalid names are code bugs, not
+  # transient failures, so retries cannot fix them.
+  class InvalidEventName < StandardError; end
+
   # Shapes the real evo-flow DTOs (camelCase, single-tenant: NO accountId).
   # track  -> TrackEventDto    (uses `event`)
   # identify -> IdentifyEventDto (uses `eventName`)
@@ -6,6 +13,7 @@ module EvoFlow
   class PayloadBuilder
     # Exactly 5 kwargs (RuboCop ParameterLists max 5 — do not add a 6th).
     def self.build_track(event_name:, contact_id:, properties:, occurred_at:, message_id:)
+      validate_event_name!(event_name)
       {
         messageId: message_id,
         contactId: contact_id.to_s,
@@ -16,6 +24,7 @@ module EvoFlow
     end
 
     def self.build_identify(event_name:, contact_id:, traits:, occurred_at:, message_id:)
+      validate_event_name!(event_name)
       {
         messageId: message_id,
         contactId: contact_id.to_s,
@@ -24,6 +33,17 @@ module EvoFlow
         timestamp: iso8601(occurred_at)
       }
     end
+
+    # Single source of truth for the canonical list is
+    # lib/events/evo_flow_event_names.rb (EvoFlow::EVENT_NAMES).
+    # Uses .inspect so nil/non-string values render unambiguously in the
+    # error message (e.g. "unknown event_name: nil" rather than a trailing colon).
+    def self.validate_event_name!(event_name)
+      return if EvoFlow::EVENT_NAMES.include?(event_name)
+
+      raise EvoFlow::InvalidEventName, "unknown event_name: #{event_name.inspect}"
+    end
+    private_class_method :validate_event_name!
 
     # Deterministic, forward-looking idempotency key. NOTE: evo-flow has no
     # consumer-side dedup yet (clickhouse contact_events is MergeTree); Sidekiq

--- a/app/workers/evo_flow/publish_event_worker.rb
+++ b/app/workers/evo_flow/publish_event_worker.rb
@@ -11,6 +11,12 @@ module EvoFlow
   #
   # Signature is perform(path, payload) — Client#post needs the target path;
   # documented divergence from EVO-1238's perform(payload).
+  #
+  # Exceptions to F4: EvoFlow::InvalidEventName and EvoFlow::ConfigurationError
+  # are NOT retried — both are code/config bugs, not transient failures
+  # (rescued earliest in #perform, logged + dropped). Configuration won't fix
+  # itself on retry; retrying just floods the Dead Set with the same env-var
+  # error and triggers spurious :evo_flow_publish_failed broadcasts.
   class PublishEventWorker
     include Sidekiq::Worker
     sidekiq_options queue: :integrations, retry: 5
@@ -66,6 +72,19 @@ module EvoFlow
     def perform(path, payload)
       EvoFlow::Client.new.post(path, payload)
       Rails.logger.info("[EvoFlow] published path=#{path} messageId=#{message_id(payload)}")
+    rescue EvoFlow::InvalidEventName => e
+      # F4 exception: code bug, not transient — log and drop so Sidekiq treats
+      # the job as success (no retry, no Dead Set entry, no Wisper broadcast).
+      # MUST stay above the StandardError rescue (InvalidEventName < StandardError).
+      Rails.logger.error("[EvoFlow] dropped: invalid event_name path=#{path} msg=#{e.message}")
+      nil
+    rescue EvoFlow::ConfigurationError => e
+      # F4 exception: env/config bug, not transient. Retrying just floods the
+      # Dead Set with the same env-var error and triggers spurious
+      # :evo_flow_publish_failed broadcasts. Surface the bug via a single
+      # error log instead. MUST stay above the StandardError rescue.
+      Rails.logger.error("[EvoFlow] dropped: configuration error path=#{path} msg=#{e.message}")
+      nil
     rescue EvoFlow::HTTPError => e
       Rails.logger.warn(
         "[EvoFlow] publish failed (will retry) path=#{path} code=#{e.code} msg=#{e.message}"

--- a/app/workers/evo_flow/publish_event_worker.rb
+++ b/app/workers/evo_flow/publish_event_worker.rb
@@ -17,6 +17,10 @@ module EvoFlow
   # (rescued earliest in #perform, logged + dropped). Configuration won't fix
   # itself on retry; retrying just floods the Dead Set with the same env-var
   # error and triggers spurious :evo_flow_publish_failed broadcasts.
+  # Drops still emit Wisper :evo_flow_publish_dropped (data[:reason]) so that
+  # alerts can fire on "integration silently parked" — distinct from the
+  # transient :evo_flow_publish_failed channel that listeners may treat as
+  # retry/escalation noise.
   class PublishEventWorker
     include Sidekiq::Worker
     sidekiq_options queue: :integrations, retry: 5
@@ -40,6 +44,16 @@ module EvoFlow
 
       def broadcast_failed(path:, payload:, error:)
         publish('evo_flow_publish_failed', data: { path: path, payload: payload, error: error })
+      end
+
+      # F4 drops (InvalidEventName / ConfigurationError) are deliberate, not
+      # transient — emit a distinct event so alerts can wire to "integration
+      # silently parked" without firing on the retry-then-Dead-Set path.
+      def broadcast_dropped(reason:, path:, error_message:)
+        publish(
+          'evo_flow_publish_dropped',
+          data: { reason: reason, path: path, error_message: error_message }
+        )
       end
     end
 
@@ -73,17 +87,31 @@ module EvoFlow
       EvoFlow::Client.new.post(path, payload)
       Rails.logger.info("[EvoFlow] published path=#{path} messageId=#{message_id(payload)}")
     rescue EvoFlow::InvalidEventName => e
-      # F4 exception: code bug, not transient — log and drop so Sidekiq treats
-      # the job as success (no retry, no Dead Set entry, no Wisper broadcast).
-      # MUST stay above the StandardError rescue (InvalidEventName < StandardError).
+      # Defense-in-depth: PayloadBuilder.validate_event_name! already runs at
+      # enqueue time, so this rescue is theoretically unreachable in prod.
+      # Kept to protect against (a) console / rake / one-off scripts that
+      # construct payloads without going through PayloadBuilder, and (b) jobs
+      # queued before an EVENT_NAMES shrink that replay after deploy.
+      # Behaviour: log + broadcast :evo_flow_publish_dropped so alerts fire,
+      # then return nil — Sidekiq sees success (no retry, no Dead Set entry,
+      # no spurious :evo_flow_publish_failed). MUST stay above the
+      # StandardError rescue (InvalidEventName < StandardError).
       Rails.logger.error("[EvoFlow] dropped: invalid event_name path=#{path} msg=#{e.message}")
+      FailureBroadcaster.new.broadcast_dropped(
+        reason: :invalid_event_name, path: path, error_message: e.message
+      )
       nil
     rescue EvoFlow::ConfigurationError => e
       # F4 exception: env/config bug, not transient. Retrying just floods the
-      # Dead Set with the same env-var error and triggers spurious
-      # :evo_flow_publish_failed broadcasts. Surface the bug via a single
-      # error log instead. MUST stay above the StandardError rescue.
+      # Dead Set with the same env-var error. Drop the job (Sidekiq sees
+      # success) and emit :evo_flow_publish_dropped so "integration parked"
+      # is observable to alerts — without this, a missing
+      # AUTH_APIKEY_INTEGRATION_LOCAL silently halts 100% of EvoFlow traffic
+      # behind only a log line. MUST stay above the StandardError rescue.
       Rails.logger.error("[EvoFlow] dropped: configuration error path=#{path} msg=#{e.message}")
+      FailureBroadcaster.new.broadcast_dropped(
+        reason: :configuration_error, path: path, error_message: e.message
+      )
       nil
     rescue EvoFlow::HTTPError => e
       Rails.logger.warn(

--- a/spec/lib/events/evo_flow_event_names_spec.rb
+++ b/spec/lib/events/evo_flow_event_names_spec.rb
@@ -29,5 +29,6 @@ RSpec.describe 'EvoFlow::EVENT_NAMES' do
     expect(EvoFlow::PublishEventWorker).to be < Object
     expect(EvoFlow::HTTPError).to be < StandardError
     expect(EvoFlow::ConfigurationError).to be < StandardError
+    expect(EvoFlow::InvalidEventName).to be < StandardError
   end
 end

--- a/spec/services/evo_flow/payload_builder_spec.rb
+++ b/spec/services/evo_flow/payload_builder_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe EvoFlow::PayloadBuilder do
       expect(built[:contactId]).to eq('7')
       expect(built[:properties]).to eq({})
     end
+
+    context 'when event_name is not in EvoFlow::EVENT_NAMES' do
+      it 'raises EvoFlow::InvalidEventName with the unknown name (AC1)' do
+        expect do
+          described_class.build_track(
+            event_name: 'nao_existe', contact_id: 1, properties: {},
+            occurred_at: occurred_at, message_id: 'x'
+          )
+        end.to raise_error(EvoFlow::InvalidEventName, /unknown event_name: "nao_existe"/)
+      end
+
+      it 'renders nil as `nil` (not empty) in the error message' do
+        expect do
+          described_class.build_track(
+            event_name: nil, contact_id: 1, properties: {},
+            occurred_at: occurred_at, message_id: 'x'
+          )
+        end.to raise_error(EvoFlow::InvalidEventName, /unknown event_name: nil/)
+      end
+    end
   end
 
   describe '.build_identify (real IdentifyEventDto)' do
@@ -65,6 +85,17 @@ RSpec.describe EvoFlow::PayloadBuilder do
       expect(payload).not_to have_key(:accountId)
       expect(payload).not_to have_key(:eventType)
       expect(payload).not_to have_key(:event)
+    end
+
+    context 'when event_name is not in EvoFlow::EVENT_NAMES' do
+      it 'raises EvoFlow::InvalidEventName with the unknown name (AC2b)' do
+        expect do
+          described_class.build_identify(
+            event_name: 'tambem_nao', contact_id: 1, traits: {},
+            occurred_at: occurred_at, message_id: 'x'
+          )
+        end.to raise_error(EvoFlow::InvalidEventName, /unknown event_name: "tambem_nao"/)
+      end
     end
   end
 

--- a/spec/workers/evo_flow/publish_event_worker_spec.rb
+++ b/spec/workers/evo_flow/publish_event_worker_spec.rb
@@ -55,6 +55,58 @@ RSpec.describe EvoFlow::PublishEventWorker, type: :job do
     end
   end
 
+  describe 'F4 drops -> Wisper :evo_flow_publish_dropped (M-1)' do
+    let(:listener) do
+      Class.new do
+        attr_reader :received
+
+        def evo_flow_publish_dropped(args)
+          @received = args
+        end
+      end.new
+    end
+
+    it 'broadcasts :evo_flow_publish_dropped with reason: :invalid_event_name on InvalidEventName' do
+      allow(client).to receive(:post).and_raise(EvoFlow::InvalidEventName, 'bad name')
+      allow(Rails.logger).to receive(:error)
+
+      Wisper.subscribe(listener) do
+        described_class.new.perform(path, payload)
+      end
+
+      expect(listener.received).to be_present
+      expect(listener.received[:data][:reason]).to eq(:invalid_event_name)
+      expect(listener.received[:data][:path]).to eq(path)
+      expect(listener.received[:data][:error_message]).to include('bad name')
+    end
+
+    it 'broadcasts :evo_flow_publish_dropped with reason: :configuration_error on ConfigurationError' do
+      allow(client).to receive(:post)
+        .and_raise(EvoFlow::ConfigurationError, 'AUTH_APIKEY_INTEGRATION_LOCAL is not set')
+      allow(Rails.logger).to receive(:error)
+
+      Wisper.subscribe(listener) do
+        described_class.new.perform(path, payload)
+      end
+
+      expect(listener.received).to be_present
+      expect(listener.received[:data][:reason]).to eq(:configuration_error)
+      expect(listener.received[:data][:path]).to eq(path)
+      expect(listener.received[:data][:error_message]).to include('AUTH_APIKEY_INTEGRATION_LOCAL')
+    end
+
+    it 'does NOT broadcast :evo_flow_publish_dropped on transient HTTPError (that path keeps :evo_flow_publish_failed semantics)' do
+      allow(client).to receive(:post).and_raise(EvoFlow::HTTPError.new('500', 500, nil))
+      allow(Rails.logger).to receive(:warn)
+
+      Wisper.subscribe(listener) do
+        expect { described_class.new.perform(path, payload) }.to raise_error(EvoFlow::HTTPError)
+      end
+
+      expect(listener.received).to be_nil
+    end
+  end
+
   describe '.sanitize_payload (F3)' do
     it 'redacts PII-bearing fields, keeps identifiers, tolerates symbol keys' do
       expect(described_class.sanitize_payload(payload)).to eq(

--- a/spec/workers/evo_flow/publish_event_worker_spec.rb
+++ b/spec/workers/evo_flow/publish_event_worker_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe EvoFlow::PublishEventWorker, type: :job do
       expect { described_class.new.perform(path, payload) }
         .to raise_error(ArgumentError)
     end
+
+    it 'swallows EvoFlow::InvalidEventName so Sidekiq does NOT retry (F4 exception, AC3)' do
+      allow(client).to receive(:post)
+        .and_raise(EvoFlow::InvalidEventName, 'unknown event_name: bad')
+      logged = []
+      allow(Rails.logger).to receive(:error) { |m| logged << m }
+
+      expect { described_class.new.perform(path, payload) }.not_to raise_error
+      expect(logged.join).to include('dropped: invalid event_name').and include('bad')
+    end
+
+    it 'swallows EvoFlow::ConfigurationError so Sidekiq does NOT retry (F4 exception)' do
+      allow(client).to receive(:post)
+        .and_raise(EvoFlow::ConfigurationError, 'AUTH_APIKEY_INTEGRATION_LOCAL is not set')
+      logged = []
+      allow(Rails.logger).to receive(:error) { |m| logged << m }
+
+      expect { described_class.new.perform(path, payload) }.not_to raise_error
+      expect(logged.join).to include('dropped: configuration error')
+        .and include('AUTH_APIKEY_INTEGRATION_LOCAL')
+    end
   end
 
   describe '.sanitize_payload (F3)' do


### PR DESCRIPTION
## EVO-1241 — Freeze EvoFlow EVENT_NAMES (CRM side)

Fecha o contrato no lado CRM da story 7.5. Em cima de EVO-1238 (foundation, PR #87/#88) e EVO-1240 (listeners port, PR #89): listeners passaram a emitir 9 eventos canônicos, mas `PayloadBuilder` não validava o `event_name`. Um typo (`'contac.created'`) era aceito silenciosamente, batia em `evo-flow`, parava no ClickHouse e os segment-builders nunca enxergavam o evento. Silent data gap.

Esta PR fecha o gap **no lado emissor**: `PayloadBuilder` valida contra `EvoFlow::EVENT_NAMES` (frozen na foundation) e o worker drop silencioso quando o erro é code/config bug em vez de transient.

### Mudanças

| Arquivo | Mudança |
|---|---|
| `app/services/evo_flow/payload_builder.rb` | `EvoFlow::InvalidEventName < StandardError` (module-level, espelha `HTTPError`/`ConfigurationError` em `client.rb`). `validate_event_name!` private class method chamado no topo de `build_track` e `build_identify`. |
| `app/workers/evo_flow/publish_event_worker.rb` | Dois novos `rescue` **antes** do `HTTPError`/`StandardError` existentes: `InvalidEventName` e `ConfigurationError` → log + return (sem retry, sem Dead Set, sem broadcast Wisper). |
| `spec/services/evo_flow/payload_builder_spec.rb` | Casos invalid p/ `build_track` e `build_identify` + cobertura `event_name: nil` (renderiza `"unknown event_name: nil"` via `.inspect`). |
| `spec/workers/evo_flow/publish_event_worker_spec.rb` | F4-exception specs p/ `InvalidEventName` e `ConfigurationError`; mantém F4 existente p/ `ArgumentError`/`HTTPError`. |
| `spec/lib/events/evo_flow_event_names_spec.rb` | Autoload guard estendido com `InvalidEventName`. |
| `README.md` | Seção EvoFlow integration → "Canonical event names" com regra de 3 edições coordenadas. |

### F4 exceptions (deliberadas)

A regra F4 da foundation diz: "every failure path counts as a Sidekiq retry". Esta PR introduz **duas exceções documentadas**:

- **`InvalidEventName`** — typo no listener. Retry não corrige código. Re-tentar 5× só inflaciona o Dead Set + dispara `:evo_flow_publish_failed` por bug humano.
- **`ConfigurationError`** — `AUTH_APIKEY_INTEGRATION_LOCAL` ausente, URL inválida, cleartext em prod. Retry não corrige config. Mesmo argumento.

Ordem dos `rescue` importa: `InvalidEventName < StandardError`, então as duas cláusulas novas precisam vir **antes** do `rescue StandardError`. Lock-in por spec.

### Validação

| Check | Resultado |
|---|---|
| RSpec (`payload_builder_spec` + `publish_event_worker_spec` + `evo_flow_event_names_spec`) | **31 examples, 0 failures** |
| `rails zeitwerk:check` | Pendente local (rodar com `RAILS_ENV=test`) |

```bash
POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5432 \
POSTGRES_USERNAME=postgres POSTGRES_PASSWORD=postgres_dev_password \
POSTGRES_DATABASE=evolution_test RAILS_ENV=test \
bundle exec rspec spec/services/evo_flow/payload_builder_spec.rb \
                  spec/workers/evo_flow/publish_event_worker_spec.rb \
                  spec/lib/events/evo_flow_event_names_spec.rb
```

### PRs coordenadas (mesma branch `danilocarneiro/evo-1241-freeze-evoflow-event-names`)

Merge order recomendada: **esta PR → evo-flow → monorepo**. O CI gate do monorepo só roda meaningfully depois das três mergeadas (o script compara os dois arquivos canônicos).

- **CRM (esta PR)** — define `EvoFlow::InvalidEventName` + F4 exceptions
- **evo-flow** — espelha `EVENT_NAMES` em TS + `@IsIn` nos DTOs + e2e
- **monorepo (`evo-crm-community`)** — `scripts/check-event-names-sync.sh` + job de CI

### Out of Scope

- Refinar a lista de 16 eventos (deferida).
- Versionamento (`v1`/`v2`) — single source of truth nesta sprint.
- Backfill de linhas legadas no ClickHouse cujo `event_name` está fora do enum (story 7.9 / EVO-1245).
- Listeners chamando `validate_event_name!` proativamente antes do `perform_async` (`PayloadBuilder` raise no build-time é a única porta de entrada).
- Wisper `:evo_flow_invalid_event_name` dedicado p/ ops (mantém a superfície de failure-broadcast inalterada).

### Test plan

- [ ] CI roda RSpec verde (31 examples).
- [ ] `EvoFlow::InvalidEventName < StandardError` resolve sob `Rails.application.eager_load!` (autoload guard).
- [ ] Worker swallows `InvalidEventName` e `ConfigurationError` sem broadcast `:evo_flow_publish_failed`.
- [ ] Mergear depois desta: evo-flow PR + monorepo PR.

## Summary by Sourcery

Validate EvoFlow payload event names against the canonical list and treat invalid names and configuration errors as non-retriable worker failures.

New Features:
- Introduce EvoFlow::InvalidEventName to signal usage of event names outside the canonical EvoFlow::EVENT_NAMES list.

Enhancements:
- Add event_name validation to EvoFlow::PayloadBuilder track and identify payload builders, raising EvoFlow::InvalidEventName with clear error messages.
- Handle EvoFlow::InvalidEventName and EvoFlow::ConfigurationError in EvoFlow::PublishEventWorker as terminal errors that are logged and dropped without Sidekiq retries.
- Extend EvoFlow event names autoload guard to cover the new InvalidEventName error type.

Documentation:
- Document the canonical EvoFlow event names list, its Rails and TypeScript sources, and the CI sync check in the README.

Tests:
- Add specs covering InvalidEventName raising for invalid or nil event names in PayloadBuilder.
- Add worker specs asserting that InvalidEventName and ConfigurationError are swallowed, logged, and not retried, alongside the existing failure handling behavior.