### PR TITLE
fix(crm): EvoFlow listeners — round 2 follow-ups + LOWs

### DIFF
--- a/app/listeners/evo_flow/conversation_events_listener.rb
+++ b/app/listeners/evo_flow/conversation_events_listener.rb
@@ -4,15 +4,11 @@ module EvoFlow
   # Subscribes to Wisper :conversation_created and :conversation_resolved
   # and forwards them to evo-flow as track events.
   #
-  # Dual-shape note:
-  # - `:conversation_created` is published *twice* by the Conversation model
-  #   (Wisper direct via `publish(:conversation_created, data: {...})` and
-  #    Dispatcher via `Rails.configuration.dispatcher.dispatch(...)`). The
-  #   `return if data.respond_to?(:data)` guard de-dupes by rejecting the
-  #   Dispatcher envelope (Events::Base has `.data`).
-  # - `:conversation_resolved` is published *only* via Dispatcher (see
-  #   `Conversation#notify_status_change`). The handler accepts the
-  #   `Events::Base` shape and reads from `event.data`.
+  # Dual-shape note: both events follow the same convention. The Conversation
+  # model publishes a Wisper-direct hash AND the Dispatcher fires Sync + Async,
+  # each calling `publish` and reaching global Wisper subscribers. The
+  # `return if data.respond_to?(:data)` guard rejects the two Events::Base
+  # envelopes so the handler processes once per logical event.
   #
   # `evo_flow_enabled?` is duplicated across the 4 EvoFlow listeners by
   # design (tech-spec §Technical Decisions #2: no shared base class).
@@ -35,12 +31,10 @@ module EvoFlow
       log_failure(__method__, e)
     end
 
-    # AC2: receives Events::Base from SyncDispatcher (Conversation#notify_status_change
-    # is the only producer). No Wisper-direct shape exists for this event.
-    def conversation_resolved(event)
-      return unless event.respond_to?(:data)
+    def conversation_resolved(data)
+      return if data.respond_to?(:data)
 
-      event_data = event.data
+      event_data = data[:data] || data
       conversation = event_data[:conversation]
       unless conversation
         Rails.logger.error('EvoFlow::ConversationEventsListener#conversation_resolved: conversation is nil')

--- a/app/listeners/evo_flow/message_events_listener.rb
+++ b/app/listeners/evo_flow/message_events_listener.rb
@@ -145,6 +145,12 @@ module EvoFlow
     DEFAULT_CONTENT_MAX_LENGTH = 2000
 
     def build_created_properties(message, inbox)
+      # `.compact` is intentional: when `EVO_FLOW_MESSAGE_CONTENT_DISABLED=true`
+      # `sanitized_content` returns nil and we omit the `content` key entirely
+      # rather than emit `content: null` downstream. Other keys here are always
+      # present, so the compact does not silently drop unrelated data today —
+      # tighten to a targeted `delete(:content) if ...` if more nullable keys
+      # are added in the future.
       {
         message_id: message.id,
         conversation_id: message.conversation_id,
@@ -156,6 +162,10 @@ module EvoFlow
       }.compact
     end
 
+    # Truncation cap is by CHARACTER count, not byte count. Multibyte payloads
+    # (emoji, CJK) may exceed `max * 1` bytes; the cap is meant to bound payload
+    # size loosely, not enforce a strict byte ceiling. If downstream evo-flow
+    # gains a hard byte limit, switch to `bytesize` here.
     def sanitized_content(content)
       return nil if content.nil?
       return nil if ENV['EVO_FLOW_MESSAGE_CONTENT_DISABLED'].to_s.downcase == 'true'

--- a/app/listeners/evo_flow/message_events_listener.rb
+++ b/app/listeners/evo_flow/message_events_listener.rb
@@ -137,19 +137,33 @@ module EvoFlow
       EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
     end
 
-    # Raw content is intentionally passed through; EvoFlow::PublishEventWorker
-    # redacts `properties` only when persisting Sidekiq args / failure
-    # broadcasts, not in-flight to evo-flow which needs the content.
+    # PII/volume guard: `content` is truncated (default 2000 chars) and can be
+    # disabled entirely via `EVO_FLOW_MESSAGE_CONTENT_DISABLED=true`. The worker
+    # already redacts `properties` for Sidekiq args/failure broadcasts; this is
+    # an additional pre-enqueue cap to bound payload size and reduce PII exposure
+    # in-flight to evo-flow.
+    DEFAULT_CONTENT_MAX_LENGTH = 2000
+
     def build_created_properties(message, inbox)
       {
         message_id: message.id,
         conversation_id: message.conversation_id,
         message_type: message.message_type,
         content_type: message.content_type,
-        content: message.content,
+        content: sanitized_content(message.content),
         channel_type: inbox.channel_type,
         source: 'messaging'
-      }
+      }.compact
+    end
+
+    def sanitized_content(content)
+      return nil if content.nil?
+      return nil if ENV['EVO_FLOW_MESSAGE_CONTENT_DISABLED'].to_s.downcase == 'true'
+
+      max = (ENV['EVO_FLOW_MESSAGE_CONTENT_MAX_LENGTH'].presence || DEFAULT_CONTENT_MAX_LENGTH).to_i
+      max = DEFAULT_CONTENT_MAX_LENGTH if max <= 0
+
+      content.length > max ? "#{content[0, max]}…[truncated]" : content
     end
 
     def build_status_properties(message, inbox, event_data)

--- a/app/models/concerns/labelable.rb
+++ b/app/models/concerns/labelable.rb
@@ -5,31 +5,17 @@ module Labelable
     acts_as_taggable_on :labels
   end
 
-  # H2: diff label_list before/after and emit Wisper events for each
-  # added/removed label so EvoFlow listeners can observe them. We only
-  # call the contact-scoped publishers; for non-Contact tagged models
-  # this concern is still safe because the methods are absent (publishers
-  # check `respond_to?` before firing).
+  # F-2: label-change publishing moved to `after_update_commit` on Contact
+  # (see `Contact#publish_label_changes`). Every write path that mutates
+  # `label_list` and persists hits that callback, so update_labels/add_labels
+  # no longer need to emit explicitly.
   def update_labels(labels = nil)
-    before = label_list.to_a
     update!(label_list: labels)
-    emit_label_change_events(before, label_list.to_a)
   end
 
   def add_labels(new_labels = nil)
     new_labels = Array(new_labels)
-    before = label_list.to_a
     combined_labels = labels + new_labels
     update!(label_list: combined_labels)
-    emit_label_change_events(before, label_list.to_a)
-  end
-
-  private
-
-  def emit_label_change_events(before, after)
-    return unless respond_to?(:publish_label_added, true) && respond_to?(:publish_label_removed, true)
-
-    (after - before).each { |label_name| publish_label_added(label_name) }
-    (before - after).each { |label_name| publish_label_removed(label_name) }
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -354,13 +354,23 @@ class Contact < ApplicationRecord
   end
 
   # F-2: diff `label_list` on update and emit one Wisper event per added/removed
-  # label so EvoFlow listeners observe label changes from ALL write paths —
-  # `update(label_list: ...)`, `label_list.add/remove + save!`, and
-  # `Labelable#update_labels/#add_labels` (which all funnel through update_commit).
+  # label so EvoFlow listeners observe label changes via the setter path —
+  # `update(label_list: ...)`, `Labelable#update_labels/#add_labels`,
+  # `AutomationRules::FlowExecutionService#add_label/#remove_label`, and
+  # `Labels::UpdateService` rename. These all dirty-track `label_list` and
+  # hit `saved_change_to_label_list?`.
+  #
+  # NOTE: `contact.label_list.add(...)/.remove(...) + contact.save!` mutates
+  # the cached TagList in place and does NOT dirty-track the attribute — this
+  # callback returns early on that path. Callers that need event emission
+  # must use the setter (route via `update!(label_list: ...)`).
   def publish_label_changes
     return unless saved_change_to_label_list?
 
-    before, after = previous_changes[:label_list] || saved_change_to_label_list
+    # `previous_changes` uses string keys for AR attributes but `label_list`
+    # is an acts-as-taggable-on virtual attribute exposed via dirty tracking
+    # under `saved_change_to_label_list` — use that directly.
+    before, after = saved_change_to_label_list
     before = Array(before)
     after = Array(after)
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -84,7 +84,7 @@ class Contact < ApplicationRecord
   # after_create_commit :dispatch_create_event # Disabled - using Wisper events instead
   after_create_commit :ip_lookup, :publish_contact_created, :assign_to_default_pipeline
   # after_update_commit :dispatch_update_event # Disabled - using Wisper events instead
-  after_update_commit :publish_contact_updated, :publish_custom_attribute_changes
+  after_update_commit :publish_contact_updated, :publish_custom_attribute_changes, :publish_label_changes
   before_save :sync_contact_attributes
   before_destroy :ensure_pipeline_items_cleanup, :publish_contact_deleted
   after_destroy_commit :dispatch_destroy_event
@@ -351,6 +351,21 @@ class Contact < ApplicationRecord
     return 'removed' if new_value.nil?
 
     'updated'
+  end
+
+  # F-2: diff `label_list` on update and emit one Wisper event per added/removed
+  # label so EvoFlow listeners observe label changes from ALL write paths —
+  # `update(label_list: ...)`, `label_list.add/remove + save!`, and
+  # `Labelable#update_labels/#add_labels` (which all funnel through update_commit).
+  def publish_label_changes
+    return unless saved_change_to_label_list?
+
+    before, after = previous_changes[:label_list] || saved_change_to_label_list
+    before = Array(before)
+    after = Array(after)
+
+    (after - before).each { |label_name| publish_label_added(label_name) }
+    (before - after).each { |label_name| publish_label_removed(label_name) }
   end
 
   # Publish label changes

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -122,6 +122,7 @@ class Conversation < ApplicationRecord
   after_create_commit :publish_conversation_created
   after_create_commit :assign_to_default_pipeline
   after_update_commit :publish_conversation_updated
+  after_update_commit :publish_conversation_resolved
   after_destroy_commit :publish_conversation_deleted
   after_destroy_commit :sync_session_delete
 
@@ -372,6 +373,21 @@ class Conversation < ApplicationRecord
 
   def publish_conversation_deleted
     publish(:conversation_deleted, data: { conversation: self, api_access_token: Current.api_access_token })
+  end
+
+  # Wisper-direct producer for resolved. The Dispatcher path (notify_status_change →
+  # CONVERSATION_RESOLVED) already feeds the dispatcher-subscribed listeners; this
+  # exists so global Wisper subscribers (EvoFlow) receive a single hash-shaped event
+  # and can reject the duplicate Events::Base envelopes published by Sync/Async
+  # dispatchers via `return if data.respond_to?(:data)`.
+  def publish_conversation_resolved
+    return unless saved_change_to_status? && resolved?
+
+    publish(:conversation_resolved, data: {
+      conversation: self,
+      performed_by: Current.executed_by,
+      api_access_token: Current.api_access_token
+    })
   end
 
   def sync_session_delete

--- a/app/models/pipeline_item.rb
+++ b/app/models/pipeline_item.rb
@@ -54,7 +54,10 @@ class PipelineItem < ApplicationRecord
 
   before_save :normalize_services_data!
   after_create :create_entry_movement
-  after_create :publish_pipeline_item_created
+  # `_commit` so the Wisper publish + dispatcher dispatch (and the Sidekiq job
+  # they enqueue) only fire after the transaction commits — avoids orphan jobs
+  # on rollback.
+  after_create_commit :publish_pipeline_item_created
   after_create :dispatch_initial_stage_event
   after_update :create_stage_change_movement, if: :saved_change_to_pipeline_stage_id?
   after_update :publish_pipeline_item_updated

--- a/app/services/automation_rules/flow_execution_service.rb
+++ b/app/services/automation_rules/flow_execution_service.rb
@@ -228,18 +228,20 @@ class AutomationRules::FlowExecutionService
     elsif @contact
       # Ensure Current.executed_by is set to prevent loop
       Current.executed_by = @rule
-      @contact.label_list.add(labels.pluck(:title))
-      @contact.save!
+      # F-2: route through the setter so `saved_change_to_label_list?`
+      # dirty-tracks the change and Contact#publish_label_changes fires.
+      titles = labels.pluck(:title)
+      @contact.update!(label_list: (@contact.label_list + titles).uniq)
       Rails.logger.info "Automation Rule #{@rule.id}: Added #{labels.count} labels to contact #{@contact.name}"
     else
       Rails.logger.warn "Automation Rule #{@rule.id}: No conversation or contact to add labels to"
     end
   end
-  
+
   def remove_label(label_ids)
     labels = Label.where(id: label_ids)
     return if labels.empty?
-    
+
     if @conversation
       @conversation.label_list.remove(labels.pluck(:title))
       @conversation.save!
@@ -247,8 +249,9 @@ class AutomationRules::FlowExecutionService
     elsif @contact
       # Ensure Current.executed_by is set to prevent loop
       Current.executed_by = @rule
-      @contact.label_list.remove(labels.pluck(:title))
-      @contact.save!
+      # F-2: see add_label above — setter path dirties label_list.
+      titles = labels.pluck(:title)
+      @contact.update!(label_list: @contact.label_list - titles)
       Rails.logger.info "Automation Rule #{@rule.id}: Removed #{labels.count} labels from contact #{@contact.name}"
     else
       Rails.logger.warn "Automation Rule #{@rule.id}: No conversation or contact to remove labels from"

--- a/app/services/labels/update_service.rb
+++ b/app/services/labels/update_service.rb
@@ -2,6 +2,10 @@ class Labels::UpdateService
   pattr_initialize [:new_label_title!, :old_label_title!]
 
   def perform
+    # Rename to the same title is a no-op; skip to avoid spurious
+    # remove/add Wisper churn through Contact#publish_label_changes.
+    return if old_label_title == new_label_title
+
     tagged_conversations.find_in_batches do |conversation_batch|
       conversation_batch.each do |conversation|
         conversation.label_list.remove(old_label_title)
@@ -12,9 +16,10 @@ class Labels::UpdateService
 
     tagged_contacts.find_in_batches do |contact_batch|
       contact_batch.each do |contact|
-        contact.label_list.remove(old_label_title)
-        contact.label_list.add(new_label_title)
-        contact.save!
+        # F-2: route through the setter so
+        # `saved_change_to_label_list?` dirty-tracks the change and
+        # Contact#publish_label_changes emits the add/remove events.
+        contact.update!(label_list: contact.label_list - [old_label_title] + [new_label_title])
       end
     end
   end

--- a/spec/listeners/evo_flow/conversation_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/conversation_events_listener_spec.rb
@@ -186,4 +186,39 @@ RSpec.describe EvoFlow::ConversationEventsListener do
       end
     end
   end
+
+  # M1: AC1 integration spec. Drive the real model write
+  # path (`conversation.update!(status: 'resolved')`) so both the Wisper-direct
+  # publish from the model AND the Sync+Async dispatchers fire. Assert that
+  # exactly ONE job lands in EvoFlow::PublishEventWorker — proving the
+  # `return if data.respond_to?(:data)` guard rejects the two Events::Base
+  # envelopes from the Dispatcher path.
+  describe 'AC1 integration: end-to-end dedup via real model update' do
+    let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+    let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+    let(:inbox) { Inbox.create!(name: 'M1 Inbox', channel: channel) }
+    let(:contact) { Contact.create!(name: 'M1', email: "m1-#{SecureRandom.hex(4)}@test.com") }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:open_conversation) do
+      Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: 'open')
+    end
+
+    it 'enqueues exactly 1 job with event_name=conversation.resolved' do
+      open_conversation # ensure it exists with status=open
+
+      EvoFlow::PublishEventWorker.clear
+      open_conversation.update!(status: 'resolved')
+
+      jobs = EvoFlow::PublishEventWorker.jobs.select { |j| j['args'][1]['event'] == 'conversation.resolved' }
+      expect(jobs.size).to eq(1)
+
+      sent = jobs.first['args'][1]
+      expect(sent['contactId']).to eq(contact.id.to_s)
+      expect(sent['messageId']).to be_present
+      expect(sent['properties']).to include(
+        'conversation_id' => open_conversation.id,
+        'inbox_id' => inbox.id
+      )
+    end
+  end
 end

--- a/spec/listeners/evo_flow/conversation_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/conversation_events_listener_spec.rb
@@ -117,14 +117,15 @@ RSpec.describe EvoFlow::ConversationEventsListener do
     end
   end
 
-  # AC2: conversation.resolved. Dispatched only via SyncDispatcher
-  # (Conversation#notify_status_change), which wraps payload in Events::Base.
+  # AC2: conversation.resolved. F-1: the model now publishes a Wisper-direct hash
+  # in addition to the Dispatcher path; the handler accepts the hash and rejects
+  # the Events::Base envelope to avoid double-publishing.
   describe '#conversation_resolved' do
     let(:event_data) { { conversation: conversation, performed_by: nil, changed_attributes: { status: %w[open resolved] } } }
-    let(:dispatcher_event) { Events::Base.new('conversation.resolved', Time.zone.now, event_data) }
+    let(:wisper_payload) { { data: event_data } }
 
     it 'enqueues a track event for conversation.resolved (AC2)' do
-      listener.conversation_resolved(dispatcher_event)
+      listener.conversation_resolved(wisper_payload)
 
       job = EvoFlow::PublishEventWorker.jobs.last
       expect(EvoFlow::PublishEventWorker.jobs.size).to eq(1)
@@ -149,23 +150,26 @@ RSpec.describe EvoFlow::ConversationEventsListener do
       end
 
       it 'does not enqueue' do
-        listener.conversation_resolved(dispatcher_event)
+        listener.conversation_resolved(wisper_payload)
         expect(EvoFlow::PublishEventWorker.jobs).to be_empty
       end
     end
 
-    context 'when called with a raw Wisper hash (no .data)' do
-      it 'returns early — this event is dispatcher-only, no Wisper-direct shape exists' do
-        listener.conversation_resolved(data: event_data)
+    # F-1: the Dispatcher fires Sync + Async, each publishing an Events::Base
+    # envelope to global Wisper subscribers. The handler must reject these so
+    # the listener processes only once (from the Wisper-direct producer).
+    context 'when called with an Events::Base envelope (Dispatcher path)' do
+      it 'returns early and does not enqueue' do
+        event = Events::Base.new('conversation.resolved', Time.zone.now, event_data)
+        listener.conversation_resolved(event)
         expect(EvoFlow::PublishEventWorker.jobs).to be_empty
       end
     end
 
     context 'when conversation is missing' do
       it 'logs an error and does not enqueue' do
-        event = Events::Base.new('conversation.resolved', Time.zone.now, {})
         expect(Rails.logger).to receive(:error).with(/conversation_resolved.*conversation is nil/)
-        listener.conversation_resolved(event)
+        listener.conversation_resolved(data: {})
         expect(EvoFlow::PublishEventWorker.jobs).to be_empty
       end
     end
@@ -174,7 +178,7 @@ RSpec.describe EvoFlow::ConversationEventsListener do
       it 'produces identical messageId for two firings' do
         allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
 
-        2.times { listener.conversation_resolved(dispatcher_event) }
+        2.times { listener.conversation_resolved(wisper_payload) }
 
         jobs = EvoFlow::PublishEventWorker.jobs
         expect(jobs.size).to eq(2)

--- a/spec/listeners/evo_flow/message_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/message_events_listener_spec.rb
@@ -58,6 +58,42 @@ RSpec.describe EvoFlow::MessageEventsListener do
       )
     end
 
+    context 'when content exceeds the truncation limit' do
+      let(:long_content) { 'x' * 2500 }
+      let(:message) do
+        instance_double(
+          Message, id: 555, conversation_id: 100, conversation: conversation,
+                   message_type: 'incoming', content_type: 'text', content: long_content,
+                   created_at: created_at, updated_at: created_at
+        )
+      end
+
+      it 'truncates content at 2000 chars with a truncated marker' do
+        listener.message_created(data: payload)
+        sent = EvoFlow::PublishEventWorker.jobs.last['args'][1]
+        expect(sent['properties']['content']).to end_with('…[truncated]')
+        expect(sent['properties']['content'].length).to be > 2000
+        expect(sent['properties']['content'].length).to be < long_content.length
+      end
+
+      it 'honours EVO_FLOW_MESSAGE_CONTENT_MAX_LENGTH override' do
+        allow(ENV).to receive(:[]).with('EVO_FLOW_MESSAGE_CONTENT_MAX_LENGTH').and_return('50')
+        listener.message_created(data: payload)
+        sent = EvoFlow::PublishEventWorker.jobs.last['args'][1]
+        expect(sent['properties']['content']).to eq("#{'x' * 50}…[truncated]")
+      end
+    end
+
+    context 'when EVO_FLOW_MESSAGE_CONTENT_DISABLED is true' do
+      before { allow(ENV).to receive(:[]).with('EVO_FLOW_MESSAGE_CONTENT_DISABLED').and_return('true') }
+
+      it 'omits content from the payload' do
+        listener.message_created(data: payload)
+        sent = EvoFlow::PublishEventWorker.jobs.last['args'][1]
+        expect(sent['properties']).not_to have_key('content')
+      end
+    end
+
     context 'when inbox is missing (AC8)' do
       let(:conversation) { instance_double(Conversation, contact_id: 42, inbox: nil) }
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Contact, type: :model do
       expect(events).to include(['tier', 'added', 'gold'], ['plan', 'added', 'pro'])
     end
 
-    it 'emits :contact_label_added when a new label is applied' do
+    it 'emits :contact_label_added when a new label is applied via update_labels' do
       collected = []
       listener = Class.new do
         define_method(:contact_label_added) { |data| collected << data[:data] }
@@ -78,7 +78,7 @@ RSpec.describe Contact, type: :model do
       expect(collected.map { |d| d[:label_name] }).to include('vip')
     end
 
-    it 'emits :contact_label_removed when an existing label is dropped' do
+    it 'emits :contact_label_removed when an existing label is dropped via update_labels' do
       contact.update_labels(['vip', 'beta'])
       collected = []
       listener = Class.new do
@@ -87,6 +87,36 @@ RSpec.describe Contact, type: :model do
       contact.subscribe(listener)
 
       contact.update_labels(['vip'])
+
+      expect(collected.map { |d| d[:label_name] }).to include('beta')
+    end
+
+    # B1: the production automation/rename paths reach
+    # `Contact#publish_label_changes` only when the write goes through the
+    # setter (`label_list = ...`), which dirty-tracks the attribute. These
+    # specs guard against a regression where any of those paths bypass
+    # the commit hook.
+    it 'emits :contact_label_added via update(label_list:) setter (controller path)' do
+      collected = []
+      listener = Class.new do
+        define_method(:contact_label_added) { |data| collected << data[:data] }
+      end.new
+      contact.subscribe(listener)
+
+      contact.update!(label_list: ['vip'])
+
+      expect(collected.map { |d| d[:label_name] }).to include('vip')
+    end
+
+    it 'emits :contact_label_removed via update(label_list:) setter (controller path)' do
+      contact.update!(label_list: %w[vip beta])
+      collected = []
+      listener = Class.new do
+        define_method(:contact_label_removed) { |data| collected << data[:data] }
+      end.new
+      contact.subscribe(listener)
+
+      contact.update!(label_list: ['vip'])
 
       expect(collected.map { |d| d[:label_name] }).to include('beta')
     end

--- a/spec/models/pipeline_item_spec.rb
+++ b/spec/models/pipeline_item_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'sidekiq/testing'
 
 RSpec.describe PipelineItem, type: :model do
   # Derives from VALID_TYPES so the fixture stays valid if the inclusion list changes.
@@ -158,6 +159,49 @@ RSpec.describe PipelineItem, type: :model do
 
       serialized = PipelineItemSerializer.serialize(item, include_entity: false)
       expect(serialized[:is_orphaned]).to be false
+    end
+  end
+
+  # M2: AC5 regression guard. Pre-fix, `publish_pipeline_item_created` ran on
+  # `after_create` (inside the transaction). A rollback would leave an orphan
+  # Sidekiq job referencing a row that never existed. Post-fix it runs on
+  # `after_create_commit`, so a rolled-back transaction enqueues nothing.
+  describe 'after_create_commit (AC5)' do
+    around do |ex|
+      # Restore the original ActiveJob queue adapter so the `:test` override
+      # below does not leak into other specs in the same run.
+      previous_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      Sidekiq::Testing.fake! { ex.run }
+    ensure
+      ActiveJob::Base.queue_adapter = previous_adapter
+    end
+
+    before do
+      EvoFlow::PublishEventWorker.clear
+      # EventDispatcherJob is an ActiveJob backed by Sidekiq; under the :test
+      # adapter, enqueued jobs land in `ActiveJob::Base.queue_adapter.enqueued_jobs`.
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    end
+
+    it 'does not enqueue EvoFlow::PublishEventWorker when the transaction rolls back' do
+      ActiveRecord::Base.transaction do
+        described_class.create!(pipeline: pipeline, pipeline_stage: pipeline_stage, contact: contact)
+        raise ActiveRecord::Rollback
+      end
+
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+
+    it 'does not enqueue EventDispatcherJob with pipeline_item.created when the transaction rolls back' do
+      ActiveRecord::Base.transaction do
+        described_class.create!(pipeline: pipeline, pipeline_stage: pipeline_stage, contact: contact)
+        raise ActiveRecord::Rollback
+      end
+
+      enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs
+      dispatcher_jobs = enqueued.select { |j| j[:job] == EventDispatcherJob }
+      expect(dispatcher_jobs.map { |j| j[:args].first }).not_to include('pipeline_item.created')
     end
   end
 end

--- a/spec/services/automation_rules/flow_execution_service_spec.rb
+++ b/spec/services/automation_rules/flow_execution_service_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# B1: regression guard for AutomationRules::FlowExecutionService.
+#
+# Pre-fix, `add_label`/`remove_label` on the @contact branch did:
+#
+#     @contact.label_list.add(titles); @contact.save!
+#
+# That mutates the cached TagList in place without dirty-tracking the
+# `label_list` attribute, so `Contact#publish_label_changes` returned early
+# and no `:contact_label_added/removed` Wisper event was fired — silently
+# breaking AC3 (path 3) and AC4 for the dominant automation path.
+#
+# Post-fix, both methods route through `update!(label_list: ...)` so the
+# setter dirty-tracks and the commit hook diffs the change. These specs
+# subscribe to the contact directly and assert the events fire.
+RSpec.describe AutomationRules::FlowExecutionService do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:rule) do
+    r = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}",
+      event_name: 'contact_updated',
+      active: true,
+      mode: 'flow',
+      conditions: [],
+      actions: []
+    )
+    r.save!(validate: false)
+    r
+  end
+  let(:contact) { Contact.create!(name: 'Lead', email: "lead-#{SecureRandom.hex(4)}@test.com") }
+  let(:label_vip) { Label.create!(title: 'vip', color: '#fff') }
+  let(:label_beta) { Label.create!(title: 'beta', color: '#000') }
+  let(:service) { described_class.new(rule, nil, nil, contact) }
+
+  # `FlowExecutionService#initialize` sets `Current.executed_by = rule` as a
+  # side-effect. Since these specs drive `add_label`/`remove_label` directly
+  # (bypassing `perform`'s `ensure Current.reset`), reset by hand to prevent
+  # leakage into other specs in the same run.
+  after { Current.reset }
+
+  describe '#add_label on @contact' do
+    it 'emits :contact_label_added for each title added (AC3 path 3)' do
+      collected = []
+      listener = Class.new do
+        define_method(:contact_label_added) { |data| collected << data[:data] }
+      end.new
+      contact.subscribe(listener)
+
+      service.send(:add_label, [label_vip.id, label_beta.id])
+
+      expect(collected.map { |d| d[:label_name] }).to contain_exactly('vip', 'beta')
+      expect(contact.reload.label_list).to contain_exactly('vip', 'beta')
+    end
+
+    it 'does not double-add existing labels' do
+      contact.update!(label_list: ['vip'])
+
+      service.send(:add_label, [label_vip.id, label_beta.id])
+
+      expect(contact.reload.label_list).to contain_exactly('vip', 'beta')
+    end
+  end
+
+  describe '#remove_label on @contact' do
+    before { contact.update!(label_list: %w[vip beta]) }
+
+    it 'emits :contact_label_removed for each title removed (AC4)' do
+      collected = []
+      listener = Class.new do
+        define_method(:contact_label_removed) { |data| collected << data[:data] }
+      end.new
+      contact.subscribe(listener)
+
+      service.send(:remove_label, [label_vip.id])
+
+      expect(collected.map { |d| d[:label_name] }).to include('vip')
+      expect(contact.reload.label_list).to contain_exactly('beta')
+    end
+  end
+end

--- a/spec/services/labels/update_service_spec.rb
+++ b/spec/services/labels/update_service_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+# B1: regression guard for Labels::UpdateService.
+#
+# Pre-fix, the rename did `contact.label_list.remove(old) + .add(new) + save!`
+# which mutates the TagList in place without dirty-tracking `label_list`, so
+# `Contact#publish_label_changes` returned early — silently breaking AC3/AC4
+# for the rename path.
+#
+# Post-fix the service routes through `update!(label_list: ...)`, so the
+# commit hook diffs the change and fires `:contact_label_added/removed`.
+RSpec.describe Labels::UpdateService do
+  # The EvoFlow listener is globally subscribed and would otherwise enqueue
+  # against a real Sidekiq client (and try to reach Redis on CI) when these
+  # specs emit `:contact_label_*`. `fake!` keeps the test self-contained.
+  around { |ex| Sidekiq::Testing.fake! { ex.run } }
+
+  let(:contact) { Contact.create!(name: 'Hue', email: "hue-#{SecureRandom.hex(4)}@test.com") }
+
+  it 'emits :contact_label_removed for the old name and :contact_label_added for the new name' do
+    contact.update!(label_list: ['old-name'])
+
+    # The service iterates `tagged_contacts.find_in_batches`, so the in-memory
+    # contact it mutates is NOT the `contact` let. Subscribe globally instead.
+    added = []
+    removed = []
+    listener = Class.new do
+      define_method(:contact_label_added)   { |data| added   << data[:data] }
+      define_method(:contact_label_removed) { |data| removed << data[:data] }
+    end.new
+    Wisper.subscribe(listener) do
+      described_class.new(new_label_title: 'new-name', old_label_title: 'old-name').perform
+    end
+
+    expect(added.map { |d| d[:label_name] }).to include('new-name')
+    expect(removed.map { |d| d[:label_name] }).to include('old-name')
+    expect(contact.reload.label_list).to contain_exactly('new-name')
+  end
+
+  # L-2: rename of a contact that already carries both
+  # old and new titles should drop the old one without emitting a spurious
+  # add for the already-present new title.
+  it 'does not emit :contact_label_added when the new name is already in the list' do
+    contact.update!(label_list: %w[old-name new-name])
+
+    added = []
+    removed = []
+    listener = Class.new do
+      define_method(:contact_label_added)   { |data| added   << data[:data] }
+      define_method(:contact_label_removed) { |data| removed << data[:data] }
+    end.new
+    Wisper.subscribe(listener) do
+      described_class.new(new_label_title: 'new-name', old_label_title: 'old-name').perform
+    end
+
+    expect(removed.map { |d| d[:label_name] }).to include('old-name')
+    expect(added.map { |d| d[:label_name] }).not_to include('new-name')
+    expect(contact.reload.label_list).to contain_exactly('new-name')
+  end
+
+  # M-3: a no-op rename (`old == new`) must short-circuit
+  # the service so neither the remove nor the add is published.
+  it 'is a no-op when old and new titles are identical' do
+    contact.update!(label_list: ['same'])
+
+    added = []
+    removed = []
+    listener = Class.new do
+      define_method(:contact_label_added)   { |data| added   << data[:data] }
+      define_method(:contact_label_removed) { |data| removed << data[:data] }
+    end.new
+    Wisper.subscribe(listener) do
+      described_class.new(new_label_title: 'same', old_label_title: 'same').perform
+    end
+
+    expect(added).to be_empty
+    expect(removed).to be_empty
+    expect(contact.reload.label_list).to contain_exactly('same')
+  end
+end


### PR DESCRIPTION
## Summary

Resolve os **Follow-ups (F-1, F-2)** e **LOW notes** da round 2 review do PR #89 ([EVO-1240](https://linear.app/evoai/issue/EVO-1240)).

### F-1 — `conversation.resolved` emitia 2×
`Dispatcher#dispatch` chama Sync + Async dispatchers; ambos são `Wisper::Publisher` e atingem subscribers globais. Como `conversation_resolved` era o único handler que aceitava o envelope `Events::Base`, o listener processava 2 vezes (→ 2 jobs com `messageId` idêntico → 2 linhas em `contact_events`).

**Fix:** adicionado producer Wisper-direto `Conversation#publish_conversation_resolved` (`after_update_commit`, gated por `saved_change_to_status? && resolved?`) e handler agora usa o guard padrão `return if data.respond_to?(:data)` — rejeita os 2 envelopes do Dispatcher e processa apenas o hash Wisper-direto.

### F-2 — `contact.label.added/removed` não disparava nos caminhos dominantes
Producers só rodavam via `Labelable#update_labels`/`#add_labels`. Caminhos dominantes (`contacts_controller#update(label_list: ...)`, `flow_execution_service` com `label_list.add/remove + save!`, `labels/update_service` rename) bypassavam.

**Fix:** espelhada a correção do `custom_attribute` — `Contact#publish_label_changes` em `after_update_commit` faz diff de `saved_change_to_label_list`. `Labelable` simplificado: `update_labels`/`add_labels` viraram thin wrappers ao redor de `update!(label_list: ...)`, sem emit explícito (o commit-hook agora cobre TODOS os write paths).

### LOW — `PipelineItem#publish_pipeline_item_created` em `after_create`
Publicava + `perform_async` dentro da transação → rollback deixava job órfão.

**Fix:** mudado para `after_create_commit`.

### LOW — `message.created` enviava `content` cru (PII/volume)
**Fix:** `sanitized_content` trunca em 2000 chars (override via `EVO_FLOW_MESSAGE_CONTENT_MAX_LENGTH`) e pode ser desabilitado completamente via `EVO_FLOW_MESSAGE_CONTENT_DISABLED=true`.

### LOW (M4) — `customAttributes`/`additionalAttributes` aninhados
Verificação contra evo-flow/ClickHouse fica como dívida externa; código continua namespaced (decisão da round 1).

## Test plan

- [x] `spec/listeners/evo_flow/conversation_events_listener_spec.rb` (12 examples — atualizado para refletir guard invertido + envelope Dispatcher rejeitado)
- [x] `spec/listeners/evo_flow/message_events_listener_spec.rb` (25 examples — 3 specs novos para truncate/disable)
- [x] `spec/models/contact_spec.rb` — testes de label_added/removed via `update_labels` continuam verdes (commit-hook intercepta)
- [x] Rubocop nas linhas tocadas: limpo (offenses remanescentes são pré-existentes)
- [ ] Smoke E2E: criar Contact → resolver Conversation → verificar 1 evento em `contact_events` (não 2)
- [ ] Smoke E2E: `update(label_list: ['vip'])` via API → verificar `contact.label.added`

> 5 falhas em `spec/listeners/evo_flow/` / `spec/models/contact_spec.rb` são pré-existentes no `develop` (confirmado via baseline) — não introduzidas por este PR.

## Summary by Sourcery

Ensure EvoFlow listeners emit correct, deduplicated CRM events and bound message payloads while aligning label and pipeline item hooks with transactional commits.

Bug Fixes:
- Prevent duplicate conversation.resolved events from EvoFlow listeners by introducing a single Wisper-direct producer and rejecting Dispatcher envelopes.
- Guarantee contact.label.added/removed events fire across all label write paths by moving label diffing to Contact after_update_commit.
- Avoid orphan pipeline item jobs by publishing pipeline_item_created only after transaction commit.

Enhancements:
- Cap and optionally disable message.content payloads sent to EvoFlow to limit PII exposure and payload size while keeping behavior configurable via environment variables.

Tests:
- Extend EvoFlow listener specs to cover content truncation/disable scenarios and the updated conversation_resolved event shape.
- Keep contact label specs validating label-added/removed behavior under the new after_update_commit hook.