### PR TITLE
feat(extension-points): wire plugin_loader routes into host router (EVO-1431)

### DIFF
--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -120,9 +120,24 @@ EvoExtensionPoints::PluginLoader.register_plugin(:my_consumer) do |plugin|
 end
 ```
 
+**Host-side consumption.** The host invokes the registered callbacks at
+two points in the boot sequence:
+
+- `on_boot` — driven by `PluginLoader.load_all`, called from
+  `config/initializers/evo_extension_points.rb` in an `after_initialize`
+  hook.
+- `routes` — driven by `PluginLoader.draw_routes(mapper)`, called from
+  `config/routes.rb` at the end of the `Rails.application.routes.draw`
+  block. The `mapper` is the routing mapper (`self` of the draw block).
+  Both are no-ops in the community release — the registry is empty until
+  a consumer gem registers a plugin. A consumer's `Railtie`/`Engine`
+  initializer MUST run before route drawing, so the `routes` callback is
+  present when `draw_routes` iterates the registry.
+
 **Breaking-change policy:** removing or renaming `register_plugin`,
-`plugins`, `on_boot` or `routes` is a major bump. Adding new lifecycle
-hooks (`on_shutdown`, `on_request_start`, etc.) is a minor bump.
+`plugins`, `on_boot`, `routes`, `load_all` or `draw_routes` is a major
+bump. Adding new lifecycle hooks (`on_shutdown`, `on_request_start`,
+etc.) is a minor bump.
 
 ### 4. `theme_tokens`
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -733,5 +733,9 @@ Rails.application.routes.draw do
     post 'onboarding', to: 'onboarding#create'
   end
 
+  # Enterprise / consumer plugins mount their routes through the plugin_loader
+  # extension point. No-op in the community release — the registry is empty
+  # unless a consumer gem registers a plugin. See EXTENSION_POINTS.md §3.
+  EvoExtensionPoints::PluginLoader.draw_routes(self)
 
 end

--- a/lib/evo_extension_points/plugin_loader.rb
+++ b/lib/evo_extension_points/plugin_loader.rb
@@ -55,6 +55,19 @@ module EvoExtensionPoints
         nil
       end
 
+      # Host-side counterpart of load_all for the `routes` lifecycle hook.
+      # The host calls this from inside `config/routes.rb` so every registered
+      # plugin can mount its engine/routes onto the application router. The
+      # given +mapper+ is the routing mapper (the `self` of a `routes.draw`
+      # block). No-op in the community release — `registry` is empty until a
+      # consumer gem registers a plugin.
+      def draw_routes(mapper)
+        registry.each_value do |registration|
+          registration.routes_callbacks.each { |callback| callback.call(mapper) }
+        end
+        nil
+      end
+
       def reset!
         @registry = nil
       end

--- a/spec/integration/plugin_loader_routes_spec.rb
+++ b/spec/integration/plugin_loader_routes_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Proves the host side of the plugin_loader routes contract end-to-end: a
+# plugin registered through EvoExtensionPoints::PluginLoader has its `routes`
+# callback drawn onto the real application router by the `draw_routes(self)`
+# call in config/routes.rb, and the contributed route becomes reachable.
+RSpec.describe 'plugin_loader routes integration', type: :request do
+  after do
+    EvoExtensionPoints::PluginLoader.reset!
+    Rails.application.reload_routes!
+  end
+
+  it 'does not contribute any route when no plugin is registered' do
+    Rails.application.reload_routes!
+    get '/__plugin_loader_probe'
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'mounts a route contributed by a registered plugin after reload' do
+    EvoExtensionPoints::PluginLoader.register_plugin(:probe) do |plugin|
+      plugin.routes do |mapper|
+        mapper.get '/__plugin_loader_probe',
+                   to: ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['probe-ok']] }
+      end
+    end
+    Rails.application.reload_routes!
+
+    get '/__plugin_loader_probe'
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq('probe-ok')
+  end
+end

--- a/spec/lib/evo_extension_points_spec.rb
+++ b/spec/lib/evo_extension_points_spec.rb
@@ -77,6 +77,21 @@ RSpec.describe EvoExtensionPoints do
       described_class.load_all
       expect(booted).to eq([:demo])
     end
+
+    it 'draw_routes is a no-op when nothing is registered' do
+      mapper = double('mapper')
+      expect { described_class.draw_routes(mapper) }.not_to raise_error
+    end
+
+    it 'draw_routes invokes every plugin routes callback with the mapper' do
+      mapper = double('mapper')
+      received = []
+      described_class.register_plugin(:demo) do |plugin|
+        plugin.routes { |m| received << m }
+      end
+      described_class.draw_routes(mapper)
+      expect(received).to eq([mapper])
+    end
   end
 
   describe EvoExtensionPoints::ThemeTokens do


### PR DESCRIPTION
## EVO-1431 — story 1.17.1 (parte community)

Completa o extension point `plugin_loader`. `PluginRegistration` já aceitava um
callback `routes`, mas **nenhum código do host o invocava** — a API documentada
`plugin.routes { |mapper| ... }` (EXTENSION_POINTS.md §3) era código morto do
lado host.

### Mudanças
- `PluginLoader.draw_routes(mapper)` — contraparte de `load_all` para o hook
  `routes`: itera as registrations e invoca os `routes_callbacks`.
- `config/routes.rb` chama `EvoExtensionPoints::PluginLoader.draw_routes(self)`
  ao final do bloco `draw`. No-op no release community (registry vazio) → FR93
  preservado.

### Testes
- `spec/lib/evo_extension_points_spec.rb` — unit de `draw_routes`.
- `spec/integration/plugin_loader_routes_spec.rb` — `type: :request`, prova que
  a rota contribuída por um plugin registrado fica acessível após reload.
- Suíte verde (21 ex.); verificado também com a gem licensing real:
  `GET /enterprise/v1/health` → 200.

Parte de um conjunto de 3 PRs (gem + docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire the plugin_loader routes extension point into the host router so registered plugins can contribute routes at runtime.

New Features:
- Allow plugins registered via PluginLoader to mount their routes onto the host application router through a routes callback hook.

Tests:
- Add unit tests for PluginLoader.draw_routes covering empty and populated registries.
- Add integration request spec verifying that routes contributed by a registered plugin become accessible after route reload.