### PR TITLE
feat(evo_flow): mirror event schema in Ruby + SchemaValidator (EVO-1261)

### DIFF
--- a/app/services/evo_flow/event_schema.rb
+++ b/app/services/evo_flow/event_schema.rb
@@ -16,6 +16,19 @@ module EvoFlow
       DEFINITIONS[event_name]
     end
 
+    # Recursively freezes a hash and any nested hash values so runtime code
+    # cannot mutate the schema (defense against accidental in-process edits).
+    # Plain `.each_value(&:freeze)` only freezes the outer entries; the
+    # inner `required:` / `optional:` hashes stay mutable without this.
+    def self.deep_freeze(obj)
+      case obj
+      when Hash
+        obj.each_value { |v| deep_freeze(v) }
+        obj.freeze
+      end
+      obj
+    end
+
     DEFINITIONS = {
     'contact.created' => {
       category: :contact,
@@ -138,7 +151,7 @@ module EvoFlow
       required: {},
       optional: {}
     }
-    }.each_value(&:freeze).freeze
+    }.tap { |defs| deep_freeze(defs) }
 
     # Sanity check at load time: every EVENT_NAME must have a schema entry.
     # Mirrors the TS-side assertCatalogCoversAllNames().

--- a/app/services/evo_flow/event_schema.rb
+++ b/app/services/evo_flow/event_schema.rb
@@ -25,8 +25,7 @@ module EvoFlow
         middle_name: :string, last_name: :string, location: :string, country_code: :string,
         contact_type: :string, blocked: :boolean, created_at: :date, updated_at: :date,
         customAttributes: :object, additionalAttributes: :object, created_via: :string
-      },
-      allow_extra_properties: true
+      }
     },
     'contact.updated' => {
       category: :contact,
@@ -37,38 +36,32 @@ module EvoFlow
         contact_type: :string, blocked: :boolean, created_at: :date, updated_at: :date,
         customAttributes: :object, additionalAttributes: :object, created_via: :string,
         changes: :object
-      },
-      allow_extra_properties: true
+      }
     },
     'contact.deleted' => {
       category: :contact,
       required: { source: :string, deleted_at: :date },
-      optional: { reason: :string },
-      allow_extra_properties: true
+      optional: { reason: :string }
     },
     'contact.label.added' => {
       category: :contact,
       required: { labelName: :string, labelId: :string, source: :string },
-      optional: {},
-      allow_extra_properties: true
+      optional: {}
     },
     'contact.label.removed' => {
       category: :contact,
       required: { labelName: :string, labelId: :string, source: :string },
-      optional: {},
-      allow_extra_properties: true
+      optional: {}
     },
     'contact.custom_attribute.changed' => {
       category: :contact,
       required: { attributeName: :string, source: :string },
-      optional: { attributeValue: :string, changeType: :string, oldValue: :string },
-      allow_extra_properties: true
+      optional: { attributeValue: :string, changeType: :string, oldValue: :string }
     },
     'conversation.created' => {
       category: :conversation,
       required: { conversation_id: :uuid, inbox_id: :number, source: :string },
-      optional: { inbox_name: :string, channel_type: :string },
-      allow_extra_properties: true
+      optional: { inbox_name: :string, channel_type: :string }
     },
     'conversation.resolved' => {
       category: :conversation,
@@ -76,8 +69,7 @@ module EvoFlow
       optional: {
         inbox_name: :string, channel_type: :string,
         resolved_by_id: :string, resolved_by_type: :string, resolution_time_seconds: :number
-      },
-      allow_extra_properties: true
+      }
     },
     'message.created' => {
       category: :message,
@@ -85,8 +77,7 @@ module EvoFlow
         message_id: :uuid, channel_type: :string, conversation_id: :uuid,
         source: :string, message_type: :string
       },
-      optional: { content_type: :string, content: :string },
-      allow_extra_properties: true
+      optional: { content_type: :string, content: :string }
     },
     'message.delivered' => {
       category: :message,
@@ -96,8 +87,7 @@ module EvoFlow
       optional: {
         message_type: :string, content_type: :string, content: :string,
         previous_status: :string, status: :string, external_error: :string
-      },
-      allow_extra_properties: true
+      }
     },
     'message.read' => {
       category: :message,
@@ -107,8 +97,7 @@ module EvoFlow
       optional: {
         message_type: :string, content_type: :string, content: :string,
         previous_status: :string, status: :string, external_error: :string
-      },
-      allow_extra_properties: true
+      }
     },
     'message.failed' => {
       category: :message,
@@ -118,8 +107,7 @@ module EvoFlow
       optional: {
         message_type: :string, content_type: :string, content: :string,
         previous_status: :string, status: :string, external_error: :string
-      },
-      allow_extra_properties: true
+      }
     },
     'campaign.triggered' => {
       category: :campaign,
@@ -128,32 +116,27 @@ module EvoFlow
         conversation_id: :uuid, contact_id: :uuid, is_lead: :boolean,
         pipeline_name: :string, pipeline_stage_id: :uuid, pipeline_stage_name: :string,
         assigned_by_id: :number, custom_fields: :object
-      },
-      allow_extra_properties: true
+      }
     },
     'campaign.message.sent' => {
       category: :campaign,
       required: { campaign_id: :uuid, message_id: :uuid, source: :string },
-      optional: { contact_id: :uuid, channel_type: :string, template_id: :uuid },
-      allow_extra_properties: true
+      optional: { contact_id: :uuid, channel_type: :string, template_id: :uuid }
     },
     'campaign.message.opened' => {
       category: :campaign,
       required: { campaign_id: :uuid, message_id: :uuid, source: :string },
-      optional: { contact_id: :uuid, opened_at: :date },
-      allow_extra_properties: true
+      optional: { contact_id: :uuid, opened_at: :date }
     },
     'campaign.message.clicked' => {
       category: :campaign,
       required: { campaign_id: :uuid, message_id: :uuid, source: :string },
-      optional: { contact_id: :uuid, url: :string, clicked_at: :date },
-      allow_extra_properties: true
+      optional: { contact_id: :uuid, url: :string, clicked_at: :date }
     },
     'custom' => {
       category: :custom,
       required: {},
-      optional: {},
-      allow_extra_properties: true
+      optional: {}
     }
     }.each_value(&:freeze).freeze
 

--- a/app/services/evo_flow/event_schema.rb
+++ b/app/services/evo_flow/event_schema.rb
@@ -1,8 +1,8 @@
 module EvoFlow
-  # Ruby mirror of evo-flow/src/modules/events/manifest/event-catalog.ts.
-  # Locked in lockstep by scripts/check-event-manifest-sync.sh (CI gate).
-  # When adding/changing an event schema, edit BOTH this file and the TS
-  # catalog — the CI script fails the build on drift.
+  # Ruby mirror of evo-flow/src/modules/events/manifest/event-catalog.ts
+  # and evo-ai-frontend-community/src/lib/events-manifest/catalog.ts.
+  # The three mirrors are kept in sync by convention; an automated CI sync
+  # gate is tracked as a follow-up (no enforcement at the moment).
   #
   # Categories: contact | conversation | message | campaign | custom.
   # FieldType (TS): string | number | boolean | date | uuid | object
@@ -73,12 +73,12 @@ module EvoFlow
     },
     'conversation.created' => {
       category: :conversation,
-      required: { conversation_id: :uuid, inbox_id: :number, source: :string },
+      required: { conversation_id: :uuid, inbox_id: :uuid, source: :string },
       optional: { inbox_name: :string, channel_type: :string }
     },
     'conversation.resolved' => {
       category: :conversation,
-      required: { conversation_id: :uuid, inbox_id: :number, source: :string },
+      required: { conversation_id: :uuid, inbox_id: :uuid, source: :string },
       optional: {
         inbox_name: :string, channel_type: :string,
         resolved_by_id: :string, resolved_by_type: :string, resolution_time_seconds: :number
@@ -128,7 +128,7 @@ module EvoFlow
       optional: {
         conversation_id: :uuid, contact_id: :uuid, is_lead: :boolean,
         pipeline_name: :string, pipeline_stage_id: :uuid, pipeline_stage_name: :string,
-        assigned_by_id: :number, custom_fields: :object
+        assigned_by_id: :uuid, custom_fields: :object
       }
     },
     'campaign.message.sent' => {

--- a/app/services/evo_flow/event_schema.rb
+++ b/app/services/evo_flow/event_schema.rb
@@ -1,0 +1,165 @@
+module EvoFlow
+  # Ruby mirror of evo-flow/src/modules/events/manifest/event-catalog.ts.
+  # Locked in lockstep by scripts/check-event-manifest-sync.sh (CI gate).
+  # When adding/changing an event schema, edit BOTH this file and the TS
+  # catalog — the CI script fails the build on drift.
+  #
+  # Categories: contact | conversation | message | campaign | custom.
+  # FieldType (TS): string | number | boolean | date | uuid | object
+  # In Ruby, the validator (EvoFlow::SchemaValidator) maps each type to a
+  # concrete predicate — see schema_validator.rb.
+  #
+  # Wrapped in a class (rather than a top-level EVENT_SCHEMA constant) so
+  # Zeitwerk's expected_definition check passes for this file's path.
+  class EventSchema
+    def self.fetch(event_name)
+      DEFINITIONS[event_name]
+    end
+
+    DEFINITIONS = {
+    'contact.created' => {
+      category: :contact,
+      required: { id: :uuid, source: :string },
+      optional: {
+        name: :string, email: :string, phone_number: :string, identifier: :string,
+        middle_name: :string, last_name: :string, location: :string, country_code: :string,
+        contact_type: :string, blocked: :boolean, created_at: :date, updated_at: :date,
+        customAttributes: :object, additionalAttributes: :object, created_via: :string
+      },
+      allow_extra_properties: true
+    },
+    'contact.updated' => {
+      category: :contact,
+      required: { id: :uuid, source: :string },
+      optional: {
+        name: :string, email: :string, phone_number: :string, identifier: :string,
+        middle_name: :string, last_name: :string, location: :string, country_code: :string,
+        contact_type: :string, blocked: :boolean, created_at: :date, updated_at: :date,
+        customAttributes: :object, additionalAttributes: :object, created_via: :string,
+        changes: :object
+      },
+      allow_extra_properties: true
+    },
+    'contact.deleted' => {
+      category: :contact,
+      required: { source: :string, deleted_at: :date },
+      optional: { reason: :string },
+      allow_extra_properties: true
+    },
+    'contact.label.added' => {
+      category: :contact,
+      required: { labelName: :string, labelId: :string, source: :string },
+      optional: {},
+      allow_extra_properties: true
+    },
+    'contact.label.removed' => {
+      category: :contact,
+      required: { labelName: :string, labelId: :string, source: :string },
+      optional: {},
+      allow_extra_properties: true
+    },
+    'contact.custom_attribute.changed' => {
+      category: :contact,
+      required: { attributeName: :string, source: :string },
+      optional: { attributeValue: :string, changeType: :string, oldValue: :string },
+      allow_extra_properties: true
+    },
+    'conversation.created' => {
+      category: :conversation,
+      required: { conversation_id: :uuid, inbox_id: :number, source: :string },
+      optional: { inbox_name: :string, channel_type: :string },
+      allow_extra_properties: true
+    },
+    'conversation.resolved' => {
+      category: :conversation,
+      required: { conversation_id: :uuid, inbox_id: :number, source: :string },
+      optional: {
+        inbox_name: :string, channel_type: :string,
+        resolved_by_id: :string, resolved_by_type: :string, resolution_time_seconds: :number
+      },
+      allow_extra_properties: true
+    },
+    'message.created' => {
+      category: :message,
+      required: {
+        message_id: :uuid, channel_type: :string, conversation_id: :uuid,
+        source: :string, message_type: :string
+      },
+      optional: { content_type: :string, content: :string },
+      allow_extra_properties: true
+    },
+    'message.delivered' => {
+      category: :message,
+      required: {
+        message_id: :uuid, channel_type: :string, conversation_id: :uuid, source: :string
+      },
+      optional: {
+        message_type: :string, content_type: :string, content: :string,
+        previous_status: :string, status: :string, external_error: :string
+      },
+      allow_extra_properties: true
+    },
+    'message.read' => {
+      category: :message,
+      required: {
+        message_id: :uuid, channel_type: :string, conversation_id: :uuid, source: :string
+      },
+      optional: {
+        message_type: :string, content_type: :string, content: :string,
+        previous_status: :string, status: :string, external_error: :string
+      },
+      allow_extra_properties: true
+    },
+    'message.failed' => {
+      category: :message,
+      required: {
+        message_id: :uuid, channel_type: :string, conversation_id: :uuid, source: :string
+      },
+      optional: {
+        message_type: :string, content_type: :string, content: :string,
+        previous_status: :string, status: :string, external_error: :string
+      },
+      allow_extra_properties: true
+    },
+    'campaign.triggered' => {
+      category: :campaign,
+      required: { pipeline_item_id: :uuid, pipeline_id: :uuid, source: :string },
+      optional: {
+        conversation_id: :uuid, contact_id: :uuid, is_lead: :boolean,
+        pipeline_name: :string, pipeline_stage_id: :uuid, pipeline_stage_name: :string,
+        assigned_by_id: :number, custom_fields: :object
+      },
+      allow_extra_properties: true
+    },
+    'campaign.message.sent' => {
+      category: :campaign,
+      required: { campaign_id: :uuid, message_id: :uuid, source: :string },
+      optional: { contact_id: :uuid, channel_type: :string, template_id: :uuid },
+      allow_extra_properties: true
+    },
+    'campaign.message.opened' => {
+      category: :campaign,
+      required: { campaign_id: :uuid, message_id: :uuid, source: :string },
+      optional: { contact_id: :uuid, opened_at: :date },
+      allow_extra_properties: true
+    },
+    'campaign.message.clicked' => {
+      category: :campaign,
+      required: { campaign_id: :uuid, message_id: :uuid, source: :string },
+      optional: { contact_id: :uuid, url: :string, clicked_at: :date },
+      allow_extra_properties: true
+    },
+    'custom' => {
+      category: :custom,
+      required: {},
+      optional: {},
+      allow_extra_properties: true
+    }
+    }.each_value(&:freeze).freeze
+
+    # Sanity check at load time: every EVENT_NAME must have a schema entry.
+    # Mirrors the TS-side assertCatalogCoversAllNames().
+    missing = EvoFlow::EVENT_NAMES.reject { |name| DEFINITIONS.key?(name) }
+    raise "EvoFlow::EventSchema::DEFINITIONS is missing entries: #{missing.join(', ')}" if missing.any?
+  end
+end

--- a/app/services/evo_flow/invalid_event_payload.rb
+++ b/app/services/evo_flow/invalid_event_payload.rb
@@ -11,10 +11,12 @@ module EvoFlow
 
     def initialize(event_name:, field:, reason:, details: nil)
       @event_name = event_name
-      @field = field
+      # L2 fix: field is always a String so alerts/dashboards parsing both
+      # Ruby and TS error shapes get the same value.
+      @field = field.to_s
       @reason = reason
       details_str = details ? " (#{details})" : ''
-      super("Invalid EvoFlow payload for #{event_name.inspect}: #{reason} on field #{field.inspect}#{details_str}")
+      super("Invalid EvoFlow payload for #{event_name.inspect}: #{reason} on field #{@field.inspect}#{details_str}")
     end
   end
 end

--- a/app/services/evo_flow/invalid_event_payload.rb
+++ b/app/services/evo_flow/invalid_event_payload.rb
@@ -1,0 +1,20 @@
+module EvoFlow
+  # Raised when an event payload (track properties / identify traits) is
+  # missing a required field or carries a value whose type does not match
+  # the schema declared in EvoFlow::EVENT_SCHEMA.
+  #
+  # F4-style exception: a payload bug is a producer bug, not a transient
+  # failure. PublishEventWorker drops it (log + broadcast :evo_flow_publish_dropped)
+  # without retry, matching the InvalidEventName contract.
+  class InvalidEventPayload < StandardError
+    attr_reader :event_name, :field, :reason
+
+    def initialize(event_name:, field:, reason:, details: nil)
+      @event_name = event_name
+      @field = field
+      @reason = reason
+      details_str = details ? " (#{details})" : ''
+      super("Invalid EvoFlow payload for #{event_name.inspect}: #{reason} on field #{field.inspect}#{details_str}")
+    end
+  end
+end

--- a/app/services/evo_flow/payload_builder.rb
+++ b/app/services/evo_flow/payload_builder.rb
@@ -11,6 +11,7 @@ module EvoFlow
     # Exactly 5 kwargs (RuboCop ParameterLists max 5 — do not add a 6th).
     def self.build_track(event_name:, contact_id:, properties:, occurred_at:, message_id:)
       validate_event_name!(event_name)
+      EvoFlow::SchemaValidator.validate!(event_name, properties || {})
       {
         messageId: message_id,
         contactId: contact_id.to_s,
@@ -22,6 +23,7 @@ module EvoFlow
 
     def self.build_identify(event_name:, contact_id:, traits:, occurred_at:, message_id:)
       validate_event_name!(event_name)
+      EvoFlow::SchemaValidator.validate!(event_name, traits || {})
       {
         messageId: message_id,
         contactId: contact_id.to_s,

--- a/app/services/evo_flow/schema_validator.rb
+++ b/app/services/evo_flow/schema_validator.rb
@@ -17,9 +17,9 @@ module EvoFlow
 
       schema[:required].each do |field, type|
         value = normalized[field.to_s]
-        if value.nil?
+        if missing?(value, type)
           raise EvoFlow::InvalidEventPayload.new(
-            event_name: event_name, field: field, reason: :missing_required
+            event_name: event_name, field: field.to_s, reason: :missing_required
           )
         end
         assert_type!(event_name, field, type, value)
@@ -27,11 +27,21 @@ module EvoFlow
 
       schema[:optional].each do |field, type|
         value = normalized[field.to_s]
-        next if value.nil?
+        next if missing?(value, type)
 
         assert_type!(event_name, field, type, value)
       end
     end
+
+    # AC3: a required field is missing when it is nil OR an empty string for
+    # string-like types. false/0 stay valid for their types.
+    def self.missing?(value, type)
+      return true if value.nil?
+      return true if [:string, :uuid].include?(type) && value.is_a?(String) && value.empty?
+
+      false
+    end
+    private_class_method :missing?
 
     def self.stringify_keys(hash)
       return {} if hash.nil?
@@ -44,7 +54,7 @@ module EvoFlow
       return if matches_type?(type, value)
 
       raise EvoFlow::InvalidEventPayload.new(
-        event_name: event_name, field: field, reason: :invalid_type,
+        event_name: event_name, field: field.to_s, reason: :invalid_type,
         details: "expected #{type}, got #{value.class}"
       )
     end
@@ -63,14 +73,17 @@ module EvoFlow
     end
     private_class_method :matches_type?
 
-    # Listeners pass UUIDs as strings AND raw integers (legacy contact_id paths).
-    # Accept both — server-side downstream coerces to string.
+    # Listeners pass UUIDs as canonical strings AND raw integers (legacy
+    # contact_id paths). Accept canonical UUIDs, numeric strings (string-encoded
+    # legacy ids), or any Numeric value. Arbitrary strings like "hello" are
+    # rejected so the :uuid type does not lie about validation.
     def self.matches_uuid?(value)
-      return true if value.is_a?(String) && UUID_REGEX.match?(value)
-      return true if value.is_a?(String) && value.length.positive?
       return true if value.is_a?(Integer) || value.is_a?(Numeric)
+      return false unless value.is_a?(String)
+      return false if value.empty?
+      return true if UUID_REGEX.match?(value)
 
-      false
+      !!(Integer(value) rescue false)
     end
     private_class_method :matches_uuid?
 

--- a/app/services/evo_flow/schema_validator.rb
+++ b/app/services/evo_flow/schema_validator.rb
@@ -1,0 +1,88 @@
+module EvoFlow
+  # Validates an event payload (properties for track, traits for identify)
+  # against the schema declared in EvoFlow::EVENT_SCHEMA.
+  #
+  # Called from EvoFlow::PayloadBuilder.build_track / build_identify after
+  # validate_event_name!. Raises EvoFlow::InvalidEventPayload, which the
+  # worker treats the same as InvalidEventName: log + drop + broadcast
+  # :evo_flow_publish_dropped, no retry.
+  class SchemaValidator
+    UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i.freeze
+
+    def self.validate!(event_name, payload)
+      schema = EvoFlow::EventSchema.fetch(event_name)
+      return if schema.nil?
+
+      normalized = stringify_keys(payload)
+
+      schema[:required].each do |field, type|
+        value = normalized[field.to_s]
+        if value.nil?
+          raise EvoFlow::InvalidEventPayload.new(
+            event_name: event_name, field: field, reason: :missing_required
+          )
+        end
+        assert_type!(event_name, field, type, value)
+      end
+
+      schema[:optional].each do |field, type|
+        value = normalized[field.to_s]
+        next if value.nil?
+
+        assert_type!(event_name, field, type, value)
+      end
+    end
+
+    def self.stringify_keys(hash)
+      return {} if hash.nil?
+
+      hash.each_with_object({}) { |(k, v), acc| acc[k.to_s] = v }
+    end
+    private_class_method :stringify_keys
+
+    def self.assert_type!(event_name, field, type, value)
+      return if matches_type?(type, value)
+
+      raise EvoFlow::InvalidEventPayload.new(
+        event_name: event_name, field: field, reason: :invalid_type,
+        details: "expected #{type}, got #{value.class}"
+      )
+    end
+    private_class_method :assert_type!
+
+    def self.matches_type?(type, value)
+      case type
+      when :string then value.is_a?(String)
+      when :number then value.is_a?(Numeric)
+      when :boolean then [true, false].include?(value)
+      when :object then value.is_a?(Hash)
+      when :uuid then matches_uuid?(value)
+      when :date then matches_date?(value)
+      else false
+      end
+    end
+    private_class_method :matches_type?
+
+    # Listeners pass UUIDs as strings AND raw integers (legacy contact_id paths).
+    # Accept both — server-side downstream coerces to string.
+    def self.matches_uuid?(value)
+      return true if value.is_a?(String) && UUID_REGEX.match?(value)
+      return true if value.is_a?(String) && value.length.positive?
+      return true if value.is_a?(Integer) || value.is_a?(Numeric)
+
+      false
+    end
+    private_class_method :matches_uuid?
+
+    def self.matches_date?(value)
+      return true if value.respond_to?(:iso8601)
+      return false unless value.is_a?(String)
+
+      Time.iso8601(value)
+      true
+    rescue ArgumentError
+      false
+    end
+    private_class_method :matches_date?
+  end
+end

--- a/app/workers/evo_flow/publish_event_worker.rb
+++ b/app/workers/evo_flow/publish_event_worker.rb
@@ -101,6 +101,16 @@ module EvoFlow
         reason: :invalid_event_name, path: path, error_message: e.message
       )
       nil
+    rescue EvoFlow::InvalidEventPayload => e
+      # Same F4 contract as InvalidEventName: payload-schema bugs are producer
+      # bugs, not transient failures. Retry will keep producing the same
+      # malformed payload until exhaustion. Drop + broadcast so alerts can
+      # surface "events silently parked" without polluting the retry pipeline.
+      Rails.logger.error("[EvoFlow] dropped: invalid payload path=#{path} msg=#{e.message}")
+      FailureBroadcaster.new.broadcast_dropped(
+        reason: :invalid_event_payload, path: path, error_message: e.message
+      )
+      nil
     rescue EvoFlow::ConfigurationError => e
       # F4 exception: env/config bug, not transient. Retrying just floods the
       # Dead Set with the same env-var error. Drop the job (Sidekiq sees

--- a/config/initializers/evo_flow_listeners.rb
+++ b/config/initializers/evo_flow_listeners.rb
@@ -12,5 +12,12 @@ Rails.application.config.after_initialize do
   Wisper.subscribe(EvoFlow::MessageEventsListener.new)
   Wisper.subscribe(EvoFlow::PipelineEventsListener.new)
 
+  # Eager-reference EventSchema so its boot-time sanity check (verifies every
+  # EVENT_NAME has a DEFINITIONS entry) runs at startup, not lazily on the
+  # first event publish. Without this Zeitwerk would only load EventSchema
+  # when the first publisher calls into it — potentially hours after a deploy
+  # that broke the EVENT_NAMES <-> DEFINITIONS sync.
+  EvoFlow::EventSchema
+
   Rails.logger.info 'EvoFlow listeners registered (contact, conversation, message, pipeline)'
 end

--- a/lib/events/evo_flow_event_names.rb
+++ b/lib/events/evo_flow_event_names.rb
@@ -7,6 +7,7 @@ module EvoFlow
     conversation.created conversation.resolved
     message.created message.delivered message.read message.failed
     campaign.triggered campaign.message.sent campaign.message.opened campaign.message.clicked
+    custom
   ].freeze
 
   # Feature gate. Primary ENV is `EVO_FLOW_ENABLED`; legacy

--- a/spec/listeners/evo_flow/conversation_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/conversation_events_listener_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe EvoFlow::ConversationEventsListener do
       Conversation,
       id: 100,
       contact_id: 42,
-      inbox_id: 7,
+      inbox_id: '550e8400-e29b-41d4-a716-446655440007',
       inbox: inbox,
       created_at: created_at,
       updated_at: updated_at
@@ -47,7 +47,7 @@ RSpec.describe EvoFlow::ConversationEventsListener do
       expect(sent['messageId']).to eq(fixed_digest)
       expect(sent['properties']).to include(
         'conversation_id' => 100,
-        'inbox_id' => 7,
+        'inbox_id' => '550e8400-e29b-41d4-a716-446655440007',
         'inbox_name' => 'Support',
         'channel_type' => 'Channel::WebWidget',
         'source' => 'conversation_management'
@@ -136,7 +136,7 @@ RSpec.describe EvoFlow::ConversationEventsListener do
       expect(sent['contactId']).to eq('42')
       expect(sent['properties']).to include(
         'conversation_id' => 100,
-        'inbox_id' => 7,
+        'inbox_id' => '550e8400-e29b-41d4-a716-446655440007',
         'channel_type' => 'Channel::WebWidget',
         'resolution_time_seconds' => 1800,
         'source' => 'conversation_management'

--- a/spec/services/evo_flow/payload_builder_spec.rb
+++ b/spec/services/evo_flow/payload_builder_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe EvoFlow::PayloadBuilder do
         described_class.build_track(
           event_name: 'message.delivered',
           contact_id: 1,
-          properties: { channel_type: 'Channel::Whatsapp', conversation_id: 'c1', source: 'm' },
+          properties: { channel_type: 'Channel::Whatsapp', conversation_id: '550e8400-e29b-41d4-a716-446655440002', source: 'm' },
           occurred_at: occurred_at,
           message_id: 'x'
         )
@@ -169,19 +169,28 @@ RSpec.describe EvoFlow::PayloadBuilder do
   # builder raises EvoFlow::InvalidEventName. Caught in CI, not prod —
   # listeners rescue StandardError and tag enqueue-loss.
   describe 'event_name validation (AC6)' do
-    # Kitchen-sink payload covers required fields of every canonical event in
-    # EVENT_NAMES so the loop exercises name validation without tripping the
-    # EVO-1261 SchemaValidator. allow_extra_properties=true everywhere accepts
-    # the unused keys per event.
+    # L3: derive the union of required fields directly from EVENT_SCHEMA so
+    # adding a new event with a new required field automatically updates this
+    # fixture — no silent coverage gap on the loop test below.
     let(:kitchen_sink_properties) do
-      {
-        id: 'c-1', source: 'source', deleted_at: occurred_at,
-        labelName: 'lbl', labelId: 'lbl-1', attributeName: 'attr',
-        conversation_id: 'conv-1', inbox_id: 7,
-        message_id: 'msg-1', channel_type: 'Channel::Whatsapp', message_type: 'incoming',
-        pipeline_item_id: 'pi-1', pipeline_id: 'p-1',
-        campaign_id: 'cmp-1'
-      }
+      union = EvoFlow::EVENT_NAMES.each_with_object({}) do |name, acc|
+        schema = EvoFlow::EventSchema.fetch(name)
+        next unless schema
+
+        schema[:required].each { |field, type| acc[field] ||= sample_value(type) }
+      end
+      union
+    end
+
+    def sample_value(type)
+      case type
+      when :string then 'sample'
+      when :number then 7
+      when :boolean then false
+      when :object then {}
+      when :uuid then '550e8400-e29b-41d4-a716-446655440000'
+      when :date then occurred_at
+      end
     end
 
     it 'accepts canonical event_names from EvoFlow::EVENT_NAMES' do

--- a/spec/services/evo_flow/payload_builder_spec.rb
+++ b/spec/services/evo_flow/payload_builder_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe EvoFlow::PayloadBuilder do
   let(:occurred_at) { Time.zone.parse('2026-05-19T12:00:00Z') }
 
   describe '.build_track (real TrackEventDto)' do
+    # Use the 'custom' sentinel for DTO-shape tests so they stay decoupled from
+    # any specific event's schema (EVO-1261 SchemaValidator runs on canonical
+    # names; custom is the documented free-form fallback).
     subject(:payload) do
       described_class.build_track(
-        event_name: 'contact.created',
+        event_name: 'custom',
         contact_id: 42,
         properties: { a: 1 },
         occurred_at: occurred_at,
@@ -18,7 +21,7 @@ RSpec.describe EvoFlow::PayloadBuilder do
       expect(payload).to eq(
         messageId: 'sha',
         contactId: '42',
-        event: 'contact.created',
+        event: 'custom',
         properties: { a: 1 },
         timestamp: occurred_at.utc.iso8601
       )
@@ -32,7 +35,7 @@ RSpec.describe EvoFlow::PayloadBuilder do
 
     it 'stringifies contactId and defaults nil properties to {}' do
       built = described_class.build_track(
-        event_name: 'contact.created', contact_id: 7,
+        event_name: 'custom', contact_id: 7,
         properties: nil, occurred_at: occurred_at, message_id: 'x'
       )
       expect(built[:contactId]).to eq('7')
@@ -58,12 +61,25 @@ RSpec.describe EvoFlow::PayloadBuilder do
         end.to raise_error(EvoFlow::InvalidEventName, /Unknown EvoFlow event_name: nil/)
       end
     end
+
+    # EVO-1261: SchemaValidator runs after validate_event_name!.
+    it 'raises EvoFlow::InvalidEventPayload when required schema fields are missing' do
+      expect do
+        described_class.build_track(
+          event_name: 'message.delivered',
+          contact_id: 1,
+          properties: { channel_type: 'Channel::Whatsapp', conversation_id: 'c1', source: 'm' },
+          occurred_at: occurred_at,
+          message_id: 'x'
+        )
+      end.to raise_error(EvoFlow::InvalidEventPayload, /message_id/)
+    end
   end
 
   describe '.build_identify (real IdentifyEventDto)' do
     subject(:payload) do
       described_class.build_identify(
-        event_name: 'contact.updated',
+        event_name: 'custom',
         contact_id: 42,
         traits: { email: 'x' },
         occurred_at: occurred_at,
@@ -75,7 +91,7 @@ RSpec.describe EvoFlow::PayloadBuilder do
       expect(payload).to eq(
         messageId: 'sha',
         contactId: '42',
-        eventName: 'contact.updated',
+        eventName: 'custom',
         traits: { email: 'x' },
         timestamp: occurred_at.utc.iso8601
       )
@@ -96,6 +112,19 @@ RSpec.describe EvoFlow::PayloadBuilder do
           )
         end.to raise_error(EvoFlow::InvalidEventName, /Unknown EvoFlow event_name: "tambem_nao"/)
       end
+    end
+
+    # EVO-1261: SchemaValidator runs after validate_event_name!.
+    it 'raises EvoFlow::InvalidEventPayload when traits miss a required field' do
+      expect do
+        described_class.build_identify(
+          event_name: 'contact.created',
+          contact_id: 1,
+          traits: { source: 'contact_created' },
+          occurred_at: occurred_at,
+          message_id: 'x'
+        )
+      end.to raise_error(EvoFlow::InvalidEventPayload, /id/)
     end
   end
 
@@ -140,11 +169,26 @@ RSpec.describe EvoFlow::PayloadBuilder do
   # builder raises EvoFlow::InvalidEventName. Caught in CI, not prod —
   # listeners rescue StandardError and tag enqueue-loss.
   describe 'event_name validation (AC6)' do
+    # Kitchen-sink payload covers required fields of every canonical event in
+    # EVENT_NAMES so the loop exercises name validation without tripping the
+    # EVO-1261 SchemaValidator. allow_extra_properties=true everywhere accepts
+    # the unused keys per event.
+    let(:kitchen_sink_properties) do
+      {
+        id: 'c-1', source: 'source', deleted_at: occurred_at,
+        labelName: 'lbl', labelId: 'lbl-1', attributeName: 'attr',
+        conversation_id: 'conv-1', inbox_id: 7,
+        message_id: 'msg-1', channel_type: 'Channel::Whatsapp', message_type: 'incoming',
+        pipeline_item_id: 'pi-1', pipeline_id: 'p-1',
+        campaign_id: 'cmp-1'
+      }
+    end
+
     it 'accepts canonical event_names from EvoFlow::EVENT_NAMES' do
       EvoFlow::EVENT_NAMES.each do |name|
         expect do
           described_class.build_track(
-            event_name: name, contact_id: 1, properties: {},
+            event_name: name, contact_id: 1, properties: kitchen_sink_properties,
             occurred_at: occurred_at, message_id: 'x'
           )
         end.not_to raise_error

--- a/spec/services/evo_flow/schema_validator_spec.rb
+++ b/spec/services/evo_flow/schema_validator_spec.rb
@@ -149,6 +149,24 @@ RSpec.describe EvoFlow::SchemaValidator do
       end
     end
 
+    # F4: deep-freeze invariant — defends against runtime mutation of the
+    # schema by production code.
+    context 'F4: schema is deep-frozen' do
+      it 'freezes the outer DEFINITIONS hash' do
+        expect(EvoFlow::EventSchema::DEFINITIONS).to be_frozen
+      end
+
+      it 'freezes per-event entry hashes' do
+        expect(EvoFlow::EventSchema::DEFINITIONS['message.delivered']).to be_frozen
+      end
+
+      it 'freezes nested required/optional hashes' do
+        entry = EvoFlow::EventSchema::DEFINITIONS['message.delivered']
+        expect(entry[:required]).to be_frozen
+        expect(entry[:optional]).to be_frozen
+      end
+    end
+
     context 'type validation' do
       it 'rejects boolean where uuid is expected' do
         expect do

--- a/spec/services/evo_flow/schema_validator_spec.rb
+++ b/spec/services/evo_flow/schema_validator_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe EvoFlow::SchemaValidator do
           described_class.validate!(
             'message.delivered',
             channel_type: 'Channel::Whatsapp',
-            conversation_id: 'conv-uuid',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
             source: 'messaging'
           )
         end.to raise_error(EvoFlow::InvalidEventPayload) do |err|
           expect(err.event_name).to eq('message.delivered')
-          expect(err.field).to eq(:message_id)
+          expect(err.field).to eq('message_id')
           expect(err.reason).to eq(:missing_required)
         end
       end
@@ -42,9 +42,9 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!(
             'message.delivered',
-            message_id: 'msg-1',
+            message_id: '550e8400-e29b-41d4-a716-446655440000',
             channel_type: 'Channel::Whatsapp',
-            conversation_id: 'conv-1',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
             source: 'messaging'
           )
         end.not_to raise_error
@@ -54,9 +54,9 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!(
             'message.delivered',
-            'message_id' => 'msg-1',
+            'message_id' => '550e8400-e29b-41d4-a716-446655440000',
             'channel_type' => 'Channel::Whatsapp',
-            'conversation_id' => 'conv-1',
+            'conversation_id' => '550e8400-e29b-41d4-a716-446655440001',
             'source' => 'messaging'
           )
         end.not_to raise_error
@@ -68,14 +68,84 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!('contact.created', source: 'contact_created')
         end.to raise_error(EvoFlow::InvalidEventPayload) do |err|
-          expect(err.field).to eq(:id)
+          expect(err.field).to eq('id')
         end
       end
 
       it 'accepts contact.created when id and source are present' do
         expect do
-          described_class.validate!('contact.created', id: 'c-1', source: 'contact_created')
+          described_class.validate!('contact.created', id: '550e8400-e29b-41d4-a716-446655440000', source: 'contact_created')
         end.not_to raise_error
+      end
+    end
+
+    context 'H1: empty string is treated as missing for string-like required fields' do
+      it 'raises MissingRequiredField when message_id is empty string' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            message_id: '',
+            channel_type: 'Channel::Whatsapp',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440002',
+            source: 'messaging'
+          )
+        end.to raise_error(EvoFlow::InvalidEventPayload) do |err|
+          expect(err.field).to eq('message_id')
+          expect(err.reason).to eq(:missing_required)
+        end
+      end
+
+      it 'accepts false/0 for boolean/number fields (not treated as missing)' do
+        expect do
+          described_class.validate!(
+            'campaign.triggered',
+            pipeline_item_id: '550e8400-e29b-41d4-a716-446655440000', pipeline_id: '550e8400-e29b-41d4-a716-446655440001', source: 's',
+            is_lead: false, assigned_by_id: 0
+          )
+        end.not_to raise_error
+      end
+    end
+
+    context 'M1: :uuid type strictness' do
+      it 'rejects arbitrary non-UUID non-numeric strings' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            message_id: 'not-a-uuid', channel_type: 'Channel::Whatsapp',
+            conversation_id: 'also-not-a-uuid', source: 's'
+          )
+        end.to raise_error(EvoFlow::InvalidEventPayload)
+      end
+
+      it 'accepts canonical UUID strings' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            message_id: '550e8400-e29b-41d4-a716-446655440000',
+            channel_type: 'Channel::Whatsapp',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
+            source: 's'
+          )
+        end.not_to raise_error
+      end
+
+      it 'accepts numeric strings (legacy contact_id paths emit "42")' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            message_id: '42', channel_type: 'Channel::Whatsapp',
+            conversation_id: '99', source: 's'
+          )
+        end.not_to raise_error
+      end
+    end
+
+    # L4: invariant — custom MUST always accept any payload.
+    context 'L4: custom sentinel invariant (AC4)' do
+      it 'has empty required and empty optional schemas' do
+        schema = EvoFlow::EventSchema.fetch('custom')
+        expect(schema[:required]).to eq({})
+        expect(schema[:optional]).to eq({})
       end
     end
 
@@ -86,11 +156,11 @@ RSpec.describe EvoFlow::SchemaValidator do
             'message.delivered',
             message_id: true,
             channel_type: 'Channel::Whatsapp',
-            conversation_id: 'conv-1',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
             source: 'messaging'
           )
         end.to raise_error(EvoFlow::InvalidEventPayload) do |err|
-          expect(err.field).to eq(:message_id)
+          expect(err.field).to eq('message_id')
           expect(err.reason).to eq(:invalid_type)
         end
       end
@@ -101,7 +171,7 @@ RSpec.describe EvoFlow::SchemaValidator do
             'message.created',
             message_id: 42,
             channel_type: 'Channel::Whatsapp',
-            conversation_id: 'conv-1',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
             source: 'messaging',
             message_type: 'incoming'
           )
@@ -142,7 +212,7 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!(
             'conversation.created',
-            conversation_id: 'conv-1',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
             inbox_id: 'seven',
             source: 'conversation_management'
           )
@@ -155,7 +225,7 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!(
             'conversation.created',
-            conversation_id: 'conv-1', inbox_id: 7, source: 'conversation_management'
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001', inbox_id: 7, source: 'conversation_management'
           )
         end.not_to raise_error
       end
@@ -164,7 +234,7 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!(
             'conversation.created',
-            conversation_id: 'conv-1', inbox_id: 7, source: 'conversation_management',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001', inbox_id: 7, source: 'conversation_management',
             channel_type: 12345
           )
         end.to raise_error(EvoFlow::InvalidEventPayload)

--- a/spec/services/evo_flow/schema_validator_spec.rb
+++ b/spec/services/evo_flow/schema_validator_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe EvoFlow::SchemaValidator do
         end.to raise_error(EvoFlow::InvalidEventPayload)
       end
 
-      it 'rejects a string where number is expected' do
+      it 'rejects an arbitrary string where uuid is expected' do
         expect do
           described_class.validate!(
             'conversation.created',
@@ -243,7 +243,9 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!(
             'conversation.created',
-            conversation_id: '550e8400-e29b-41d4-a716-446655440001', inbox_id: 7, source: 'conversation_management'
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
+            inbox_id: '550e8400-e29b-41d4-a716-446655440002',
+            source: 'conversation_management'
           )
         end.not_to raise_error
       end
@@ -252,7 +254,9 @@ RSpec.describe EvoFlow::SchemaValidator do
         expect do
           described_class.validate!(
             'conversation.created',
-            conversation_id: '550e8400-e29b-41d4-a716-446655440001', inbox_id: 7, source: 'conversation_management',
+            conversation_id: '550e8400-e29b-41d4-a716-446655440001',
+            inbox_id: '550e8400-e29b-41d4-a716-446655440002',
+            source: 'conversation_management',
             channel_type: 12345
           )
         end.to raise_error(EvoFlow::InvalidEventPayload)

--- a/spec/services/evo_flow/schema_validator_spec.rb
+++ b/spec/services/evo_flow/schema_validator_spec.rb
@@ -1,0 +1,174 @@
+require 'rails_helper'
+
+RSpec.describe EvoFlow::SchemaValidator do
+  describe '.validate!' do
+    context 'when the event name is not in the schema (unknown / future)' do
+      it 'passes through silently to preserve forward-compat' do
+        expect do
+          described_class.validate!('not.a.real.event', {})
+        end.not_to raise_error
+      end
+    end
+
+    context 'when the event is "custom"' do
+      it 'accepts any free-form payload (AC4)' do
+        expect do
+          described_class.validate!('custom', { anything: 1, deeply: 'whatever' })
+        end.not_to raise_error
+      end
+
+      it 'accepts an empty payload' do
+        expect { described_class.validate!('custom', {}) }.not_to raise_error
+      end
+    end
+
+    context 'AC3 — required-field enforcement (track event)' do
+      it 'raises InvalidEventPayload when message.delivered is missing message_id' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            channel_type: 'Channel::Whatsapp',
+            conversation_id: 'conv-uuid',
+            source: 'messaging'
+          )
+        end.to raise_error(EvoFlow::InvalidEventPayload) do |err|
+          expect(err.event_name).to eq('message.delivered')
+          expect(err.field).to eq(:message_id)
+          expect(err.reason).to eq(:missing_required)
+        end
+      end
+
+      it 'accepts message.delivered when all required fields are present' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            message_id: 'msg-1',
+            channel_type: 'Channel::Whatsapp',
+            conversation_id: 'conv-1',
+            source: 'messaging'
+          )
+        end.not_to raise_error
+      end
+
+      it 'tolerates string keys (Sidekiq round-trips through JSON)' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            'message_id' => 'msg-1',
+            'channel_type' => 'Channel::Whatsapp',
+            'conversation_id' => 'conv-1',
+            'source' => 'messaging'
+          )
+        end.not_to raise_error
+      end
+    end
+
+    context 'AC3 — required-field enforcement (identify event)' do
+      it 'raises InvalidEventPayload when contact.created traits lack id' do
+        expect do
+          described_class.validate!('contact.created', source: 'contact_created')
+        end.to raise_error(EvoFlow::InvalidEventPayload) do |err|
+          expect(err.field).to eq(:id)
+        end
+      end
+
+      it 'accepts contact.created when id and source are present' do
+        expect do
+          described_class.validate!('contact.created', id: 'c-1', source: 'contact_created')
+        end.not_to raise_error
+      end
+    end
+
+    context 'type validation' do
+      it 'rejects boolean where uuid is expected' do
+        expect do
+          described_class.validate!(
+            'message.delivered',
+            message_id: true,
+            channel_type: 'Channel::Whatsapp',
+            conversation_id: 'conv-1',
+            source: 'messaging'
+          )
+        end.to raise_error(EvoFlow::InvalidEventPayload) do |err|
+          expect(err.field).to eq(:message_id)
+          expect(err.reason).to eq(:invalid_type)
+        end
+      end
+
+      it 'accepts numeric uuid values from legacy contact_id paths' do
+        expect do
+          described_class.validate!(
+            'message.created',
+            message_id: 42,
+            channel_type: 'Channel::Whatsapp',
+            conversation_id: 'conv-1',
+            source: 'messaging',
+            message_type: 'incoming'
+          )
+        end.not_to raise_error
+      end
+
+      it 'accepts ISO-8601 strings for date fields' do
+        expect do
+          described_class.validate!(
+            'contact.deleted',
+            source: 'contact_deleted',
+            deleted_at: '2026-05-25T12:00:00Z'
+          )
+        end.not_to raise_error
+      end
+
+      it 'accepts Time/ActiveSupport::TimeWithZone for date fields' do
+        expect do
+          described_class.validate!(
+            'contact.deleted',
+            source: 'contact_deleted',
+            deleted_at: Time.zone.parse('2026-05-25T12:00:00Z')
+          )
+        end.not_to raise_error
+      end
+
+      it 'rejects an unparseable string for a date field' do
+        expect do
+          described_class.validate!(
+            'contact.deleted',
+            source: 'contact_deleted',
+            deleted_at: 'not-a-date'
+          )
+        end.to raise_error(EvoFlow::InvalidEventPayload)
+      end
+
+      it 'rejects a string where number is expected' do
+        expect do
+          described_class.validate!(
+            'conversation.created',
+            conversation_id: 'conv-1',
+            inbox_id: 'seven',
+            source: 'conversation_management'
+          )
+        end.to raise_error(EvoFlow::InvalidEventPayload)
+      end
+    end
+
+    context 'optional fields' do
+      it 'allows the field to be absent' do
+        expect do
+          described_class.validate!(
+            'conversation.created',
+            conversation_id: 'conv-1', inbox_id: 7, source: 'conversation_management'
+          )
+        end.not_to raise_error
+      end
+
+      it 'still type-checks the field when present' do
+        expect do
+          described_class.validate!(
+            'conversation.created',
+            conversation_id: 'conv-1', inbox_id: 7, source: 'conversation_management',
+            channel_type: 12345
+          )
+        end.to raise_error(EvoFlow::InvalidEventPayload)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `EvoFlow::EventSchema::DEFINITIONS` — Ruby mirror of the TS catalog from evolution-foundation/evo-flow#4. Identical structure (categories, required, optional, types). Deep-frozen at load time.
- Adds `EvoFlow::SchemaValidator.validate!(event_name, payload)` called from `EvoFlow::PayloadBuilder.build_track` / `build_identify` after the existing `validate_event_name!`. Raises `EvoFlow::InvalidEventPayload` (new F4-style exception, no retry).
- `PublishEventWorker` rescues `InvalidEventPayload` mirroring the `InvalidEventName` contract: log + broadcast `:evo_flow_publish_dropped`, no retry, no Dead Set entry.
- Promotes `custom` to a first-class entry in `EvoFlow::EVENT_NAMES` so `validate_event_name!` accepts the AC4 fallback sentinel.
- Eager-references `EvoFlow::EventSchema` in `config/initializers/evo_flow_listeners.rb` so the boot-time invariant assertion runs at startup, not lazily on first publish.

## Security

- Defense-in-depth: schema check runs at the publisher (here) AND at the gateway (evo-flow pipe in #4). Either layer alone leaves a hole.
- `:uuid` type accepts canonical UUIDs, integer strings (legacy `contact_id` paths emit `"42"`), or `Numeric` values; arbitrary strings like `"hello"` are rejected.
- Empty strings treated as missing for `:string` and `:uuid` required fields (closes AC3 hole).
- `EVENT_SCHEMA` is deep-frozen so runtime code cannot mutate the contract from production code paths.
- `InvalidEventPayload#field` is always String (consistent with the TS pipe error shape) so alerts/dashboards parsing both surfaces don't need to coerce.

## Test plan

- `bundle exec rspec spec/services/evo_flow/` → 59/59 passing
- Smoke (CRM running local): create a contact → observe `:evo_flow_publish_dropped` does NOT fire for `:invalid_event_payload` (validator agrees with what the existing listeners emit).

## Changed Files

- `app/services/evo_flow/event_schema.rb` (new — Ruby mirror)
- `app/services/evo_flow/schema_validator.rb` (new)
- `app/services/evo_flow/invalid_event_payload.rb` (new exception)
- `app/services/evo_flow/payload_builder.rb` (wires validator into build_track/build_identify)
- `app/workers/evo_flow/publish_event_worker.rb` (rescue InvalidEventPayload)
- `lib/events/evo_flow_event_names.rb` (added `custom` to EVENT_NAMES)
- `config/initializers/evo_flow_listeners.rb` (eager-references EventSchema)
- `spec/services/evo_flow/schema_validator_spec.rb` (new)
- `spec/services/evo_flow/payload_builder_spec.rb` (extended; kitchen_sink now derived from schema, no longer hand-maintained)

## Linked Issue

- https://linear.app/evoai/issue/EVO-1261

## Related PRs

- evo-flow: https://github.com/evolution-foundation/evo-flow/pull/4
- evo-ai-frontend-community: `<EventSelector>` + `<EventPropertiesForm>` shared components