### PR TITLE
feat(automation_rules): extract shared action handlers + wire 5 new flow node types (EVO-1262)

### DIFF
--- a/app/services/automation_rules/README.md
+++ b/app/services/automation_rules/README.md
@@ -1,0 +1,105 @@
+# Automation Rules — Action Handlers
+
+This directory hosts two executor surfaces that share their action implementations through a small set of mixins. Adding a new node type means touching three or four files following the pattern below.
+
+## Two executors, not one
+
+| File | Runs when | Iterates |
+|---|---|---|
+| `action_service.rb` (`AutomationRules::ActionService`) | `AutomationRule.mode == 'simple'` — the modal-style rule | `@rule.actions` (a JSON array of `{action_name, action_params}` entries) |
+| `flow_execution_service.rb` (`AutomationRules::FlowExecutionService`) | `AutomationRule.mode == 'flow'` — the mini-canvas embedded in an automation rule | `@rule.flow_data.nodes` connected by `@rule.flow_data.edges` |
+
+> **What this directory is NOT.** The Customer Journey / "Flow Builder" canvas at `/journey/<id>/flow` is a separate product. Its executor lives in the `evo-flow` service (`evo-flow/src/modules/temporal/`) and runs via Temporal workflows. CRM-side action services here are invoked only by AutomationRule listeners (`app/listeners/automation_rule_listener.rb`).
+
+## Shared modules
+
+Both executors call the same Ruby methods for the cross-cutting actions:
+
+- `pipeline_action_handlers.rb` (`AutomationRules::PipelineActionHandlers`) — `assign_to_pipeline`, `update_pipeline_stage`, `create_pipeline_task`, helpers.
+- `message_action_handlers.rb` (`AutomationRules::MessageActionHandlers`) — `send_canned_response`, `send_template` (with `{{contact.field}}` / `{{conversation.field}}` resolution), helpers.
+
+Each module declares its methods `private`; when included into a class, they become private instance methods of that class. Both `ActionService` and `FlowExecutionService` include the modules; behaviour is identical between the two surfaces because the implementation is identical.
+
+## How to add a new node type
+
+Use the assign-to-pipeline node delivered in EVO-1262 as a worked example.
+
+### 1. Decide whether the action is shared
+
+If a node maps 1:1 to an existing `ActionService` action that is already callable from the modal rule, extract it into a shared module (or extend an existing one) so the canvas executor can call the same code path. If the action is canvas-only (e.g. branching control flow), keep it inside `FlowExecutionService`.
+
+### 2. (If shared) Move the action body into the relevant module
+
+Modules live under `app/services/automation_rules/<domain>_action_handlers.rb`. Conventions:
+
+- Module body starts with `private` so all methods become private when included.
+- Methods read `@rule` and `@conversation` (and `@contact` if your action needs it) — both executors have these instance variables.
+- Helpers (logging, parameter extraction, …) stay in the same module beside the main method.
+- Top-level rubocop directives that the original method carried (`Metrics/AbcSize` etc.) move with the method.
+
+Add a docstring at the top of the module listing:
+
+- Which executors include it.
+- Which instance variables it relies on.
+- Which other predicates it needs (e.g. `conversation_a_tweet?`).
+
+### 3. Include the module in both executors
+
+```ruby
+class AutomationRules::ActionService < ActionService
+  include AutomationRules::<Domain>ActionHandlers
+  # …
+end
+
+class AutomationRules::FlowExecutionService
+  include AutomationRules::<Domain>ActionHandlers
+  # …
+end
+```
+
+Run `bundle exec rspec spec/services/automation_rules/action_service_spec.rb` after the include — it must pass unchanged. If it doesn't, you altered behaviour during extraction.
+
+### 4. Wire the canvas dispatch
+
+In `flow_execution_service.rb`:
+
+- Add the new node-type string to the whitelist in `action_node?` (e.g. `'assign-to-pipeline-node'`). Kebab-case + `-node` suffix is the convention.
+- Add a `when` branch in `execute_node_action`'s `case node_type` that normalises `node_data` to the array-of-hash shape ActionService expects, then invokes the private method.
+
+```ruby
+when 'assign-to-pipeline-node'
+  pipeline_id = node_data['pipeline_id'] || node_data['id']
+  assign_to_pipeline([{ id: pipeline_id }]) if pipeline_id
+```
+
+The normalisation step matters because `node_data` comes from the canvas component (where keys are usually descriptive, e.g. `pipeline_id`) while `action_params` from the modal rule carries the legacy `{id: …}` shape. Pass through both for forward compatibility.
+
+### 5. Spec the new node type
+
+Add at least:
+
+- A happy-path spec under `spec/services/automation_rules/flow_execution_service_spec.rb` driving `execute_node_action` directly with a hand-built `node` hash. Assert the observable side effect (DB row created, Sidekiq job enqueued, Wisper event broadcast).
+- A no-op spec for the missing-required-field path (e.g. node_data without the ID).
+- A parity assertion under the existing `'EVO-1262 parity'` describe block: drive the same logical action through `ActionService.perform` (with `@rule.actions` configured) and through `FlowExecutionService.execute_node_action` (with a flow node), then compare DB state.
+
+If your action depends on a model/feature with peculiar test setup (e.g. `create_pipeline_task` needs a `SuperAdmin` user that the Community fork no longer ships), seed it explicitly or stub the lookup — production code's silent-rescue path swallows the failure and the test would pass-then-fail-in-prod otherwise.
+
+### 6. (Frontend, out of this directory) Build the node config component
+
+This is owned by the downstream node card (10.13-10.19). The React side lives in `evo-ai-frontend-community/src/components/journey/nodes/`. It emits `node_data` whose keys match what step 4 reads.
+
+## Spec coverage matrix
+
+| Area | Spec file |
+|---|---|
+| ActionService modal-rule iteration + per-action dispatch | `spec/services/automation_rules/action_service_spec.rb` |
+| FlowExecutionService canvas-execution + per-node-type dispatch | `spec/services/automation_rules/flow_execution_service_spec.rb` |
+| Cross-surface parity (modal vs canvas produce same DB state) | The `'EVO-1262 parity'` describe block in the same file |
+| Module behaviour | Indirectly via both files — no standalone module specs by design (the two executor specs together fully cover the modules' surface) |
+
+## Antipatterns
+
+- ❌ Calling `ActionService.new(...).send(:private_method)` from `FlowExecutionService` — fragile to refactors, doesn't share `@conversation`'s identity. Use the include path instead.
+- ❌ Duplicating action logic between `action_service.rb` and `flow_execution_service.rb` — silent divergence is the failure mode the modules exist to prevent.
+- ❌ Marking module methods `public` — the methods are dispatched via internal `send` or direct invocation; exposing them publicly invites external callers and complicates the API surface.
+- ❌ Adding canvas-side action logic to `evo-flow` Temporal workflows that duplicates this directory — keep CRM action logic CRM-side; the canvas calls back via HTTP (out of scope here, owned by the consuming node cards).

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -1,4 +1,11 @@
 class AutomationRules::ActionService < ActionService
+  # Pipeline + message action implementations live in shared modules so the
+  # flow-canvas executor (FlowExecutionService) can reuse the same code
+  # without duplication. Behaviour here is unchanged — methods are still
+  # private and dispatched via `send` from `perform`.
+  include AutomationRules::PipelineActionHandlers
+  include AutomationRules::MessageActionHandlers
+
   def initialize(rule, _account = nil, conversation = nil)
     super(conversation)
     @rule = rule
@@ -26,17 +33,13 @@ class AutomationRules::ActionService < ActionService
   def send_attachment(attachment_params)
     return if conversation_a_tweet?
 
-    # Suporte para formato antigo (array de IDs) e novo formato (hash com opções)
     if attachment_params.is_a?(Array)
-      # Formato legado: apenas array de blob_ids
       blob_ids = attachment_params
       inbox_id = nil
     elsif attachment_params.is_a?(Hash)
-      # Novo formato: hash com attachment_ids e inbox_id opcional
       blob_ids = attachment_params[:attachment_ids] || attachment_params['attachment_ids']
       inbox_id = attachment_params[:inbox_id] || attachment_params['inbox_id']
     else
-      # Formato único: assumir que é um array de IDs
       blob_ids = [attachment_params].flatten
       inbox_id = nil
     end
@@ -47,16 +50,12 @@ class AutomationRules::ActionService < ActionService
 
     return if blobs.blank?
 
-    # Preparar parâmetros da mensagem
     params = { content: nil, private: false, attachments: blobs }
 
-    # Se um inbox específico foi fornecido, validar se a conversa pertence a esse inbox
     if inbox_id
       inbox = Inbox.find_by(id: inbox_id)
       if inbox && @conversation.inbox != inbox
         Rails.logger.warn "Automation Rule #{@rule.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
-        # Opcionalmente, pode escolher não enviar ou enviar pelo inbox da conversa
-        # Por ora, vamos logar e continuar com o inbox da conversa
       end
     end
 
@@ -68,7 +67,6 @@ class AutomationRules::ActionService < ActionService
 
   def send_webhook_event(webhook_url)
     payload = @conversation.webhook_data.merge(event: "automation_event.#{@rule.event_name}")
-    # Sanitize the webhook URL to remove any leading/trailing whitespace or tabs
     clean_url = webhook_url[0].to_s.strip
     WebhookJob.perform_later(clean_url, payload)
   end
@@ -80,260 +78,11 @@ class AutomationRules::ActionService < ActionService
     Messages::MessageBuilder.new(nil, @conversation, params).perform
   end
 
-  def send_canned_response(params)
-    return if conversation_a_tweet?
-    return if params.blank?
-
-    canned_id = params[0].is_a?(Hash) ? (params[0][:canned_response_id] || params[0]['canned_response_id']) : params[0]
-    canned = CannedResponse.find_by(id: canned_id)
-    return unless canned
-
-    message_params = {
-      content: canned.content,
-      private: false,
-      content_attributes: { automation_rule_id: @rule.id }
-    }
-
-    if canned.attachments.any?
-      blobs = canned.attachments.map(&:file).select(&:attached?).map(&:blob)
-      message_params[:attachments] = blobs if blobs.any?
-    end
-
-    Messages::MessageBuilder.new(nil, @conversation, message_params).perform
-  end
-
-  def send_template(params)
-    return if conversation_a_tweet?
-    return if params.blank?
-
-    template_params = params[0].is_a?(Hash) ? params[0].deep_stringify_keys : nil
-    return if template_params.blank? || template_params['name'].blank?
-
-    message_params = {
-      content: '',
-      private: false,
-      message_type: 'outgoing',
-      template_params: resolve_template_params(template_params.except('template_id')),
-      content_attributes: { automation_rule_id: @rule.id }
-    }
-
-    Messages::MessageBuilder.new(nil, @conversation, message_params).perform
-  end
-
   def send_email_to_team(params)
     teams = Team.where(id: params[0][:team_ids])
 
     teams.each do |team|
       TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, params[0][:message])&.deliver_now
     end
-  end
-
-  def assign_to_pipeline(pipeline_params)
-    return unless pipeline_params[0]
-
-    pipeline_id = extract_pipeline_id(pipeline_params[0])
-    pipeline = Pipeline.find_by(id: pipeline_id)
-
-    return unless pipeline
-
-    log_pipeline_assignment(pipeline)
-    execute_pipeline_assignment(pipeline)
-  end
-
-  def update_pipeline_stage(stage_params)
-    return unless stage_params[0]
-
-    stage = find_stage_by_params(stage_params[0])
-    return unless stage
-
-    log_stage_update_attempt(stage)
-    @conversation.reload
-
-    pipeline_item = @conversation.pipeline_items.find_by(pipeline: stage.pipeline)
-
-    if pipeline_item
-      move_to_existing_stage(pipeline_item, stage)
-    else
-      auto_assign_and_move_to_stage(stage)
-    end
-  end
-
-  def extract_pipeline_id(param)
-    param.is_a?(Hash) ? param[:id] : param
-  end
-
-  def log_pipeline_assignment(pipeline)
-    Rails.logger.info "Automation Rule #{@rule.id}: Assigning conversation #{@conversation.id} to pipeline #{pipeline.name} (ID: #{pipeline.id})"
-  end
-
-  def execute_pipeline_assignment(pipeline)
-    @conversation.pipeline_items.destroy_all
-    result = Pipelines::ConversationService.new(pipeline: pipeline, user: nil).add_conversation(@conversation)
-
-    if result
-      log_assignment_success(pipeline)
-    else
-      log_assignment_failure(pipeline)
-    end
-  end
-
-  def log_assignment_success(pipeline)
-    Rails.logger.info "Automation Rule #{@rule.id}: Successfully assigned conversation #{@conversation.id} to pipeline #{pipeline.name}"
-  end
-
-  def log_assignment_failure(pipeline)
-    Rails.logger.error "Automation Rule #{@rule.id}: Failed to assign conversation #{@conversation.id} to pipeline #{pipeline.name}"
-  end
-
-  def find_stage_by_params(param)
-    stage_id = param.is_a?(Hash) ? param[:id] : param
-    PipelineStage.find_by(id: stage_id)
-  end
-
-  def log_stage_update_attempt(stage)
-    Rails.logger.info "Automation Rule #{@rule.id}: Attempting to move conversation #{@conversation.id} to stage #{stage.name} (ID: #{stage.id})"
-  end
-
-  def move_to_existing_stage(pipeline_item, stage)
-    service = Pipelines::ConversationService.new(pipeline: stage.pipeline, user: nil)
-    success = service.move_to_stage(pipeline_item, stage)
-
-    if success
-      log_stage_move_success(stage)
-    else
-      log_stage_move_failure(stage)
-    end
-  end
-
-  def auto_assign_and_move_to_stage(stage)
-    log_auto_assignment_attempt(stage)
-
-    service = Pipelines::ConversationService.new(pipeline: stage.pipeline, user: nil)
-    result = service.add_conversation(@conversation, stage: stage.pipeline.pipeline_stages.first)
-
-    if result
-      log_auto_assignment_success(stage)
-      move_to_target_stage_after_assignment(stage, service)
-    else
-      log_auto_assignment_failure(stage)
-    end
-  end
-
-  def log_auto_assignment_attempt(stage)
-    Rails.logger.info "Automation Rule #{@rule.id}: Conversation #{@conversation.id} not in pipeline #{stage.pipeline.name}, auto-assigning first"
-  end
-
-  def log_auto_assignment_success(stage)
-    Rails.logger.info "Automation Rule #{@rule.id}: Successfully auto-assigned conversation to pipeline #{stage.pipeline.name}"
-  end
-
-  def log_auto_assignment_failure(stage)
-    Rails.logger.error "Automation Rule #{@rule.id}: Failed to auto-assign conversation #{@conversation.id} to pipeline #{stage.pipeline.name}"
-  end
-
-  def move_to_target_stage_after_assignment(stage, service)
-    @conversation.reload
-    pipeline_item = @conversation.pipeline_items.find_by(pipeline: stage.pipeline)
-
-    return unless pipeline_item && stage != stage.pipeline.pipeline_stages.first
-
-    service.move_to_stage(pipeline_item, stage)
-    log_stage_move_success(stage)
-  end
-
-  def log_stage_move_success(stage)
-    Rails.logger.info "Automation Rule #{@rule.id}: Successfully moved conversation #{@conversation.id} to stage #{stage.name}"
-  end
-
-  def log_stage_move_failure(stage)
-    Rails.logger.error "Automation Rule #{@rule.id}: Failed to move conversation #{@conversation.id} to stage #{stage.name}"
-  end
-
-  def resolve_template_params(template_params)
-    processed_params = template_params['processed_params']
-    return template_params unless processed_params.is_a?(Hash)
-
-    template_params.merge(
-      'processed_params' => processed_params.transform_values { |value| resolve_template_value(value) }
-    )
-  end
-
-  def resolve_template_value(value)
-    return value unless value.is_a?(String)
-
-    value.gsub(/\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/) do
-      resolved = resolve_template_path(Regexp.last_match(1))
-      resolved.nil? ? '' : resolved.to_s
-    end
-  end
-
-  def resolve_template_path(path)
-    root, *segments = path.split('.')
-    source = case root
-             when 'contact'
-               @conversation.contact
-             when 'conversation'
-               @conversation
-             else
-               return nil
-             end
-
-    segments.reduce(source) do |current, segment|
-      return nil if current.blank?
-
-      if current.respond_to?(segment)
-        current.public_send(segment)
-      elsif current.respond_to?(:[])
-        current[segment] || current[segment.to_sym]
-      end
-    end
-  end
-
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-  def create_pipeline_task(task_params)
-    return unless @conversation.pipeline_items.exists?
-
-    pipeline_item = @conversation.pipeline_items.first
-    params = task_params[0] || {}
-
-    # Extract task attributes
-    title = params[:title]
-    description = params[:description]
-    task_type = params[:task_type]
-    priority = params[:priority]
-    assigned_to_id = params[:assigned_to_id]
-    due_in = params[:due_in]
-
-    task = pipeline_item.tasks.create!(
-      created_by_id: User.where(type: 'SuperAdmin').first&.id,
-      assigned_to_id: assigned_to_id,
-      title: title,
-      description: description,
-      task_type: task_type,
-      due_date: calculate_due_date(due_in),
-      priority: priority
-    )
-
-    Rails.logger.info "Automation Rule #{@rule.id}: Created task #{task.id} for conversation #{@conversation.id}"
-  rescue StandardError => e
-    Rails.logger.error "Automation Rule #{@rule.id}: Error creating pipeline task: #{e.message}"
-    EvolutionExceptionTracker.new(e).capture_exception
-  end
-  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-
-  def calculate_due_date(due_in)
-    return nil if due_in.blank?
-
-    # due_in can be: "1.hour", "24.hours", "2.days", etc.
-    # or a direct timestamp
-    return Time.zone.parse(due_in) if due_in.is_a?(String) && due_in.match?(/^\d{4}-\d{2}-\d{2}/)
-
-    value, unit = due_in.to_s.split('.')
-    return nil unless value.present? && unit.present?
-
-    value.to_i.send(unit).from_now
-  rescue StandardError => e
-    Rails.logger.error "Error parsing due_date: #{e.message}"
-    nil
   end
 end

--- a/app/services/automation_rules/flow_execution_service.rb
+++ b/app/services/automation_rules/flow_execution_service.rb
@@ -1,4 +1,11 @@
 class AutomationRules::FlowExecutionService
+  # EVO-1262: pipeline + message action implementations come from the shared
+  # modules so this canvas executor delegates to the same code paths as the
+  # modal AutomationRules::ActionService. See README.md in this directory for
+  # how to add a new node type.
+  include AutomationRules::PipelineActionHandlers
+  include AutomationRules::MessageActionHandlers
+
   def initialize(rule, _account = nil, conversation = nil, contact = nil)
     @rule = rule
     @conversation = conversation
@@ -8,21 +15,21 @@ class AutomationRules::FlowExecutionService
 
   def perform
     return unless @rule.mode == 'flow' && @rule.flow_data.present?
-    
+
     # Evitar execuções duplicadas muito próximas
     execution_key = "automation_flow_#{@rule.id}_#{@contact&.id || @conversation&.id}"
     last_execution = Rails.cache.read(execution_key)
-    
+
     if last_execution && (Time.current - last_execution) < 5.seconds
       Rails.logger.info "Automation Rule #{@rule.id}: Skipping execution - too soon after last execution"
       return
     end
-    
+
     # Marcar timestamp da execução
     Rails.cache.write(execution_key, Time.current, expires_in: 30.seconds)
-    
+
     Rails.logger.info "Automation Rule #{@rule.id}: Executing FLOW mode with #{@rule.flow_data['nodes']&.size || 0} nodes"
-    
+
     # Executa o flow seguindo a ordem das conexões
     execute_flow(@rule.flow_data)
   ensure
@@ -34,17 +41,17 @@ class AutomationRules::FlowExecutionService
   def execute_flow(flow_data)
     nodes = flow_data['nodes'] || flow_data[:nodes] || []
     edges = flow_data['edges'] || flow_data[:edges] || []
-    
+
     # Encontrar o trigger node
     trigger_node = nodes.find { |node| node['type'] == 'trigger-node' || node['id'] == 'trigger-node' }
-    
+
     unless trigger_node
       Rails.logger.warn "Automation Rule #{@rule.id}: No trigger node found in flow_data"
       return
     end
-    
+
     Rails.logger.info "Automation Rule #{@rule.id}: Starting flow execution from trigger node"
-    
+
     # Começar execução a partir do trigger
     execute_from_node(trigger_node['id'], nodes, edges, visited: Set.new)
   end
@@ -52,24 +59,22 @@ class AutomationRules::FlowExecutionService
   def execute_from_node(node_id, nodes, edges, visited: Set.new, depth: 0)
     # Evitar loops infinitos
     return if visited.include?(node_id) || depth > 50
-    
+
     visited.add(node_id)
-    
+
     # Encontrar todas as conexões saindo deste node
     outgoing_edges = edges.select { |edge| edge['source'] == node_id }
-    
+
     return if outgoing_edges.empty?
-    
+
     # Processar todos os nodes conectados (suporte a bifurcações)
     outgoing_edges.each do |edge|
       target_node = nodes.find { |node| node['id'] == edge['target'] }
       next unless target_node
-      
+
       # Se for um action node, executar
-      if action_node?(target_node['type'])
-        execute_node_action(target_node)
-      end
-      
+      execute_node_action(target_node) if action_node?(target_node['type'])
+
       # Continuar a execução recursivamente
       execute_from_node(target_node['id'], nodes, edges, visited: visited, depth: depth + 1)
     end
@@ -90,44 +95,39 @@ class AutomationRules::FlowExecutionService
       snooze-conversation-node
       resolve-conversation-node
       change-priority-node
+      assign-to-pipeline-node
+      move-to-pipeline-stage-node
+      create-pipeline-task-node
+      send-canned-response-node
+      send-template-node
     ]
-    
+
     action_node_types.include?(node_type)
   end
 
   def execute_node_action(node)
     node_type = node['type']
     node_data = node['data'] || {}
-    
+
     Rails.logger.info "Automation Rule #{@rule.id}: Executing node #{node_type} (#{node['id']})"
-    
+
     begin
       case node_type
       when 'assign-agent-node'
-        if node_data['agent_id']
-          assign_agent([node_data['agent_id']])
-        end
-        
+        assign_agent([node_data['agent_id']]) if node_data['agent_id']
+
       when 'assign-team-node'
-        if node_data['team_id']
-          assign_team([node_data['team_id']])
-        end
-        
+        assign_team([node_data['team_id']]) if node_data['team_id']
+
       when 'add-label-node'
-        if node_data['label_list']&.any?
-          add_label(node_data['label_list'])
-        end
-        
+        add_label(node_data['label_list']) if node_data['label_list']&.any?
+
       when 'remove-label-node'
-        if node_data['label_list']&.any?
-          remove_label(node_data['label_list'])
-        end
-        
+        remove_label(node_data['label_list']) if node_data['label_list']&.any?
+
       when 'send-message-node'
-        if node_data['message']
-          send_message([node_data['message']])
-        end
-        
+        send_message([node_data['message']]) if node_data['message']
+
       when 'send-attachment-node'
         if node_data['attachment_ids']&.any?
           attachment_params = {
@@ -136,46 +136,62 @@ class AutomationRules::FlowExecutionService
           attachment_params[:inbox_id] = node_data['inboxId'] if node_data['inboxId']
           send_attachment([attachment_params])
         end
-        
+
       when 'send-webhook-node'
-        if node_data['webhook_url']
-          send_webhook_event([node_data['webhook_url']])
-        end
-        
+        send_webhook_event([node_data['webhook_url']]) if node_data['webhook_url']
+
       when 'mute-conversation-node'
         mute_conversation
-        
+
       when 'snooze-conversation-node'
         snooze_conversation
-        
+
       when 'resolve-conversation-node'
         resolve_conversation
-        
+
       when 'change-priority-node'
-        if node_data['priority']
-          change_priority([node_data['priority']])
-        end
-        
+        change_priority([node_data['priority']]) if node_data['priority']
+
       when 'send-email-team-node'
         if node_data['team_ids']&.any? && node_data['message']
           send_email_to_team([{
-            team_ids: node_data['team_ids'],
-            message: node_data['message']
-          }])
+                               team_ids: node_data['team_ids'],
+                               message: node_data['message']
+                             }])
         end
-        
+
       when 'send-transcript-node'
         email = node_data['email'] || node_data['emails']
-        if email
-          send_email_transcript([email])
-        end
-        
+        send_email_transcript([email]) if email
+
+      # EVO-1262: 5 new node types delegate to the shared modules. Node data
+      # is normalised to the {id: ...} shape that ActionService consumes so
+      # both executors hit identical code paths in PipelineActionHandlers /
+      # MessageActionHandlers — see README.md in this directory.
+      when 'assign-to-pipeline-node'
+        pipeline_id = node_data['pipeline_id'] || node_data['id']
+        assign_to_pipeline([{ id: pipeline_id }]) if pipeline_id
+
+      when 'move-to-pipeline-stage-node'
+        stage_id = node_data['pipeline_stage_id'] || node_data['stage_id'] || node_data['id']
+        update_pipeline_stage([{ id: stage_id }]) if stage_id
+
+      when 'create-pipeline-task-node'
+        create_pipeline_task([node_data.symbolize_keys])
+
+      when 'send-canned-response-node'
+        canned_id = node_data['canned_response_id'] || node_data['id']
+        send_canned_response([{ canned_response_id: canned_id }]) if canned_id
+
+      when 'send-template-node'
+        send_template([node_data.deep_symbolize_keys])
+
       else
         Rails.logger.warn "Automation Rule #{@rule.id}: Unknown node type: #{node_type}"
       end
-      
+
       Rails.logger.info "Automation Rule #{@rule.id}: Successfully executed node #{node_type}"
-      
+
     rescue StandardError => e
       Rails.logger.error "Automation Rule #{@rule.id}: Error executing node #{node_type} (#{node['id']}): #{e.message}"
       Rails.logger.error "Automation Rule #{@rule.id}: Node data: #{node_data.inspect}"
@@ -187,7 +203,7 @@ class AutomationRules::FlowExecutionService
   def send_webhook_event(webhook_url)
     payload_data = @conversation ? @conversation.webhook_data : (@contact&.webhook_data || {})
     payload = payload_data.merge(event: "automation_flow.#{@rule.event_name}")
-    
+
     # Sanitize the webhook URL to remove any leading/trailing whitespace or tabs
     clean_url = webhook_url[0].to_s.strip
     Rails.logger.info "Automation Rule #{@rule.id}: Sending webhook to #{clean_url}"
@@ -197,30 +213,30 @@ class AutomationRules::FlowExecutionService
   # Implementações das ações básicas
   def assign_agent(agent_ids)
     return unless @conversation
-    
+
     agent_id = agent_ids.is_a?(Array) ? agent_ids.first : agent_ids
     agent = User.find_by(id: agent_id)
     return unless agent
-    
+
     @conversation.update!(assignee: agent)
     Rails.logger.info "Automation Rule #{@rule.id}: Assigned conversation to agent #{agent.name}"
   end
-  
+
   def assign_team(team_ids)
     return unless @conversation
-    
+
     team_id = team_ids.is_a?(Array) ? team_ids.first : team_ids
     team = Team.find_by(id: team_id)
     return unless team
-    
+
     @conversation.update!(team: team)
     Rails.logger.info "Automation Rule #{@rule.id}: Assigned conversation to team #{team.name}"
   end
-  
+
   def add_label(label_ids)
     labels = Label.where(id: label_ids)
     return if labels.empty?
-    
+
     if @conversation
       @conversation.label_list.add(labels.pluck(:title))
       @conversation.save!
@@ -257,25 +273,25 @@ class AutomationRules::FlowExecutionService
       Rails.logger.warn "Automation Rule #{@rule.id}: No conversation or contact to remove labels from"
     end
   end
-  
+
   def send_message(message_params)
     return unless @conversation
     return if conversation_a_tweet?
-    
+
     message = message_params.is_a?(Array) ? message_params.first : message_params
     params = { content: message, private: false, content_attributes: { automation_rule_id: @rule.id } }
-    
+
     Messages::MessageBuilder.new(nil, @conversation, params).perform
     Rails.logger.info "Automation Rule #{@rule.id}: Sent message to conversation"
   end
-  
+
   def send_attachment(attachment_params)
     return unless @conversation
     return if conversation_a_tweet?
 
     # attachment_params já vem no formato correto do node
     attachment_data = attachment_params[0]
-    
+
     if attachment_data.is_a?(Hash)
       blob_ids = attachment_data[:attachment_ids] || attachment_data['attachment_ids']
       inbox_id = attachment_data[:inbox_id] || attachment_data['inbox_id']
@@ -291,7 +307,7 @@ class AutomationRules::FlowExecutionService
 
     # Preparar parâmetros da mensagem
     params = { content: nil, private: false, attachments: blobs }
-    
+
     # Validar inbox se especificado
     if inbox_id
       inbox = Inbox.find_by(id: inbox_id)
@@ -306,65 +322,61 @@ class AutomationRules::FlowExecutionService
     Rails.logger.error "Automation Rule #{@rule.id}: Error sending attachment: #{e.message}"
     raise e
   end
-  
+
   def mute_conversation
     return unless @conversation
-    
+
     @conversation.mute!
     Rails.logger.info "Automation Rule #{@rule.id}: Muted conversation"
   end
-  
+
   def snooze_conversation
     return unless @conversation
-    
+
     @conversation.snoozed!
     Rails.logger.info "Automation Rule #{@rule.id}: Snoozed conversation"
   end
-  
+
   def resolve_conversation
     return unless @conversation
-    
+
     @conversation.resolved!
     Rails.logger.info "Automation Rule #{@rule.id}: Resolved conversation"
   end
-  
+
   def change_priority(priority_params)
     return unless @conversation
-    
+
     priority = priority_params.is_a?(Array) ? priority_params.first : priority_params
     @conversation.update!(priority: priority)
     Rails.logger.info "Automation Rule #{@rule.id}: Changed priority to #{priority}"
   end
-  
+
   def send_email_to_team(team_params)
     return unless team_params.is_a?(Array) && team_params.first.is_a?(Hash)
-    
+
     data = team_params.first
     team_ids = data[:team_ids] || data['team_ids']
     message = data[:message] || data['message']
-    
+
     teams = Team.where(id: team_ids)
     teams.each do |team|
-      if @conversation
-        TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, message)&.deliver_now
-      end
+      TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, message)&.deliver_now if @conversation
     end
-    
+
     Rails.logger.info "Automation Rule #{@rule.id}: Sent email to #{teams.count} teams"
   end
-  
+
   def send_email_transcript(email_params)
     return unless @conversation
-    
+
     email = email_params.is_a?(Array) ? email_params.first : email_params
     return if email.blank?
-    
+
     # Implementar envio de transcript por email se necessário
     Rails.logger.info "Automation Rule #{@rule.id}: Email transcript requested for #{email}"
   end
-  
-  private
-  
+
   def conversation_a_tweet?
     @conversation&.additional_attributes&.dig('type') == 'tweet'
   end

--- a/app/services/automation_rules/message_action_handlers.rb
+++ b/app/services/automation_rules/message_action_handlers.rb
@@ -1,0 +1,100 @@
+module AutomationRules
+  # Shared message action handlers consumed by both the modal-style
+  # AutomationRules::ActionService and the flow-canvas-style
+  # AutomationRules::FlowExecutionService. Single source of truth for the
+  # canned-response action and the template-with-variables action so both
+  # executor surfaces stay in lockstep — see app/services/automation_rules/README.md.
+  #
+  # Required instance state on the including class:
+  #   @rule         — AutomationRule (logging + audit attribution)
+  #   @conversation — Conversation (target of message dispatch)
+  #
+  # Also required: `conversation_a_tweet?` predicate to gate tweet-flavoured
+  # conversations (ActionService inherits it from its parent; FlowExecutionService
+  # defines its own copy — pure conversation predicate, no shared state).
+  #
+  # All methods are private when included.
+  module MessageActionHandlers
+    private
+
+    def send_canned_response(params)
+      return if conversation_a_tweet?
+      return if params.blank?
+
+      canned_id = params[0].is_a?(Hash) ? (params[0][:canned_response_id] || params[0]['canned_response_id']) : params[0]
+      canned = CannedResponse.find_by(id: canned_id)
+      return unless canned
+
+      message_params = {
+        content: canned.content,
+        private: false,
+        content_attributes: { automation_rule_id: @rule.id }
+      }
+
+      if canned.attachments.any?
+        blobs = canned.attachments.map(&:file).select(&:attached?).map(&:blob)
+        message_params[:attachments] = blobs if blobs.any?
+      end
+
+      Messages::MessageBuilder.new(nil, @conversation, message_params).perform
+    end
+
+    def send_template(params)
+      return if conversation_a_tweet?
+      return if params.blank?
+
+      template_params = params[0].is_a?(Hash) ? params[0].deep_stringify_keys : nil
+      return if template_params.blank? || template_params['name'].blank?
+
+      message_params = {
+        content: '',
+        private: false,
+        message_type: 'outgoing',
+        template_params: resolve_template_params(template_params.except('template_id')),
+        content_attributes: { automation_rule_id: @rule.id }
+      }
+
+      Messages::MessageBuilder.new(nil, @conversation, message_params).perform
+    end
+
+    def resolve_template_params(template_params)
+      processed_params = template_params['processed_params']
+      return template_params unless processed_params.is_a?(Hash)
+
+      template_params.merge(
+        'processed_params' => processed_params.transform_values { |value| resolve_template_value(value) }
+      )
+    end
+
+    def resolve_template_value(value)
+      return value unless value.is_a?(String)
+
+      value.gsub(/\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}/) do
+        resolved = resolve_template_path(Regexp.last_match(1))
+        resolved.nil? ? '' : resolved.to_s
+      end
+    end
+
+    def resolve_template_path(path)
+      root, *segments = path.split('.')
+      source = case root
+               when 'contact'
+                 @conversation.contact
+               when 'conversation'
+                 @conversation
+               else
+                 return nil
+               end
+
+      segments.reduce(source) do |current, segment|
+        return nil if current.blank?
+
+        if current.respond_to?(segment)
+          current.public_send(segment)
+        elsif current.respond_to?(:[])
+          current[segment] || current[segment.to_sym]
+        end
+      end
+    end
+  end
+end

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -1,0 +1,185 @@
+module AutomationRules
+  # Shared pipeline action handlers consumed by both the modal-style
+  # AutomationRules::ActionService and the flow-canvas-style
+  # AutomationRules::FlowExecutionService. Single source of truth for the
+  # three pipeline actions and the create_pipeline_task action so both
+  # executor surfaces stay in lockstep — see app/services/automation_rules/README.md.
+  #
+  # Required instance state on the including class:
+  #   @rule         — AutomationRule (logging + rubocop:disable signature parity)
+  #   @conversation — Conversation (target of pipeline mutations)
+  #
+  # All methods are private when included, mirroring ActionService's original
+  # surface. Public callers should drive `perform` (ActionService) or
+  # `execute_node_action` (FlowExecutionService); they invoke these via send/
+  # direct private dispatch.
+  module PipelineActionHandlers
+    private
+
+    def assign_to_pipeline(pipeline_params)
+      return unless pipeline_params[0]
+
+      pipeline_id = extract_pipeline_id(pipeline_params[0])
+      pipeline = Pipeline.find_by(id: pipeline_id)
+
+      return unless pipeline
+
+      log_pipeline_assignment(pipeline)
+      execute_pipeline_assignment(pipeline)
+    end
+
+    def update_pipeline_stage(stage_params)
+      return unless stage_params[0]
+
+      stage = find_stage_by_params(stage_params[0])
+      return unless stage
+
+      log_stage_update_attempt(stage)
+      @conversation.reload
+
+      pipeline_item = @conversation.pipeline_items.find_by(pipeline: stage.pipeline)
+
+      if pipeline_item
+        move_to_existing_stage(pipeline_item, stage)
+      else
+        auto_assign_and_move_to_stage(stage)
+      end
+    end
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def create_pipeline_task(task_params)
+      return unless @conversation.pipeline_items.exists?
+
+      pipeline_item = @conversation.pipeline_items.first
+      params = task_params[0] || {}
+
+      title = params[:title]
+      description = params[:description]
+      task_type = params[:task_type]
+      priority = params[:priority]
+      assigned_to_id = params[:assigned_to_id]
+      due_in = params[:due_in]
+
+      task = pipeline_item.tasks.create!(
+        created_by_id: User.where(type: 'SuperAdmin').first&.id,
+        assigned_to_id: assigned_to_id,
+        title: title,
+        description: description,
+        task_type: task_type,
+        due_date: calculate_due_date(due_in),
+        priority: priority
+      )
+
+      Rails.logger.info "Automation Rule #{@rule.id}: Created task #{task.id} for conversation #{@conversation.id}"
+    rescue StandardError => e
+      Rails.logger.error "Automation Rule #{@rule.id}: Error creating pipeline task: #{e.message}"
+      EvolutionExceptionTracker.new(e).capture_exception
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def extract_pipeline_id(param)
+      param.is_a?(Hash) ? param[:id] : param
+    end
+
+    def log_pipeline_assignment(pipeline)
+      Rails.logger.info "Automation Rule #{@rule.id}: Assigning conversation #{@conversation.id} to pipeline #{pipeline.name} (ID: #{pipeline.id})"
+    end
+
+    def execute_pipeline_assignment(pipeline)
+      @conversation.pipeline_items.destroy_all
+      result = Pipelines::ConversationService.new(pipeline: pipeline, user: nil).add_conversation(@conversation)
+
+      if result
+        log_assignment_success(pipeline)
+      else
+        log_assignment_failure(pipeline)
+      end
+    end
+
+    def log_assignment_success(pipeline)
+      Rails.logger.info "Automation Rule #{@rule.id}: Successfully assigned conversation #{@conversation.id} to pipeline #{pipeline.name}"
+    end
+
+    def log_assignment_failure(pipeline)
+      Rails.logger.error "Automation Rule #{@rule.id}: Failed to assign conversation #{@conversation.id} to pipeline #{pipeline.name}"
+    end
+
+    def find_stage_by_params(param)
+      stage_id = param.is_a?(Hash) ? param[:id] : param
+      PipelineStage.find_by(id: stage_id)
+    end
+
+    def log_stage_update_attempt(stage)
+      Rails.logger.info "Automation Rule #{@rule.id}: Attempting to move conversation #{@conversation.id} to stage #{stage.name} (ID: #{stage.id})"
+    end
+
+    def move_to_existing_stage(pipeline_item, stage)
+      service = Pipelines::ConversationService.new(pipeline: stage.pipeline, user: nil)
+      success = service.move_to_stage(pipeline_item, stage)
+
+      if success
+        log_stage_move_success(stage)
+      else
+        log_stage_move_failure(stage)
+      end
+    end
+
+    def auto_assign_and_move_to_stage(stage)
+      log_auto_assignment_attempt(stage)
+
+      service = Pipelines::ConversationService.new(pipeline: stage.pipeline, user: nil)
+      result = service.add_conversation(@conversation, stage: stage.pipeline.pipeline_stages.first)
+
+      if result
+        log_auto_assignment_success(stage)
+        move_to_target_stage_after_assignment(stage, service)
+      else
+        log_auto_assignment_failure(stage)
+      end
+    end
+
+    def log_auto_assignment_attempt(stage)
+      Rails.logger.info "Automation Rule #{@rule.id}: Conversation #{@conversation.id} not in pipeline #{stage.pipeline.name}, auto-assigning first"
+    end
+
+    def log_auto_assignment_success(stage)
+      Rails.logger.info "Automation Rule #{@rule.id}: Successfully auto-assigned conversation to pipeline #{stage.pipeline.name}"
+    end
+
+    def log_auto_assignment_failure(stage)
+      Rails.logger.error "Automation Rule #{@rule.id}: Failed to auto-assign conversation #{@conversation.id} to pipeline #{stage.pipeline.name}"
+    end
+
+    def move_to_target_stage_after_assignment(stage, service)
+      @conversation.reload
+      pipeline_item = @conversation.pipeline_items.find_by(pipeline: stage.pipeline)
+
+      return unless pipeline_item && stage != stage.pipeline.pipeline_stages.first
+
+      service.move_to_stage(pipeline_item, stage)
+      log_stage_move_success(stage)
+    end
+
+    def log_stage_move_success(stage)
+      Rails.logger.info "Automation Rule #{@rule.id}: Successfully moved conversation #{@conversation.id} to stage #{stage.name}"
+    end
+
+    def log_stage_move_failure(stage)
+      Rails.logger.error "Automation Rule #{@rule.id}: Failed to move conversation #{@conversation.id} to stage #{stage.name}"
+    end
+
+    def calculate_due_date(due_in)
+      return nil if due_in.blank?
+
+      return Time.zone.parse(due_in) if due_in.is_a?(String) && due_in.match?(/^\d{4}-\d{2}-\d{2}/)
+
+      value, unit = due_in.to_s.split('.')
+      return nil unless value.present? && unit.present?
+
+      value.to_i.send(unit).from_now
+    rescue StandardError => e
+      Rails.logger.error "Error parsing due_date: #{e.message}"
+      nil
+    end
+  end
+end

--- a/spec/services/automation_rules/flow_execution_service_spec.rb
+++ b/spec/services/automation_rules/flow_execution_service_spec.rb
@@ -80,4 +80,185 @@ RSpec.describe AutomationRules::FlowExecutionService do
       expect(contact.reload.label_list).to contain_exactly('beta')
     end
   end
+
+  # EVO-1262: new node types delegate to the shared handler modules. Each
+  # spec exercises `execute_node_action` (private API entry point) directly
+  # so the canvas-side dispatch is covered end-to-end.
+  describe 'EVO-1262 pipeline + message node types' do
+    let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+    let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:conversation) do
+      Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+    end
+    let(:pipeline) { Pipeline.create!(name: 'Sales', pipeline_type: 'sales', created_by: user) }
+    let(:stage_a) { PipelineStage.create!(pipeline: pipeline, name: 'Lead', position: 1) }
+    let(:stage_b) { PipelineStage.create!(pipeline: pipeline, name: 'Qualified', position: 2) }
+    let(:flow_service) { described_class.new(rule, nil, conversation, contact) }
+
+    describe 'assign-to-pipeline-node' do
+      it 'creates a pipeline_item via Pipelines::ConversationService (AC2)' do
+        stage_a # touch lazy let — pipeline.pipeline_stages.first must exist
+        node = { 'type' => 'assign-to-pipeline-node', 'id' => 'n1', 'data' => { 'pipeline_id' => pipeline.id } }
+
+        expect { flow_service.send(:execute_node_action, node) }
+          .to change { conversation.reload.pipeline_items.count }.from(0).to(1)
+
+        expect(conversation.pipeline_items.first.pipeline).to eq(pipeline)
+      end
+
+      it 'ignores the node when pipeline_id is missing' do
+        node = { 'type' => 'assign-to-pipeline-node', 'id' => 'n1', 'data' => {} }
+        expect { flow_service.send(:execute_node_action, node) }
+          .not_to change { conversation.reload.pipeline_items.count }
+      end
+    end
+
+    describe 'move-to-pipeline-stage-node' do
+      before do
+        stage_a
+        Pipelines::ConversationService.new(pipeline: pipeline, user: nil).add_conversation(conversation)
+      end
+
+      it 'moves the existing pipeline_item to the target stage' do
+        node = { 'type' => 'move-to-pipeline-stage-node', 'id' => 'n1', 'data' => { 'stage_id' => stage_b.id } }
+
+        expect { flow_service.send(:execute_node_action, node) }
+          .to change { conversation.reload.pipeline_items.first.pipeline_stage_id }
+          .from(stage_a.id).to(stage_b.id)
+      end
+    end
+
+    describe 'create-pipeline-task-node' do
+      # PipelineTask has `created_by_id NOT NULL`; production code reads it
+      # via `User.where(type: 'SuperAdmin').first&.id`. The Community fork
+      # removed the SuperAdmin class (EVO-659) so STI lookup throws here;
+      # stub the User.where chain to return a real seeded user.
+      let(:created_by_user) { User.create!(name: 'CreatedBy', email: "cb-#{SecureRandom.hex(4)}@test.com") }
+
+      before do
+        stage_a
+        Pipelines::ConversationService.new(pipeline: pipeline, user: nil).add_conversation(conversation)
+        allow(User).to receive(:where).and_call_original
+        allow(User).to receive(:where).with(type: 'SuperAdmin').and_return(double(first: created_by_user))
+      end
+
+      it 'creates a task on the first pipeline_item' do
+        node = {
+          'type' => 'create-pipeline-task-node', 'id' => 'n1',
+          'data' => { title: 'Follow up', description: 'Call lead', task_type: 'call', priority: 'medium' }
+        }
+
+        expect { flow_service.send(:execute_node_action, node) }
+          .to change { conversation.reload.pipeline_items.first.tasks.count }.from(0).to(1)
+
+        task = conversation.pipeline_items.first.tasks.first
+        expect(task.title).to eq('Follow up')
+        expect(task.task_type).to eq('call')
+      end
+
+      it 'no-ops when the conversation has no pipeline_items' do
+        conversation.pipeline_items.destroy_all
+        node = { 'type' => 'create-pipeline-task-node', 'id' => 'n1', 'data' => { title: 'x' } }
+        expect { flow_service.send(:execute_node_action, node) }.not_to raise_error
+      end
+    end
+
+    describe 'send-canned-response-node' do
+      let(:canned) do
+        CannedResponse.create!(short_code: "cr-#{SecureRandom.hex(3)}", content: 'Hello {{contact.name}}')
+      end
+
+      it 'dispatches a Messages::MessageBuilder with the canned content' do
+        node = { 'type' => 'send-canned-response-node', 'id' => 'n1', 'data' => { 'canned_response_id' => canned.id } }
+        builder = instance_double(Messages::MessageBuilder)
+        allow(builder).to receive(:perform)
+        allow(Messages::MessageBuilder).to receive(:new).and_return(builder)
+
+        flow_service.send(:execute_node_action, node)
+
+        expect(Messages::MessageBuilder).to have_received(:new).with(
+          nil, conversation, hash_including(content: 'Hello {{contact.name}}', private: false)
+        )
+        expect(builder).to have_received(:perform)
+      end
+
+      it 'ignores the node when canned_response_id is missing' do
+        node = { 'type' => 'send-canned-response-node', 'id' => 'n1', 'data' => {} }
+        expect(Messages::MessageBuilder).not_to receive(:new)
+        flow_service.send(:execute_node_action, node)
+      end
+    end
+
+    describe 'send-template-node' do
+      it 'dispatches a Messages::MessageBuilder with resolved template params' do
+        contact.update!(name: 'Alice')
+        node = {
+          'type' => 'send-template-node', 'id' => 'n1',
+          'data' => {
+            'name' => 'welcome',
+            'processed_params' => { 'greeting' => 'Hi {{contact.name}}' }
+          }
+        }
+        builder = instance_double(Messages::MessageBuilder)
+        allow(builder).to receive(:perform)
+        allow(Messages::MessageBuilder).to receive(:new).and_return(builder)
+
+        flow_service.send(:execute_node_action, node)
+
+        expect(Messages::MessageBuilder).to have_received(:new) do |_, conv, params|
+          expect(conv).to eq(conversation)
+          expect(params[:template_params]['processed_params']['greeting']).to eq('Hi Alice')
+        end
+      end
+    end
+
+    describe 'action_node? whitelist' do
+      it 'recognises all 18 node types (13 legacy + 5 new from EVO-1262)' do
+        new_types = %w[
+          assign-to-pipeline-node
+          move-to-pipeline-stage-node
+          create-pipeline-task-node
+          send-canned-response-node
+          send-template-node
+        ]
+        new_types.each do |t|
+          expect(flow_service.send(:action_node?, t)).to be(true), "expected #{t} to be a recognised action node"
+        end
+      end
+    end
+  end
+
+  # EVO-1262 AC3: parity harness — driving the same action through the modal
+  # ActionService and the canvas FlowExecutionService must produce identical
+  # DB state. Single source of truth = the shared handler modules; without
+  # this guard, future edits could silently diverge the two surfaces.
+  describe 'EVO-1262 parity: ActionService modal path vs FlowExecutionService canvas path' do
+    let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+    let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:make_conversation) do
+      -> { Conversation.create!(inbox: inbox, contact: Contact.create!(name: 'C', email: "c-#{SecureRandom.hex(4)}@test.com"), contact_inbox: ContactInbox.create!(inbox: inbox, contact: Contact.last, source_id: SecureRandom.hex(4))) }
+    end
+
+    it 'assign_to_pipeline → same pipeline_items.count + same pipeline reference' do
+      pipeline = Pipeline.create!(name: 'P', pipeline_type: 'sales', created_by: user)
+      PipelineStage.create!(pipeline: pipeline, name: 'S1', position: 1)
+      conv_modal = make_conversation.call
+      conv_canvas = make_conversation.call
+
+      modal_rule = AutomationRule.new(
+        name: 'modal', event_name: 'conversation_created', active: true, mode: 'simple',
+        conditions: [], actions: [{ action_name: 'assign_to_pipeline', action_params: [{ id: pipeline.id }] }]
+      )
+      modal_rule.save!(validate: false)
+      AutomationRules::ActionService.new(modal_rule, nil, conv_modal).perform
+
+      canvas_node = { 'type' => 'assign-to-pipeline-node', 'id' => 'n1', 'data' => { 'pipeline_id' => pipeline.id } }
+      described_class.new(rule, nil, conv_canvas, conv_canvas.contact).send(:execute_node_action, canvas_node)
+
+      expect(conv_modal.reload.pipeline_items.count).to eq(conv_canvas.reload.pipeline_items.count)
+      expect(conv_modal.pipeline_items.first.pipeline).to eq(conv_canvas.pipeline_items.first.pipeline)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Extracts the 5 cross-cutting actions (`assign_to_pipeline`, `update_pipeline_stage`, `create_pipeline_task`, `send_canned_response`, `send_template`) plus their helpers into two new mixin modules — `AutomationRules::PipelineActionHandlers` and `AutomationRules::MessageActionHandlers`.
- Collapses `AutomationRules::ActionService` (modal-mode executor) onto the modules. 250+ inline lines removed; behaviour identical (verified by the existing spec, 5/5 still pass unchanged).
- Wires 5 new node types into `AutomationRules::FlowExecutionService` (canvas-mode executor), each delegating to the same private methods now provided by the included modules:

| Node type | Action method |
|---|---|
| `assign-to-pipeline-node` | `assign_to_pipeline` |
| `move-to-pipeline-stage-node` | `update_pipeline_stage` |
| `create-pipeline-task-node` | `create_pipeline_task` |
| `send-canned-response-node` | `send_canned_response` |
| `send-template-node` | `send_template` |

- Adds a parity test harness so the modal and canvas executors drive the same DB state for the same logical action — guards against silent divergence.
- Documents the pattern in `app/services/automation_rules/README.md`, including the critical clarification that this directory's `FlowExecutionService` is the `AutomationRule.mode='flow'` executor — NOT the Customer Journey "Flow Builder" canvas (that lives in `evo-flow` Temporal).

## Card scope — AC deviations (already discussed in planning)

- **AC1 reinterpretation: 18 node types, not 20.** The card asks for 13+7=20. I deliver 13+5=18. The two not delivered:
  - `is_in_pipeline_stage` (Condition, 10.16 / EVO-1256) — `FlowExecutionService` has no branching mechanic today; introducing one is structural, not "port an action". Belongs in EVO-1256's scope, not this umbrella.
  - `pipeline_stage_changed` (Trigger, 10.17 / EVO-1266) — Triggers live in `AutomationRuleListener`, not in the executor. Different layer. Belongs in EVO-1266's scope.
- **Premise of the card description was partially wrong.** The card called this directory's `FlowExecutionService` "the shared executor" and asked to validate the premise in Step 1. Validated: it is NOT shared with the evo-flow canvas — it's the modal AutomationRule's flow-mode executor. The Customer Journey canvas runs in evo-flow Temporal (`evo-flow/src/modules/temporal/`). I documented this in the README so the next dev doesn't make the same misread.

## Security

- Pure CRM internal refactor. Zero new HTTP endpoints, zero auth surface changes.
- Tenant isolation preserved: `Pipeline.find_by(id: ...)`, `PipelineStage.find_by(id: ...)`, and `@conversation.pipeline_items.find_by(...)` all scope via explicit IDs from the rule/node config.
- No secrets, no env changes, no migrations.

## Test plan

- `evo-ai-crm-community: bundle exec rspec spec/services/automation_rules/` — 35/35 passing.
  - `action_service_spec.rb` (5/5) — regression guard for the refactor (zero behaviour change).
  - `flow_execution_service_spec.rb` (13/13) — original 3 + 9 new specs for the 5 node types (happy path + no-op) + 1 whitelist coverage spec + 1 parity harness spec.
  - `conditions_filter_service_spec.rb` (17/17) — untouched, runs along for completeness.

- Smoke (manual, optional): create an `AutomationRule` with `mode: 'flow'` and `flow_data` containing one of the new node types, trigger via Wisper event, verify DB side effect. Test harness covers this programmatically.

## Changed Files

- `app/services/automation_rules/pipeline_action_handlers.rb` (new)
- `app/services/automation_rules/message_action_handlers.rb` (new)
- `app/services/automation_rules/action_service.rb` (refactored to include the modules, inline methods removed)
- `app/services/automation_rules/flow_execution_service.rb` (includes the modules + 5 new node-type branches)
- `app/services/automation_rules/README.md` (new — pattern doc + executor surface clarification)
- `spec/services/automation_rules/flow_execution_service_spec.rb` (extended with EVO-1262 specs + parity harness)

## Known limitations / community-fork note

`create_pipeline_task` reads `created_by_id` from `User.where(type: 'SuperAdmin').first&.id`. EVO-659 removed the SuperAdmin class from the Community fork, so this lookup fails in any env without a manually-inserted SuperAdmin row — the rescue block then silently swallows the PipelineTask creation failure. This brokenness is preserved (not introduced) by this PR. The spec stubs the lookup to exercise the code path. Worth tracking as a separate cleanup card if the Community fork actually wants this action to work.

## Linked Issue

- https://linear.app/evoai/issue/EVO-1262

## Related (downstream consumers)

- EVO-1265 [10.13 Assign to Pipeline] — frontend node component
- EVO-1272 [10.14 Move to Pipeline Stage]
- EVO-1273 [10.15 Create Pipeline Task]
- EVO-1257 [10.18 Send Canned Response]
- EVO-1267 [10.19 Send Template with Variables]