### PR TITLE
chore(db): regenerate schema.rb for AddEvolutionHubMetaToChannels (EVO-1455)

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_18_133933) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_20_192951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -342,6 +342,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_18_133933) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "instagram_id"
+    t.jsonb "evolution_hub_meta", default: {}, null: false
     t.index ["page_id"], name: "index_channel_facebook_pages_on_page_id", unique: true
   end
 
@@ -351,6 +352,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_18_133933) do
     t.string "instagram_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.jsonb "evolution_hub_meta", default: {}, null: false
     t.index ["instagram_id"], name: "index_channel_instagram_on_instagram_id", unique: true
   end
 


### PR DESCRIPTION
## Summary

Resolves `ActiveRecord::PendingMigrationError` that aborts rspec load on every CI run, blocking CI on PR #95 (EVO-1261) and PR #96 (EVO-1262). Adds the 2 jsonb columns from migration `20260520192951_add_evolution_hub_meta_to_channels.rb` to `db/schema.rb` and bumps the schema version.

## Surgical, not full regen

`bundle exec rails db:migrate` locally produced 5 changes against `db/schema.rb`. This PR applies only the 3 that belong to the migration:

| # | Change | Applied? |
|---|---|---|
| 1 | version bump `2026_05_18_133933` → `2026_05_20_192951` | ✓ |
| 2 | `channel_facebook_pages.evolution_hub_meta` jsonb column | ✓ |
| 3 | `channel_instagram.evolution_hub_meta` jsonb column | ✓ |
| 4 | `uq_campaign_executions_active_per_campaign` index WHERE clause reformatted | ✗ — PG serialization drift, same semantics |
| 5 | `products_kind_check` / `products_status_check` reformatted | ✗ — same |

Also explicitly **preserved** the trailing trigger function block (the "L1 fix" that defines `update_updated_at_column()` + `CREATE TRIGGER` for `campaign_executions`). A naive `db:migrate` removes it because the Rails schema dumper does not know about PG trigger functions; the block was added by hand to fix `db:prepare` on fresh DBs in CI.

## Security

- N/A — schema bookkeeping only, no schema change beyond the already-merged migration.

## Test plan

- [ ] `evo-ai-crm-community: RAILS_ENV=test bundle exec rspec spec/services/evo_flow/client_spec.rb` → 15/15 ✓ (verified locally; suite loads without `PendingMigrationError`)
- [ ] After merge, re-run CI on PR #95 and PR #96 → expect `Spec staleness guard (EVO-1141)` and `Verify EvoExtensionPoints contract` jobs to go green

## Changed Files

- `db/schema.rb` (1 file, +3/-1)

## Linked Issue

- EVO-1455 (https://linear.app/evoai/issue/EVO-1455)
- Unblocks CI on: EVO-1261 (PR #95), EVO-1262 (PR #96)

## Summary by Sourcery

Update database schema version and align schema.rb with the previously merged AddEvolutionHubMetaToChannels migration.

New Features:
- Add evolution_hub_meta jsonb column to channel_facebook_pages in the schema.
- Add evolution_hub_meta jsonb column to channel_instagram in the schema.

Bug Fixes:
- Resolve pending migration errors in CI by syncing schema.rb with the latest migration.