### PR TITLE
feat(crm): proxy /contacts/:id/events com enrich (EVO-1243)

### DIFF
--- a/app/controllers/api/v1/evo_flow/contact_events_controller.rb
+++ b/app/controllers/api/v1/evo_flow/contact_events_controller.rb
@@ -1,0 +1,105 @@
+class Api::V1::EvoFlow::ContactEventsController < Api::V1::BaseController
+  EVO_FLOW_QUERY_KEYS = %i[event_type event_name channel campaign_id occurred_after occurred_before cursor limit].freeze
+
+  SNAKE_TO_CAMEL = {
+    event_type: :eventType,
+    event_name: :eventName,
+    channel: :channel,
+    campaign_id: :campaignId,
+    occurred_after: :occurredAfter,
+    occurred_before: :occurredBefore,
+    cursor: :cursor,
+    limit: :limit
+  }.freeze
+
+  CHANNEL_LABELS = {
+    'api' => 'API',
+    'email' => 'Email',
+    'facebook_page' => 'Facebook',
+    'facebook' => 'Facebook',
+    'instagram' => 'Instagram',
+    'line' => 'LINE',
+    'sms' => 'SMS',
+    'telegram' => 'Telegram',
+    'twilio_sms' => 'Twilio SMS',
+    'twitter_profile' => 'Twitter',
+    'twitter' => 'Twitter',
+    'web_widget' => 'Website',
+    'whatsapp' => 'WhatsApp'
+  }.freeze
+
+  # NOTE: Action stays user-agnostic — Service Token auth path leaves
+  # Current.user nil. If user-scoped authorization is added, also require
+  # Bearer / API Access Token.
+  def index
+    body = client.get("/contacts/#{params[:contact_id]}/events", translated_filters)
+    body['events'] = (body['events'] || []).map { |evt| enrich_event(evt) }
+    render json: body, status: :ok
+  rescue EvoFlow::HTTPError => e
+    handle_evo_flow_error(e)
+  end
+
+  private
+
+  def client
+    @client ||= EvoFlow::Client.new
+  end
+
+  def translated_filters
+    params.permit(*EVO_FLOW_QUERY_KEYS).to_h.symbolize_keys.each_with_object({}) do |(k, v), acc|
+      next if v.blank?
+
+      acc[SNAKE_TO_CAMEL[k]] = v
+    end
+  end
+
+  def enrich_event(evt)
+    props = evt['properties'] || {}
+    enriched = {}
+    enriched[:campaign_name] = enrich_campaign(props['campaign_id']) if props['campaign_id'].present?
+    enriched[:channel_label] = enrich_channel(props['channel'])      if props['channel'].present?
+    enriched[:agent_name]    = enrich_agent(props['agent_id'])       if props['agent_id'].present?
+    evt.merge('enriched' => enriched)
+  end
+
+  # skip_nil: prevents poisoning the cache with nil when the upstream id
+  # is unknown to the CRM (e.g., a campaign created moments earlier).
+  def enrich_campaign(id)
+    Rails.cache.fetch("evo_flow:enrich:campaign:#{id}", expires_in: 60.seconds, skip_nil: true) do
+      Campaign.find_by(id: id)&.name
+    end
+  end
+
+  # No cache: CHANNEL_LABELS is a frozen constant; an in-memory hash
+  # lookup is cheaper than a Rails.cache round-trip.
+  def enrich_channel(key)
+    CHANNEL_LABELS[key.to_s] || key.to_s
+  end
+
+  def enrich_agent(id)
+    Rails.cache.fetch("evo_flow:enrich:agent:#{id}", expires_in: 60.seconds, skip_nil: true) do
+      User.find_by(id: id)&.name
+    end
+  end
+
+  # 5xx and network failures are already logged as :error by EvoFlow::Client
+  # (raise_api_error). Only emit a controller-level warn for network failures
+  # (code.nil?), which the Client doesn't log on its own.
+  def handle_evo_flow_error(error)
+    if error.code.nil? || (500..599).cover?(error.code)
+      Rails.logger.warn("[EvoFlow][ContactEvents] degraded -- code=#{error.code.inspect} msg=#{error.message}") if error.code.nil?
+      render json: { events: [], degraded: true }, status: :ok
+    else
+      render json: safe_parse(error.response) || { error: 'upstream error' }, status: error.code
+    end
+  end
+
+  def safe_parse(body)
+    body = body.body if body.respond_to?(:body)
+    return body if body.is_a?(Hash)
+
+    JSON.parse(body)
+  rescue StandardError
+    nil
+  end
+end

--- a/app/controllers/api/v1/evo_flow/contact_events_controller.rb
+++ b/app/controllers/api/v1/evo_flow/contact_events_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::EvoFlow::ContactEventsController < Api::V1::BaseController
-  EVO_FLOW_QUERY_KEYS = %i[event_type event_name channel campaign_id occurred_after occurred_before cursor limit].freeze
-
+  # Single source of truth for outbound filters. The whitelist is derived from
+  # SNAKE_TO_CAMEL.keys below so the two can never drift apart -- adding a key
+  # here automatically adds it to params.permit and to the camelCase output.
   SNAKE_TO_CAMEL = {
     event_type: :eventType,
     event_name: :eventName,
@@ -46,20 +47,24 @@ class Api::V1::EvoFlow::ContactEventsController < Api::V1::BaseController
   end
 
   def translated_filters
-    params.permit(*EVO_FLOW_QUERY_KEYS).to_h.symbolize_keys.each_with_object({}) do |(k, v), acc|
+    params.permit(*SNAKE_TO_CAMEL.keys).to_h.symbolize_keys.each_with_object({}) do |(k, v), acc|
       next if v.blank?
 
-      acc[SNAKE_TO_CAMEL[k]] = v
+      acc[SNAKE_TO_CAMEL.fetch(k)] = v
     end
   end
 
+  # `enriched` is dropped from the event when no property resolves to a value
+  # (campaign/agent not found in Postgres or no enrichable key in properties),
+  # keeping the response payload tight.
   def enrich_event(evt)
     props = evt['properties'] || {}
-    enriched = {}
-    enriched[:campaign_name] = enrich_campaign(props['campaign_id']) if props['campaign_id'].present?
-    enriched[:channel_label] = enrich_channel(props['channel'])      if props['channel'].present?
-    enriched[:agent_name]    = enrich_agent(props['agent_id'])       if props['agent_id'].present?
-    evt.merge('enriched' => enriched)
+    enriched = {
+      campaign_name: (enrich_campaign(props['campaign_id']) if props['campaign_id'].present?),
+      channel_label: (enrich_channel(props['channel']) if props['channel'].present?),
+      agent_name: (enrich_agent(props['agent_id']) if props['agent_id'].present?)
+    }.compact
+    enriched.empty? ? evt : evt.merge('enriched' => enriched)
   end
 
   # skip_nil: prevents poisoning the cache with nil when the upstream id

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,0 +1,10 @@
+class Campaign < ApplicationRecord
+  # `campaigns.type` is a plain string column (not STI). Disable AR's
+  # automatic single-table inheritance lookup so `find_by(id:)` works
+  # regardless of the row's `type` value. If a future story introduces
+  # real STI (OngoingCampaign / OneOffCampaign), revert this line and
+  # update the EvoFlow enrich path that depends on Campaign.find_by.
+  self.inheritance_column = nil
+
+  default_scope { where(deleted_at: nil) }
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,10 +1,11 @@
 class Campaign < ApplicationRecord
-  # `campaigns.type` is a plain string column (not STI). Disable AR's
-  # automatic single-table inheritance lookup so `find_by(id:)` works
-  # regardless of the row's `type` value. If a future story introduces
-  # real STI (OngoingCampaign / OneOffCampaign), revert this line and
-  # update the EvoFlow enrich path that depends on Campaign.find_by.
-  self.inheritance_column = nil
+  # `campaigns.type` is a plain string column (not STI). Point AR's
+  # inheritance_column at a non-existent column so the STI lookup is a no-op
+  # and `find_by(id:)` works regardless of the row's `type` value. If a
+  # future story introduces real STI (OngoingCampaign / OneOffCampaign),
+  # revert this line and update the EvoFlow enrich path that depends on
+  # Campaign.find_by.
+  self.inheritance_column = :_type_disabled
 
   default_scope { where(deleted_at: nil) }
 end

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -52,6 +52,17 @@ module EvoFlow
       raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
     end
 
+    def get(path, params = {})
+      response = self.class.get(join(@api_url, path),
+                                query: params.compact,
+                                headers: request_headers,
+                                timeout: @timeout)
+      handle_response(response)
+    rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError,
+           OpenSSL::SSL::SSLError => e
+      raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
+    end
+
     private
 
     def validate_config!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -219,6 +219,10 @@ Rails.application.routes.draw do
       resources :contact_companies, only: [:create, :destroy], path: 'contacts/:contact_id/companies', controller: 'contact_companies'
       resource :contact_bulk_transfer, only: [:create], path: 'contacts/bulk_transfer', controller: 'contact_bulk_transfers'
 
+      scope module: 'evo_flow' do
+        resources :contact_events, only: [:index], path: 'contacts/:contact_id/events', param: :contact_id
+      end
+
       resources :csat_survey_responses, only: [:index], controller: 'csat_survey_responses' do
         collection do
           get :metrics

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Campaign, type: :model do
+  let(:attrs) do
+    {
+      title: 'Black Friday',
+      name: "campaign-#{SecureRandom.hex(4)}",
+      type: 'Default'
+    }
+  end
+
+  describe '.find_by(id:)' do
+    it 'returns the active record by id and exposes #name' do
+      campaign = described_class.create!(attrs)
+      expect(described_class.find_by(id: campaign.id)&.name).to eq(attrs[:name])
+    end
+  end
+
+  describe 'default_scope' do
+    it 'excludes rows soft-deleted via deleted_at' do
+      campaign = described_class.create!(attrs)
+      campaign.update!(deleted_at: Time.current)
+      expect(described_class.find_by(id: campaign.id)).to be_nil
+      expect(described_class.unscoped.find_by(id: campaign.id)).to be_present
+    end
+  end
+end

--- a/spec/requests/api/v1/evo_flow/contact_events_spec.rb
+++ b/spec/requests/api/v1/evo_flow/contact_events_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe 'GET /api/v1/contacts/:contact_id/events', type: :request do
+  let(:service_token) { 'spec-service-token' }
+  let(:integration_key) { 'spec-integration-key' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+  let(:contact_id) { SecureRandom.uuid }
+  let(:base_url) { ENV.fetch('EVO_FLOW_API_URL', 'http://evo-flow:3000/api/v1') }
+  let(:events_url) { "#{base_url}/contacts/#{contact_id}/events" }
+
+  around do |example|
+    ENV['EVOAI_CRM_API_TOKEN'] = service_token
+    ENV['AUTH_APIKEY_INTEGRATION_LOCAL'] = integration_key
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+  ensure
+    Rails.cache.clear
+    Rails.cache = original_cache
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    ENV.delete('AUTH_APIKEY_INTEGRATION_LOCAL')
+    Current.reset
+  end
+
+  def json_response
+    response.parsed_body
+  end
+
+  describe 'AC1 — happy path proxy' do
+    it 'proxies to evo-flow with limit=10 and returns events/pagination' do
+      stub = stub_request(:get, events_url)
+             .with(query: { 'limit' => '10' })
+             .to_return(
+               status: 200,
+               body: { events: [], pagination: { hasNext: false, nextCursor: nil, limit: 10 } }.to_json,
+               headers: { 'Content-Type' => 'application/json' }
+             )
+
+      get "/api/v1/contacts/#{contact_id}/events", params: { limit: 10 }, headers: headers
+
+      expect(stub).to have_been_requested
+      expect(response).to have_http_status(:ok)
+      expect(json_response).to include('events', 'pagination')
+    end
+  end
+
+  describe 'AC2 — enrich campaign_name' do
+    it 'enriches each event with campaign_name from Postgres' do
+      campaign = Campaign.create!(title: 'BF', name: "black-friday-#{SecureRandom.hex(2)}", type: 'Default')
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [{ id: 'e1', properties: { 'campaign_id' => campaign.id } }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response.dig('events', 0, 'enriched', 'campaign_name')).to eq(campaign.name)
+    end
+  end
+
+  describe 'AC3 — cache (Rails.cache hit)' do
+    it 'hits Postgres exactly once across two requests and both responses are enriched' do
+      campaign = Campaign.create!(title: 'BF', name: "cached-#{SecureRandom.hex(2)}", type: 'Default')
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [{ properties: { 'campaign_id' => campaign.id } }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(Campaign).to receive(:find_by).once.and_call_original
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(json_response.dig('events', 0, 'enriched', 'campaign_name')).to eq(campaign.name)
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+      expect(response).to have_http_status(:ok)
+      expect(json_response.dig('events', 0, 'enriched', 'campaign_name')).to eq(campaign.name)
+    end
+  end
+
+  describe 'AC4 — degradação 5xx' do
+    it 'returns 200 with events:[] degraded:true on upstream 503 (Client already logs :error; controller does not double-log)' do
+      stub_request(:get, events_url).to_return(status: 503, body: 'upstream down')
+      expect(Rails.logger).not_to receive(:warn)
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response).to eq('events' => [], 'degraded' => true)
+    end
+  end
+
+  describe 'AC5 — propagação 4xx (404)' do
+    it 'propagates 404 with upstream body' do
+      stub_request(:get, events_url)
+        .to_return(
+          status: 404,
+          body: { error: 'not found' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(json_response).to include('error' => 'not found')
+    end
+  end
+
+  describe 'AC6 — auth' do
+    it 'returns 401 without any auth header' do
+      get "/api/v1/contacts/#{contact_id}/events"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'AC7 — snake_case → camelCase' do
+    it 'translates whitelisted filters and drops non-whitelisted ones' do
+      stub = stub_request(:get, events_url)
+             .with(query: hash_including(
+               'eventType' => 'track',
+               'campaignId' => '7',
+               'occurredAfter' => '2026-05-01'
+             ))
+             .to_return(status: 200, body: { events: [] }.to_json,
+                        headers: { 'Content-Type' => 'application/json' })
+
+      get "/api/v1/contacts/#{contact_id}/events",
+          params: { event_type: 'track', campaign_id: '7', occurred_after: '2026-05-01', foo: 'bar' },
+          headers: headers
+
+      expect(stub).to have_been_requested
+      expect(WebMock).not_to have_requested(:get, events_url).with(query: hash_including('foo'))
+    end
+  end
+
+  describe 'AC8 — enrich channel_label' do
+    it 'maps known channel to display label' do
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [{ properties: { 'channel' => 'whatsapp' } }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response.dig('events', 0, 'enriched', 'channel_label')).to eq('WhatsApp')
+    end
+
+    it 'maps both facebook and facebook_page to Facebook' do
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [
+            { properties: { 'channel' => 'facebook' } },
+            { properties: { 'channel' => 'facebook_page' } }
+          ] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(json_response.dig('events', 0, 'enriched', 'channel_label')).to eq('Facebook')
+      expect(json_response.dig('events', 1, 'enriched', 'channel_label')).to eq('Facebook')
+    end
+
+    it 'falls back to the original key for unknown channel' do
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [{ properties: { 'channel' => 'foo' } }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(json_response.dig('events', 0, 'enriched', 'channel_label')).to eq('foo')
+    end
+  end
+
+  describe 'AC9 — enrich agent_name' do
+    it 'enriches with User.name from Postgres' do
+      agent = User.create!(name: 'Daniela', email: "daniela-#{SecureRandom.hex(2)}@example.com")
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [{ properties: { 'agent_id' => agent.id } }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(json_response.dig('events', 0, 'enriched', 'agent_name')).to eq('Daniela')
+    end
+  end
+
+  describe 'AC10 — network failure degrades to events:[]' do
+    it 'degrades on timeout (EvoFlow::HTTPError with code=nil) and emits a controller-level warn' do
+      stub_request(:get, events_url).to_timeout
+      expect(Rails.logger).to receive(:warn).with(/degraded.*code=nil/)
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response).to eq('events' => [], 'degraded' => true)
+    end
+  end
+end

--- a/spec/requests/api/v1/evo_flow/contact_events_spec.rb
+++ b/spec/requests/api/v1/evo_flow/contact_events_spec.rb
@@ -203,6 +203,38 @@ RSpec.describe 'GET /api/v1/contacts/:contact_id/events', type: :request do
     end
   end
 
+  describe 'enrich payload hygiene' do
+    it "omits the 'enriched' key entirely when the event has no enrichable property" do
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [{ id: 'e1', properties: { 'foo' => 'bar' } }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response.dig('events', 0)).not_to have_key('enriched')
+    end
+
+    it 'omits nil enrich values instead of returning enriched.campaign_name = nil' do
+      missing_id = SecureRandom.uuid
+      stub_request(:get, events_url)
+        .to_return(
+          status: 200,
+          body: { events: [{ properties: { 'campaign_id' => missing_id, 'channel' => 'whatsapp' } }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      get "/api/v1/contacts/#{contact_id}/events", headers: headers
+
+      enriched = json_response.dig('events', 0, 'enriched')
+      expect(enriched).to eq('channel_label' => 'WhatsApp')
+      expect(enriched).not_to have_key('campaign_name')
+    end
+  end
+
   describe 'AC10 — network failure degrades to events:[]' do
     it 'degrades on timeout (EvoFlow::HTTPError with code=nil) and emits a controller-level warn' do
       stub_request(:get, events_url).to_timeout

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -106,6 +106,66 @@ RSpec.describe EvoFlow::Client do
     end
   end
 
+  describe '#get' do
+    let(:events_path) { '/contacts/42/events' }
+    let(:events_url) { "#{api_url}/contacts/42/events" }
+
+    it 'GETs the full /api/v1 URL with the integration API key header and returns parsed body' do
+      stub = stub_request(:get, events_url)
+             .with(
+               query: { 'limit' => '10' },
+               headers: { 'X-Integration-API-Key' => api_key }
+             )
+             .to_return(
+               status: 200,
+               body: { events: [], pagination: { hasNext: false } }.to_json,
+               headers: { 'Content-Type' => 'application/json' }
+             )
+
+      result = client.get(events_path, limit: 10)
+
+      expect(stub).to have_been_requested
+      expect(result).to include('events' => [])
+      expect(result['pagination']).to include('hasNext' => false)
+    end
+
+    it 'omits keys whose value is nil from the outbound query string (params.compact)' do
+      stub = stub_request(:get, events_url)
+             .with(query: hash_including('limit' => '10'))
+             .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      client.get(events_path, limit: 10, cursor: nil)
+
+      expect(stub).to have_been_requested
+      expect(WebMock).not_to have_requested(:get, events_url).with(query: hash_including('cursor'))
+    end
+
+    it 'raises EvoFlow::HTTPError with code 500 on upstream 5xx' do
+      stub_request(:get, events_url).to_return(status: 500, body: 'boom')
+
+      expect { client.get(events_path) }
+        .to raise_error(EvoFlow::HTTPError) { |error|
+          expect(error.code).to eq(500)
+          expect(error.response.body).to eq('boom')
+        }
+    end
+
+    it 'raises EvoFlow::HTTPError with code 404 on upstream 4xx' do
+      stub_request(:get, events_url).to_return(status: 404, body: { error: 'nope' }.to_json,
+                                               headers: { 'Content-Type' => 'application/json' })
+
+      expect { client.get(events_path) }
+        .to raise_error(EvoFlow::HTTPError) { |error| expect(error.code).to eq(404) }
+    end
+
+    it 'raises EvoFlow::HTTPError with nil code on a network timeout' do
+      stub_request(:get, events_url).to_timeout
+
+      expect { client.get(events_path) }
+        .to raise_error(EvoFlow::HTTPError) { |error| expect(error.code).to be_nil }
+    end
+  end
+
   describe 'configuration safety' do
     it 'raises ConfigurationError when the API key is blank (F13)' do
       expect { described_class.new(api_url: api_url, api_key: '') }


### PR DESCRIPTION
## Summary

- Adiciona `Api::V1::EvoFlow::ContactEventsController` em `GET /api/v1/contacts/:contact_id/events`, fazendo **proxy autenticado** ao `GET /contacts/:id/events` do `evo-flow` (story 7.6 / EVO-1242). Auth herdada de `Api::V1::BaseController` (Service Token / Bearer / API Access Token via `EvoAuthConcern`).
- **Enrich por evento** (`enriched: { campaign_name, channel_label, agent_name }`) com `Rails.cache.fetch` TTL 60s para Postgres lookups (`Campaign.find_by`, `User.find_by`) usando `skip_nil:` para não cachear ID inexistente. `channel_label` via lookup direto em hash frozen (sem cache — round-trip de Redis em produção sairia mais caro que o hash em memória).
- **Degradação graciosa:** network failure (`code.nil?`) ou 5xx upstream → `200 { events: [], degraded: true }`. `Rails.logger.warn` apenas em network failure (5xx já é logado como `:error` pelo `EvoFlow::Client#raise_api_error`; evita log duplicado). 4xx propagado com body original.
- **Tradução snake_case → camelCase** dos filtros (`event_type → eventType`, `campaign_id → campaignId`, etc.) via whitelist `params.permit` antes de chamar `Client#get`.
- Estende `EvoFlow::Client` com `#get(path, params)` espelhando `#post` (mesmo `handle_response`, `join`, `request_headers`, rescue chain).

**Divergência consciente do AC original (Devise → EvoAuth):** documentada em `tech-spec-evo-1243-... §Technical Decisions §2` e confirmada com TL em 2026-05-26. Uniformidade > letra do AC; nenhum controller `Api::V1::*` neste repo usa Devise.

**`Campaign` model criado nesta story** (`app/models/campaign.rb`) deliberadamente mínimo: `default_scope { where(deleted_at: nil) }` + `self.inheritance_column = nil` (a coluna `type` é string plano, não STI). Comentário no model alerta sobre o ponto caso outra story introduza STI real (`OngoingCampaign`/`OneOffCampaign`).

## Test plan

- [ ] CI verde contra `develop`.
- [ ] **Local rspec:** 34 examples / 0 failures em 3 specs:
  - [ ] `spec/services/evo_flow/client_spec.rb` — describe `#get` (happy path, `params.compact`, 500, 404, timeout)
  - [ ] `spec/models/campaign_spec.rb` — `find_by(id:)` + `default_scope` soft-delete
  - [ ] `spec/requests/api/v1/evo_flow/contact_events_spec.rb` — AC1-AC10:
    - [ ] AC1 happy path (`limit=10`, `events` + `pagination`)
    - [ ] AC2 enrich `campaign_name` (Postgres)
    - [ ] AC3 cache (`Campaign.find_by` chamado **exatamente 1×** em 2 requests; ambas respostas com `enriched.campaign_name`)
    - [ ] AC4 degradação 503 (`logger.warn` **não** disparado — Client já loga error)
    - [ ] AC5 propagação 404 com body original
    - [ ] AC6 401 sem auth
    - [ ] AC7 snake → camel + filtros não whitelisted (`foo=bar`) descartados
    - [ ] AC8 enrich `channel_label` (whatsapp/facebook/facebook_page/unknown fallback)
    - [ ] AC9 enrich `agent_name` (`User`)
    - [ ] AC10 network timeout degrada + `logger.warn` com `code=nil`
- [ ] **Local rubocop:** 0 offenses nos arquivos do PR.
- [ ] **Smoke E2E (rails runner + WebMock):** status 200, `events[].enriched` populado, outbound query camelCase (`campaignId=...&limit=5`), filtros não whitelisted dropados.
- [ ] **Manual:** subir `evo-flow` + CRM via docker-compose, gerar `api_access_token`, `curl -H 'X-Api-Access-Token: <t>' '/api/v1/contacts/<uuid>/events?limit=5&campaign_id=<uuid>'` e verificar payload.

## Notas

- **Bloqueia:** EVO-1244 (story 7.8 — UI Vue da timeline de eventos).
- **Bloqueadores:** EVO-1242 (entregue, story 7.6); EVO-1238 (transitivo, `Client#post`); EVO-1239 (PR #94 — já mergeada em `develop`).
- **`db/schema.rb`** não foi tocada neste PR. A migration pendente `20260520192951_add_evolution_hub_meta_to_channels` está coberta pelo PR #97 (`chore(db)`).

## Summary by Sourcery

Add an authenticated proxy endpoint for contact events backed by evo-flow and support enrichment of event data.

New Features:
- Expose GET /api/v1/contacts/:contact_id/events to proxy evo-flow contact events with translated query filters.
- Enrich proxied contact events with campaign, channel, and agent metadata using short-lived caching.
- Introduce a minimal Campaign model to support campaign lookups for event enrichment.
- Extend EvoFlow::Client with a GET method to call evo-flow read endpoints.

Tests:
- Add request specs covering happy path, filtering, enrichment, caching, auth, and degradation behavior for the contact events endpoint.
- Add specs for EvoFlow::Client#get covering query construction, error handling, and timeouts.
- Add specs for the Campaign model default scope and soft-delete behavior.