### PR TITLE
fix(crm): route WhatsApp Cloud send errors through StatusUpdateService funnel (EVO-1460)

### DIFF
--- a/app/services/whatsapp/providers/base_service.rb
+++ b/app/services/whatsapp/providers/base_service.rb
@@ -49,9 +49,11 @@ class Whatsapp::Providers::BaseService
     error_message = error_message(response)
     return if error_message.blank?
 
-    @message.external_error = error_message
-    @message.status = :failed
-    @message.save!
+    # EVO-1460 follow-up: route through the funnel so Wisper :message_status_changed
+    # is published — handle_error used to bypass it via save! and the nil return tricked
+    # send_on_whatsapp_service's `== false` guard, leaving Cloud failures invisible to
+    # the EvoFlow listener (EVO-1240).
+    Messages::StatusUpdateService.new(@message, 'failed', error_message).perform
   end
 
   def create_buttons(items)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -437,9 +437,8 @@ module Whatsapp
         Rails.logger.error("WhatsApp Cloud audio send failed for message #{message.id}: #{error_message}")
         return if message.blank?
 
-        message.external_error = error_message
-        message.status = :failed
-        message.save!
+        # EVO-1460 follow-up: same bypass as handle_error — see base_service.rb.
+        Messages::StatusUpdateService.new(message, 'failed', error_message).perform
       end
 
       def find_template_by_id(template_id)

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -57,7 +57,11 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect(message.external_error).to be_nil
     end
 
-    it 'marks message as failed when message dispatch returns provider error' do
+    # EVO-1460 follow-up: handle_error and mark_audio_upload_failed used to write
+    # message.status = :failed + save! directly, bypassing Wisper. They now route
+    # through Messages::StatusUpdateService so :message_status_changed is published
+    # for the EvoFlow listener (EVO-1240).
+    it 'routes provider error to Messages::StatusUpdateService (handle_error funnel)' do
       service.instance_variable_set(:@message, message)
 
       failed_message_response = instance_double(
@@ -70,27 +74,31 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect(service).to receive(:upload_media_to_whatsapp).with(temp_file.path, 'audio/webm').and_return('media_123')
       allow(HTTParty).to receive(:post).and_return(failed_message_response)
 
+      status_service = instance_double(Messages::StatusUpdateService, perform: true)
+      expect(Messages::StatusUpdateService).to receive(:new)
+        .with(message, 'failed', 'Invalid audio payload')
+        .and_return(status_service)
+
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
-      expect(message.status).to eq(:failed)
-      expect(message.external_error).to eq('Invalid audio payload')
-      expect(message.saved).to eq(true)
     end
 
-    it 'marks message as failed when upload raises format rejection error' do
+    it 'routes audio upload failure to Messages::StatusUpdateService (mark_audio_upload_failed funnel)' do
       allow(service).to receive(:upload_media_to_whatsapp).and_raise(
         described_class::AudioUploadError,
         'WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED - WhatsApp API Error (131053) - Unsupported media type'
       )
       expect(HTTParty).not_to receive(:post)
 
+      status_service = instance_double(Messages::StatusUpdateService, perform: true)
+      expect(Messages::StatusUpdateService).to receive(:new)
+        .with(message, 'failed', a_string_including('WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED'))
+        .and_return(status_service)
+
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
-      expect(message.status).to eq(:failed)
-      expect(message.external_error).to include('WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED')
-      expect(message.saved).to eq(true)
       expect(File).to have_received(:delete).with(temp_file.path)
     end
 


### PR DESCRIPTION
## Summary

Follow-up da EVO-1239 / PR #94 (`feat(crm): publish Wisper :message_status_changed for all channels`).

Durante review do código mergeado identifiquei dois bypasses remanescentes **no provider WhatsApp Cloud** que escapavam pelo retorno `nil` e nunca publicavam `:message_status_changed` no caminho de erro de envio outbound — ironicamente o canal-título da própria 1239.

- **Bug 1 —** `Whatsapp::Providers::BaseService#handle_error` (`app/services/whatsapp/providers/base_service.rb:44-55`): fazia `@message.update!(status: :failed)` direto + return `nil`. Como em Ruby `nil == false` é `false`, a guarda `if message_id == false` em `send_on_whatsapp_service.rb:142` não disparava o `StatusUpdateService`.
- **Bug 2 —** `WhatsappCloudService#mark_audio_upload_failed` (`app/services/whatsapp/providers/whatsapp_cloud_service.rb:436-443`): mesmo padrão, mesmo escape via `nil`.

**Efeito prático:** mensagem ficava `status=failed` mas Wisper nunca era publicado → o listener da 7.4 (EVO-1240) ficaria cego para falhas de envio outbound no Cloud. Providers que retornam `false` (evolution_go, etc.) já funcionavam com a 1239 — só o Cloud escapava pelo `nil`.

### Mudança

Ambos os sites agora delegam para `Messages::StatusUpdateService.new(message, 'failed', error_message).perform`, mantendo a tese "no more bypasses" da 1239.

Alternativa descartada: tratar `nil` na guarda do `send_on_whatsapp_service` — band-aid que deixava o bypass no BaseService intacto para qualquer call site futuro.

## Test plan

- [x] `bundle exec rspec spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb` — 5 examples, 0 failures (specs reescritos para validar delegação ao funil, mesmo estilo do `send_on_whatsapp_service_spec.rb`)
- [x] `bundle exec rspec spec/services/whatsapp/send_on_whatsapp_service_spec.rb` — 7 examples, 0 failures (regressão da 1239 segue verde)
- [ ] Smoke local: disparar envio outbound no Cloud para número inválido → verificar log do `:message_status_changed`
- [ ] Confirmar que EVO-1240 captura o evento `message.failed` nesse caminho

## Notas

- Não toca outros providers (evolution_go, 360dialog, baileys) — já cobertos pela 1239.
- Não mexe na guarda `== false` do `send_on_whatsapp_service` (descartado).
- `handle_error` é compartilhado via herança, mas o `StatusUpdateService` é channel-agnostic — mudança safe para todos os providers que herdam de `BaseService`.

Refs: [EVO-1460](https://linear.app/evoai/issue/EVO-1460/), [EVO-1239](https://linear.app/evoai/issue/EVO-1239/), [EVO-1240](https://linear.app/evoai/issue/EVO-1240/)

## Summary by Sourcery

Route WhatsApp Cloud outbound send failures through the shared message status update funnel so status change events are published consistently.

Bug Fixes:
- Ensure WhatsApp Cloud provider errors in handle_error update message status via Messages::StatusUpdateService instead of directly mutating and saving the message, so :message_status_changed events are emitted.
- Ensure WhatsApp Cloud audio upload failures use Messages::StatusUpdateService to mark messages as failed and record error details, avoiding silent bypass of status change notifications.

Tests:
- Update WhatsApp Cloud service specs to assert delegation of provider and audio upload errors to Messages::StatusUpdateService rather than direct message persistence.