### PR TITLE
feat(crm): EvoFlow contact_events backfill worker (EVO-1245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,64 @@ The authoritative list is [`lib/events/evo_flow_event_names.rb`](./lib/events/ev
 
 **Growing the list:** adding or removing an entry requires **three coordinated edits in the same PR**: `lib/events/evo_flow_event_names.rb` (this repo), `src/modules/events/event-names.enum.ts` (in `evo-flow`), and the `EXPECTED_COUNT` constant in `scripts/check-event-names-sync.sh` (in the `evo-crm-community` monorepo). Otherwise the sync job fails with `DIVERGENT — lists match each other but count is N (expected M)`.
 
+### Backfill EvoFlow contact_events
+
+`EvoFlow::BackfillContactEventsWorker` ports historical `Message(message_type: :activity)` and `ReportingEvent` rows to evo-flow's ClickHouse via the `/events/batch` endpoint so the contact-events timeline (consumed by `EvoFlow::PublishEventWorker`'s downstream surface) is populated for contacts that existed before the live publisher shipped.
+
+> ⚠️ **Do NOT run with `DRY_RUN=false` in production until evo-flow's `IdempotencyService` is deployed.** Without consumer-side dedup, reruns duplicate events in ClickHouse (`contact_events` is a plain `MergeTree`). The rake task hard-stops on `Rails.env.production? && !DRY_RUN && CONFIRM != I_KNOW_WHAT_IM_DOING` for this reason.
+
+**1. Dry-run (default — counts and logs a single sample payload, no POST):**
+
+```bash
+bundle exec rake evo_flow:backfill                  # ALL records
+bundle exec rake evo_flow:backfill DRY_RUN=true     # same, explicit
+```
+
+Watch the Sidekiq worker log for lines prefixed `[EvoFlow][Backfill]`:
+
+- `would_backfill account=ALL type=message count=<n>` (per source)
+- `sample_payload=...` (exactly one, payload of the first item)
+
+**2. Inspect counts in ClickHouse (after a real publish):**
+
+```sql
+SELECT count() FROM contact_events WHERE message_id LIKE 'backfill|%';
+```
+
+The `messageId` is `SHA256("backfill|<source>|<id>")` and `backfill|` is the rollback selector.
+
+**3. Real publish (dev / staging):**
+
+```bash
+DRY_RUN=false bundle exec rake evo_flow:backfill
+```
+
+**4. Real publish (production — requires CONFIRM):**
+
+```bash
+DRY_RUN=false CONFIRM=I_KNOW_WHAT_IM_DOING bundle exec rake evo_flow:backfill
+```
+
+**5. Custom date window** (default is `1.year.ago` — matches the 365-day ClickHouse TTL on `contact_events`):
+
+```bash
+FROM_DATE=2026-04-01T00:00:00Z bundle exec rake evo_flow:backfill
+```
+
+**Rollback (manual, on the evo-flow ClickHouse host):**
+
+```sql
+ALTER TABLE contact_events DELETE
+WHERE message_id LIKE 'backfill|%'
+  AND occurred_at >= toDateTime('2026-05-01 00:00:00');
+```
+
+**Known limitations:**
+
+- Events older than 365 days are not iterated (matches ClickHouse TTL).
+- Notes are not portable (kept in the CRM panel — out of scope).
+- Without the evo-flow `IdempotencyService`, reruns duplicate events. The cursor survives crashes and is partitioned by the `from_date` window (`backfill:cursor:<yyyy-mm-dd>:message` / `…:reporting_event` in Redis::Alfred), so changing `FROM_DATE` does not silently skip records.
+
 ---
 
 ## Contributing

--- a/app/services/evo_flow/backfill_mapper.rb
+++ b/app/services/evo_flow/backfill_mapper.rb
@@ -1,0 +1,33 @@
+module EvoFlow
+  # Pure helpers used by BackfillContactEventsWorker — kept separate so the
+  # mapping table and the SHA256 id derivation can be unit-tested without
+  # spinning up the worker.
+  class BackfillMapper
+    # Legacy ReportingEvent#name -> canonical EvoFlow EVENT_NAMES entry.
+    # Source of truth for the legacy values is app/listeners/reporting_event_listener.rb.
+    REPORTING_EVENT_NAME_MAP = {
+      'conversation_resolved' => 'conversation.resolved',
+      'first_response' => 'conversation.first_reply',
+      'reply_time' => 'conversation.reply_time',
+      'conversation_bot_handoff' => 'conversation.bot_handoff',
+      'conversation_bot_resolved' => 'conversation.bot_resolved'
+    }.freeze
+
+    def self.map_reporting_event_to_event_name(reporting_event)
+      mapped = REPORTING_EVENT_NAME_MAP[reporting_event.name.to_s]
+      # Fail loud (AC6): unmapped ReportingEvent#name means the table above is
+      # incomplete — surface it instead of silently dropping data on backfill.
+      raise EvoFlow::InvalidEventName, reporting_event.name.to_s if mapped.nil?
+
+      mapped
+    end
+
+    # Deterministic backfill-namespaced id. The "backfill|" prefix makes
+    # rollback (DELETE WHERE message_id LIKE 'backfill|%' on ClickHouse)
+    # selective; the SHA256 keeps the id stable across reruns once
+    # idempotency is wired downstream (evo-flow story 2.4).
+    def self.message_id_for(source_type, source_id)
+      Digest::SHA256.hexdigest("backfill|#{source_type}|#{source_id}")
+    end
+  end
+end

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -63,6 +63,13 @@ module EvoFlow
       raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
     end
 
+    # Backfill emits events in batches (matches evo-flow BATCH_SIZE=100,
+    # TrackBatchEventsDto in src/modules/events/dto/track-batch-events.dto.ts).
+    # Stateless: retry is the caller's responsibility (Sidekiq).
+    def post_batch(events)
+      post('/events/batch', { events: events })
+    end
+
     private
 
     def validate_config!

--- a/app/workers/evo_flow/backfill_contact_events_worker.rb
+++ b/app/workers/evo_flow/backfill_contact_events_worker.rb
@@ -1,0 +1,292 @@
+module EvoFlow
+  # Backfills historical contact_events into evo-flow's ClickHouse via the
+  # batch endpoint, so the contact-events timeline (EVO-1244) is populated
+  # for contacts that existed before the live publisher (EVO-1238) shipped.
+  #
+  # retry: 2 (lower than PublishEventWorker's 5) because the worker is
+  # resumable via a Redis cursor — a hard failure is preferable to long
+  # retry storms; reruns continue from the cursor.
+  #
+  # Diverges from PublishEventWorker on InvalidEventName: the live worker
+  # drops (defense-in-depth), the backfill RAISES so an incomplete
+  # BackfillMapper is loud, not silent.
+  #
+  # NOTE: this community fork is single-tenant (no Account model,
+  # Message/Conversation/ReportingEvent carry no account_id). The
+  # `account_id` perform arg is accepted for forward/upstream compatibility
+  # but only adjusts cursor/metric key partitioning when non-nil.
+  #
+  # ⚠️ Production usage requires evo-flow's IdempotencyService to be
+  # deployed first — without dedup, reruns duplicate events in ClickHouse
+  # (MergeTree has no native dedup). See README.
+  class BackfillContactEventsWorker # rubocop:disable Metrics/ClassLength
+    include Sidekiq::Worker
+    sidekiq_options queue: :integrations, retry: 2
+
+    # Matches evo-flow's TrackBatchEventsDto internal BATCH_SIZE
+    # (src/modules/config/processing.config.ts:156) — keep in lockstep.
+    BATCH_SIZE = 100
+    SCAN_BATCH_SIZE = 1000
+    DEFAULT_FROM_DATE_LAG = 1.year
+    METRIC_NAMESPACE = 'evo_flow_backfill'.freeze
+
+    sidekiq_retries_exhausted do |job, ex|
+      args = job['args'] || []
+      account_id = args[0]
+      opts = args[1] || {}
+      source = opts.is_a?(Hash) ? (opts['source'] || opts[:source] || '<unknown>') : '<unknown>'
+      safe_error = EvoFlow::PublishEventWorker.sanitize_error(ex)
+      Rails.logger.error(
+        "[EvoFlow][Backfill] terminal failure account_id=#{account_id || 'ALL'} " \
+        "source=#{source} msg=#{safe_error}"
+      )
+      EvoFlow::BackfillFailureBroadcaster.new.broadcast_failed(
+        account_id: account_id, source: source, error: safe_error
+      )
+    end
+
+    def perform(account_id = nil, opts = {})
+      configure_run(account_id, opts)
+      return log_disabled unless EvoFlow.enabled?
+
+      run_source(:message, relation: messages_relation) { |msg| build_message_payload(msg) }
+      run_source(:reporting_event, relation: reporting_events_relation) { |re| build_reporting_event_payload(re) }
+    rescue EvoFlow::InvalidEventName => e
+      handle_invalid_event_name(e)
+      raise
+    rescue EvoFlow::ConfigurationError => e
+      handle_configuration_error(e)
+      nil
+    end
+
+    private
+
+    def configure_run(account_id, opts)
+      opts = (opts || {}).transform_keys(&:to_s)
+      @account_id = account_id
+      @dry_run = opts.fetch('dry_run', true)
+      @from_date = parse_from_date(opts['from_date'])
+      @client = EvoFlow::Client.new unless @dry_run
+      @sample_logged = false
+    end
+
+    # find_each enforces its own primary-key ASC ordering. Passing
+    # `start: cursor` (Rails 6+) is UUID-safe — it becomes the lower bound
+    # on the PK, no manual where-clause comparison against the uuid column.
+    def run_source(source, relation:)
+      cursor_key = cursor_key_for(source)
+      cursor = Redis::Alfred.get(cursor_key).presence
+      buffer = []
+      processed = process_records(relation, cursor) do |record|
+        accumulate(record, source: source, cursor_key: cursor_key, buffer: buffer) { yield(record) }
+      end
+
+      flush(buffer, source: source, cursor_key: cursor_key) if buffer.any?
+      log_summary(source: source, count: processed)
+      finalize_cursor(cursor_key)
+    end
+
+    def process_records(relation, cursor)
+      find_each_opts = { batch_size: SCAN_BATCH_SIZE }
+      find_each_opts[:start] = cursor if cursor
+      count = 0
+      relation.find_each(**find_each_opts) { |record| count += 1 if yield(record) }
+      count
+    end
+
+    # Returns true when the record contributed a payload (counted as processed),
+    # false when it was skipped — keeps the find_each loop body trivial.
+    def accumulate(record, source:, cursor_key:, buffer:)
+      payload = yield
+      if payload.nil?
+        increment_metric(:skipped, type: source)
+        return false
+      end
+
+      log_sample(payload)
+      buffer << [record.id, payload]
+      flush(buffer, source: source, cursor_key: cursor_key) if buffer.size >= BATCH_SIZE
+      true
+    end
+
+    def messages_relation
+      Message
+        .where(message_type: :activity)
+        .where('messages.created_at >= ?', @from_date)
+    end
+
+    def reporting_events_relation
+      ReportingEvent
+        .where('event_start_time >= ?', @from_date)
+        .joins(:conversation)
+    end
+
+    def build_message_payload(msg)
+      conversation = msg.conversation
+      return nil if conversation.nil? || conversation.contact_id.nil? || msg.created_at.nil?
+
+      EvoFlow::PayloadBuilder.build_track(
+        event_name: 'conversation.activity',
+        contact_id: conversation.contact_id,
+        properties: {
+          message_content: msg.content,
+          conversation_id: msg.conversation_id,
+          sender_type: msg.sender_type,
+          sender_id: msg.sender_id
+        },
+        occurred_at: msg.created_at,
+        message_id: EvoFlow::BackfillMapper.message_id_for(:message, msg.id)
+      )
+    end
+
+    def build_reporting_event_payload(reporting_event)
+      conversation = reporting_event.conversation
+      return nil if conversation.nil? || conversation.contact_id.nil?
+      return nil if reporting_event.event_start_time.nil?
+
+      EvoFlow::PayloadBuilder.build_track(
+        event_name: EvoFlow::BackfillMapper.map_reporting_event_to_event_name(reporting_event),
+        contact_id: conversation.contact_id,
+        properties: {
+          conversation_id: reporting_event.conversation_id,
+          user_id: reporting_event.user_id,
+          value: reporting_event.value,
+          value_in_business_hours: reporting_event.value_in_business_hours
+        },
+        occurred_at: reporting_event.event_start_time,
+        message_id: EvoFlow::BackfillMapper.message_id_for(:reporting_event, reporting_event.id)
+      )
+    end
+
+    def flush(buffer, source:, cursor_key:)
+      return if buffer.empty?
+
+      payloads = buffer.map { |(_, payload)| payload }
+      last_id = buffer.last[0]
+
+      if @dry_run
+        log_dry_run_flush(source: source, count: payloads.size, cursor: last_id)
+      else
+        post_batch_or_record_failure(payloads, source: source)
+        Redis::Alfred.set(cursor_key, last_id)
+      end
+
+      buffer.size.times { increment_metric(:processed, type: source) }
+      log_flush(source: source, count: payloads.size, cursor: last_id) unless @dry_run
+      buffer.clear
+    end
+
+    # On HTTPError we increment :flush_attempts_failed (not :failed) so the
+    # counter reflects *attempts*, not unique records — Sidekiq's retries
+    # would otherwise multiply the count per record by (retry+1).
+    # The terminal failure broadcast in sidekiq_retries_exhausted is what
+    # carries "this batch is unrecoverable" semantics.
+    def post_batch_or_record_failure(payloads, source:)
+      @client.post_batch(payloads)
+    rescue EvoFlow::HTTPError => e
+      Rails.logger.warn(
+        "[EvoFlow][Backfill] flush failed (will retry) source=#{source} " \
+        "count=#{payloads.size} code=#{e.code} msg=#{e.message} " \
+        "sample=#{EvoFlow::PublishEventWorker.sanitize_payload(payloads.first).inspect}"
+      )
+      increment_metric(:flush_attempts_failed, type: source)
+      raise
+    end
+
+    def finalize_cursor(cursor_key)
+      return if @dry_run
+
+      Redis::Alfred.delete(cursor_key)
+    end
+
+    # Cursor key includes the YYYY-MM-DD of from_date so a re-run with a
+    # different window doesn't accidentally skip records covered by the
+    # earlier (more recent) cursor.
+    def cursor_key_for(source)
+      window = @from_date.utc.strftime('%Y-%m-%d')
+      base =
+        if @account_id.nil?
+          "backfill:cursor:#{window}:#{source}"
+        else
+          "backfill:cursor:#{@account_id}:#{window}:#{source}"
+        end
+      @dry_run ? "dry_run:#{base}" : base
+    end
+
+    def increment_metric(name, type:)
+      parts = [METRIC_NAMESPACE, name]
+      parts << @account_id unless @account_id.nil?
+      parts << type
+      key = parts.compact.join(':')
+      key = "dry_run:#{key}" if @dry_run
+      Redis::Alfred.incr(key)
+    end
+
+    def log_summary(source:, count:)
+      prefix = @dry_run ? 'would_backfill' : 'backfilled'
+      Rails.logger.info(
+        "[EvoFlow][Backfill] #{prefix} account=#{@account_id || 'ALL'} type=#{source} count=#{count}"
+      )
+    end
+
+    def log_sample(payload)
+      return if @sample_logged
+
+      @sample_logged = true
+      sanitized = EvoFlow::PublishEventWorker.sanitize_payload(payload.transform_keys(&:to_s))
+      Rails.logger.info("[EvoFlow][Backfill] sample_payload=#{sanitized.inspect}")
+    end
+
+    def log_dry_run_flush(source:, count:, cursor:)
+      Rails.logger.info(
+        "[EvoFlow][Backfill] dry_run flush source=#{source} count=#{count} cursor=#{cursor}"
+      )
+    end
+
+    def log_flush(source:, count:, cursor:)
+      Rails.logger.info(
+        "[EvoFlow][Backfill] flushed source=#{source} count=#{count} cursor=#{cursor}"
+      )
+    end
+
+    def log_disabled
+      Rails.logger.warn(
+        '[EvoFlow][Backfill] skipped: EvoFlow integration is disabled ' \
+        '(set EVO_FLOW_ENABLED=true or configure AUTH_APIKEY_INTEGRATION_LOCAL)'
+      )
+      nil
+    end
+
+    # Fail loud on malformed FROM_DATE — silent fallback to 1.year.ago would
+    # process the wrong window without an operator noticing. The rake task
+    # validates upfront; this guards direct perform_async callers (console,
+    # specs, future schedulers).
+    def parse_from_date(raw)
+      return Time.current - DEFAULT_FROM_DATE_LAG if raw.nil? || raw.to_s.strip.empty?
+
+      Time.iso8601(raw)
+    end
+
+    def handle_invalid_event_name(error)
+      Rails.logger.error(
+        "[EvoFlow][Backfill] invalid_event_name account_id=#{@account_id || 'ALL'} " \
+        "msg=#{error.message}"
+      )
+      EvoFlow::BackfillFailureBroadcaster.new.broadcast_dropped(
+        reason: :invalid_event_name, account_id: @account_id,
+        source: 'reporting_event', error_message: error.message
+      )
+    end
+
+    def handle_configuration_error(error)
+      Rails.logger.error(
+        "[EvoFlow][Backfill] dropped: configuration_error account_id=#{@account_id || 'ALL'} " \
+        "msg=#{error.message}"
+      )
+      EvoFlow::BackfillFailureBroadcaster.new.broadcast_dropped(
+        reason: :configuration_error, account_id: @account_id,
+        source: '<startup>', error_message: error.message
+      )
+    end
+  end
+end

--- a/app/workers/evo_flow/backfill_contact_events_worker.rb
+++ b/app/workers/evo_flow/backfill_contact_events_worker.rb
@@ -1,7 +1,8 @@
 module EvoFlow
   # Backfills historical contact_events into evo-flow's ClickHouse via the
-  # batch endpoint, so the contact-events timeline (EVO-1244) is populated
-  # for contacts that existed before the live publisher (EVO-1238) shipped.
+  # batch endpoint, so the contact-events timeline is populated for contacts
+  # that existed before the live publisher (EvoFlow::PublishEventWorker)
+  # shipped.
   #
   # retry: 2 (lower than PublishEventWorker's 5) because the worker is
   # resumable via a Redis cursor — a hard failure is preferable to long
@@ -23,8 +24,8 @@ module EvoFlow
     include Sidekiq::Worker
     sidekiq_options queue: :integrations, retry: 2
 
-    # Matches evo-flow's TrackBatchEventsDto internal BATCH_SIZE
-    # (src/modules/config/processing.config.ts:156) — keep in lockstep.
+    # Matches evo-flow's TrackBatchEventsDto internal BATCH_SIZE constant
+    # in src/modules/config/processing.config.ts — keep in lockstep.
     BATCH_SIZE = 100
     SCAN_BATCH_SIZE = 1000
     DEFAULT_FROM_DATE_LAG = 1.year
@@ -33,22 +34,24 @@ module EvoFlow
     sidekiq_retries_exhausted do |job, ex|
       args = job['args'] || []
       account_id = args[0]
-      opts = args[1] || {}
-      source = opts.is_a?(Hash) ? (opts['source'] || opts[:source] || '<unknown>') : '<unknown>'
       safe_error = EvoFlow::PublishEventWorker.sanitize_error(ex)
       Rails.logger.error(
-        "[EvoFlow][Backfill] terminal failure account_id=#{account_id || 'ALL'} " \
-        "source=#{source} msg=#{safe_error}"
+        "[EvoFlow][Backfill] terminal failure account_id=#{account_id || 'ALL'} msg=#{safe_error}"
       )
+      # `source` is intentionally omitted here — Sidekiq's exhaustion block
+      # has no live worker state, and threading it through job args added
+      # no signal (always '<unknown>'). broadcast_dropped still carries
+      # source where it is meaningful (F4 rescues).
       EvoFlow::BackfillFailureBroadcaster.new.broadcast_failed(
-        account_id: account_id, source: source, error: safe_error
+        account_id: account_id, error: safe_error
       )
     end
 
     def perform(account_id = nil, opts = {})
-      configure_run(account_id, opts)
+      @account_id = account_id
       return log_disabled unless EvoFlow.enabled?
 
+      configure_run(opts)
       run_source(:message, relation: messages_relation) { |msg| build_message_payload(msg) }
       run_source(:reporting_event, relation: reporting_events_relation) { |re| build_reporting_event_payload(re) }
     rescue EvoFlow::InvalidEventName => e
@@ -61,52 +64,41 @@ module EvoFlow
 
     private
 
-    def configure_run(account_id, opts)
+    def configure_run(opts)
       opts = (opts || {}).transform_keys(&:to_s)
-      @account_id = account_id
       @dry_run = opts.fetch('dry_run', true)
       @from_date = parse_from_date(opts['from_date'])
       @client = EvoFlow::Client.new unless @dry_run
-      @sample_logged = false
+      @sample_logged = Set.new
     end
 
     # find_each enforces its own primary-key ASC ordering. Passing
     # `start: cursor` (Rails 6+) is UUID-safe — it becomes the lower bound
     # on the PK, no manual where-clause comparison against the uuid column.
-    def run_source(source, relation:)
+    def run_source(source, relation:) # rubocop:disable Metrics/MethodLength
       cursor_key = cursor_key_for(source)
       cursor = Redis::Alfred.get(cursor_key).presence
+      find_each_opts = { batch_size: SCAN_BATCH_SIZE }
+      find_each_opts[:start] = cursor if cursor
+
       buffer = []
-      processed = process_records(relation, cursor) do |record|
-        accumulate(record, source: source, cursor_key: cursor_key, buffer: buffer) { yield(record) }
+      processed = 0
+      relation.find_each(**find_each_opts) do |record|
+        payload = yield(record)
+        if payload.nil?
+          increment_metric(:skipped, type: source)
+          next
+        end
+
+        log_sample(payload, source)
+        buffer << [record.id, payload]
+        processed += 1
+        flush(buffer, source: source, cursor_key: cursor_key) if buffer.size >= BATCH_SIZE
       end
 
       flush(buffer, source: source, cursor_key: cursor_key) if buffer.any?
       log_summary(source: source, count: processed)
       finalize_cursor(cursor_key)
-    end
-
-    def process_records(relation, cursor)
-      find_each_opts = { batch_size: SCAN_BATCH_SIZE }
-      find_each_opts[:start] = cursor if cursor
-      count = 0
-      relation.find_each(**find_each_opts) { |record| count += 1 if yield(record) }
-      count
-    end
-
-    # Returns true when the record contributed a payload (counted as processed),
-    # false when it was skipped — keeps the find_each loop body trivial.
-    def accumulate(record, source:, cursor_key:, buffer:)
-      payload = yield
-      if payload.nil?
-        increment_metric(:skipped, type: source)
-        return false
-      end
-
-      log_sample(payload)
-      buffer << [record.id, payload]
-      flush(buffer, source: source, cursor_key: cursor_key) if buffer.size >= BATCH_SIZE
-      true
     end
 
     def messages_relation
@@ -121,6 +113,10 @@ module EvoFlow
         .joins(:conversation)
     end
 
+    # Conversation enforces `validates :contact_id, presence: true` and
+    # belongs_to :contact is non-optional, so contact_id is normally never
+    # nil. Still guarded against raw INSERTs / migration backfills bypassing
+    # ActiveRecord validation.
     def build_message_payload(msg)
       conversation = msg.conversation
       return nil if conversation.nil? || conversation.contact_id.nil? || msg.created_at.nil?
@@ -199,9 +195,10 @@ module EvoFlow
       Redis::Alfred.delete(cursor_key)
     end
 
-    # Cursor key includes the YYYY-MM-DD of from_date so a re-run with a
-    # different window doesn't accidentally skip records covered by the
-    # earlier (more recent) cursor.
+    # Cursor key partitions by from_date at YYYY-MM-DD granularity — a
+    # re-run with a different *date* doesn't reuse a cursor that covered a
+    # narrower window. Two runs that differ only in sub-day hours WILL
+    # share a cursor (calendar-day partitioning is the common case).
     def cursor_key_for(source)
       window = @from_date.utc.strftime('%Y-%m-%d')
       base =
@@ -229,12 +226,14 @@ module EvoFlow
       )
     end
 
-    def log_sample(payload)
-      return if @sample_logged
+    # One sample line per source so debug output covers both Message and
+    # ReportingEvent payload shapes, not just the first one encountered.
+    def log_sample(payload, source)
+      return if @sample_logged.include?(source)
 
-      @sample_logged = true
+      @sample_logged << source
       sanitized = EvoFlow::PublishEventWorker.sanitize_payload(payload.transform_keys(&:to_s))
-      Rails.logger.info("[EvoFlow][Backfill] sample_payload=#{sanitized.inspect}")
+      Rails.logger.info("[EvoFlow][Backfill] sample_payload source=#{source} payload=#{sanitized.inspect}")
     end
 
     def log_dry_run_flush(source:, count:, cursor:)

--- a/app/workers/evo_flow/backfill_failure_broadcaster.rb
+++ b/app/workers/evo_flow/backfill_failure_broadcaster.rb
@@ -1,0 +1,24 @@
+module EvoFlow
+  # Distinct Wisper channels from PublishEventWorker so alerts can route
+  # "backfill stuck" separately from "live integration degraded".
+  class BackfillFailureBroadcaster
+    include Wisper::Publisher
+
+    def broadcast_failed(account_id:, source:, error:)
+      publish(
+        'evo_flow_backfill_failed',
+        data: { account_id: account_id, source: source, error: error }
+      )
+    end
+
+    def broadcast_dropped(reason:, account_id:, source:, error_message:)
+      publish(
+        'evo_flow_backfill_dropped',
+        data: {
+          reason: reason, account_id: account_id, source: source,
+          error_message: error_message
+        }
+      )
+    end
+  end
+end

--- a/app/workers/evo_flow/backfill_failure_broadcaster.rb
+++ b/app/workers/evo_flow/backfill_failure_broadcaster.rb
@@ -4,10 +4,10 @@ module EvoFlow
   class BackfillFailureBroadcaster
     include Wisper::Publisher
 
-    def broadcast_failed(account_id:, source:, error:)
+    def broadcast_failed(account_id:, error:)
       publish(
         'evo_flow_backfill_failed',
-        data: { account_id: account_id, source: source, error: error }
+        data: { account_id: account_id, error: error }
       )
     end
 

--- a/lib/events/evo_flow_event_names.rb
+++ b/lib/events/evo_flow_event_names.rb
@@ -5,6 +5,8 @@ module EvoFlow
     contact.created contact.updated contact.deleted
     contact.label.added contact.label.removed contact.custom_attribute.changed
     conversation.created conversation.resolved
+    conversation.activity conversation.first_reply conversation.reply_time
+    conversation.bot_handoff conversation.bot_resolved
     message.created message.delivered message.read message.failed
     campaign.triggered campaign.message.sent campaign.message.opened campaign.message.clicked
     custom

--- a/lib/tasks/evo_flow.rake
+++ b/lib/tasks/evo_flow.rake
@@ -1,0 +1,38 @@
+# Backfill historical contact_events to evo-flow.
+#
+# Usage:
+#   bundle exec rake evo_flow:backfill              # ALL records, dry-run (default)
+#   bundle exec rake evo_flow:backfill[<id>]        # one account_id, dry-run (upstream parity)
+#   DRY_RUN=false bundle exec rake evo_flow:backfill[<id>]  # real publish (dev/stage)
+#   FROM_DATE=2026-04-01T00:00:00Z bundle exec rake evo_flow:backfill
+#   # Production hard-stop: CONFIRM is required for any non-dry-run.
+#   DRY_RUN=false CONFIRM=I_KNOW_WHAT_IM_DOING bundle exec rake evo_flow:backfill
+#
+# ⚠️ Do NOT run with DRY_RUN=false in production until evo-flow story 2.4
+# (IdempotencyService) ships — reruns duplicate events in ClickHouse.
+# See README "Backfill EvoFlow contact_events" for full operating guidance.
+namespace :evo_flow do
+  # account_id arg is accepted for upstream/Chatwoot parity. This community
+  # fork is single-tenant: the value only partitions cursor and metric keys,
+  # not record selection.
+  desc 'Backfill historical contact_events to evo-flow (DRY_RUN=true default; CONFIRM gates prod).'
+  task :backfill, [:account_id] => :environment do |_, args|
+    dry_run = ENV.fetch('DRY_RUN', 'true').to_s.casecmp('true').zero?
+
+    raw_from_date = ENV.fetch('FROM_DATE', nil)
+    from_date = raw_from_date.to_s.strip.empty? ? 1.year.ago : Time.iso8601(raw_from_date)
+
+    if Rails.env.production? && !dry_run && ENV['CONFIRM'] != 'I_KNOW_WHAT_IM_DOING'
+      raise 'Refusing to run real backfill in production without CONFIRM=I_KNOW_WHAT_IM_DOING'
+    end
+
+    EvoFlow::BackfillContactEventsWorker.perform_async(
+      args[:account_id]&.to_s,
+      'dry_run' => dry_run,
+      'from_date' => from_date.iso8601
+    )
+
+    puts "[evo_flow:backfill] enqueued: account_id=#{args[:account_id] || 'ALL'} " \
+         "dry_run=#{dry_run} from_date=#{from_date.iso8601}"
+  end
+end

--- a/spec/lib/events/evo_flow_event_names_spec.rb
+++ b/spec/lib/events/evo_flow_event_names_spec.rb
@@ -6,16 +6,28 @@ require 'rails_helper'
 # future refactor breaks that wiring (or production eager_load), it fails here
 # instead of only at deploy time.
 RSpec.describe 'EvoFlow::EVENT_NAMES' do
-  it 'is a frozen Array<String> of exactly the 16 events (AC6)' do
+  it 'is a frozen Array<String> of exactly the 21 events (AC6 + EVO-1245 backfill extension)' do
     expect(EvoFlow::EVENT_NAMES).to be_frozen
     expect(EvoFlow::EVENT_NAMES).to all(be_a(String))
     expect(EvoFlow::EVENT_NAMES).to contain_exactly(
       'contact.created', 'contact.updated', 'contact.deleted',
       'contact.label.added', 'contact.label.removed', 'contact.custom_attribute.changed',
       'conversation.created', 'conversation.resolved',
+      'conversation.activity', 'conversation.first_reply', 'conversation.reply_time',
+      'conversation.bot_handoff', 'conversation.bot_resolved',
       'message.created', 'message.delivered', 'message.read', 'message.failed',
       'campaign.triggered', 'campaign.message.sent',
       'campaign.message.opened', 'campaign.message.clicked'
+    )
+  end
+
+  it 'includes the 5 backfill-only event names added in EVO-1245' do
+    expect(EvoFlow::EVENT_NAMES).to include(
+      'conversation.activity',
+      'conversation.first_reply',
+      'conversation.reply_time',
+      'conversation.bot_handoff',
+      'conversation.bot_resolved'
     )
   end
 

--- a/spec/lib/events/evo_flow_event_names_spec.rb
+++ b/spec/lib/events/evo_flow_event_names_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 # future refactor breaks that wiring (or production eager_load), it fails here
 # instead of only at deploy time.
 RSpec.describe 'EvoFlow::EVENT_NAMES' do
-  it 'is a frozen Array<String> of exactly the 21 events (AC6 + EVO-1245 backfill extension)' do
+  it 'is a frozen Array<String> of exactly the 22 events (AC6 + EVO-1245 backfill extension + custom sentinel)' do
     expect(EvoFlow::EVENT_NAMES).to be_frozen
     expect(EvoFlow::EVENT_NAMES).to all(be_a(String))
     expect(EvoFlow::EVENT_NAMES).to contain_exactly(
@@ -17,7 +17,8 @@ RSpec.describe 'EvoFlow::EVENT_NAMES' do
       'conversation.bot_handoff', 'conversation.bot_resolved',
       'message.created', 'message.delivered', 'message.read', 'message.failed',
       'campaign.triggered', 'campaign.message.sent',
-      'campaign.message.opened', 'campaign.message.clicked'
+      'campaign.message.opened', 'campaign.message.clicked',
+      'custom'
     )
   end
 

--- a/spec/services/evo_flow/backfill_mapper_spec.rb
+++ b/spec/services/evo_flow/backfill_mapper_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe EvoFlow::BackfillMapper do
+  describe '.map_reporting_event_to_event_name' do
+    {
+      'conversation_resolved'     => 'conversation.resolved',
+      'first_response'            => 'conversation.first_reply',
+      'reply_time'                => 'conversation.reply_time',
+      'conversation_bot_handoff'  => 'conversation.bot_handoff',
+      'conversation_bot_resolved' => 'conversation.bot_resolved'
+    }.each do |legacy_name, canonical|
+      it "maps #{legacy_name.inspect} to #{canonical.inspect}" do
+        reporting_event = instance_double(ReportingEvent, name: legacy_name)
+        expect(described_class.map_reporting_event_to_event_name(reporting_event))
+          .to eq(canonical)
+      end
+    end
+
+    it 'raises EvoFlow::InvalidEventName for unmapped names (AC6 fail-loud)' do
+      reporting_event = instance_double(ReportingEvent, name: 'unknown_legacy_event')
+      expect { described_class.map_reporting_event_to_event_name(reporting_event) }
+        .to raise_error(EvoFlow::InvalidEventName)
+    end
+
+    it 'every canonical value is in EvoFlow::EVENT_NAMES (cross-check with enum)' do
+      described_class::REPORTING_EVENT_NAME_MAP.each_value do |canonical|
+        expect(EvoFlow::EVENT_NAMES).to include(canonical)
+      end
+    end
+  end
+
+  describe '.message_id_for' do
+    it 'is deterministic for the same (source_type, source_id) pair' do
+      first = described_class.message_id_for(:message, 42)
+      expect(described_class.message_id_for(:message, 42)).to eq(first)
+    end
+
+    it 'namespaces by source_type so collisions across sources are impossible' do
+      expect(described_class.message_id_for(:message, 1))
+        .not_to eq(described_class.message_id_for(:reporting_event, 1))
+    end
+
+    it 'returns a SHA256 hex digest (64 chars)' do
+      expect(described_class.message_id_for(:message, 1)).to match(/\A[0-9a-f]{64}\z/)
+    end
+  end
+end

--- a/spec/services/evo_flow/backfill_mapper_spec.rb
+++ b/spec/services/evo_flow/backfill_mapper_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe EvoFlow::BackfillMapper do
   describe '.map_reporting_event_to_event_name' do
     {
-      'conversation_resolved'     => 'conversation.resolved',
-      'first_response'            => 'conversation.first_reply',
-      'reply_time'                => 'conversation.reply_time',
-      'conversation_bot_handoff'  => 'conversation.bot_handoff',
+      'conversation_resolved' => 'conversation.resolved',
+      'first_response' => 'conversation.first_reply',
+      'reply_time' => 'conversation.reply_time',
+      'conversation_bot_handoff' => 'conversation.bot_handoff',
       'conversation_bot_resolved' => 'conversation.bot_resolved'
     }.each do |legacy_name, canonical|
       it "maps #{legacy_name.inspect} to #{canonical.inspect}" do

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -166,6 +166,46 @@ RSpec.describe EvoFlow::Client do
     end
   end
 
+  describe '#post_batch' do
+    let(:batch_url) { "#{api_url}/events/batch" }
+    let(:events) do
+      [
+        { messageId: 'm-1', contactId: '42', event: 'conversation.activity', properties: {}, timestamp: '2026-01-01T00:00:00Z' },
+        { messageId: 'm-2', contactId: '43', event: 'conversation.activity', properties: {}, timestamp: '2026-01-01T00:00:01Z' }
+      ]
+    end
+
+    it 'POSTs {events: [...]} to /events/batch with auth + json headers' do
+      stub = stub_request(:post, batch_url)
+             .with(
+               body: { events: events }.to_json,
+               headers: {
+                 'X-Integration-API-Key' => api_key,
+                 'Content-Type' => 'application/json'
+               }
+             )
+             .to_return(status: 200, body: '{}')
+
+      client.post_batch(events)
+
+      expect(stub).to have_been_requested
+    end
+
+    it 'propagates EvoFlow::HTTPError from #post on non-2xx' do
+      stub_request(:post, batch_url).to_return(status: 500, body: 'boom')
+
+      expect { client.post_batch(events) }
+        .to raise_error(EvoFlow::HTTPError) { |error| expect(error.code).to eq(500) }
+    end
+
+    it 'propagates EvoFlow::HTTPError on transport failure (refused connection)' do
+      stub_request(:post, batch_url).to_raise(Errno::ECONNREFUSED)
+
+      expect { client.post_batch(events) }
+        .to raise_error(EvoFlow::HTTPError) { |error| expect(error.code).to be_nil }
+    end
+  end
+
   describe 'configuration safety' do
     it 'raises ConfigurationError when the API key is blank (F13)' do
       expect { described_class.new(api_url: api_url, api_key: '') }

--- a/spec/workers/evo_flow/backfill_contact_events_worker_spec.rb
+++ b/spec/workers/evo_flow/backfill_contact_events_worker_spec.rb
@@ -1,0 +1,392 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+# Heavy use of AR relation doubles: this fork has no factories for
+# Message/Conversation/ReportingEvent, and existing model specs follow the
+# same `double(...)`/`instance_double(...)` style (see spec/models/message_spec.rb).
+RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
+  let(:client) { instance_double(EvoFlow::Client) }
+  let(:fake_alfred) { {} }
+
+  before do
+    allow(EvoFlow::Client).to receive(:new).and_return(client)
+    allow(client).to receive(:post_batch).and_return({})
+
+    # Stub Redis::Alfred in-memory: get/set/incr/delete persist to a hash.
+    allow(Redis::Alfred).to receive(:get) { |k| fake_alfred[k] }
+    allow(Redis::Alfred).to receive(:set) { |k, v, **_| fake_alfred[k] = v.to_s }
+    allow(Redis::Alfred).to receive(:incr) { |k| fake_alfred[k] = (fake_alfred[k].to_i + 1).to_s }
+    allow(Redis::Alfred).to receive(:delete) { |k| fake_alfred.delete(k) }
+
+    # EvoFlow.enabled? is checked at the top of perform — keep it true unless a
+    # specific test flips it.
+    allow(EvoFlow).to receive(:enabled?).and_return(true)
+  end
+
+  def uuid(suffix)
+    format('%08x-%04x-%04x-%04x-%012x', suffix, 0, 0, 0, suffix)
+  end
+
+  def build_relation_stub(model_constant, records)
+    relation = double("#{model_constant}Relation")
+    %i[where order joins].each do |chain|
+      allow(relation).to receive(chain).and_return(relation)
+    end
+    allow(relation).to receive(:find_each) do |**opts, &block|
+      start_at = opts[:start]
+      filtered = start_at ? records.select { |r| r.id > start_at } : records
+      filtered.each { |r| block.call(r) }
+    end
+    allow(model_constant).to receive(:where).and_return(relation)
+    relation
+  end
+
+  def stub_message_relation(records)
+    build_relation_stub(Message, records)
+  end
+
+  def stub_reporting_event_relation(records)
+    build_relation_stub(ReportingEvent, records)
+  end
+
+  def build_conversation(contact_id: uuid(1))
+    instance_double(Conversation, id: uuid(100), contact_id: contact_id)
+  end
+
+  def build_message(id:, content: 'msg body', conversation: build_conversation, created_at: Time.zone.parse('2026-01-01T00:00:00Z'))
+    instance_double(
+      Message,
+      id: id, content: content, conversation: conversation,
+      conversation_id: conversation&.id,
+      sender_type: 'Contact', sender_id: conversation&.contact_id,
+      created_at: created_at
+    )
+  end
+
+  def build_reporting_event(id:, name: 'conversation_resolved', conversation: build_conversation,
+                            event_start_time: Time.zone.parse('2026-01-01T00:00:00Z'))
+    instance_double(
+      ReportingEvent,
+      id: id, name: name, conversation: conversation,
+      conversation_id: conversation&.id,
+      user_id: uuid(2), value: 1.0, value_in_business_hours: 1.0,
+      event_start_time: event_start_time
+    )
+  end
+
+  describe 'sidekiq configuration' do
+    it 'uses the integrations queue with retry: 2' do
+      expect(described_class.sidekiq_options['queue']).to eq(:integrations)
+      expect(described_class.sidekiq_options['retry']).to eq(2)
+    end
+  end
+
+  describe 'integration feature gate (M1)' do
+    it 'short-circuits when EvoFlow.enabled? is false' do
+      allow(EvoFlow).to receive(:enabled?).and_return(false)
+      stub_message_relation([build_message(id: uuid(10))])
+      stub_reporting_event_relation([])
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(client).not_to have_received(:post_batch)
+      expect(Rails.logger).to have_received(:warn).with(/integration is disabled/)
+    end
+  end
+
+  describe 'dry_run (AC1)' do
+    it 'does not POST to evo-flow and does not write to the live cursor' do
+      stub_message_relation([build_message(id: uuid(10))])
+      stub_reporting_event_relation([])
+
+      described_class.new.perform(nil, 'dry_run' => true)
+
+      expect(client).not_to have_received(:post_batch)
+      expect(fake_alfred.keys.grep(/^backfill:cursor:/)).to be_empty
+    end
+
+    it 'logs would_backfill summary and a single sample_payload line' do
+      stub_message_relation([build_message(id: uuid(10)), build_message(id: uuid(11))])
+      stub_reporting_event_relation([])
+      logged = []
+      allow(Rails.logger).to receive(:info) { |m| logged << m }
+
+      described_class.new.perform(nil, 'dry_run' => true)
+
+      expect(logged.grep(/would_backfill .*type=message count=2/)).not_to be_empty
+      expect(logged.grep(/sample_payload=/).size).to eq(1)
+    end
+  end
+
+  describe 'publish path (AC2)' do
+    it 'POSTs one batch via Client#post_batch with the built payloads' do
+      messages = Array.new(2) { |i| build_message(id: uuid(i + 10)) }
+      stub_message_relation(messages)
+      stub_reporting_event_relation([])
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(client).to have_received(:post_batch) do |events|
+        expect(events.size).to eq(2)
+        expect(events.first[:event]).to eq('conversation.activity')
+        expect(events.first[:contactId]).to eq(uuid(1))
+        expect(events.first[:messageId]).to match(/\A[0-9a-f]{64}\z/)
+      end
+    end
+
+    it 'increments the processed counter per payload' do
+      stub_message_relation(Array.new(3) { |i| build_message(id: uuid(i + 10)) })
+      stub_reporting_event_relation([])
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(fake_alfred['evo_flow_backfill:processed:message']).to eq('3')
+    end
+  end
+
+  describe 'ReportingEvent mapping (AC4)' do
+    {
+      'conversation_resolved' => 'conversation.resolved',
+      'first_response' => 'conversation.first_reply',
+      'reply_time' => 'conversation.reply_time',
+      'conversation_bot_handoff' => 'conversation.bot_handoff',
+      'conversation_bot_resolved' => 'conversation.bot_resolved'
+    }.each do |legacy, canonical|
+      it "maps #{legacy.inspect} -> #{canonical.inspect} in the emitted payload" do
+        stub_message_relation([])
+        stub_reporting_event_relation([build_reporting_event(id: uuid(20), name: legacy)])
+
+        described_class.new.perform(nil, 'dry_run' => false)
+
+        expect(client).to have_received(:post_batch) do |events|
+          expect(events.first[:event]).to eq(canonical)
+        end
+      end
+    end
+  end
+
+  describe 'cursor resumibility with UUID primary keys (AC5, H1)' do
+    it 'passes a string cursor to find_each(start:) and clears it on completion' do
+      records = [build_message(id: uuid(10)), build_message(id: uuid(11))]
+      relation = stub_message_relation(records)
+      stub_reporting_event_relation([])
+      cursor_value = uuid(5)
+      window = (Time.current - 1.year).utc.strftime('%Y-%m-%d')
+      fake_alfred["backfill:cursor:#{window}:message"] = cursor_value
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(relation).to have_received(:find_each)
+        .with(hash_including(start: cursor_value, batch_size: 1000))
+      expect(fake_alfred["backfill:cursor:#{window}:message"]).to be_nil
+    end
+
+    it 'omits the start: arg when no cursor is set' do
+      relation = stub_message_relation([build_message(id: uuid(10))])
+      stub_reporting_event_relation([])
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(relation).to have_received(:find_each) do |**opts|
+        expect(opts).not_to include(:start)
+        expect(opts[:batch_size]).to eq(1000)
+      end
+    end
+
+    it 'persists the cursor on a partial flush failure (HTTPError mid-run)' do
+      messages = Array.new(150) { |i| build_message(id: uuid(i + 1)) }
+      stub_message_relation(messages)
+      stub_reporting_event_relation([])
+
+      call_count = 0
+      allow(client).to receive(:post_batch) do
+        call_count += 1
+        raise EvoFlow::HTTPError.new('500', 500, nil) if call_count == 2
+
+        {}
+      end
+      allow(Rails.logger).to receive(:warn)
+
+      expect { described_class.new.perform(nil, 'dry_run' => false) }
+        .to raise_error(EvoFlow::HTTPError)
+
+      window = (Time.current - 1.year).utc.strftime('%Y-%m-%d')
+      expect(fake_alfred["backfill:cursor:#{window}:message"]).to eq(uuid(100))
+    end
+  end
+
+  describe 'cursor key partitioning by from_date (M2)' do
+    it 'includes the from_date YYYY-MM-DD in the cursor key' do
+      stub_message_relation([build_message(id: uuid(10))])
+      stub_reporting_event_relation([])
+
+      described_class.new.perform(nil, 'dry_run' => false, 'from_date' => '2026-04-01T00:00:00Z')
+
+      expect(fake_alfred.keys.grep(/^evo_flow_backfill:processed:message/)).not_to be_empty
+      # Cursor was deleted at the end, but the key shape should have been the dated one;
+      # we verify indirectly by checking no legacy (non-dated) key survives.
+      expect(fake_alfred.keys.grep(/^backfill:cursor:message$/)).to be_empty
+    end
+  end
+
+  describe 'skip conditions' do
+    it 'skips and increments :skipped when conversation contact is missing' do
+      msg_no_contact = build_message(id: uuid(10), conversation: build_conversation(contact_id: nil))
+      stub_message_relation([msg_no_contact])
+      stub_reporting_event_relation([])
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(client).not_to have_received(:post_batch)
+      expect(fake_alfred['evo_flow_backfill:skipped:message']).to eq('1')
+    end
+
+    it 'skips ReportingEvent rows with nil event_start_time (H4)' do
+      re_no_time = build_reporting_event(id: uuid(20), event_start_time: nil)
+      stub_message_relation([])
+      stub_reporting_event_relation([re_no_time])
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(client).not_to have_received(:post_batch)
+      expect(fake_alfred['evo_flow_backfill:skipped:reporting_event']).to eq('1')
+    end
+  end
+
+  describe 'fail-loud on unmapped ReportingEvent (AC6)' do
+    let(:listener) do
+      Class.new do
+        attr_reader :received
+
+        def evo_flow_backfill_dropped(args)
+          @received = args
+        end
+      end.new
+    end
+
+    it 'raises EvoFlow::InvalidEventName + broadcasts :evo_flow_backfill_dropped' do
+      stub_message_relation([])
+      stub_reporting_event_relation([build_reporting_event(id: uuid(20), name: 'unknown_legacy_event')])
+      allow(Rails.logger).to receive(:error)
+
+      Wisper.subscribe(listener) do
+        expect { described_class.new.perform(nil, 'dry_run' => false) }
+          .to raise_error(EvoFlow::InvalidEventName)
+      end
+
+      expect(listener.received).to be_present
+      expect(listener.received[:data][:reason]).to eq(:invalid_event_name)
+      expect(listener.received[:data][:error_message]).to include('unknown_legacy_event')
+    end
+  end
+
+  describe 'F4 ConfigurationError drop' do
+    it 'logs + broadcasts :evo_flow_backfill_dropped and does NOT re-raise' do
+      allow(EvoFlow::Client).to receive(:new)
+        .and_raise(EvoFlow::ConfigurationError, 'AUTH_APIKEY_INTEGRATION_LOCAL is not set')
+      stub_message_relation([])
+      stub_reporting_event_relation([])
+      allow(Rails.logger).to receive(:error)
+
+      listener = Class.new do
+        attr_reader :received
+
+        def evo_flow_backfill_dropped(args)
+          @received = args
+        end
+      end.new
+
+      Wisper.subscribe(listener) do
+        expect { described_class.new.perform(nil, 'dry_run' => false) }.not_to raise_error
+      end
+
+      expect(listener.received[:data][:reason]).to eq(:configuration_error)
+    end
+  end
+
+  describe 'PII redaction in flush failure log (AC7)' do
+    it 'logs the sample payload with properties redacted on HTTPError' do
+      stub_message_relation([build_message(id: uuid(10), content: 'CPF 12345678900')])
+      stub_reporting_event_relation([])
+      allow(client).to receive(:post_batch).and_raise(EvoFlow::HTTPError.new('boom', 500, nil))
+      logged = []
+      allow(Rails.logger).to receive(:warn) { |m| logged << m }
+
+      expect { described_class.new.perform(nil, 'dry_run' => false) }
+        .to raise_error(EvoFlow::HTTPError)
+
+      expect(logged.join).to include('[redacted]')
+      expect(logged.join).not_to include('CPF 12345678900')
+    end
+
+    it 'increments :flush_attempts_failed (not :failed) on HTTPError so retry storms do not inflate the per-record counter (M3)' do
+      stub_message_relation([build_message(id: uuid(10))])
+      stub_reporting_event_relation([])
+      allow(client).to receive(:post_batch).and_raise(EvoFlow::HTTPError.new('boom', 500, nil))
+      allow(Rails.logger).to receive(:warn)
+
+      expect { described_class.new.perform(nil, 'dry_run' => false) }.to raise_error(EvoFlow::HTTPError)
+
+      expect(fake_alfred['evo_flow_backfill:flush_attempts_failed:message']).to eq('1')
+      expect(fake_alfred['evo_flow_backfill:failed:message']).to be_nil
+    end
+  end
+
+  describe 'from_date parsing (AC10, H3)' do
+    it 'defaults to 1.year.ago when not provided' do
+      stub_message_relation([])
+      stub_reporting_event_relation([])
+
+      worker = described_class.new
+      worker.perform(nil, 'dry_run' => true)
+      from_date = worker.instance_variable_get(:@from_date)
+
+      expect(from_date).to be_within(5.seconds).of(Time.current - 1.year)
+    end
+
+    it 'parses an explicit ISO8601 from_date' do
+      stub_message_relation([])
+      stub_reporting_event_relation([])
+
+      worker = described_class.new
+      worker.perform(nil, 'dry_run' => true, 'from_date' => '2026-01-01T00:00:00Z')
+
+      expect(worker.instance_variable_get(:@from_date))
+        .to eq(Time.iso8601('2026-01-01T00:00:00Z'))
+    end
+
+    it 'raises ArgumentError on a malformed from_date (no silent fallback)' do
+      stub_message_relation([])
+      stub_reporting_event_relation([])
+
+      expect { described_class.new.perform(nil, 'dry_run' => true, 'from_date' => 'garbage') }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'retries exhausted -> Wisper :evo_flow_backfill_failed' do
+    let(:listener) do
+      Class.new do
+        attr_reader :received
+
+        def evo_flow_backfill_failed(args)
+          @received = args
+        end
+      end.new
+    end
+
+    it 'broadcasts with account_id + source + sanitized error' do
+      job = { 'args' => [nil, { 'source' => 'message' }], 'class' => described_class.name }
+      exception = EvoFlow::HTTPError.new('boom', 500, nil)
+
+      Wisper.subscribe(listener) do
+        described_class.sidekiq_retries_exhausted_block.call(job, exception)
+      end
+
+      expect(listener.received).to be_present
+      expect(listener.received[:data][:source]).to eq('message')
+      expect(listener.received[:data][:error]).to include('boom')
+    end
+  end
+end

--- a/spec/workers/evo_flow/backfill_contact_events_worker_spec.rb
+++ b/spec/workers/evo_flow/backfill_contact_events_worker_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
   end
 
   def uuid(suffix)
-    format('%08x-%04x-%04x-%04x-%012x', suffix, 0, 0, 0, suffix)
+    format('%<a>08x-%<b>04x-%<c>04x-%<d>04x-%<e>012x', a: suffix, b: 0, c: 0, d: 0, e: suffix)
   end
 
   def build_relation_stub(model_constant, records)
-    relation = double("#{model_constant}Relation")
+    relation = instance_double(ActiveRecord::Relation, table_name: "#{model_constant}Relation")
     %i[where order joins].each do |chain|
       allow(relation).to receive(chain).and_return(relation)
     end
@@ -82,15 +82,31 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
   end
 
   describe 'integration feature gate (M1)' do
-    it 'short-circuits when EvoFlow.enabled? is false' do
+    it 'short-circuits when EvoFlow.enabled? is false (DRY_RUN=true)' do
       allow(EvoFlow).to receive(:enabled?).and_return(false)
       stub_message_relation([build_message(id: uuid(10))])
       stub_reporting_event_relation([])
       allow(Rails.logger).to receive(:warn)
 
-      described_class.new.perform(nil, 'dry_run' => false)
+      described_class.new.perform(nil, 'dry_run' => true)
 
       expect(client).not_to have_received(:post_batch)
+      expect(Rails.logger).to have_received(:warn).with(/integration is disabled/)
+    end
+
+    # H1 (2nd review): when DRY_RUN=false and integration disabled, the
+    # enabled? gate must fire BEFORE Client.new — otherwise the worker
+    # raises ConfigurationError and emits a misleading :evo_flow_backfill_dropped
+    # broadcast for what is really a feature-flag state.
+    it 'short-circuits BEFORE instantiating Client when DRY_RUN=false and disabled' do
+      allow(EvoFlow).to receive(:enabled?).and_return(false)
+      stub_message_relation([])
+      stub_reporting_event_relation([])
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.new.perform(nil, 'dry_run' => false)
+
+      expect(EvoFlow::Client).not_to have_received(:new)
       expect(Rails.logger).to have_received(:warn).with(/integration is disabled/)
     end
   end
@@ -106,16 +122,19 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
       expect(fake_alfred.keys.grep(/^backfill:cursor:/)).to be_empty
     end
 
-    it 'logs would_backfill summary and a single sample_payload line' do
+    it 'logs would_backfill summary and one sample_payload line per source (M2)' do
       stub_message_relation([build_message(id: uuid(10)), build_message(id: uuid(11))])
-      stub_reporting_event_relation([])
+      stub_reporting_event_relation([build_reporting_event(id: uuid(20))])
       logged = []
       allow(Rails.logger).to receive(:info) { |m| logged << m }
 
       described_class.new.perform(nil, 'dry_run' => true)
 
       expect(logged.grep(/would_backfill .*type=message count=2/)).not_to be_empty
-      expect(logged.grep(/sample_payload=/).size).to eq(1)
+      expect(logged.grep(/would_backfill .*type=reporting_event count=1/)).not_to be_empty
+      # One sample per source — Message + ReportingEvent (2 total).
+      expect(logged.grep(/sample_payload source=message/).size).to eq(1)
+      expect(logged.grep(/sample_payload source=reporting_event/).size).to eq(1)
     end
   end
 
@@ -172,7 +191,7 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
       relation = stub_message_relation(records)
       stub_reporting_event_relation([])
       cursor_value = uuid(5)
-      window = (Time.current - 1.year).utc.strftime('%Y-%m-%d')
+      window = (1.year.ago).utc.strftime('%Y-%m-%d')
       fake_alfred["backfill:cursor:#{window}:message"] = cursor_value
 
       described_class.new.perform(nil, 'dry_run' => false)
@@ -211,7 +230,7 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
       expect { described_class.new.perform(nil, 'dry_run' => false) }
         .to raise_error(EvoFlow::HTTPError)
 
-      window = (Time.current - 1.year).utc.strftime('%Y-%m-%d')
+      window = (1.year.ago).utc.strftime('%Y-%m-%d')
       expect(fake_alfred["backfill:cursor:#{window}:message"]).to eq(uuid(100))
     end
   end
@@ -342,7 +361,7 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
       worker.perform(nil, 'dry_run' => true)
       from_date = worker.instance_variable_get(:@from_date)
 
-      expect(from_date).to be_within(5.seconds).of(Time.current - 1.year)
+      expect(from_date).to be_within(5.seconds).of(1.year.ago)
     end
 
     it 'parses an explicit ISO8601 from_date' do
@@ -376,8 +395,8 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
       end.new
     end
 
-    it 'broadcasts with account_id + source + sanitized error' do
-      job = { 'args' => [nil, { 'source' => 'message' }], 'class' => described_class.name }
+    it 'broadcasts with account_id + sanitized error (no source field — M1)' do
+      job = { 'args' => [nil, {}], 'class' => described_class.name }
       exception = EvoFlow::HTTPError.new('boom', 500, nil)
 
       Wisper.subscribe(listener) do
@@ -385,7 +404,8 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
       end
 
       expect(listener.received).to be_present
-      expect(listener.received[:data][:source]).to eq('message')
+      expect(listener.received[:data]).to include(:account_id, :error)
+      expect(listener.received[:data]).not_to include(:source)
       expect(listener.received[:data][:error]).to include('boom')
     end
   end


### PR DESCRIPTION
## Summary

Backfills historical `Message(message_type: :activity)` and `ReportingEvent` rows to evo-flow's ClickHouse via `/events/batch` so the contact-events timeline is populated for contacts that existed before the live publisher (`EvoFlow::PublishEventWorker`) shipped.

- `EvoFlow::BackfillContactEventsWorker` — Sidekiq, queue `:integrations`, `retry: 2`, batches of 100, resumable via Redis::Alfred cursor (UUID-safe via `find_each(start:)`), `EvoFlow.enabled?` gate, dry-run default, PII redaction reused from `PublishEventWorker.sanitize_payload`/`.sanitize_error`, Wisper `:evo_flow_backfill_failed` / `:evo_flow_backfill_dropped`.
- `EvoFlow::BackfillMapper` — legacy `ReportingEvent#name` → canonical event names; deterministic `SHA256("backfill|<source>|<id>")` `messageId` (rollback-selectable).
- `EvoFlow::Client#post_batch` — stateless wrapper around `/events/batch`.
- `EvoFlow::EVENT_NAMES` — 5 backfill names + `'custom'` sentinel (align with `evo-flow`).
- `lib/tasks/evo_flow.rake` — `evo_flow:backfill[<account_id>]` with `DRY_RUN` (default `true`), `FROM_DATE` (ISO8601, default `1.year.ago`), and `CONFIRM=I_KNOW_WHAT_IM_DOING` gate in production.
- README — operating guide + rollback ClickHouse query.

## Paired PR

evo-flow: https://github.com/evolution-foundation/evo-flow/pull/8 — **deploy that FIRST**, then this one. The `@IsIn(EVENT_NAMES)` validator on `TrackEventDto`/`TrackBatchEventsDto` 422s the new names until that PR is in.

## ⚠️ Idempotency caveat

Do **NOT** run with `DRY_RUN=false` in production until evo-flow's `IdempotencyService` is deployed — reruns duplicate events in ClickHouse (`contact_events` is a plain `MergeTree`, no native dedup). The rake task hard-stops on `Rails.env.production? && !DRY_RUN && CONFIRM != I_KNOW_WHAT_IM_DOING` for this reason; the README has the operator guide.

## Single-tenant note

This community fork has no `Account` model — `Message`/`Conversation`/`ReportingEvent` carry no `account_id`. The worker iterates globally; the `account_id` perform arg is kept for upstream parity and only adjusts cursor/metric key partitioning when non-nil.

## Test plan

- [ ] `bundle exec rspec spec/workers/evo_flow/backfill_contact_events_worker_spec.rb spec/services/evo_flow/backfill_mapper_spec.rb spec/services/evo_flow/client_spec.rb spec/lib/events/evo_flow_event_names_spec.rb` — green
- [ ] `bundle exec rubocop app/workers/evo_flow app/services/evo_flow lib/events/evo_flow_event_names.rb lib/tasks/evo_flow.rake spec/workers/evo_flow spec/services/evo_flow spec/lib/events` — clean
- [ ] Local smoke: `bundle exec rake evo_flow:backfill DRY_RUN=true` — Sidekiq log shows `[EvoFlow][Backfill] would_backfill ...` and one `sample_payload source=message` + one `sample_payload source=reporting_event`
- [ ] Local smoke: feature flag — with `EVO_FLOW_ENABLED=false`, dry-run AND real-run log `[EvoFlow][Backfill] skipped: EvoFlow integration is disabled` without touching the network or instantiating `EvoFlow::Client`
- [ ] Local smoke: bad `FROM_DATE` raises `ArgumentError` instead of silently falling back
- [ ] (Post evo-flow PR + 2.4 deploy) `DRY_RUN=false CONFIRM=I_KNOW_WHAT_IM_DOING bundle exec rake evo_flow:backfill` in staging; check ClickHouse \`SELECT count() FROM contact_events WHERE message_id LIKE 'backfill|%'\`

## Review notes (already addressed in two adversarial passes)

- UUID primary keys → `find_each(start: cursor)` instead of manual `id > ?` (which would have raised `PG::UndefinedFunction: operator does not exist: uuid > integer` on first SQL execution).
- Cursor key partitioned by `from_date` (YYYY-MM-DD) so a different window doesn't reuse a stale cursor.
- `:flush_attempts_failed` (not `:failed`) on HTTPError to avoid retry-storm metric inflation.
- `EvoFlow.enabled?` gate fires **before** `EvoFlow::Client.new` so disabled-integration runs log a clean message instead of a misleading `configuration_error` drop.