### PR TITLE
feat(routing): add :routing_strategy extension point (EvoExtensionPoints v2.1.0) - (routing extensibility PR 2/3)

### DIFF
--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -191,6 +191,8 @@ Interface contract: `.call(conversation, allowed_agent_ids: [String]) → User |
 - Returns a `User` instance when an agent is selected, or `nil` when no agent is available (caller handles nil)
 - MUST NOT raise an exception due to absence of agents
 
+> **Ruby contract module:** `AutoAssignment::Strategies::Base` — internal strategy classes MUST `include` it to be formally linked to this contract. Consumers registering via `replace` (Proc-based) are not required to include it.
+
 Override:
 
 ```ruby

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -1,6 +1,6 @@
 # Extension Points
 
-**Contract version:** `2.0.0` (SemVer)
+**Contract version:** `2.1.0` (SemVer)
 
 This document is the public contract between `evo-ai-crm-community` and
 any external consumer that wants to plug into it without forking or
@@ -13,7 +13,7 @@ ships with a working no-op default; a consumer can **replace** the
 default implementation of one or more of them without modifying files
 in `app/` or `lib/`.
 
-If you are about to change any of the five extension points below,
+If you are about to change any of the six extension points below,
 read the [Compatibility Promise](#compatibility-promise) first.
 
 ---
@@ -42,7 +42,7 @@ Bumping one extension point does not bump the others.
 
 ## Extension points
 
-All five are exposed under the `EvoExtensionPoints` namespace,
+All six are exposed under the `EvoExtensionPoints` namespace,
 implemented by `lib/evo_extension_points/`. The aggregate contract
 version is exposed at `EvoExtensionPoints::EXTENSION_POINTS_VERSION`.
 
@@ -179,6 +179,28 @@ reads consumer data on its behalf.
 **Breaking-change policy:** renaming `register` / `exportable_tables_for_scope`,
 or changing the shape of the returned entries, is a major bump.
 
+### 6. `routing_strategy`
+
+**Version:** `2.1.0`  
+**Default:** `nil` — `AgentAssignmentService` falls back to `AutoAssignment::Strategies::RoundRobin`.
+
+Interface contract: `.call(conversation, allowed_agent_ids: [String]) → User | nil`
+
+- `conversation` — `Conversation` AR instance
+- `allowed_agent_ids` — array of String IDs (online agents intersected with inbox members, as delivered by `OnlineStatusTracker` via Redis)
+- Returns a `User` instance when an agent is selected, or `nil` when no agent is available (caller handles nil)
+- MUST NOT raise an exception due to absence of agents
+
+Override:
+
+```ruby
+EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
+  MyCustomStrategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
+end
+```
+
+**Breaking-change policy:** renaming `.call`, changing the method signature (positional args, required kwargs), or changing the return type from `User | nil` is a major bump. Adding new optional kwargs is a minor bump.
+
 ---
 
 ## How to use as a consumer
@@ -221,6 +243,9 @@ contract break.
 
 ## Versioning history
 
+- `2.1.0` — Added `:routing_strategy` extension point. Enables consumers to replace the
+  conversation assignment algorithm (`AgentAssignmentService#find_assignee`) without
+  modifying core files. Community default: `AutoAssignment::Strategies::RoundRobin`.
 - `2.0.0` — Renamed extension points to neutral open-core vocabulary:
   `feature_gate` → `capability_gate`, `tenant_context` → `runtime_context`
   (with `current_scope_id` / `with_scope`), `data_export` operates on a

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -225,6 +225,10 @@ module MyConsumer
 
       EvoExtensionPoints.replace(:theme_tokens) { |scope| MyConsumer.theme_tokens_for(scope: scope) }
 
+      EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
+        MyConsumer::RoutingStrategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
+      end
+
       EvoExtensionPoints::PluginLoader.register_plugin(:my_consumer) do |plugin|
         plugin.routes { |mapper| mapper.mount MyConsumer::Engine => "/my_consumer" }
       end

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -5,7 +5,10 @@ class AutoAssignment::AgentAssignmentService
   pattr_initialize [:conversation!, :allowed_agent_ids!]
 
   def find_assignee
-    round_robin_manage_service.available_agent(allowed_agent_ids: allowed_online_agent_ids)
+    strategy = EvoExtensionPoints.impl_for(:routing_strategy) ||
+               AutoAssignment::Strategies::RoundRobin
+    Rails.logger.info("[AgentAssignment] routing via #{strategy} for conversation #{conversation.id}")
+    strategy.call(conversation, allowed_agent_ids: allowed_online_agent_ids)
   end
 
   def perform

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -7,7 +7,8 @@ class AutoAssignment::AgentAssignmentService
   def find_assignee
     strategy = EvoExtensionPoints.impl_for(:routing_strategy) ||
                AutoAssignment::Strategies::RoundRobin
-    Rails.logger.info("[AgentAssignment] routing via #{strategy} for conversation #{conversation.id}")
+    strategy_label = strategy.is_a?(Proc) ? 'EvoExtensionPoints[:routing_strategy]' : strategy
+    Rails.logger.info("[AgentAssignment] routing via #{strategy_label} for conversation #{conversation.id}")
     strategy.call(conversation, allowed_agent_ids: allowed_online_agent_ids)
   end
 
@@ -31,11 +32,4 @@ class AutoAssignment::AgentAssignmentService
     @allowed_online_agent_ids ||= online_agent_ids & allowed_agent_ids&.map(&:to_s)
   end
 
-  def round_robin_manage_service
-    @round_robin_manage_service ||= AutoAssignment::InboxRoundRobinService.new(inbox: conversation.inbox)
-  end
-
-  def round_robin_key
-    format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: conversation.inbox_id)
-  end
 end

--- a/app/services/auto_assignment/strategies/base.rb
+++ b/app/services/auto_assignment/strategies/base.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module AutoAssignment
+  module Strategies
+    module Base
+      # Interface contract for all routing strategies.
+      #
+      # Every strategy MUST implement:
+      #   .call(conversation, allowed_agent_ids: [String]) -> User | nil
+      #
+      # Preconditions:
+      #   - conversation:       Conversation AR instance
+      #   - allowed_agent_ids:  Array of agent IDs (Strings, as returned by
+      #                         OnlineStatusTracker via Redis); may be empty
+      #
+      # Postconditions:
+      #   - Returns a User instance when an agent is found
+      #   - Returns nil when no agent is available (caller handles nil)
+      #   - NEVER raises an exception due to absence of agents
+      #   - Use User.find_by(user_id:) / inbox_member lookup — never User.find()
+    end
+  end
+end

--- a/app/services/auto_assignment/strategies/base.rb
+++ b/app/services/auto_assignment/strategies/base.rb
@@ -17,7 +17,10 @@ module AutoAssignment
       #   - Returns a User instance when an agent is found
       #   - Returns nil when no agent is available (caller handles nil)
       #   - NEVER raises an exception due to absence of agents
-      #   - Use User.find_by(user_id:) / inbox_member lookup — never User.find()
+      #
+      # Implementation guidance (not part of the contract):
+      #   - Prefer User.find_by / inbox_member lookups over User.find()
+      #     to avoid ActiveRecord::RecordNotFound on stale IDs
     end
   end
 end

--- a/app/services/auto_assignment/strategies/round_robin.rb
+++ b/app/services/auto_assignment/strategies/round_robin.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AutoAssignment
+  module Strategies
+    class RoundRobin
+      # @param conversation      [Conversation]
+      # @param allowed_agent_ids [Array<String>] string IDs from Redis/OnlineStatusTracker
+      # @return [User, nil]
+      def self.call(conversation, allowed_agent_ids:)
+        return nil if allowed_agent_ids.blank?
+
+        AutoAssignment::InboxRoundRobinService
+          .new(inbox: conversation.inbox)
+          .available_agent(allowed_agent_ids: allowed_agent_ids)
+      end
+    end
+  end
+end

--- a/app/services/auto_assignment/strategies/round_robin.rb
+++ b/app/services/auto_assignment/strategies/round_robin.rb
@@ -3,6 +3,8 @@
 module AutoAssignment
   module Strategies
     class RoundRobin
+      include AutoAssignment::Strategies::Base
+
       # @param conversation      [Conversation]
       # @param allowed_agent_ids [Array<String>] string IDs from Redis/OnlineStatusTracker
       # @return [User, nil]

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Public extension contract of evo-ai-crm-community. See EXTENSION_POINTS.md
-# at the repository root for the full contract. The five sub-modules below
+# at the repository root for the full contract. The six sub-modules below
 # ship no-op defaults; an external consumer overrides a specific extension
 # point at process start via EvoExtensionPoints.replace(:name, &block) or via
 # the per-module register* / replace* APIs.

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -11,16 +11,18 @@ require_relative 'evo_extension_points/runtime_context'
 require_relative 'evo_extension_points/plugin_loader'
 require_relative 'evo_extension_points/theme_tokens'
 require_relative 'evo_extension_points/data_export'
+require_relative 'evo_extension_points/routing_strategy'
 require_relative 'evo_extension_points/contract_check'
 
 module EvoExtensionPoints
-  EXTENSION_POINTS_VERSION = '2.0.0'
+  EXTENSION_POINTS_VERSION = '2.1.0'
 
   KNOWN_KEYS = %i[
     capability_gate
     runtime_context_current_id
     runtime_context_with_scope
     theme_tokens
+    routing_strategy
   ].freeze
 
   class UnknownExtensionPoint < ArgumentError; end

--- a/lib/evo_extension_points/routing_strategy.rb
+++ b/lib/evo_extension_points/routing_strategy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Routing strategy extension point. Community default: nil (no-op).
+  # AgentAssignmentService falls back to AutoAssignment::Strategies::RoundRobin
+  # when no override is registered.
+  #
+  # Override via:
+  #   EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
+  #     MyCustomStrategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
+  #   end
+  #
+  # Interface contract: .call(conversation, allowed_agent_ids: [String]) → User | nil
+  # See EXTENSION_POINTS.md for the full contract and versioning policy.
+  module RoutingStrategy
+    # No-op: nil → AgentAssignmentService uses Strategies::RoundRobin as fallback
+  end
+end

--- a/lib/evo_extension_points/routing_strategy.rb
+++ b/lib/evo_extension_points/routing_strategy.rb
@@ -11,6 +11,7 @@ module EvoExtensionPoints
   #   end
   #
   # Interface contract: .call(conversation, allowed_agent_ids: [String]) → User | nil
+  # Ruby contract module: AutoAssignment::Strategies::Base (include in strategy classes)
   # See EXTENSION_POINTS.md for the full contract and versioning policy.
   module RoutingStrategy
     # No-op: nil → AgentAssignmentService uses Strategies::RoundRobin as fallback

--- a/spec/lib/evo_extension_points/routing_strategy_spec.rb
+++ b/spec/lib/evo_extension_points/routing_strategy_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'evo_extension_points'
+
+RSpec.describe 'EvoExtensionPoints :routing_strategy' do
+  after { EvoExtensionPoints.reset! }
+
+  it 'is declared in KNOWN_KEYS' do
+    expect(EvoExtensionPoints::KNOWN_KEYS).to include(:routing_strategy)
+  end
+
+  it 'returns nil without override' do
+    expect(EvoExtensionPoints.impl_for(:routing_strategy)).to be_nil
+  end
+
+  it 'is a Module under EvoExtensionPoints (satisfies contract_check guard-rail)' do
+    expect(EvoExtensionPoints::RoutingStrategy).to be_a(Module)
+  end
+
+  describe 'with override' do
+    let(:custom_strategy) { double('CustomStrategy') }
+
+    before do
+      EvoExtensionPoints.replace(:routing_strategy) do |_conversation, allowed_agent_ids:|
+        custom_strategy
+      end
+    end
+
+    it 'impl_for returns a callable Proc' do
+      expect(EvoExtensionPoints.impl_for(:routing_strategy)).to respond_to(:call)
+    end
+
+    it 'the registered proc delegates to the custom impl' do
+      impl = EvoExtensionPoints.impl_for(:routing_strategy)
+      expect(impl.call(nil, allowed_agent_ids: [])).to eq(custom_strategy)
+    end
+
+    it 'impl_for returns nil after reset!' do
+      EvoExtensionPoints.reset!
+      expect(EvoExtensionPoints.impl_for(:routing_strategy)).to be_nil
+    end
+  end
+end

--- a/spec/lib/evo_extension_points_spec.rb
+++ b/spec/lib/evo_extension_points_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe EvoExtensionPoints do
   after { EvoExtensionPoints.reset! } # rubocop:disable RSpec/DescribedClass
 
   describe 'EXTENSION_POINTS_VERSION' do
-    it 'advertises the 2.0.0 neutral contract' do
-      expect(described_class::EXTENSION_POINTS_VERSION).to eq('2.0.0')
+    it 'advertises the 2.1.0 contract' do
+      expect(described_class::EXTENSION_POINTS_VERSION).to eq('2.1.0')
     end
   end
 

--- a/spec/services/auto_assignment/agent_assignment_service_spec.rb
+++ b/spec/services/auto_assignment/agent_assignment_service_spec.rb
@@ -66,8 +66,9 @@ RSpec.describe AutoAssignment::AgentAssignmentService do
         expect(service.find_assignee).to eq(custom_agent)
       end
 
-      it 'logs the routing strategy used' do
-        expect(Rails.logger).to receive(:info).with(/\[AgentAssignment\] routing via.*for conversation #{conversation.id}/)
+      it 'logs EvoExtensionPoints[:routing_strategy] as the strategy label' do
+        expect(Rails.logger).to receive(:info)
+          .with(/\[AgentAssignment\] routing via EvoExtensionPoints\[:routing_strategy\] for conversation #{conversation.id}/)
         service.find_assignee
       end
     end

--- a/spec/services/auto_assignment/agent_assignment_service_spec.rb
+++ b/spec/services/auto_assignment/agent_assignment_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutoAssignment::AgentAssignmentService do
+  let(:channel)       { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox)         { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact)       { Contact.create!(name: 'Test Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation)  { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:agent)         { User.create!(name: 'Agent', email: "a-#{SecureRandom.hex(4)}@test.com") }
+  let(:agent_ids)     { [agent.id] }
+
+  subject(:service) do
+    described_class.new(conversation: conversation, allowed_agent_ids: agent_ids)
+  end
+
+  after { EvoExtensionPoints.reset! }
+
+  describe '#find_assignee' do
+    context 'without routing_strategy override (default RoundRobin)' do
+      let(:mock_service) { instance_double(AutoAssignment::InboxRoundRobinService) }
+
+      before do
+        allow(AutoAssignment::InboxRoundRobinService)
+          .to receive(:new)
+          .with(inbox: conversation.inbox)
+          .and_return(mock_service)
+        allow(mock_service)
+          .to receive(:available_agent)
+          .with(allowed_agent_ids: anything)
+          .and_return(agent)
+        allow(OnlineStatusTracker).to receive(:get_available_users).and_return({ agent.id.to_s => 'online' })
+      end
+
+      it 'delegates to AutoAssignment::Strategies::RoundRobin' do
+        expect(AutoAssignment::Strategies::RoundRobin)
+          .to receive(:call)
+          .with(conversation, allowed_agent_ids: anything)
+          .and_call_original
+        service.find_assignee
+      end
+
+      it 'returns the agent selected by RoundRobin' do
+        expect(service.find_assignee).to eq(agent)
+      end
+
+      it 'logs the routing strategy used' do
+        expect(Rails.logger).to receive(:info).with(/\[AgentAssignment\] routing via.*for conversation #{conversation.id}/)
+        service.find_assignee
+      end
+    end
+
+    context 'with routing_strategy override registered' do
+      let(:custom_agent) { User.create!(name: 'Custom Agent', email: "custom-#{SecureRandom.hex(4)}@test.com") }
+
+      before do
+        allow(OnlineStatusTracker).to receive(:get_available_users).and_return({ agent.id.to_s => 'online' })
+        EvoExtensionPoints.replace(:routing_strategy) do |_conversation, allowed_agent_ids:|
+          custom_agent
+        end
+      end
+
+      it 'uses the registered override instead of RoundRobin' do
+        expect(AutoAssignment::Strategies::RoundRobin).not_to receive(:call)
+        expect(service.find_assignee).to eq(custom_agent)
+      end
+
+      it 'logs the routing strategy used' do
+        expect(Rails.logger).to receive(:info).with(/\[AgentAssignment\] routing via.*for conversation #{conversation.id}/)
+        service.find_assignee
+      end
+    end
+  end
+end

--- a/spec/services/auto_assignment/strategies/round_robin_spec.rb
+++ b/spec/services/auto_assignment/strategies/round_robin_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression guard for AutoAssignment::Strategies::RoundRobin (Story 1.1).
+#
+# Verifies that the RoundRobin strategy facade produces identical results to
+# calling AutoAssignment::InboxRoundRobinService directly.  This spec is a
+# MERGE GATE: if behaviour diverges for the same inputs the PR must NOT merge.
+RSpec.describe AutoAssignment::Strategies::RoundRobin do
+  let(:channel)       { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox)         { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact)       { Contact.create!(name: 'Test Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation)  { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:agent)         { User.create!(name: 'Agent', email: "a-#{SecureRandom.hex(4)}@test.com") }
+
+  # -----------------------------------------------------------------------
+  # Regression guard: conversation.inbox must equal the inbox attribute used
+  # by InboxRoundRobinService so the facade is a true equivalent.
+  # -----------------------------------------------------------------------
+  it 'conversation.inbox equals the inbox passed to InboxRoundRobinService' do
+    expect(conversation.inbox).to eq(inbox)
+  end
+
+  describe '.call' do
+    subject(:result) { described_class.call(conversation, allowed_agent_ids: agent_ids) }
+
+    context 'when allowed_agent_ids is empty' do
+      let(:agent_ids) { [] }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when allowed_agent_ids is nil-like (blank)' do
+      let(:agent_ids) { nil }
+
+      it 'returns nil without raising' do
+        expect { result }.not_to raise_error
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when InboxRoundRobinService returns an agent' do
+      let(:agent_ids) { [agent.id.to_s] }
+      let(:mock_service) { instance_double(AutoAssignment::InboxRoundRobinService) }
+
+      before do
+        allow(AutoAssignment::InboxRoundRobinService)
+          .to receive(:new)
+          .with(inbox: conversation.inbox)
+          .and_return(mock_service)
+
+        allow(mock_service)
+          .to receive(:available_agent)
+          .with(allowed_agent_ids: agent_ids)
+          .and_return(agent)
+      end
+
+      it 'returns the same User as InboxRoundRobinService' do
+        expect(result).to eq(agent)
+      end
+
+      it 'passes allowed_agent_ids unchanged to InboxRoundRobinService' do
+        expect(mock_service).to receive(:available_agent).with(allowed_agent_ids: agent_ids)
+        result
+      end
+    end
+
+    context 'when InboxRoundRobinService returns nil (no agent available)' do
+      let(:agent_ids) { [agent.id.to_s] }
+      let(:mock_service) { instance_double(AutoAssignment::InboxRoundRobinService) }
+
+      before do
+        allow(AutoAssignment::InboxRoundRobinService)
+          .to receive(:new)
+          .with(inbox: conversation.inbox)
+          .and_return(mock_service)
+
+        allow(mock_service)
+          .to receive(:available_agent)
+          .with(allowed_agent_ids: agent_ids)
+          .and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Declares `:routing_strategy` as a new extension point in `EvoExtensionPoints`, bumping the contract from `2.0.0` → `2.1.0`.
- Adds `EvoExtensionPoints::RoutingStrategy` — a no-op module that satisfies the `contract_check` guard-rail (CI EVO-1287). Community default: `nil`, which triggers the RoundRobin fallback.
- Wires `AgentAssignmentService#find_assignee` to the extension point: resolves [impl_for(:routing_strategy)](cci:1:evo-ai-crm-community/lib/evo_extension_points.rb:38:4-40:7) at runtime; falls back to [AutoAssignment::Strategies::RoundRobin](cci:2:evo-ai-crm-community/app/services/auto_assignment/strategies/round_robin.rb:4:4-17:7) (introduced in PR 1) when no override is registered. Proc overrides log as `EvoExtensionPoints[:routing_strategy]` for observability.
- **Zero behaviour change in the community release** — without an override, assignment continues via [Strategies::RoundRobin](cci:2:evo-ai-crm-community/app/services/auto_assignment/strategies/round_robin.rb:4:4-17:7) exactly as before.
- Documents `:routing_strategy` in [EXTENSION_POINTS.md](cci:7:evo-ai-crm-community/EXTENSION_POINTS.md:0:0-0:0) under `### 6.` with interface contract, `Strategies::Base` reference, default, and consumer example.
- This is PR 2 of 3 in the extensible routing roadmap. PR 3 adds `BalancedLoad` and `FallbackChain` strategies.

> **⚠️ Stacked PR** — base branch is `feat/routing-extract-round-robin` (PR 1). Once PR 1 merges to `develop`, the base of this PR updates automatically and the diff shows only this PR's changes.

## Security

- Pure internal refactor. Zero new HTTP endpoints, zero auth surface changes.
- No new gems, no migrations, no environment variables.
- Extension point override executes only code explicitly registered by a consumer at process boot (Railtie/Engine initializer).

## Test plan

```
bundle exec rspec spec/lib/evo_extension_points/routing_strategy_spec.rb \
               spec/lib/evo_extension_points_spec.rb \
               spec/lib/evo_extension_points/contract_check_spec.rb \
               spec/services/auto_assignment/agent_assignment_service_spec.rb \
               spec/services/auto_assignment/strategies/round_robin_spec.rb \
               --format documentation
# → 44/44 passing
```

- [routing_strategy_spec.rb](cci:7:evo-ai-crm-community/spec/lib/evo_extension_points/routing_strategy_spec.rb:0:0-0:0) (6/6): key in KNOWN_KEYS, nil without override, module satisfies guard-rail, override returns callable Proc, Proc delegates to registered impl, [reset!](cci:1:evo-ai-crm-community/lib/evo_extension_points.rb:42:4-46:7) clears override.
- [evo_extension_points_spec.rb](cci:7:evo-ai-crm-community/spec/lib/evo_extension_points_spec.rb:0:0-0:0) (22/22): version assertion updated to `2.1.0`; all existing extension point specs unchanged.
- [contract_check_spec.rb](cci:7:evo-ai-crm-community/spec/lib/evo_extension_points/contract_check_spec.rb:0:0-0:0) (7/7): integration test confirms `documented_points == implemented_points` with `routing_strategy` included on both sides.
- [agent_assignment_service_spec.rb](cci:7:evo-ai-crm-community/spec/services/auto_assignment/agent_assignment_service_spec.rb:0:0-0:0) (5/5): without override → delegates to [Strategies::RoundRobin](cci:2:evo-ai-crm-community/app/services/auto_assignment/strategies/round_robin.rb:4:4-17:7); with override → uses registered impl; logger fires in both cases (override logs as `EvoExtensionPoints[:routing_strategy]`).
- [round_robin_spec.rb](cci:7:evo-ai-crm-community/spec/services/auto_assignment/strategies/round_robin_spec.rb:0:0-0:0) (6/6): regression guard — no regressions.

## Changed Files

- [lib/evo_extension_points/routing_strategy.rb](cci:7:evo-ai-crm-community/lib/evo_extension_points/routing_strategy.rb:0:0-0:0) (new — no-op module, references `Strategies::Base`)
- [lib/evo_extension_points.rb](cci:7:evo-ai-crm-community/lib/evo_extension_points.rb:0:0-0:0) (modified — `require_relative`, `:routing_strategy` in `KNOWN_KEYS`, version `2.1.0`, comment "five→six")
- [app/services/auto_assignment/agent_assignment_service.rb](cci:7:evo-ai-crm-community/app/services/auto_assignment/agent_assignment_service.rb:0:0-0:0) (modified — [find_assignee](cci:1:evo-ai-crm-community/app/services/auto_assignment/agent_assignment_service.rb:6:2-11:5) wired to extension point, dead methods removed, log label improvement)
- [EXTENSION_POINTS.md](cci:7:evo-ai-crm-community/EXTENSION_POINTS.md:0:0-0:0) (modified — `### 6. routing_strategy` section, `Strategies::Base` note, consumer example, versioning history)
- [spec/lib/evo_extension_points/routing_strategy_spec.rb](cci:7:evo-ai-crm-community/spec/lib/evo_extension_points/routing_strategy_spec.rb:0:0-0:0) (new — 6 examples)
- [spec/services/auto_assignment/agent_assignment_service_spec.rb](cci:7:evo-ai-crm-community/spec/services/auto_assignment/agent_assignment_service_spec.rb:0:0-0:0) (new — 5 examples)
- [spec/lib/evo_extension_points_spec.rb](cci:7:evo-ai-crm-community/spec/lib/evo_extension_points_spec.rb:0:0-0:0) (modified — version assertion `2.1.0`)

## Code Review Fixes Applied

- Comment drift: "five sub-modules" → "six"
- Removed dead private methods ([round_robin_manage_service](cci:1:evo-ai-crm-community/app/services/auto_assignment/agent_assignment_service.rb:33:2-35:5), [round_robin_key](cci:1:evo-ai-crm-community/app/services/auto_assignment/agent_assignment_service.rb:37:2-39:5))
- Log readability: Proc override now logs as `EvoExtensionPoints[:routing_strategy]` instead of `#<Proc:...>`
- Consumer example in [EXTENSION_POINTS.md](cci:7:evo-ai-crm-community/EXTENSION_POINTS.md:0:0-0:0) now includes `:routing_strategy`
- Cross-referenced `AutoAssignment::Strategies::Base` as the formal Ruby contract module

## Linked Issue

- Routing extensibility roadmap — PR 2 of 3

## Related (downstream consumers)

- [**PR 1** (prerequisite)](https://github.com/evolution-foundation/evo-ai-crm-community/pull/102) — `feat/routing-extract-round-robin`: introduces [AutoAssignment::Strategies::RoundRobin](cci:2://evo-ai-crm-community/app/services/auto_assignment/strategies/round_robin.rb:4:4-17:7) facade used as fallback here
- **PR 3** — `feat/routing-balanced-load-fallback`: adds `BalancedLoad` and `FallbackChain` strategies (depends on this PR)