### PR TITLE
feat(segments): proxy delete/recompute/contact-ids through CRM (EVO-1569)

### DIFF
--- a/app/controllers/api/v1/evo_flow/segments_controller.rb
+++ b/app/controllers/api/v1/evo_flow/segments_controller.rb
@@ -35,6 +35,34 @@ class Api::V1::EvoFlow::SegmentsController < Api::V1::BaseController
     handle_evo_flow_error(e)
   end
 
+  # DELETE /api/v1/segments/:id
+  def destroy
+    render json: client.delete("/segments/#{params[:id]}"), status: :ok
+  rescue EvoFlow::HTTPError => e
+    handle_evo_flow_error(e)
+  end
+
+  # POST /api/v1/segments/:id/recompute
+  def recompute
+    render json: client.post("/segments/#{params[:id]}/recompute", {}), status: :ok
+  rescue EvoFlow::HTTPError => e
+    handle_evo_flow_error(e)
+  end
+
+  # POST /api/v1/segments/recompute-all
+  def recompute_all
+    render json: client.post('/segments/recompute-all', {}), status: :ok
+  rescue EvoFlow::HTTPError => e
+    handle_evo_flow_error(e)
+  end
+
+  # GET /api/v1/segments/:id/contact-ids
+  def contact_ids
+    render json: client.get("/segments/#{params[:id]}/contact-ids", contact_ids_params), status: :ok
+  rescue EvoFlow::HTTPError => e
+    handle_evo_flow_error(e)
+  end
+
   # POST /api/v1/segments/preview
   def preview
     render json: client.post('/segments/preview', { definition: preview_definition }), status: :ok
@@ -50,6 +78,12 @@ class Api::V1::EvoFlow::SegmentsController < Api::V1::BaseController
 
   def list_params
     params.permit(:page, :limit, :search, :status).to_h
+  end
+
+  # Param-clean: only pagination is forwarded. No account/account_id is read
+  # (AC3 — account is resolved server-side by evo-flow, never from the request).
+  def contact_ids_params
+    params.permit(:limit, :offset).to_h
   end
 
   def segment_payload

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -74,6 +74,18 @@ module EvoFlow
       raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
     end
 
+    # No body: evo-flow returns a JSON delete result (or an empty 204, in which
+    # case parse_body yields nil — fine to render).
+    def delete(path)
+      response = self.class.delete(join(@api_url, path),
+                                   headers: request_headers,
+                                   timeout: @timeout)
+      handle_response(response)
+    rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError,
+           OpenSSL::SSL::SSLError => e
+      raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
+    end
+
     # Backfill emits events in batches (matches evo-flow BATCH_SIZE=100,
     # TrackBatchEventsDto in src/modules/events/dto/track-batch-events.dto.ts).
     # Stateless: retry is the caller's responsibility (Sidekiq).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -221,9 +221,14 @@ Rails.application.routes.draw do
 
       scope module: 'evo_flow' do
         resources :contact_events, only: [:index], path: 'contacts/:contact_id/events', param: :contact_id
-        resources :segments, only: %i[index show create update] do
+        resources :segments, only: %i[index show create update destroy] do
+          member do
+            post :recompute
+            get :contact_ids, path: 'contact-ids'
+          end
           collection do
             post :preview
+            post :recompute_all, path: 'recompute-all'
           end
         end
       end

--- a/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
@@ -93,4 +93,162 @@ RSpec.describe Api::V1::EvoFlow::SegmentsController, type: :controller do
       expect(response.parsed_body).to eq('id' => 'seg-9', 'name' => 'Renamed')
     end
   end
+
+  describe 'DELETE #destroy' do
+    it 'forwards a DELETE to evo-flow and returns 200 with the body pass-through' do
+      allow(fake_client).to receive(:delete)
+        .with('/segments/seg-1')
+        .and_return({ 'id' => 'seg-1', 'deleted' => true })
+
+      delete :destroy, params: { id: 'seg-1' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(fake_client).to have_received(:delete).with('/segments/seg-1')
+      expect(response.parsed_body).to eq('id' => 'seg-1', 'deleted' => true)
+    end
+
+    it 'ignores account-related params (AC3 — account never read from the request)' do
+      allow(fake_client).to receive(:delete).with('/segments/seg-1').and_return({})
+
+      delete :destroy, params: { id: 'seg-1', account_id: 'acc-evil', account: 'x' }, as: :json
+
+      # The forwarded path carries only the id; no account is appended.
+      expect(fake_client).to have_received(:delete).with('/segments/seg-1')
+    end
+
+    it 'renders an empty (204/null) evo-flow body without error (AC6)' do
+      allow(fake_client).to receive(:delete).with('/segments/seg-1').and_return(nil)
+
+      delete :destroy, params: { id: 'seg-1' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      # `render json: nil` serialises to the literal "null"; the FE only needs
+      # a successful resolve, so this is the expected harmless body.
+      expect(response.body).to eq('null')
+    end
+
+    it 'passes an evo-flow 404 through verbatim under an errors key' do
+      error_body = { 'message' => 'Segment not found' }
+      response_double = instance_double(HTTParty::Response, parsed_response: error_body)
+      allow(fake_client).to receive(:delete)
+        .and_raise(EvoFlow::HTTPError.new('evo-flow API error', 404, response_double))
+
+      delete :destroy, params: { id: 'missing' }, as: :json
+
+      expect(response).to have_http_status(404)
+      expect(response.parsed_body).to eq('errors' => error_body)
+    end
+  end
+
+  describe 'POST #recompute' do
+    it 'forwards an empty-body POST to evo-flow for the given id' do
+      allow(fake_client).to receive(:post)
+        .with('/segments/seg-1/recompute', {})
+        .and_return({ 'segmentId' => 'seg-1', 'contactsAdded' => 3 })
+
+      post :recompute, params: { id: 'seg-1' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(fake_client).to have_received(:post).with('/segments/seg-1/recompute', {})
+      expect(response.parsed_body).to eq('segmentId' => 'seg-1', 'contactsAdded' => 3)
+    end
+
+    it 'ignores account-related params (AC3 — empty body forwarded, no account)' do
+      allow(fake_client).to receive(:post)
+        .with('/segments/seg-1/recompute', {})
+        .and_return({})
+
+      post :recompute, params: { id: 'seg-1', account_id: 'acc-evil', account: 'x' }, as: :json
+
+      # Body is a hardcoded {}; no account/account_id is forwarded to evo-flow.
+      expect(fake_client).to have_received(:post).with('/segments/seg-1/recompute', {})
+    end
+
+    it 'passes an evo-flow 422 through verbatim under an errors key' do
+      error_body = { 'message' => 'recompute failed' }
+      response_double = instance_double(HTTParty::Response, parsed_response: error_body)
+      allow(fake_client).to receive(:post)
+        .and_raise(EvoFlow::HTTPError.new('evo-flow API error', 422, response_double))
+
+      post :recompute, params: { id: 'seg-1' }, as: :json
+
+      expect(response).to have_http_status(422)
+      expect(response.parsed_body).to eq('errors' => error_body)
+    end
+  end
+
+  describe 'POST #recompute_all' do
+    it 'forwards an empty-body POST to the collection recompute-all endpoint' do
+      allow(fake_client).to receive(:post)
+        .with('/segments/recompute-all', {})
+        .and_return({ 'results' => [], 'totalProcessingTimeMs' => 12 })
+
+      post :recompute_all, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(fake_client).to have_received(:post).with('/segments/recompute-all', {})
+      expect(response.parsed_body).to eq('results' => [], 'totalProcessingTimeMs' => 12)
+    end
+
+    it 'ignores account-related params (AC3 — empty body forwarded, no account)' do
+      allow(fake_client).to receive(:post)
+        .with('/segments/recompute-all', {})
+        .and_return({ 'results' => [] })
+
+      post :recompute_all, params: { account_id: 'acc-evil', account: 'x' }, as: :json
+
+      expect(fake_client).to have_received(:post).with('/segments/recompute-all', {})
+    end
+
+    it 'passes an evo-flow 5xx through verbatim under an errors key' do
+      error_body = { 'message' => 'upstream boom' }
+      response_double = instance_double(HTTParty::Response, parsed_response: error_body)
+      allow(fake_client).to receive(:post)
+        .and_raise(EvoFlow::HTTPError.new('evo-flow API error', 502, response_double))
+
+      post :recompute_all, as: :json
+
+      expect(response).to have_http_status(502)
+      expect(response.parsed_body).to eq('errors' => error_body)
+    end
+  end
+
+  describe 'GET #contact_ids' do
+    it 'forwards :limit/:offset pagination to evo-flow and returns the body' do
+      allow(fake_client).to receive(:get)
+        .with('/segments/seg-1/contact-ids', { 'limit' => '50', 'offset' => '100' })
+        .and_return({ 'contactIds' => %w[c1 c2], 'total' => 2, 'limit' => 50, 'offset' => 100 })
+
+      get :contact_ids, params: { id: 'seg-1', limit: '50', offset: '100' }
+
+      expect(response).to have_http_status(:ok)
+      expect(fake_client).to have_received(:get)
+        .with('/segments/seg-1/contact-ids', { 'limit' => '50', 'offset' => '100' })
+      expect(response.parsed_body).to eq(
+        'contactIds' => %w[c1 c2], 'total' => 2, 'limit' => 50, 'offset' => 100
+      )
+    end
+
+    it 'ignores account-related params (AC3 — account never read from the request)' do
+      allow(fake_client).to receive(:get)
+        .with('/segments/seg-1/contact-ids', {})
+        .and_return({ 'contactIds' => [], 'total' => 0 })
+
+      get :contact_ids, params: { id: 'seg-1', account_id: 'acc-evil', account: 'x' }
+
+      expect(fake_client).to have_received(:get).with('/segments/seg-1/contact-ids', {})
+    end
+
+    it 'passes an evo-flow 404 through verbatim under an errors key' do
+      error_body = { 'message' => 'Segment not found' }
+      response_double = instance_double(HTTParty::Response, parsed_response: error_body)
+      allow(fake_client).to receive(:get)
+        .and_raise(EvoFlow::HTTPError.new('evo-flow API error', 404, response_double))
+
+      get :contact_ids, params: { id: 'missing' }
+
+      expect(response).to have_http_status(404)
+      expect(response.parsed_body).to eq('errors' => error_body)
+    end
+  end
 end

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -206,6 +206,58 @@ RSpec.describe EvoFlow::Client do
     end
   end
 
+  describe '#delete' do
+    let(:segment_path) { '/segments/seg-1' }
+    let(:segment_url) { "#{api_url}/segments/seg-1" }
+
+    it 'DELETEs the full /api/v1 URL with auth header and returns the parsed body' do
+      stub = stub_request(:delete, segment_url)
+             .with(headers: { 'X-Integration-API-Key' => api_key })
+             .to_return(
+               status: 200,
+               body: { id: 'seg-1', deleted: true }.to_json,
+               headers: { 'Content-Type' => 'application/json' }
+             )
+
+      result = client.delete(segment_path)
+
+      expect(stub).to have_been_requested
+      expect(result).to include('id' => 'seg-1', 'deleted' => true)
+    end
+
+    it 'returns nil on an empty 204 (no body to parse)' do
+      stub_request(:delete, segment_url).to_return(status: 204, body: '')
+
+      expect(client.delete(segment_path)).to be_nil
+    end
+
+    it 'keeps the /api/v1 prefix and never hits the bare root' do
+      good = stub_request(:delete, segment_url).to_return(status: 200, body: '{}')
+      root = stub_request(:delete, 'http://evo-flow:3000/segments/seg-1')
+
+      client.delete(segment_path)
+      client.delete('segments/seg-1') # no leading slash
+
+      expect(good).to have_been_requested.times(2)
+      expect(root).not_to have_been_requested
+    end
+
+    it 'raises EvoFlow::HTTPError with code 404 on upstream 4xx' do
+      stub_request(:delete, segment_url).to_return(status: 404, body: { error: 'nope' }.to_json,
+                                                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { client.delete(segment_path) }
+        .to raise_error(EvoFlow::HTTPError) { |error| expect(error.code).to eq(404) }
+    end
+
+    it 'raises EvoFlow::HTTPError with nil code on a network timeout' do
+      stub_request(:delete, segment_url).to_timeout
+
+      expect { client.delete(segment_path) }
+        .to raise_error(EvoFlow::HTTPError) { |error| expect(error.code).to be_nil }
+    end
+  end
+
   describe 'configuration safety' do
     it 'raises ConfigurationError when the API key is blank (F13)' do
       expect { described_class.new(api_url: api_url, api_key: '') }


### PR DESCRIPTION
## Summary
Follow-up da 7.11 (EVO-1247, já mergeada na `develop`). Estende o `Api::V1::EvoFlow::SegmentsController` com as 4 ações que faltavam para fechar o contrato pelo único trust boundary (evo-flow encapsulado atrás do CRM), eliminando as últimas chamadas diretas do browser ao evo-flow.

- Novas ações: `destroy`, `recompute` (member), `recompute_all` (collection), `contact_ids` (member) → encaminhadas via `EvoFlow::Client`.
- `EvoFlow::Client` ganha `.delete` (sem body; trata 204→nil).
- Rotas: `DELETE /segments/:id`, `POST /segments/:id/recompute`, `POST /segments/recompute-all`, `GET /segments/:id/contact-ids` (overrides kebab-case).
- **Account resolvido server-side pelo evo-flow** — o proxy encaminha só `:id`/`:limit`/`:offset`, nunca um `account`/`account_id` vindo da request (AC3).
- Erros do evo-flow propagados verbatim sob `errors`, preservando o status HTTP upstream.

## Test plan
- `bundle exec rspec spec/controllers/api/v1/evo_flow/segments_controller_spec.rb spec/services/evo_flow/client_spec.rb` → verde (sucesso + pass-through de erro + AC3 account-ignored para destroy/recompute/recompute_all/contact_ids; `#delete` 200 / 204→nil / 404 / timeout).
- Smoke server-side contra o stack vivo (CRM :3000): as 4 rotas retornam **401** sem auth (registradas + atrás do `authenticate_request!`); rota inexistente retorna **404** — confirmando o auth-gate, não catch-all.

## Notas
- Endpoints no evo-flow (`DELETE /segments/:id`, `:id/recompute`, `recompute-all`, `:id/contact-ids`) já existem — só muda quem os chama.
- Single-tenant: nenhum `account` no body.
- Round-trip real CRM→evo-flow ainda não validado e2e neste ambiente (app evo-flow não orquestrado nos composes locais).
- Par no FE: migração das 5 chamadas em `segmentsService.ts` (PR irmão no `evo-ai-frontend-community`).
- Linear: EVO-1569.