### PR TITLE
fix(evo_flow): proxy lê eventos do envelope data.events (EVO-1571)

### DIFF
--- a/app/controllers/api/v1/evo_flow/contact_events_controller.rb
+++ b/app/controllers/api/v1/evo_flow/contact_events_controller.rb
@@ -34,7 +34,12 @@ class Api::V1::EvoFlow::ContactEventsController < Api::V1::BaseController
   # Bearer / API Access Token.
   def index
     body = client.get("/contacts/#{params[:contact_id]}/events", translated_filters)
-    body['events'] = (body['events'] || []).map { |evt| enrich_event(evt) }
+    # evo-flow wraps successful responses as `{ success, data: { events,
+    # pagination }, meta }` (global ResponseTransformInterceptor). Enrich the
+    # events wherever they actually live — under `data` when enveloped, or at
+    # the top level for a bare `{ events: [...] }` shape (older/stubbed).
+    container = body.is_a?(Hash) && body['data'].is_a?(Hash) ? body['data'] : body
+    container['events'] = (container['events'] || []).map { |evt| enrich_event(evt) }
     render json: body, status: :ok
   rescue EvoFlow::HTTPError => e
     handle_evo_flow_error(e)


### PR DESCRIPTION
## Summary
- Corrige o proxy `Api::V1::EvoFlow::ContactEventsController#index` (story 7.7).
- Lê/enriquece os eventos em `data.events` (o evo-flow embrulha a resposta em `{ success, data: { events, pagination }, meta }`), suportando também o shape bare `{ events }`.

## Bug (causa raiz da aba vazia)
O proxy lia `body['events']` — nível errado do envelope → `nil` → injetava um `events: []` vazio no topo. A FE (`contactEventsService.unwrap`) pegava esse array vazio e nunca olhava `data.events`. A aba "Eventos" do contato vinha **sempre vazia, com HTTP 200**, mesmo com eventos no ClickHouse.

## Test plan
- `bundle exec rspec spec/requests/api/v1/evo_flow/contact_events_spec.rb`
- **Atenção:** a request spec provavelmente mocka o `EvoFlow::Client` com o shape antigo (não-embrulhado), mascarando o bug — vale ajustar o mock pro shape real (`{ data: { events } }`).
- E2E: editar um contato → abrir a aba Eventos → os eventos aparecem.

Relacionado: EVO-1571

## Summary by Sourcery

Bug Fixes:
- Correct reading and enrichment of events from `data.events` (or top-level `events`) in evo-flow responses to avoid returning an empty events array.