### PR TITLE
fix(evo_flow): emite `source` required nos payloads de backfill (EVO-1570)

### DIFF
--- a/app/services/evo_flow/backfill_mapper.rb
+++ b/app/services/evo_flow/backfill_mapper.rb
@@ -3,23 +3,50 @@ module EvoFlow
   # mapping table and the SHA256 id derivation can be unit-tested without
   # spinning up the worker.
   class BackfillMapper
-    # Legacy ReportingEvent#name -> canonical EvoFlow EVENT_NAMES entry.
-    # Source of truth for the legacy values is app/listeners/reporting_event_listener.rb.
-    REPORTING_EVENT_NAME_MAP = {
-      'conversation_resolved' => 'conversation.resolved',
-      'first_response' => 'conversation.first_reply',
-      'reply_time' => 'conversation.reply_time',
-      'conversation_bot_handoff' => 'conversation.bot_handoff',
-      'conversation_bot_resolved' => 'conversation.bot_resolved'
-    }.freeze
+    # `source` names the producing subsystem (required by EvoFlow::EventSchema
+    # for every conversation.* event), NOT the backfill itself — backfill
+    # provenance lives in the `backfill|` message_id prefix below, a separate
+    # axis. Backfilled events carry the same source the live producer would emit
+    # (conversation.resolved matches the live ConversationEventsListener; the
+    # reporting metrics name ReportingEventListener, their only producer). Both
+    # follow the shared `*_management` convention (EVO-1570).
+    CONVERSATION_SOURCE = 'conversation_management'.freeze
+    REPORTING_SOURCE = 'reporting_management'.freeze
 
-    def self.map_reporting_event_to_event_name(reporting_event)
-      mapped = REPORTING_EVENT_NAME_MAP[reporting_event.name.to_s]
-      # Fail loud (AC6): unmapped ReportingEvent#name means the table above is
-      # incomplete — surface it instead of silently dropping data on backfill.
-      raise EvoFlow::InvalidEventName, reporting_event.name.to_s if mapped.nil?
+    # Single source of truth per legacy ReportingEvent#name: the canonical
+    # EvoFlow event, its source, and how the row's `value`/timestamp land on the
+    # event's schema optionals (EvoFlow::EventSchema). `value` is seconds for the
+    # timing events; bot_* carry only a timestamp. `value_field`/`time_field` are
+    # omitted when the schema has no home for them. Source of truth for the
+    # legacy names is app/listeners/reporting_event_listener.rb.
+    REPORTING_EVENTS = {
+      'conversation_resolved' => {
+        event: 'conversation.resolved', source: CONVERSATION_SOURCE,
+        value_field: :resolution_time_seconds
+      },
+      'first_response' => {
+        event: 'conversation.first_reply', source: REPORTING_SOURCE,
+        value_field: :response_time_seconds, time_field: :replied_at, time_from: :event_end_time
+      },
+      'reply_time' => {
+        event: 'conversation.reply_time', source: REPORTING_SOURCE,
+        value_field: :reply_time_seconds, time_field: :measured_at, time_from: :event_end_time
+      },
+      'conversation_bot_handoff' => {
+        event: 'conversation.bot_handoff', source: REPORTING_SOURCE,
+        time_field: :handoff_at, time_from: :event_start_time
+      },
+      'conversation_bot_resolved' => {
+        event: 'conversation.bot_resolved', source: REPORTING_SOURCE,
+        time_field: :resolved_at, time_from: :event_end_time
+      }
+    }.transform_values(&:freeze).freeze
 
-      mapped
+    # Fail loud (AC6): an unmapped ReportingEvent#name means the table above is
+    # incomplete — surface it instead of silently dropping data on backfill.
+    def self.reporting_event_descriptor(reporting_event)
+      REPORTING_EVENTS[reporting_event.name.to_s] ||
+        raise(EvoFlow::InvalidEventName, reporting_event.name.to_s)
     end
 
     # Deterministic backfill-namespaced id. The "backfill|" prefix makes

--- a/app/workers/evo_flow/backfill_contact_events_worker.rb
+++ b/app/workers/evo_flow/backfill_contact_events_worker.rb
@@ -31,6 +31,19 @@ module EvoFlow
     DEFAULT_FROM_DATE_LAG = 1.year
     METRIC_NAMESPACE = 'evo_flow_backfill'.freeze
 
+    # `source` (required by EvoFlow::EventSchema for every conversation.* event)
+    # names the producing subsystem, NOT the backfill itself — backfill
+    # provenance already lives in the `backfill|` message_id prefix
+    # (BackfillMapper.message_id_for), a separate dimension. So backfilled events
+    # carry the same source the live producer would emit:
+    #   - activity messages + conversation.resolved → conversation lifecycle mgmt
+    #     (matches the live ConversationEventsListener)
+    #   - first_reply/reply_time/bot_* → the reporting subsystem (ReportingEventListener
+    #     is their only producer; no live EvoFlow emitter exists yet)
+    # Both follow the shared `*_management` source convention.
+    CONVERSATION_SOURCE = 'conversation_management'.freeze
+    REPORTING_SOURCE = 'reporting_management'.freeze
+
     sidekiq_retries_exhausted do |job, ex|
       args = job['args'] || []
       account_id = args[0]
@@ -121,14 +134,17 @@ module EvoFlow
       conversation = msg.conversation
       return nil if conversation.nil? || conversation.contact_id.nil? || msg.created_at.nil?
 
+      # Keys map onto the conversation.activity schema (required: conversation_id,
+      # source; optional: inbox_id, content). `sender_type`/`sender_id` have no
+      # schema home and are intentionally dropped rather than forwarded as unknown keys.
       EvoFlow::PayloadBuilder.build_track(
         event_name: 'conversation.activity',
         contact_id: conversation.contact_id,
         properties: {
-          message_content: msg.content,
           conversation_id: msg.conversation_id,
-          sender_type: msg.sender_type,
-          sender_id: msg.sender_id
+          inbox_id: conversation.inbox_id,
+          content: msg.content,
+          source: CONVERSATION_SOURCE
         },
         occurred_at: msg.created_at,
         message_id: EvoFlow::BackfillMapper.message_id_for(:message, msg.id)
@@ -140,18 +156,43 @@ module EvoFlow
       return nil if conversation.nil? || conversation.contact_id.nil?
       return nil if reporting_event.event_start_time.nil?
 
+      event_name = EvoFlow::BackfillMapper.map_reporting_event_to_event_name(reporting_event)
       EvoFlow::PayloadBuilder.build_track(
-        event_name: EvoFlow::BackfillMapper.map_reporting_event_to_event_name(reporting_event),
+        event_name: event_name,
         contact_id: conversation.contact_id,
-        properties: {
-          conversation_id: reporting_event.conversation_id,
-          user_id: reporting_event.user_id,
-          value: reporting_event.value,
-          value_in_business_hours: reporting_event.value_in_business_hours
-        },
+        properties: reporting_event_properties(event_name, reporting_event),
         occurred_at: reporting_event.event_start_time,
         message_id: EvoFlow::BackfillMapper.message_id_for(:reporting_event, reporting_event.id)
       )
+    end
+
+    # Shapes ReportingEvent attributes onto each event's schema (EvoFlow::EventSchema).
+    # `value` lands on a different optional per event (it is seconds for the timing
+    # events), so the mapping is per-event rather than a shared hash. `user_id` and
+    # `value_in_business_hours` have no schema home and are dropped.
+    #
+    # conversation.resolved carries `conversation_management` to stay homogeneous
+    # with the live ConversationEventsListener; the four reporting metrics carry
+    # `reporting_management` (their only producer is ReportingEventListener).
+    def reporting_event_properties(event_name, reporting_event)
+      base = { conversation_id: reporting_event.conversation_id, inbox_id: reporting_event.inbox_id }
+      case event_name
+      when 'conversation.resolved'
+        base.merge(source: CONVERSATION_SOURCE, resolution_time_seconds: reporting_event.value)
+      when 'conversation.first_reply'
+        base.merge(source: REPORTING_SOURCE, response_time_seconds: reporting_event.value,
+                   replied_at: reporting_event.event_end_time)
+      when 'conversation.reply_time'
+        base.merge(source: REPORTING_SOURCE, reply_time_seconds: reporting_event.value,
+                   measured_at: reporting_event.event_end_time)
+      when 'conversation.bot_handoff'
+        base.merge(source: REPORTING_SOURCE, handoff_at: reporting_event.event_start_time)
+      when 'conversation.bot_resolved'
+        base.merge(source: REPORTING_SOURCE,
+                   resolved_at: reporting_event.event_end_time || reporting_event.event_start_time)
+      else
+        base.merge(source: REPORTING_SOURCE)
+      end
     end
 
     def flush(buffer, source:, cursor_key:)

--- a/app/workers/evo_flow/backfill_contact_events_worker.rb
+++ b/app/workers/evo_flow/backfill_contact_events_worker.rb
@@ -31,19 +31,6 @@ module EvoFlow
     DEFAULT_FROM_DATE_LAG = 1.year
     METRIC_NAMESPACE = 'evo_flow_backfill'.freeze
 
-    # `source` (required by EvoFlow::EventSchema for every conversation.* event)
-    # names the producing subsystem, NOT the backfill itself — backfill
-    # provenance already lives in the `backfill|` message_id prefix
-    # (BackfillMapper.message_id_for), a separate dimension. So backfilled events
-    # carry the same source the live producer would emit:
-    #   - activity messages + conversation.resolved → conversation lifecycle mgmt
-    #     (matches the live ConversationEventsListener)
-    #   - first_reply/reply_time/bot_* → the reporting subsystem (ReportingEventListener
-    #     is their only producer; no live EvoFlow emitter exists yet)
-    # Both follow the shared `*_management` source convention.
-    CONVERSATION_SOURCE = 'conversation_management'.freeze
-    REPORTING_SOURCE = 'reporting_management'.freeze
-
     sidekiq_retries_exhausted do |job, ex|
       args = job['args'] || []
       account_id = args[0]
@@ -144,7 +131,7 @@ module EvoFlow
           conversation_id: msg.conversation_id,
           inbox_id: conversation.inbox_id,
           content: msg.content,
-          source: CONVERSATION_SOURCE
+          source: EvoFlow::BackfillMapper::CONVERSATION_SOURCE
         },
         occurred_at: msg.created_at,
         message_id: EvoFlow::BackfillMapper.message_id_for(:message, msg.id)
@@ -156,43 +143,29 @@ module EvoFlow
       return nil if conversation.nil? || conversation.contact_id.nil?
       return nil if reporting_event.event_start_time.nil?
 
-      event_name = EvoFlow::BackfillMapper.map_reporting_event_to_event_name(reporting_event)
+      descriptor = EvoFlow::BackfillMapper.reporting_event_descriptor(reporting_event)
       EvoFlow::PayloadBuilder.build_track(
-        event_name: event_name,
+        event_name: descriptor[:event],
         contact_id: conversation.contact_id,
-        properties: reporting_event_properties(event_name, reporting_event),
+        properties: reporting_event_properties(descriptor, reporting_event),
         occurred_at: reporting_event.event_start_time,
         message_id: EvoFlow::BackfillMapper.message_id_for(:reporting_event, reporting_event.id)
       )
     end
 
-    # Shapes ReportingEvent attributes onto each event's schema (EvoFlow::EventSchema).
-    # `value` lands on a different optional per event (it is seconds for the timing
-    # events), so the mapping is per-event rather than a shared hash. `user_id` and
-    # `value_in_business_hours` have no schema home and are dropped.
-    #
-    # conversation.resolved carries `conversation_management` to stay homogeneous
-    # with the live ConversationEventsListener; the four reporting metrics carry
-    # `reporting_management` (their only producer is ReportingEventListener).
-    def reporting_event_properties(event_name, reporting_event)
-      base = { conversation_id: reporting_event.conversation_id, inbox_id: reporting_event.inbox_id }
-      case event_name
-      when 'conversation.resolved'
-        base.merge(source: CONVERSATION_SOURCE, resolution_time_seconds: reporting_event.value)
-      when 'conversation.first_reply'
-        base.merge(source: REPORTING_SOURCE, response_time_seconds: reporting_event.value,
-                   replied_at: reporting_event.event_end_time)
-      when 'conversation.reply_time'
-        base.merge(source: REPORTING_SOURCE, reply_time_seconds: reporting_event.value,
-                   measured_at: reporting_event.event_end_time)
-      when 'conversation.bot_handoff'
-        base.merge(source: REPORTING_SOURCE, handoff_at: reporting_event.event_start_time)
-      when 'conversation.bot_resolved'
-        base.merge(source: REPORTING_SOURCE,
-                   resolved_at: reporting_event.event_end_time || reporting_event.event_start_time)
-      else
-        base.merge(source: REPORTING_SOURCE)
-      end
+    # Generic builder driven by the BackfillMapper descriptor — no per-event
+    # branching here. `value`/timestamp land on the schema optionals the descriptor
+    # names (omitted when it declares none). `user_id` / `value_in_business_hours`
+    # have no schema home and are dropped.
+    def reporting_event_properties(descriptor, reporting_event)
+      props = {
+        conversation_id: reporting_event.conversation_id,
+        inbox_id: reporting_event.inbox_id,
+        source: descriptor[:source]
+      }
+      props[descriptor[:value_field]] = reporting_event.value if descriptor[:value_field]
+      props[descriptor[:time_field]] = reporting_event.public_send(descriptor[:time_from]) if descriptor[:time_field]
+      props
     end
 
     def flush(buffer, source:, cursor_key:)

--- a/spec/services/evo_flow/backfill_mapper_spec.rb
+++ b/spec/services/evo_flow/backfill_mapper_spec.rb
@@ -1,30 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe EvoFlow::BackfillMapper do
-  describe '.map_reporting_event_to_event_name' do
+  describe '.reporting_event_descriptor' do
     {
-      'conversation_resolved' => 'conversation.resolved',
-      'first_response' => 'conversation.first_reply',
-      'reply_time' => 'conversation.reply_time',
-      'conversation_bot_handoff' => 'conversation.bot_handoff',
-      'conversation_bot_resolved' => 'conversation.bot_resolved'
-    }.each do |legacy_name, canonical|
-      it "maps #{legacy_name.inspect} to #{canonical.inspect}" do
+      'conversation_resolved' => ['conversation.resolved', 'conversation_management'],
+      'first_response' => ['conversation.first_reply', 'reporting_management'],
+      'reply_time' => ['conversation.reply_time', 'reporting_management'],
+      'conversation_bot_handoff' => ['conversation.bot_handoff', 'reporting_management'],
+      'conversation_bot_resolved' => ['conversation.bot_resolved', 'reporting_management']
+    }.each do |legacy_name, (canonical, source)|
+      it "maps #{legacy_name.inspect} to #{canonical.inspect} (source=#{source})" do
         reporting_event = instance_double(ReportingEvent, name: legacy_name)
-        expect(described_class.map_reporting_event_to_event_name(reporting_event))
-          .to eq(canonical)
+        descriptor = described_class.reporting_event_descriptor(reporting_event)
+        expect(descriptor[:event]).to eq(canonical)
+        expect(descriptor[:source]).to eq(source)
       end
     end
 
     it 'raises EvoFlow::InvalidEventName for unmapped names (AC6 fail-loud)' do
       reporting_event = instance_double(ReportingEvent, name: 'unknown_legacy_event')
-      expect { described_class.map_reporting_event_to_event_name(reporting_event) }
+      expect { described_class.reporting_event_descriptor(reporting_event) }
         .to raise_error(EvoFlow::InvalidEventName)
     end
 
-    it 'every canonical value is in EvoFlow::EVENT_NAMES (cross-check with enum)' do
-      described_class::REPORTING_EVENT_NAME_MAP.each_value do |canonical|
-        expect(EvoFlow::EVENT_NAMES).to include(canonical)
+    it 'every canonical event is in EvoFlow::EVENT_NAMES (cross-check with enum)' do
+      described_class::REPORTING_EVENTS.each_value do |descriptor|
+        expect(EvoFlow::EVENT_NAMES).to include(descriptor[:event])
       end
     end
   end

--- a/spec/workers/evo_flow/backfill_contact_events_worker_spec.rb
+++ b/spec/workers/evo_flow/backfill_contact_events_worker_spec.rb
@@ -28,7 +28,11 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
   end
 
   def build_relation_stub(model_constant, records)
-    relation = instance_double(ActiveRecord::Relation, table_name: "#{model_constant}Relation")
+    # `table_name` is not a literal instance method on ActiveRecord::Relation
+    # (it is delegated), so a verifying instance_double rejects it and the whole
+    # file fails to load in a clean env. It is unused by the worker anyway, so we
+    # drop it and keep verification for the methods that matter (where/find_each).
+    relation = instance_double(ActiveRecord::Relation)
     %i[where order joins].each do |chain|
       allow(relation).to receive(chain).and_return(relation)
     end
@@ -50,7 +54,7 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
   end
 
   def build_conversation(contact_id: uuid(1))
-    instance_double(Conversation, id: uuid(100), contact_id: contact_id)
+    instance_double(Conversation, id: uuid(100), contact_id: contact_id, inbox_id: uuid(101))
   end
 
   def build_message(id:, content: 'msg body', conversation: build_conversation, created_at: Time.zone.parse('2026-01-01T00:00:00Z'))
@@ -64,13 +68,15 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
   end
 
   def build_reporting_event(id:, name: 'conversation_resolved', conversation: build_conversation,
-                            event_start_time: Time.zone.parse('2026-01-01T00:00:00Z'))
+                            event_start_time: Time.zone.parse('2026-01-01T00:00:00Z'),
+                            event_end_time: Time.zone.parse('2026-01-01T00:05:00Z'))
     instance_double(
       ReportingEvent,
       id: id, name: name, conversation: conversation,
       conversation_id: conversation&.id,
+      inbox_id: conversation&.inbox_id,
       user_id: uuid(2), value: 1.0, value_in_business_hours: 1.0,
-      event_start_time: event_start_time
+      event_start_time: event_start_time, event_end_time: event_end_time
     )
   end
 
@@ -181,6 +187,45 @@ RSpec.describe EvoFlow::BackfillContactEventsWorker, type: :worker do
         expect(client).to have_received(:post_batch) do |events|
           expect(events.first[:event]).to eq(canonical)
         end
+      end
+    end
+  end
+
+  # Regression guard: the builders previously omitted the required
+  # `source`, so every conversation.* payload raised InvalidEventPayload(:missing_required)
+  # and aborted the whole run — even under dry_run, since build_track validates while
+  # building. These assert each built payload carries `source` and re-validates clean.
+  describe 'payload <-> schema parity' do
+    def first_emitted(messages: [], reporting_events: [])
+      stub_message_relation(messages)
+      stub_reporting_event_relation(reporting_events)
+      captured = nil
+      allow(client).to receive(:post_batch) { |events| captured = events }
+      described_class.new.perform(nil, 'dry_run' => false)
+      (captured || []).first
+    end
+
+    it 'builds a conversation.activity payload that passes SchemaValidator' do
+      payload = first_emitted(messages: [build_message(id: uuid(10))])
+      expect(payload[:event]).to eq('conversation.activity')
+      expect(payload[:properties][:source]).to eq('conversation_management')
+      expect { EvoFlow::SchemaValidator.validate!(payload[:event], payload[:properties]) }
+        .not_to raise_error
+    end
+
+    {
+      'conversation_resolved' => ['conversation.resolved', 'conversation_management'],
+      'first_response' => ['conversation.first_reply', 'reporting_management'],
+      'reply_time' => ['conversation.reply_time', 'reporting_management'],
+      'conversation_bot_handoff' => ['conversation.bot_handoff', 'reporting_management'],
+      'conversation_bot_resolved' => ['conversation.bot_resolved', 'reporting_management']
+    }.each do |legacy, (canonical, expected_source)|
+      it "builds a #{canonical} payload (source=#{expected_source}) that passes SchemaValidator" do
+        payload = first_emitted(reporting_events: [build_reporting_event(id: uuid(20), name: legacy)])
+        expect(payload[:event]).to eq(canonical)
+        expect(payload[:properties][:source]).to eq(expected_source)
+        expect { EvoFlow::SchemaValidator.validate!(payload[:event], payload[:properties]) }
+          .not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Summary
- Os dois builders do `BackfillContactEventsWorker` montavam payloads **sem `source`**, que o `EvoFlow::EventSchema` declara **required** para todo evento `conversation.*`. Como `PayloadBuilder.build_track` roda `SchemaValidator.validate!` ao construir, cada payload levantava `InvalidEventPayload(:missing_required)`.
- `perform` só faz rescue de `InvalidEventName`/`ConfigurationError`, então o erro propagava como falha não-tratada e **abortava o run inteiro no 1º registro — inclusive em `dry_run`** (a validação roda antes do short-circuit do flush). O backfill estava efetivamente inoperante.
- Adiciona `source` por-evento (convenção `*_management`) e mapeia os campos extras pros optionals canônicos do schema.

## Causa raiz
Os 5 schemas novos (adicionados em `e1ff10f`, espelhados no evo-flow pela EVO-1561) declaram `source` como required; os builders nunca emitiram. O `ConversationEventsListener` em tempo real seta `source: 'conversation_management'`, mas o backfill não ganhou equivalente.

## Mudanças
- **`build_message_payload`** (`conversation.activity`): `source: 'conversation_management'` (casa com o listener live); `message_content` → `content` e `+inbox_id` (optionals do schema). `sender_type`/`sender_id` dropados — sem campo no schema.
- **`build_reporting_event_payload`**: mapeamento **por-evento** (`reporting_event_properties`).
  - `conversation.resolved` → `conversation_management` + `inbox_id` (**required**) + `resolution_time_seconds`. Este **6º evento também estava quebrado** (faltava `source` E o `inbox_id` required); não está no título do card mas é o mesmo code path.
  - `first_reply`/`reply_time`/`bot_handoff`/`bot_resolved` → `reporting_management` (único produtor é o `ReportingEventListener`; ainda não há emissor live), com `value` → o campo `*_seconds` certo + timestamps.
  - `user_id`/`value_in_business_hours` dropados — sem campo no schema.
- Proveniência de backfill continua no prefixo `backfill|` do `message_id` (`BackfillMapper`), eixo separado do `source`.

## Test plan
- `POSTGRES_PASSWORD=… bundle exec rspec spec/workers/evo_flow/backfill_contact_events_worker_spec.rb` → **32 examples, 0 failures**.
- Novo bloco "payload <-> schema parity (EVO-1570)": cada payload construído carrega `source` e re-valida limpo via `SchemaValidator` (exercita `validate!`, não só o flush de dry-run).
- `spec/services/evo_flow/` verde. As 4 falhas em `contact_events_listener_spec`/`message_events_listener_spec` são **pré-existentes** (falham idênticas em `origin/develop`) e alheias a este PR.
- Removi o `table_name` do `instance_double(ActiveRecord::Relation)` no helper `build_relation_stub`: era pré-existente, travava o arquivo inteiro num env limpo (`table_name` é delegado, não método de instância literal) e é inutilizado pelo worker. Mantive a verificação dos métodos que importam (`where`/`find_each`).
- CI não roda RSpec neste fork — verificação foi local.

## Notas
- Convenção de `source` = **subsistema produtor**, sufixo `*_management`. A **padronização ampla** (criar `EVENT_SOURCES` como SSOT, enforcement no `SchemaValidator` — hoje `source` é só `:string` e qualquer literal passa, normalizar `contact_*`/`messaging`, migração dos valores antigos no ClickHouse) fica como **card separado** (blast radius: 4 listeners + tri-mirror + migração de dado).
- Campos dropados (`sender_*`, `user_id`, `value_in_business_hours`): não têm campo no schema; declará-los exigiria mudança no tri-mirror (evo-flow + FE + Ruby) — fora de escopo deste bugfix.

Relacionado: EVO-1570