### PR TITLE
fix(crm): log warning when assign_to_pipeline pipeline_id is invalid (EVO-1265)

### DIFF
--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -22,7 +22,10 @@ module AutomationRules
       pipeline_id = extract_pipeline_id(pipeline_params[0])
       pipeline = Pipeline.find_by(id: pipeline_id)
 
-      return unless pipeline
+      unless pipeline
+        log_pipeline_not_found(pipeline_id)
+        return
+      end
 
       log_pipeline_assignment(pipeline)
       execute_pipeline_assignment(pipeline)
@@ -83,6 +86,10 @@ module AutomationRules
 
     def log_pipeline_assignment(pipeline)
       Rails.logger.info "Automation Rule #{@rule.id}: Assigning conversation #{@conversation.id} to pipeline #{pipeline.name} (ID: #{pipeline.id})"
+    end
+
+    def log_pipeline_not_found(pipeline_id)
+      Rails.logger.warn "Automation Rule #{@rule.id}: Pipeline #{pipeline_id.inspect} not found; skipping assign_to_pipeline for conversation #{@conversation.id}"
     end
 
     def execute_pipeline_assignment(pipeline)

--- a/spec/services/automation_rules/flow_execution_service_spec.rb
+++ b/spec/services/automation_rules/flow_execution_service_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe AutomationRules::FlowExecutionService do
         expect { flow_service.send(:execute_node_action, node) }
           .not_to change { conversation.reload.pipeline_items.count }
       end
+
+      it 'logs a warning and skips when pipeline_id does not match any pipeline (AC3 / EVO-1265)' do
+        stage_a # touch lazy let — keeps test isolated from setup ordering
+        nonexistent_id = SecureRandom.uuid
+        node = { 'type' => 'assign-to-pipeline-node', 'id' => 'n1', 'data' => { 'pipeline_id' => nonexistent_id } }
+
+        expect(Rails.logger).to receive(:warn).with(/Pipeline .* not found.*skipping assign_to_pipeline/i)
+
+        expect { flow_service.send(:execute_node_action, node) }
+          .not_to change { conversation.reload.pipeline_items.count }
+      end
     end
 
     describe 'move-to-pipeline-stage-node' do


### PR DESCRIPTION
## Summary

EVO-1262 (PR #96) shipped the shared `PipelineActionHandlers` mixin and wired `assign-to-pipeline-node` dispatch in `FlowExecutionService`. AC3 of EVO-1265 requires the handler to **log a warning and skip** when the configured `pipeline_id` no longer matches any pipeline (e.g., pipeline deleted after the flow rule was saved). The original implementation returned silently in that case — no warning logged, so operators had no visibility into silently-skipped nodes.

This delta closes the AC3 gap.

## Changes

- `app/services/automation_rules/pipeline_action_handlers.rb`: emit `Rails.logger.warn` with rule id, pipeline id and conversation id when `Pipeline.find_by(id: pipeline_id)` returns nil; preserves the skip semantic (no raise, no destroy of existing `pipeline_items`).
- `spec/services/automation_rules/flow_execution_service_spec.rb`: new spec asserts `Rails.logger.warn` fires with the expected message and `pipeline_items.count` is unchanged for invalid `pipeline_id`.

## Test plan

- `bundle exec rspec spec/services/automation_rules/flow_execution_service_spec.rb` — 14 examples, 0 failures (was 13).

## Linked Issue

- EVO-1265 — https://linear.app/evoai/issue/EVO-1265

## Related PRs

- `evo-ai-frontend-community` PR #119 — frontend node + panel + i18n + spec: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/119