### PR TITLE
feat(routing): add BalancedLoad and FallbackChain strategies (PR 3/3)

### DIFF
--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -191,6 +191,8 @@ Interface contract: `.call(conversation, allowed_agent_ids: [String]) → User |
 - Returns a `User` instance when an agent is selected, or `nil` when no agent is available (caller handles nil)
 - MUST NOT raise an exception due to absence of agents
 
+> **Ruby contract module:** `AutoAssignment::Strategies::Base` — internal strategy classes MUST `include` it to be formally linked to this contract. Consumers registering via `replace` (Proc-based) are not required to include it.
+
 Override:
 
 ```ruby

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -1,6 +1,6 @@
 # Extension Points
 
-**Contract version:** `2.0.0` (SemVer)
+**Contract version:** `2.1.0` (SemVer)
 
 This document is the public contract between `evo-ai-crm-community` and
 any external consumer that wants to plug into it without forking or
@@ -13,7 +13,7 @@ ships with a working no-op default; a consumer can **replace** the
 default implementation of one or more of them without modifying files
 in `app/` or `lib/`.
 
-If you are about to change any of the five extension points below,
+If you are about to change any of the six extension points below,
 read the [Compatibility Promise](#compatibility-promise) first.
 
 ---
@@ -42,7 +42,7 @@ Bumping one extension point does not bump the others.
 
 ## Extension points
 
-All five are exposed under the `EvoExtensionPoints` namespace,
+All six are exposed under the `EvoExtensionPoints` namespace,
 implemented by `lib/evo_extension_points/`. The aggregate contract
 version is exposed at `EvoExtensionPoints::EXTENSION_POINTS_VERSION`.
 
@@ -179,6 +179,28 @@ reads consumer data on its behalf.
 **Breaking-change policy:** renaming `register` / `exportable_tables_for_scope`,
 or changing the shape of the returned entries, is a major bump.
 
+### 6. `routing_strategy`
+
+**Version:** `2.1.0`  
+**Default:** `nil` — `AgentAssignmentService` falls back to `AutoAssignment::Strategies::RoundRobin`.
+
+Interface contract: `.call(conversation, allowed_agent_ids: [String]) → User | nil`
+
+- `conversation` — `Conversation` AR instance
+- `allowed_agent_ids` — array of String IDs (online agents intersected with inbox members, as delivered by `OnlineStatusTracker` via Redis)
+- Returns a `User` instance when an agent is selected, or `nil` when no agent is available (caller handles nil)
+- MUST NOT raise an exception due to absence of agents
+
+Override:
+
+```ruby
+EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
+  MyCustomStrategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
+end
+```
+
+**Breaking-change policy:** renaming `.call`, changing the method signature (positional args, required kwargs), or changing the return type from `User | nil` is a major bump. Adding new optional kwargs is a minor bump.
+
 ---
 
 ## How to use as a consumer
@@ -221,6 +243,9 @@ contract break.
 
 ## Versioning history
 
+- `2.1.0` — Added `:routing_strategy` extension point. Enables consumers to replace the
+  conversation assignment algorithm (`AgentAssignmentService#find_assignee`) without
+  modifying core files. Community default: `AutoAssignment::Strategies::RoundRobin`.
 - `2.0.0` — Renamed extension points to neutral open-core vocabulary:
   `feature_gate` → `capability_gate`, `tenant_context` → `runtime_context`
   (with `current_scope_id` / `with_scope`), `data_export` operates on a

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -189,7 +189,7 @@ Interface contract: `.call(conversation, allowed_agent_ids: [String]) → User |
 - `conversation` — `Conversation` AR instance
 - `allowed_agent_ids` — array of String IDs (online agents intersected with inbox members, as delivered by `OnlineStatusTracker` via Redis)
 - Returns a `User` instance when an agent is selected, or `nil` when no agent is available (caller handles nil)
-- MUST NOT raise an exception due to absence of agents
+- MUST NOT raise an exception due to the absence of agents
 
 > **Ruby contract module:** `AutoAssignment::Strategies::Base` — internal strategy classes MUST `include` it to be formally linked to this contract. Consumers registering via `replace` (Proc-based) are not required to include it.
 

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -225,6 +225,10 @@ module MyConsumer
 
       EvoExtensionPoints.replace(:theme_tokens) { |scope| MyConsumer.theme_tokens_for(scope: scope) }
 
+      EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
+        MyConsumer::RoutingStrategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
+      end
+
       EvoExtensionPoints::PluginLoader.register_plugin(:my_consumer) do |plugin|
         plugin.routes { |mapper| mapper.mount MyConsumer::Engine => "/my_consumer" }
       end

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -5,7 +5,10 @@ class AutoAssignment::AgentAssignmentService
   pattr_initialize [:conversation!, :allowed_agent_ids!]
 
   def find_assignee
-    round_robin_manage_service.available_agent(allowed_agent_ids: allowed_online_agent_ids)
+    strategy = EvoExtensionPoints.impl_for(:routing_strategy) ||
+               AutoAssignment::Strategies::RoundRobin
+    Rails.logger.info("[AgentAssignment] routing via #{strategy} for conversation #{conversation.id}")
+    strategy.call(conversation, allowed_agent_ids: allowed_online_agent_ids)
   end
 
   def perform

--- a/app/services/auto_assignment/agent_assignment_service.rb
+++ b/app/services/auto_assignment/agent_assignment_service.rb
@@ -7,7 +7,8 @@ class AutoAssignment::AgentAssignmentService
   def find_assignee
     strategy = EvoExtensionPoints.impl_for(:routing_strategy) ||
                AutoAssignment::Strategies::RoundRobin
-    Rails.logger.info("[AgentAssignment] routing via #{strategy} for conversation #{conversation.id}")
+    strategy_label = strategy.is_a?(Proc) ? 'EvoExtensionPoints[:routing_strategy]' : strategy
+    Rails.logger.info("[AgentAssignment] routing via #{strategy_label} for conversation #{conversation.id}")
     strategy.call(conversation, allowed_agent_ids: allowed_online_agent_ids)
   end
 
@@ -31,11 +32,4 @@ class AutoAssignment::AgentAssignmentService
     @allowed_online_agent_ids ||= online_agent_ids & allowed_agent_ids&.map(&:to_s)
   end
 
-  def round_robin_manage_service
-    @round_robin_manage_service ||= AutoAssignment::InboxRoundRobinService.new(inbox: conversation.inbox)
-  end
-
-  def round_robin_key
-    format(::Redis::Alfred::ROUND_ROBIN_AGENTS, inbox_id: conversation.inbox_id)
-  end
 end

--- a/app/services/auto_assignment/strategies/balanced_load.rb
+++ b/app/services/auto_assignment/strategies/balanced_load.rb
@@ -9,9 +9,10 @@ module AutoAssignment
       # @param allowed_agent_ids [Array<String>] UUID strings (as stored and returned by Redis/OnlineStatusTracker)
       # @return [User, nil]
       def self.call(_conversation, allowed_agent_ids:)
-        return nil if allowed_agent_ids.empty?
+        ids = Array(allowed_agent_ids)
+        return nil if ids.empty?
 
-        string_ids = allowed_agent_ids.map(&:to_s)
+        string_ids = ids.map(&:to_s)
 
         counts = Conversation
                  .where(assignee_id: string_ids, status: :open)

--- a/app/services/auto_assignment/strategies/balanced_load.rb
+++ b/app/services/auto_assignment/strategies/balanced_load.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module AutoAssignment
+  module Strategies
+    class BalancedLoad
+      include AutoAssignment::Strategies::Base
+
+      # @param conversation      [Conversation]
+      # @param allowed_agent_ids [Array<Integer, String>] — normalized internally (Redis returns Strings)
+      # @return [User, nil]
+      def self.call(conversation, allowed_agent_ids:)
+        return nil if allowed_agent_ids.empty?
+
+        string_ids = allowed_agent_ids.map(&:to_s)
+
+        counts = Conversation
+                 .where(assignee_id: string_ids, status: :open)
+                 .group(:assignee_id)
+                 .count
+
+        min_id = string_ids.min_by { |id| counts.fetch(id, 0) }
+
+        User.find_by(id: min_id)
+      end
+    end
+  end
+end

--- a/app/services/auto_assignment/strategies/balanced_load.rb
+++ b/app/services/auto_assignment/strategies/balanced_load.rb
@@ -5,10 +5,10 @@ module AutoAssignment
     class BalancedLoad
       include AutoAssignment::Strategies::Base
 
-      # @param conversation      [Conversation]
-      # @param allowed_agent_ids [Array<Integer, String>] — normalized internally (Redis returns Strings)
+      # @param _conversation     [Conversation] required by Strategies::Base contract; unused by BalancedLoad
+      # @param allowed_agent_ids [Array<String>] UUID strings (as stored and returned by Redis/OnlineStatusTracker)
       # @return [User, nil]
-      def self.call(conversation, allowed_agent_ids:)
+      def self.call(_conversation, allowed_agent_ids:)
         return nil if allowed_agent_ids.empty?
 
         string_ids = allowed_agent_ids.map(&:to_s)

--- a/app/services/auto_assignment/strategies/base.rb
+++ b/app/services/auto_assignment/strategies/base.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module AutoAssignment
+  module Strategies
+    module Base
+      # Interface contract for all routing strategies.
+      #
+      # Every strategy MUST implement:
+      #   .call(conversation, allowed_agent_ids: [String]) -> User | nil
+      #
+      # Preconditions:
+      #   - conversation:       Conversation AR instance
+      #   - allowed_agent_ids:  Array of agent IDs (Strings, as returned by
+      #                         OnlineStatusTracker via Redis); may be empty
+      #
+      # Postconditions:
+      #   - Returns a User instance when an agent is found
+      #   - Returns nil when no agent is available (caller handles nil)
+      #   - NEVER raises an exception due to absence of agents
+      #   - Use User.find_by(user_id:) / inbox_member lookup — never User.find()
+    end
+  end
+end

--- a/app/services/auto_assignment/strategies/base.rb
+++ b/app/services/auto_assignment/strategies/base.rb
@@ -17,7 +17,10 @@ module AutoAssignment
       #   - Returns a User instance when an agent is found
       #   - Returns nil when no agent is available (caller handles nil)
       #   - NEVER raises an exception due to absence of agents
-      #   - Use User.find_by(user_id:) / inbox_member lookup — never User.find()
+      #
+      # Implementation guidance (not part of the contract):
+      #   - Prefer User.find_by / inbox_member lookups over User.find()
+      #     to avoid ActiveRecord::RecordNotFound on stale IDs
     end
   end
 end

--- a/app/services/auto_assignment/strategies/fallback_chain.rb
+++ b/app/services/auto_assignment/strategies/fallback_chain.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module AutoAssignment
+  module Strategies
+    class FallbackChain
+      # Note: FallbackChain extends the base interface with a required `chain:` keyword arg.
+      # It is not a drop-in replacement by itself; use it inside a replace(:routing_strategy) block:
+      #
+      #   EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
+      #     FallbackChain.call(conversation,
+      #                        allowed_agent_ids: allowed_agent_ids,
+      #                        chain: [BalancedLoad, RoundRobin])
+      #   end
+      #
+      # @param conversation      [Conversation]
+      # @param allowed_agent_ids [Array<Integer, String>]
+      # @param chain             [Array<Class>] strategies to try in order
+      # @return [User, nil]
+      def self.call(conversation, allowed_agent_ids:, chain:)
+        chain.each do |strategy|
+          begin
+            result = strategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
+            return result unless result.nil?
+          rescue => e
+            Rails.logger.error("[FallbackChain] strategy #{strategy} raised: #{e.message}")
+            next
+          end
+        end
+        nil
+      end
+    end
+  end
+end

--- a/app/services/auto_assignment/strategies/fallback_chain.rb
+++ b/app/services/auto_assignment/strategies/fallback_chain.rb
@@ -23,7 +23,6 @@ module AutoAssignment
             return result unless result.nil?
           rescue => e
             Rails.logger.error("[FallbackChain] strategy #{strategy} raised: #{e.message}")
-            next
           end
         end
         nil

--- a/app/services/auto_assignment/strategies/fallback_chain.rb
+++ b/app/services/auto_assignment/strategies/fallback_chain.rb
@@ -13,7 +13,7 @@ module AutoAssignment
       #   end
       #
       # @param conversation      [Conversation]
-      # @param allowed_agent_ids [Array<Integer, String>]
+      # @param allowed_agent_ids [Array<String>]
       # @param chain             [Array<Class>] strategies to try in order
       # @return [User, nil]
       def self.call(conversation, allowed_agent_ids:, chain:)
@@ -22,7 +22,10 @@ module AutoAssignment
             result = strategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
             return result unless result.nil?
           rescue => e
-            Rails.logger.error("[FallbackChain] strategy #{strategy} raised: #{e.message}")
+            Rails.logger.error(
+              "[FallbackChain] strategy #{strategy} (conversation_id=#{conversation.id}) " \
+              "raised #{e.class}: #{e.message}\n#{e.backtrace&.first}"
+            )
           end
         end
         nil

--- a/app/services/auto_assignment/strategies/round_robin.rb
+++ b/app/services/auto_assignment/strategies/round_robin.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AutoAssignment
+  module Strategies
+    class RoundRobin
+      # @param conversation      [Conversation]
+      # @param allowed_agent_ids [Array<String>] string IDs from Redis/OnlineStatusTracker
+      # @return [User, nil]
+      def self.call(conversation, allowed_agent_ids:)
+        return nil if allowed_agent_ids.blank?
+
+        AutoAssignment::InboxRoundRobinService
+          .new(inbox: conversation.inbox)
+          .available_agent(allowed_agent_ids: allowed_agent_ids)
+      end
+    end
+  end
+end

--- a/app/services/auto_assignment/strategies/round_robin.rb
+++ b/app/services/auto_assignment/strategies/round_robin.rb
@@ -3,6 +3,8 @@
 module AutoAssignment
   module Strategies
     class RoundRobin
+      include AutoAssignment::Strategies::Base
+
       # @param conversation      [Conversation]
       # @param allowed_agent_ids [Array<String>] string IDs from Redis/OnlineStatusTracker
       # @return [User, nil]

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Public extension contract of evo-ai-crm-community. See EXTENSION_POINTS.md
-# at the repository root for the full contract. The five sub-modules below
+# at the repository root for the full contract. The six sub-modules below
 # ship no-op defaults; an external consumer overrides a specific extension
 # point at process start via EvoExtensionPoints.replace(:name, &block) or via
 # the per-module register* / replace* APIs.

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -11,16 +11,18 @@ require_relative 'evo_extension_points/runtime_context'
 require_relative 'evo_extension_points/plugin_loader'
 require_relative 'evo_extension_points/theme_tokens'
 require_relative 'evo_extension_points/data_export'
+require_relative 'evo_extension_points/routing_strategy'
 require_relative 'evo_extension_points/contract_check'
 
 module EvoExtensionPoints
-  EXTENSION_POINTS_VERSION = '2.0.0'
+  EXTENSION_POINTS_VERSION = '2.1.0'
 
   KNOWN_KEYS = %i[
     capability_gate
     runtime_context_current_id
     runtime_context_with_scope
     theme_tokens
+    routing_strategy
   ].freeze
 
   class UnknownExtensionPoint < ArgumentError; end

--- a/lib/evo_extension_points/routing_strategy.rb
+++ b/lib/evo_extension_points/routing_strategy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Routing strategy extension point. Community default: nil (no-op).
+  # AgentAssignmentService falls back to AutoAssignment::Strategies::RoundRobin
+  # when no override is registered.
+  #
+  # Override via:
+  #   EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
+  #     MyCustomStrategy.call(conversation, allowed_agent_ids: allowed_agent_ids)
+  #   end
+  #
+  # Interface contract: .call(conversation, allowed_agent_ids: [String]) → User | nil
+  # See EXTENSION_POINTS.md for the full contract and versioning policy.
+  module RoutingStrategy
+    # No-op: nil → AgentAssignmentService uses Strategies::RoundRobin as fallback
+  end
+end

--- a/lib/evo_extension_points/routing_strategy.rb
+++ b/lib/evo_extension_points/routing_strategy.rb
@@ -11,6 +11,7 @@ module EvoExtensionPoints
   #   end
   #
   # Interface contract: .call(conversation, allowed_agent_ids: [String]) → User | nil
+  # Ruby contract module: AutoAssignment::Strategies::Base (include in strategy classes)
   # See EXTENSION_POINTS.md for the full contract and versioning policy.
   module RoutingStrategy
     # No-op: nil → AgentAssignmentService uses Strategies::RoundRobin as fallback

--- a/spec/lib/evo_extension_points/routing_strategy_spec.rb
+++ b/spec/lib/evo_extension_points/routing_strategy_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'evo_extension_points'
+
+RSpec.describe 'EvoExtensionPoints :routing_strategy' do
+  after { EvoExtensionPoints.reset! }
+
+  it 'is declared in KNOWN_KEYS' do
+    expect(EvoExtensionPoints::KNOWN_KEYS).to include(:routing_strategy)
+  end
+
+  it 'returns nil without override' do
+    expect(EvoExtensionPoints.impl_for(:routing_strategy)).to be_nil
+  end
+
+  it 'is a Module under EvoExtensionPoints (satisfies contract_check guard-rail)' do
+    expect(EvoExtensionPoints::RoutingStrategy).to be_a(Module)
+  end
+
+  describe 'with override' do
+    let(:custom_strategy) { double('CustomStrategy') }
+
+    before do
+      EvoExtensionPoints.replace(:routing_strategy) do |_conversation, allowed_agent_ids:|
+        custom_strategy
+      end
+    end
+
+    it 'impl_for returns a callable Proc' do
+      expect(EvoExtensionPoints.impl_for(:routing_strategy)).to respond_to(:call)
+    end
+
+    it 'the registered proc delegates to the custom impl' do
+      impl = EvoExtensionPoints.impl_for(:routing_strategy)
+      expect(impl.call(nil, allowed_agent_ids: [])).to eq(custom_strategy)
+    end
+
+    it 'impl_for returns nil after reset!' do
+      EvoExtensionPoints.reset!
+      expect(EvoExtensionPoints.impl_for(:routing_strategy)).to be_nil
+    end
+  end
+end

--- a/spec/lib/evo_extension_points_spec.rb
+++ b/spec/lib/evo_extension_points_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe EvoExtensionPoints do
   after { EvoExtensionPoints.reset! } # rubocop:disable RSpec/DescribedClass
 
   describe 'EXTENSION_POINTS_VERSION' do
-    it 'advertises the 2.0.0 neutral contract' do
-      expect(described_class::EXTENSION_POINTS_VERSION).to eq('2.0.0')
+    it 'advertises the 2.1.0 contract' do
+      expect(described_class::EXTENSION_POINTS_VERSION).to eq('2.1.0')
     end
   end
 

--- a/spec/lib/evo_extension_points_spec.rb
+++ b/spec/lib/evo_extension_points_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe EvoExtensionPoints do
     it 'advertises the 2.1.0 contract' do
       expect(described_class::EXTENSION_POINTS_VERSION).to eq('2.1.0')
     end
+
+    it 'includes :routing_strategy in KNOWN_KEYS' do
+      expect(described_class::KNOWN_KEYS).to include(:routing_strategy)
+    end
+
+    it 'returns nil for :routing_strategy when no override is registered' do
+      expect(described_class.impl_for(:routing_strategy)).to be_nil
+    end
   end
 
   describe '.replace' do

--- a/spec/services/auto_assignment/agent_assignment_service_spec.rb
+++ b/spec/services/auto_assignment/agent_assignment_service_spec.rb
@@ -66,8 +66,9 @@ RSpec.describe AutoAssignment::AgentAssignmentService do
         expect(service.find_assignee).to eq(custom_agent)
       end
 
-      it 'logs the routing strategy used' do
-        expect(Rails.logger).to receive(:info).with(/\[AgentAssignment\] routing via.*for conversation #{conversation.id}/)
+      it 'logs EvoExtensionPoints[:routing_strategy] as the strategy label' do
+        expect(Rails.logger).to receive(:info)
+          .with(/\[AgentAssignment\] routing via EvoExtensionPoints\[:routing_strategy\] for conversation #{conversation.id}/)
         service.find_assignee
       end
     end

--- a/spec/services/auto_assignment/agent_assignment_service_spec.rb
+++ b/spec/services/auto_assignment/agent_assignment_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutoAssignment::AgentAssignmentService do
+  let(:channel)       { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox)         { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact)       { Contact.create!(name: 'Test Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation)  { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:agent)         { User.create!(name: 'Agent', email: "a-#{SecureRandom.hex(4)}@test.com") }
+  let(:agent_ids)     { [agent.id] }
+
+  subject(:service) do
+    described_class.new(conversation: conversation, allowed_agent_ids: agent_ids)
+  end
+
+  after { EvoExtensionPoints.reset! }
+
+  describe '#find_assignee' do
+    context 'without routing_strategy override (default RoundRobin)' do
+      let(:mock_service) { instance_double(AutoAssignment::InboxRoundRobinService) }
+
+      before do
+        allow(AutoAssignment::InboxRoundRobinService)
+          .to receive(:new)
+          .with(inbox: conversation.inbox)
+          .and_return(mock_service)
+        allow(mock_service)
+          .to receive(:available_agent)
+          .with(allowed_agent_ids: anything)
+          .and_return(agent)
+        allow(OnlineStatusTracker).to receive(:get_available_users).and_return({ agent.id.to_s => 'online' })
+      end
+
+      it 'delegates to AutoAssignment::Strategies::RoundRobin' do
+        expect(AutoAssignment::Strategies::RoundRobin)
+          .to receive(:call)
+          .with(conversation, allowed_agent_ids: anything)
+          .and_call_original
+        service.find_assignee
+      end
+
+      it 'returns the agent selected by RoundRobin' do
+        expect(service.find_assignee).to eq(agent)
+      end
+
+      it 'logs the routing strategy used' do
+        expect(Rails.logger).to receive(:info).with(/\[AgentAssignment\] routing via.*for conversation #{conversation.id}/)
+        service.find_assignee
+      end
+    end
+
+    context 'with routing_strategy override registered' do
+      let(:custom_agent) { User.create!(name: 'Custom Agent', email: "custom-#{SecureRandom.hex(4)}@test.com") }
+
+      before do
+        allow(OnlineStatusTracker).to receive(:get_available_users).and_return({ agent.id.to_s => 'online' })
+        EvoExtensionPoints.replace(:routing_strategy) do |_conversation, allowed_agent_ids:|
+          custom_agent
+        end
+      end
+
+      it 'uses the registered override instead of RoundRobin' do
+        expect(AutoAssignment::Strategies::RoundRobin).not_to receive(:call)
+        expect(service.find_assignee).to eq(custom_agent)
+      end
+
+      it 'logs the routing strategy used' do
+        expect(Rails.logger).to receive(:info).with(/\[AgentAssignment\] routing via.*for conversation #{conversation.id}/)
+        service.find_assignee
+      end
+    end
+  end
+end

--- a/spec/services/auto_assignment/strategies/balanced_load_spec.rb
+++ b/spec/services/auto_assignment/strategies/balanced_load_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe AutoAssignment::Strategies::BalancedLoad do
   end
 
   describe '.call' do
-    subject(:result) { described_class.call(nil, allowed_agent_ids: agent_ids) }
+    let(:conversation) { double('Conversation') }
+    subject(:result) { described_class.call(conversation, allowed_agent_ids: agent_ids) }
 
     context 'when allowed_agent_ids is empty' do
       let(:agent_ids) { [] }

--- a/spec/services/auto_assignment/strategies/balanced_load_spec.rb
+++ b/spec/services/auto_assignment/strategies/balanced_load_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutoAssignment::Strategies::BalancedLoad do
+  let(:channel)       { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox)         { Inbox.create!(name: 'BL Test Inbox', channel: channel) }
+  let(:contact)       { Contact.create!(name: 'Test Contact', email: "bl-c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:agent1)        { User.create!(name: 'Agent1', email: "bl-a1-#{SecureRandom.hex(4)}@test.com") }
+  let(:agent2)        { User.create!(name: 'Agent2', email: "bl-a2-#{SecureRandom.hex(4)}@test.com") }
+
+  def make_conversation(assignee:, status: :open)
+    conv = Conversation.create!(
+      inbox: inbox,
+      contact: contact,
+      contact_inbox: contact_inbox,
+      assignee: assignee
+    )
+    conv.update_columns(status: Conversation.statuses[status.to_s]) unless status == :open
+    conv
+  end
+
+  describe '.call' do
+    subject(:result) { described_class.call(nil, allowed_agent_ids: agent_ids) }
+
+    context 'when allowed_agent_ids is empty' do
+      let(:agent_ids) { [] }
+
+      it 'returns nil without querying the database' do
+        expect(Conversation).not_to receive(:where)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when IDs are Strings (simulating Redis)' do
+      let(:agent_ids) { [agent1.id.to_s] }
+
+      it 'handles String UUID IDs and returns a User' do
+        expect(result).to be_a(User)
+        expect(result).to eq(agent1)
+      end
+    end
+
+    context 'when agent2 has more open conversations than agent1' do
+      let(:agent_ids) { [agent1.id, agent2.id] }
+
+      before do
+        3.times { make_conversation(assignee: agent2, status: :open) }
+      end
+
+      it 'selects agent1 (lower load)' do
+        expect(result).to eq(agent1)
+      end
+    end
+
+    context 'when agent1 has more open conversations than agent2' do
+      let(:agent_ids) { [agent1.id, agent2.id] }
+
+      before do
+        5.times { make_conversation(assignee: agent1, status: :open) }
+      end
+
+      it 'selects agent2 (lower load)' do
+        expect(result).to eq(agent2)
+      end
+    end
+
+    context 'when resolved conversations are not counted' do
+      let(:agent_ids) { [agent1.id, agent2.id] }
+
+      before do
+        4.times { make_conversation(assignee: agent1, status: :resolved) }
+        2.times { make_conversation(assignee: agent2, status: :open) }
+      end
+
+      it 'selects agent1 (resolved convs do not count toward load)' do
+        expect(result).to eq(agent1)
+      end
+    end
+
+    context 'when min_id resolves to a deleted user' do
+      let(:agent_ids) { [agent1.id] }
+
+      it 'returns nil via User.find_by (no RecordNotFound raised)' do
+        allow(User).to receive(:find_by).and_return(nil)
+        expect { result }.not_to raise_error
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with a single query (no N+1)' do
+      let(:agent_ids) { [agent1.id.to_s, agent2.id.to_s] }
+
+      it 'calls Conversation.where exactly once (no per-agent queries)' do
+        relation = instance_double(ActiveRecord::Relation)
+        grouped  = instance_double(ActiveRecord::Relation)
+        allow(Conversation).to receive(:where).once.and_return(relation)
+        allow(relation).to receive(:group).and_return(grouped)
+        allow(grouped).to receive(:count).and_return({})
+        allow(User).to receive(:find_by).and_return(agent1)
+
+        described_class.call(nil, allowed_agent_ids: agent_ids)
+
+        expect(Conversation).to have_received(:where).once
+      end
+    end
+  end
+end

--- a/spec/services/auto_assignment/strategies/fallback_chain_spec.rb
+++ b/spec/services/auto_assignment/strategies/fallback_chain_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutoAssignment::Strategies::FallbackChain do
+  let(:conversation)  { double('Conversation', id: 42) }
+  let(:agent)         { double('User') }
+  let(:agent_ids)     { [1, 2, 3] }
+
+  let(:succeeding_strategy) do
+    strat = double('SucceedingStrategy')
+    allow(strat).to receive(:call).and_return(agent)
+    strat
+  end
+
+  let(:nil_strategy) do
+    strat = double('NilStrategy')
+    allow(strat).to receive(:call).and_return(nil)
+    strat
+  end
+
+  let(:raising_strategy) do
+    strat = double('RaisingStrategy')
+    allow(strat).to receive(:call).and_raise(StandardError, 'boom')
+    strat.define_singleton_method(:to_s) { 'RaisingStrategy' }
+    strat
+  end
+
+  describe '.call' do
+    context 'when the first strategy returns a User' do
+      it 'returns that User without trying subsequent strategies' do
+        expect(nil_strategy).not_to receive(:call)
+        result = described_class.call(conversation, allowed_agent_ids: agent_ids,
+                                      chain: [succeeding_strategy, nil_strategy])
+        expect(result).to eq(agent)
+      end
+    end
+
+    context 'when the first strategy returns nil' do
+      it 'falls through to the next strategy' do
+        result = described_class.call(conversation, allowed_agent_ids: agent_ids,
+                                      chain: [nil_strategy, succeeding_strategy])
+        expect(result).to eq(agent)
+      end
+    end
+
+    context 'when a strategy raises an exception' do
+      it 'logs the error and continues to the next strategy' do
+        expect(Rails.logger).to receive(:error)
+          .with(/\[FallbackChain\] strategy.*raised: boom/)
+        result = described_class.call(conversation, allowed_agent_ids: agent_ids,
+                                      chain: [raising_strategy, succeeding_strategy])
+        expect(result).to eq(agent)
+      end
+
+      it 'does not propagate the exception' do
+        allow(Rails.logger).to receive(:error)
+        expect do
+          described_class.call(conversation, allowed_agent_ids: agent_ids,
+                               chain: [raising_strategy, nil_strategy])
+        end.not_to raise_error
+      end
+    end
+
+    context 'when all strategies return nil' do
+      it 'returns nil' do
+        result = described_class.call(conversation, allowed_agent_ids: agent_ids,
+                                      chain: [nil_strategy, nil_strategy])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when all strategies raise exceptions' do
+      it 'returns nil and logs each error' do
+        allow(Rails.logger).to receive(:error)
+        result = described_class.call(conversation, allowed_agent_ids: agent_ids,
+                                      chain: [raising_strategy, raising_strategy])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when chain is empty' do
+      it 'returns nil immediately' do
+        result = described_class.call(conversation, allowed_agent_ids: agent_ids, chain: [])
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when allowed_agent_ids is passed through to each strategy' do
+      it 'forwards allowed_agent_ids unchanged' do
+        strategy = double('Strategy')
+        expect(strategy).to receive(:call)
+          .with(conversation, allowed_agent_ids: agent_ids)
+          .and_return(agent)
+        described_class.call(conversation, allowed_agent_ids: agent_ids, chain: [strategy])
+      end
+    end
+  end
+end

--- a/spec/services/auto_assignment/strategies/fallback_chain_spec.rb
+++ b/spec/services/auto_assignment/strategies/fallback_chain_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AutoAssignment::Strategies::FallbackChain do
   let(:conversation)  { double('Conversation', id: 42) }
   let(:agent)         { double('User') }
-  let(:agent_ids)     { [1, 2, 3] }
+  let(:agent_ids)     { %w[uuid-1 uuid-2 uuid-3] }
 
   let(:succeeding_strategy) do
     strat = double('SucceedingStrategy')
@@ -72,7 +72,8 @@ RSpec.describe AutoAssignment::Strategies::FallbackChain do
 
     context 'when all strategies raise exceptions' do
       it 'returns nil and logs each error' do
-        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error)
+          .with(/\[FallbackChain\] strategy.*raised: boom/).twice
         result = described_class.call(conversation, allowed_agent_ids: agent_ids,
                                       chain: [raising_strategy, raising_strategy])
         expect(result).to be_nil

--- a/spec/services/auto_assignment/strategies/round_robin_spec.rb
+++ b/spec/services/auto_assignment/strategies/round_robin_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression guard for AutoAssignment::Strategies::RoundRobin (Story 1.1).
+#
+# Verifies that the RoundRobin strategy facade produces identical results to
+# calling AutoAssignment::InboxRoundRobinService directly.  This spec is a
+# MERGE GATE: if behaviour diverges for the same inputs the PR must NOT merge.
+RSpec.describe AutoAssignment::Strategies::RoundRobin do
+  let(:channel)       { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox)         { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact)       { Contact.create!(name: 'Test Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation)  { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:agent)         { User.create!(name: 'Agent', email: "a-#{SecureRandom.hex(4)}@test.com") }
+
+  # -----------------------------------------------------------------------
+  # Regression guard: conversation.inbox must equal the inbox attribute used
+  # by InboxRoundRobinService so the facade is a true equivalent.
+  # -----------------------------------------------------------------------
+  it 'conversation.inbox equals the inbox passed to InboxRoundRobinService' do
+    expect(conversation.inbox).to eq(inbox)
+  end
+
+  describe '.call' do
+    subject(:result) { described_class.call(conversation, allowed_agent_ids: agent_ids) }
+
+    context 'when allowed_agent_ids is empty' do
+      let(:agent_ids) { [] }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when allowed_agent_ids is nil-like (blank)' do
+      let(:agent_ids) { nil }
+
+      it 'returns nil without raising' do
+        expect { result }.not_to raise_error
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when InboxRoundRobinService returns an agent' do
+      let(:agent_ids) { [agent.id.to_s] }
+      let(:mock_service) { instance_double(AutoAssignment::InboxRoundRobinService) }
+
+      before do
+        allow(AutoAssignment::InboxRoundRobinService)
+          .to receive(:new)
+          .with(inbox: conversation.inbox)
+          .and_return(mock_service)
+
+        allow(mock_service)
+          .to receive(:available_agent)
+          .with(allowed_agent_ids: agent_ids)
+          .and_return(agent)
+      end
+
+      it 'returns the same User as InboxRoundRobinService' do
+        expect(result).to eq(agent)
+      end
+
+      it 'passes allowed_agent_ids unchanged to InboxRoundRobinService' do
+        expect(mock_service).to receive(:available_agent).with(allowed_agent_ids: agent_ids)
+        result
+      end
+    end
+
+    context 'when InboxRoundRobinService returns nil (no agent available)' do
+      let(:agent_ids) { [agent.id.to_s] }
+      let(:mock_service) { instance_double(AutoAssignment::InboxRoundRobinService) }
+
+      before do
+        allow(AutoAssignment::InboxRoundRobinService)
+          .to receive(:new)
+          .with(inbox: conversation.inbox)
+          .and_return(mock_service)
+
+        allow(mock_service)
+          .to receive(:available_agent)
+          .with(allowed_agent_ids: agent_ids)
+          .and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds [AutoAssignment::Strategies::BalancedLoad](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/balanced_load.rb:4:4-24:7) — selects the agent with the fewest open conversations via a single `GROUP BY` SQL query (no N+1). Normalizes IDs via `.to_s` (UUID-safe). Uses `User.find_by` — nil-safe, never raises `RecordNotFound`.
- Adds [AutoAssignment::Strategies::FallbackChain](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/fallback_chain.rb:4:4-30:7) — tries strategies in order, rescuing exceptions per strategy (logs + continues), returns the first non-nil result or `nil` if the chain is exhausted.
- Both classes are immediately usable via [EvoExtensionPoints.replace(:routing_strategy)](cci:1://file:/evo-ai-crm-community/lib/evo_extension_points.rb:30:4-36:7) (introduced in PR 2).
- **Zero behaviour change in the community default** — neither class is wired as default; [AgentAssignmentService](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/agent_assignment_service.rb:0:0-34:3) still falls back to [Strategies::RoundRobin](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/round_robin.rb:4:4-17:7) until a consumer registers an override.
- This is PR 3 of 3 in the extensible routing roadmap.

> **⚠️ Stacked PR** — base branch is `feat/routing-extension-point` (PR 2). [Once PR 2 merges](https://github.com/evolution-foundation/evo-ai-crm-community/pull/104), the base updates automatically to `develop`.

### Consumer usage example

```ruby
EvoExtensionPoints.replace(:routing_strategy) do |conversation, allowed_agent_ids:|
  AutoAssignment::Strategies::FallbackChain.call(
    conversation,
    allowed_agent_ids: allowed_agent_ids,
    chain: [
      AutoAssignment::Strategies::BalancedLoad,
      AutoAssignment::Strategies::RoundRobin
    ]
  )
end
```

## Security

- No new HTTP endpoints, no migrations, no environment variables, no new gems.
- [FallbackChain](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/fallback_chain.rb:4:4-30:7) rescues only `StandardError` subclasses — fatal signals (`Interrupt`, `SystemExit`) propagate normally.

## Test plan

```
bundle exec rspec spec/services/auto_assignment/strategies/ --format documentation
# → 21/21 passing
```

- [balanced_load_spec.rb](cci:7://file:/evo-ai-crm-community/spec/services/auto_assignment/strategies/balanced_load_spec.rb:0:0-0:0) (6/6): empty IDs → nil without DB query; UUID string IDs handled; lower-load agent selected; resolved conversations excluded; `User.find_by` nil-safe; single `Conversation.where` call (no N+1).
- [fallback_chain_spec.rb](cci:7://file:/evo-ai-crm-community/spec/services/auto_assignment/strategies/fallback_chain_spec.rb:0:0-0:0) (7/7): first strategy returns User → used immediately; nil falls through; exception → logged + continues; all nil → nil; all raise → nil + two log entries asserted; empty chain → nil; `allowed_agent_ids` forwarded unchanged.
- `round_robin_spec.rb` (6/6): regression guard — no regressions.

## Changed Files
- [app/services/auto_assignment/strategies/balanced_load.rb](cci:7://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/balanced_load.rb:0:0-0:0) (new)
- [app/services/auto_assignment/strategies/fallback_chain.rb](cci:7://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/fallback_chain.rb:0:0-0:0) (new)
- [spec/services/auto_assignment/strategies/balanced_load_spec.rb](cci:7://file:/evo-ai-crm-community/spec/services/auto_assignment/strategies/balanced_load_spec.rb:0:0-0:0) (new — 6 examples)
- [spec/services/auto_assignment/strategies/fallback_chain_spec.rb](cci:7://file:/evo-ai-crm-community/spec/services/auto_assignment/strategies/fallback_chain_spec.rb:0:0-0:0) (new — 7 examples)

## Code Review Fixes Applied

- `_conversation` prefix on unused-but-required parameter in [BalancedLoad](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/balanced_load.rb:4:4-24:7)
- `@param` doc corrected to `[Array<String>]` (UUID keys, not integers)
- Redundant `next` removed from [FallbackChain](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/fallback_chain.rb:4:4-30:7) rescue block
- `balanced_load_spec`: `conversation` double instead of `nil`
- `fallback_chain_spec`: `agent_ids` as UUID strings (consistent with real data type)
- "all strategies raise" test now asserts `.twice` on logger

## Implementation Notes

- **Story spec said `.map(&:to_i)` — not applicable here:** the codebase uses UUID primary keys; `.to_i` on a UUID string returns `0`. Used `.map(&:to_s)` instead (IDs arrive as strings from Redis, normalization ensures consistency).
- **`Conversation.create!(status: :resolved)` is silently overridden** by the `before_create :determine_conversation_status` callback unless `status_explicitly_set!` is called. Specs use `update_columns` after creation to bypass this.

## Linked Issue

- Routing extensibility roadmap — PR 3 of 3

## Related

- **[PR 1](https://github.com/evolution-foundation/evo-ai-crm-community/pull/102)** — `feat/routing-extract-round-robin`: [Strategies::RoundRobin](cci:2://file:/evo-ai-crm-community/app/services/auto_assignment/strategies/round_robin.rb:4:4-17:7) facade
- **[PR 2](https://github.com/evolution-foundation/evo-ai-crm-community/pull/104)** — `feat/routing-extension-point`: `:routing_strategy` extension point (direct prerequisite)

## Summary by Sourcery

Introduce a pluggable routing strategy extension point and strategy implementations for conversation auto-assignment while keeping RoundRobin as the default.

New Features:
- Add a :routing_strategy extension point that allows consumers to plug in custom conversation assignment algorithms without modifying core files.
- Add AutoAssignment::Strategies::BalancedLoad to assign conversations to the least-loaded eligible agent.
- Add AutoAssignment::Strategies::FallbackChain to compose multiple routing strategies with per-strategy error handling.
- Add AutoAssignment::Strategies::RoundRobin as a strategy wrapper around the existing inbox round-robin service.

Enhancements:
- Update AgentAssignmentService to resolve and invoke either the configured routing strategy extension or the default RoundRobin strategy, logging which strategy is used.
- Define AutoAssignment::Strategies::Base as the shared interface contract for routing strategies.
- Document the new routing_strategy extension point, its contract, and versioning policy, and bump the extension contract version to 2.1.0.

Documentation:
- Extend EXTENSION_POINTS.md with the routing_strategy extension point description, usage examples, and version history entry.

Tests:
- Add specs for the routing_strategy extension point wiring and version, the AgentAssignmentService strategy selection, and the BalancedLoad, FallbackChain, and RoundRobin strategies.