### PR TITLE
feat(crm): publish pipeline.stage_changed to evo-flow for Journey triggers (EVO-1266)

### DIFF
--- a/app/listeners/evo_flow/pipeline_events_listener.rb
+++ b/app/listeners/evo_flow/pipeline_events_listener.rb
@@ -97,7 +97,12 @@ module EvoFlow
 
     def enqueue_stage_change_track(pipeline_item, contact_id, stage_change)
       old_stage_id, new_stage_id = stage_change
-      occurred_at = Time.zone.now
+      # Use the model's `updated_at` (set by AR on the save that triggered the
+      # stage change) instead of `Time.zone.now` so that the same logical
+      # event produces a deterministic `message_id` across listener
+      # invocations and Sidekiq retries — mirrors the pattern in
+      # `enqueue_track` which uses `pipeline_item.created_at`.
+      occurred_at = pipeline_item.updated_at || Time.zone.now
       source_event_uuid = "#{pipeline_item.id}.#{new_stage_id}.#{occurred_at.to_i}"
       message_id = EvoFlow::PayloadBuilder.message_id_for(STAGE_CHANGED_EVENT_NAME, contact_id, source_event_uuid)
       payload = EvoFlow::PayloadBuilder.build_track(
@@ -115,20 +120,28 @@ module EvoFlow
       old_stage = PipelineStage.find_by(id: old_stage_id) if old_stage_id
       pipeline = new_stage&.pipeline
 
-      {
+      # `pipeline_stage_id`/`pipeline_stage_name` mirror `to_stage_id`/`to_stage_name`
+      # by design: schema treats `pipeline_stage_id` as required (matching the
+      # `campaign.triggered` convention) while journey trigger filters in the
+      # frontend use `to_stage_id`. Optional fields that resolve to nil are
+      # OMITTED rather than sent as null — `EventSchemaValidationPipe` rejects
+      # explicit `null` for typed fields (see EVO-1570 for the analogous bug
+      # on the EvoFlow backfill side).
+      properties = {
         pipeline_item_id: pipeline_item.id,
         pipeline_id: pipeline&.id,
-        pipeline_name: pipeline&.name,
         pipeline_stage_id: new_stage_id,
-        pipeline_stage_name: new_stage&.name,
-        from_stage_id: old_stage_id,
-        from_stage_name: old_stage&.name,
         to_stage_id: new_stage_id,
-        to_stage_name: new_stage&.name,
         conversation_id: pipeline_item.conversation_id,
         contact_id: contact_id,
         source: 'pipeline_management'
       }
+      properties[:pipeline_name] = pipeline.name if pipeline
+      properties[:pipeline_stage_name] = new_stage.name if new_stage
+      properties[:to_stage_name] = new_stage.name if new_stage
+      properties[:from_stage_id] = old_stage_id if old_stage_id
+      properties[:from_stage_name] = old_stage.name if old_stage
+      properties
     end
 
     # F11 fix: use the resolved contact_id for `contact_id` so deal items

--- a/app/listeners/evo_flow/pipeline_events_listener.rb
+++ b/app/listeners/evo_flow/pipeline_events_listener.rb
@@ -13,6 +13,7 @@ module EvoFlow
   class PipelineEventsListener
     TRACK_PATH = '/events/track'
     EVENT_NAME = 'campaign.triggered'
+    STAGE_CHANGED_EVENT_NAME = 'pipeline.stage_changed'
 
     def pipeline_item_created(data)
       return if data.respond_to?(:data)
@@ -29,6 +30,28 @@ module EvoFlow
       return warn_unresolved(pipeline_item) unless contact_id
 
       enqueue_track(pipeline_item, contact_id)
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    def pipeline_stage_updated(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      pipeline_item = event_data[:pipeline_item]
+      changed_attributes = event_data[:changed_attributes] || {}
+
+      unless pipeline_item
+        Rails.logger.error('EvoFlow::PipelineEventsListener#pipeline_stage_updated: pipeline_item is nil')
+        return
+      end
+      return unless changed_attributes['pipeline_stage_id'].is_a?(Array)
+      return unless evo_flow_enabled?
+
+      contact_id = resolve_contact_id(pipeline_item)
+      return warn_unresolved_stage_change(pipeline_item) unless contact_id
+
+      enqueue_stage_change_track(pipeline_item, contact_id, changed_attributes['pipeline_stage_id'])
     rescue StandardError => e
       log_failure(__method__, e)
     end
@@ -63,6 +86,49 @@ module EvoFlow
         "EvoFlow::PipelineEventsListener#pipeline_item_created: no resolvable contact_id for pipeline_item #{pipeline_item.id}"
       )
       nil
+    end
+
+    def warn_unresolved_stage_change(pipeline_item)
+      Rails.logger.warn(
+        "EvoFlow::PipelineEventsListener#pipeline_stage_updated: no resolvable contact_id for pipeline_item #{pipeline_item.id}"
+      )
+      nil
+    end
+
+    def enqueue_stage_change_track(pipeline_item, contact_id, stage_change)
+      old_stage_id, new_stage_id = stage_change
+      occurred_at = Time.zone.now
+      source_event_uuid = "#{pipeline_item.id}.#{new_stage_id}.#{occurred_at.to_i}"
+      message_id = EvoFlow::PayloadBuilder.message_id_for(STAGE_CHANGED_EVENT_NAME, contact_id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_track(
+        event_name: STAGE_CHANGED_EVENT_NAME,
+        contact_id: contact_id,
+        properties: build_stage_changed_properties(pipeline_item, contact_id, old_stage_id, new_stage_id),
+        occurred_at: occurred_at,
+        message_id: message_id
+      )
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+    end
+
+    def build_stage_changed_properties(pipeline_item, contact_id, old_stage_id, new_stage_id)
+      new_stage = pipeline_item.pipeline_stage
+      old_stage = PipelineStage.find_by(id: old_stage_id) if old_stage_id
+      pipeline = new_stage&.pipeline
+
+      {
+        pipeline_item_id: pipeline_item.id,
+        pipeline_id: pipeline&.id,
+        pipeline_name: pipeline&.name,
+        pipeline_stage_id: new_stage_id,
+        pipeline_stage_name: new_stage&.name,
+        from_stage_id: old_stage_id,
+        from_stage_name: old_stage&.name,
+        to_stage_id: new_stage_id,
+        to_stage_name: new_stage&.name,
+        conversation_id: pipeline_item.conversation_id,
+        contact_id: contact_id,
+        source: 'pipeline_management'
+      }
     end
 
     # F11 fix: use the resolved contact_id for `contact_id` so deal items

--- a/app/models/pipeline_item.rb
+++ b/app/models/pipeline_item.rb
@@ -59,7 +59,16 @@ class PipelineItem < ApplicationRecord
   # on rollback.
   after_create_commit :publish_pipeline_item_created
   after_create :dispatch_initial_stage_event
+  # EVO-1266: Wisper broadcast for journey-trigger consumption is
+  # post-commit so rollbacks don't leak orphan Sidekiq jobs (mirrors
+  # publish_pipeline_item_created above). The pre-commit
+  # `dispatch_initial_stage_event` / `create_stage_change_movement`
+  # below keep firing the legacy `Rails.configuration.dispatcher`
+  # event for AutomationRules — its in-transaction execution is an
+  # AC of that pre-existing path.
+  after_create_commit :broadcast_stage_update_to_evo_flow
   after_update :create_stage_change_movement, if: :saved_change_to_pipeline_stage_id?
+  after_update_commit :broadcast_stage_update_to_evo_flow, if: :saved_change_to_pipeline_stage_id?
   after_update :publish_pipeline_item_updated
   after_update :publish_pipeline_item_completed, if: :saved_change_to_completed_at?
   after_destroy :publish_pipeline_item_deleted
@@ -328,34 +337,45 @@ class PipelineItem < ApplicationRecord
       )
     end
 
-    changed_attributes = { 'pipeline_stage_id' => [old_stage_id, pipeline_stage_id] }
-
     # Trigger automation event for pipeline stage update
     Rails.configuration.dispatcher.dispatch(
       'pipeline_stage_updated',
       Time.zone.now,
       pipeline_item: self,
-      changed_attributes: changed_attributes
+      changed_attributes: { 'pipeline_stage_id' => [old_stage_id, pipeline_stage_id] }
     )
-
-    # EVO-1266: also broadcast via Wisper so EvoFlow::PipelineEventsListener
-    # publishes the canonical pipeline.stage_changed event to evo-flow for
-    # journey trigger consumption. Kept alongside the dispatcher call —
-    # both subscriber systems coexist (see publish_pipeline_item_created).
-    publish(:pipeline_stage_updated, data: { pipeline_item: self, changed_attributes: changed_attributes })
   end
 
   def dispatch_initial_stage_event
-    changed_attributes = { 'pipeline_stage_id' => [nil, pipeline_stage_id] }
-
     Rails.configuration.dispatcher.dispatch(
       'pipeline_stage_updated',
       Time.zone.now,
       pipeline_item: self,
-      changed_attributes: changed_attributes
+      changed_attributes: { 'pipeline_stage_id' => [nil, pipeline_stage_id] }
     )
+  end
 
-    publish(:pipeline_stage_updated, data: { pipeline_item: self, changed_attributes: changed_attributes })
+  # EVO-1266: post-commit Wisper broadcast that EvoFlow::PipelineEventsListener
+  # consumes to publish the canonical pipeline.stage_changed event to evo-flow
+  # for journey trigger matching. Runs after both `after_create_commit` (initial
+  # stage assignment — old = nil) and `after_update_commit` (subsequent stage
+  # change). Resolves the from/to ids from the dirty-tracking attribute API,
+  # which remains valid in the *_commit lifecycle.
+  def broadcast_stage_update_to_evo_flow
+    old_stage_id, new_stage_id =
+      if saved_change_to_pipeline_stage_id?
+        saved_change_to_pipeline_stage_id
+      else
+        [nil, pipeline_stage_id]
+      end
+
+    publish(
+      :pipeline_stage_updated,
+      data: {
+        pipeline_item: self,
+        changed_attributes: { 'pipeline_stage_id' => [old_stage_id, new_stage_id] }
+      }
+    )
   end
 
   # Wisper event publishers (for EvoCampaign integration)

--- a/app/models/pipeline_item.rb
+++ b/app/models/pipeline_item.rb
@@ -328,22 +328,34 @@ class PipelineItem < ApplicationRecord
       )
     end
 
+    changed_attributes = { 'pipeline_stage_id' => [old_stage_id, pipeline_stage_id] }
+
     # Trigger automation event for pipeline stage update
     Rails.configuration.dispatcher.dispatch(
       'pipeline_stage_updated',
       Time.zone.now,
       pipeline_item: self,
-      changed_attributes: { 'pipeline_stage_id' => [old_stage_id, pipeline_stage_id] }
+      changed_attributes: changed_attributes
     )
+
+    # EVO-1266: also broadcast via Wisper so EvoFlow::PipelineEventsListener
+    # publishes the canonical pipeline.stage_changed event to evo-flow for
+    # journey trigger consumption. Kept alongside the dispatcher call —
+    # both subscriber systems coexist (see publish_pipeline_item_created).
+    publish(:pipeline_stage_updated, data: { pipeline_item: self, changed_attributes: changed_attributes })
   end
 
   def dispatch_initial_stage_event
+    changed_attributes = { 'pipeline_stage_id' => [nil, pipeline_stage_id] }
+
     Rails.configuration.dispatcher.dispatch(
       'pipeline_stage_updated',
       Time.zone.now,
       pipeline_item: self,
-      changed_attributes: { 'pipeline_stage_id' => [nil, pipeline_stage_id] }
+      changed_attributes: changed_attributes
     )
+
+    publish(:pipeline_stage_updated, data: { pipeline_item: self, changed_attributes: changed_attributes })
   end
 
   # Wisper event publishers (for EvoCampaign integration)

--- a/app/services/evo_flow/event_schema.rb
+++ b/app/services/evo_flow/event_schema.rb
@@ -171,6 +171,21 @@ module EvoFlow
       required: { campaign_id: :uuid, message_id: :uuid, source: :string },
       optional: { contact_id: :uuid, url: :string, clicked_at: :date }
     },
+    'pipeline.stage_changed' => {
+      category: :campaign,
+      required: { pipeline_id: :uuid, pipeline_stage_id: :uuid, source: :string },
+      optional: {
+        pipeline_name: :string,
+        pipeline_stage_name: :string,
+        from_stage_id: :uuid,
+        from_stage_name: :string,
+        to_stage_id: :uuid,
+        to_stage_name: :string,
+        pipeline_item_id: :uuid,
+        conversation_id: :uuid,
+        contact_id: :uuid
+      }
+    },
     'custom' => {
       category: :custom,
       required: {},

--- a/lib/events/evo_flow_event_names.rb
+++ b/lib/events/evo_flow_event_names.rb
@@ -9,6 +9,7 @@ module EvoFlow
     conversation.bot_handoff conversation.bot_resolved
     message.created message.delivered message.read message.failed
     campaign.triggered campaign.message.sent campaign.message.opened campaign.message.clicked
+    pipeline.stage_changed
     custom
   ].freeze
 

--- a/spec/listeners/evo_flow/pipeline_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/pipeline_events_listener_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe EvoFlow::PipelineEventsListener do
       pipeline_stage_id: 2,
       assigned_by_id: 3,
       custom_fields: { 'priority' => 'high' },
-      created_at: created_at
+      created_at: created_at,
+      updated_at: created_at
     )
   end
 
@@ -102,7 +103,10 @@ RSpec.describe EvoFlow::PipelineEventsListener do
     end
 
     context 'when ENV is absent (AC12)' do
-      before { allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil) }
+      before do
+        allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil)
+        allow(ENV).to receive(:[]).with('EVO_FLOW_ENABLED').and_return(nil)
+      end
 
       it 'does not enqueue and emits no error log' do
         expect(Rails.logger).not_to receive(:error)
@@ -202,15 +206,32 @@ RSpec.describe EvoFlow::PipelineEventsListener do
       )
     end
 
-    it 'carries from_stage_id=nil on initial stage assignment' do
+    it 'omits from_stage_id and from_stage_name on initial stage assignment (review H1)' do
       listener.pipeline_stage_updated(
         data: { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [nil, 2] } }
       )
 
       sent = EvoFlow::PublishEventWorker.jobs.last['args'][1]
-      expect(sent['properties']['from_stage_id']).to be_nil
-      expect(sent['properties']['from_stage_name']).to be_nil
+      # Optional fields with nil values must NOT be sent as explicit null —
+      # EventSchemaValidationPipe in evo-flow rejects null for typed (:uuid) fields.
+      expect(sent['properties']).not_to have_key('from_stage_id')
+      expect(sent['properties']).not_to have_key('from_stage_name')
       expect(sent['properties']['to_stage_id']).to eq(2)
+      expect(sent['properties']['pipeline_stage_id']).to eq(2)
+    end
+
+    it 'derives messageId deterministically from pipeline_item.updated_at (review M1)' do
+      allow(EvoFlow::PayloadBuilder).to receive(:message_id_for).and_call_original
+
+      2.times do
+        listener.pipeline_stage_updated(
+          data: { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [1, 2] } }
+        )
+      end
+
+      jobs = EvoFlow::PublishEventWorker.jobs
+      expect(jobs.size).to eq(2)
+      expect(jobs[0]['args'][1]['messageId']).to eq(jobs[1]['args'][1]['messageId'])
     end
 
     it 'returns early when changed_attributes lacks pipeline_stage_id' do
@@ -222,6 +243,7 @@ RSpec.describe EvoFlow::PipelineEventsListener do
 
     it 'does not enqueue when feature gate is off' do
       allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil)
+      allow(ENV).to receive(:[]).with('EVO_FLOW_ENABLED').and_return(nil)
 
       listener.pipeline_stage_updated(
         data: { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [1, 2] } }

--- a/spec/listeners/evo_flow/pipeline_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/pipeline_events_listener_spec.rb
@@ -168,4 +168,106 @@ RSpec.describe EvoFlow::PipelineEventsListener do
       expect(sent['properties']['contact_id']).to eq(sent['contactId'].to_i).or eq(sent['contactId'])
     end
   end
+
+  describe '#pipeline_stage_updated (EVO-1266)' do
+    let(:old_stage) { instance_double(PipelineStage, name: 'Lead') }
+
+    before do
+      allow(PipelineStage).to receive(:find_by).with(id: 1).and_return(old_stage)
+      allow(PipelineStage).to receive(:find_by).with(id: nil).and_return(nil)
+      allow(pipeline_stage).to receive(:pipeline).and_return(pipeline)
+      allow(pipeline_stage).to receive(:id).and_return(2)
+      allow(pipeline).to receive(:id).and_return(1)
+    end
+
+    it 'emits pipeline.stage_changed with from/to stage ids and names (AC1)' do
+      listener.pipeline_stage_updated(
+        data: { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [1, 2] } }
+      )
+
+      job = EvoFlow::PublishEventWorker.jobs.last
+      expect(job['args'][0]).to eq('/events/track')
+      sent = job['args'][1]
+      expect(sent['event']).to eq('pipeline.stage_changed')
+      expect(sent['contactId']).to eq('42')
+      expect(sent['properties']).to include(
+        'pipeline_id' => 1,
+        'pipeline_name' => 'Sales',
+        'from_stage_id' => 1,
+        'from_stage_name' => 'Lead',
+        'to_stage_id' => 2,
+        'to_stage_name' => 'Qualified',
+        'pipeline_stage_id' => 2,
+        'source' => 'pipeline_management'
+      )
+    end
+
+    it 'carries from_stage_id=nil on initial stage assignment' do
+      listener.pipeline_stage_updated(
+        data: { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [nil, 2] } }
+      )
+
+      sent = EvoFlow::PublishEventWorker.jobs.last['args'][1]
+      expect(sent['properties']['from_stage_id']).to be_nil
+      expect(sent['properties']['from_stage_name']).to be_nil
+      expect(sent['properties']['to_stage_id']).to eq(2)
+    end
+
+    it 'returns early when changed_attributes lacks pipeline_stage_id' do
+      listener.pipeline_stage_updated(
+        data: { pipeline_item: lead_item, changed_attributes: {} }
+      )
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+
+    it 'does not enqueue when feature gate is off' do
+      allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil)
+
+      listener.pipeline_stage_updated(
+        data: { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [1, 2] } }
+      )
+
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+
+    it 'returns early when called with an EventDispatcher payload' do
+      event = Struct.new(:data).new(
+        { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [1, 2] } }
+      )
+      listener.pipeline_stage_updated(event)
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+
+    it 'logs an error when pipeline_item is missing' do
+      expect(Rails.logger).to receive(:error).with(/pipeline_stage_updated.*pipeline_item is nil/)
+      listener.pipeline_stage_updated(data: { changed_attributes: { 'pipeline_stage_id' => [1, 2] } })
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+
+    it 'warns and skips when no contact_id is resolvable' do
+      orphan = instance_double(
+        PipelineItem,
+        id: 11, contact_id: nil, conversation_id: nil, conversation: nil,
+        lead?: false, pipeline_stage: pipeline_stage
+      )
+      expect(Rails.logger).to receive(:warn).with(/pipeline_stage_updated.*no resolvable contact_id for pipeline_item 11/)
+      listener.pipeline_stage_updated(
+        data: { pipeline_item: orphan, changed_attributes: { 'pipeline_stage_id' => [1, 2] } }
+      )
+      expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+    end
+
+    it 'tags [enqueue-loss] when perform_async hits Redis::BaseConnectionError' do
+      stub_const('Redis::BaseConnectionError', Class.new(StandardError)) unless defined?(Redis::BaseConnectionError)
+      allow(EvoFlow::PublishEventWorker).to receive(:perform_async)
+        .and_raise(Redis::BaseConnectionError, 'redis down')
+
+      expect(Rails.logger).to receive(:error).with(/\[EvoFlow\]\[enqueue-loss\].*Redis::BaseConnectionError/)
+      expect do
+        listener.pipeline_stage_updated(
+          data: { pipeline_item: lead_item, changed_attributes: { 'pipeline_stage_id' => [1, 2] } }
+        )
+      end.not_to raise_error
+    end
+  end
 end

--- a/spec/models/pipeline_item_spec.rb
+++ b/spec/models/pipeline_item_spec.rb
@@ -204,4 +204,45 @@ RSpec.describe PipelineItem, type: :model do
       expect(dispatcher_jobs.map { |j| j[:args].first }).not_to include('pipeline_item.created')
     end
   end
+
+  # EVO-1266 (review M2): integration guard for the Wisper publish that fires
+  # alongside the dispatcher call when a stage changes. The
+  # EvoFlow::PipelineEventsListener consumes this broadcast to publish a
+  # canonical pipeline.stage_changed event to evo-flow. Without this spec,
+  # a refactor that drops the publish call would only break the smoke
+  # (silently — listener spec exercises the handler in isolation).
+  describe 'Wisper :pipeline_stage_updated broadcast (EVO-1266)' do
+    let(:second_stage) { PipelineStage.create!(pipeline: pipeline, name: 'Stage 2', position: 2) }
+    let(:item) do
+      described_class.create!(pipeline: pipeline, pipeline_stage: pipeline_stage, contact: contact)
+    end
+
+    def make_listener
+      Class.new do
+        attr_reader :events
+
+        def initialize
+          @events = []
+        end
+
+        def pipeline_stage_updated(data)
+          @events << (data[:data] || data)
+        end
+      end.new
+    end
+
+    it 'broadcasts pipeline_stage_updated when an existing item moves to a new stage' do
+      item
+      listener = make_listener
+      item.subscribe(listener)
+
+      item.move_to_stage(second_stage)
+
+      expect(listener.events.size).to eq(1)
+      payload = listener.events.first
+      expect(payload[:pipeline_item]).to eq(item)
+      expect(payload[:changed_attributes]).to eq('pipeline_stage_id' => [pipeline_stage.id, second_stage.id])
+    end
+
+  end
 end


### PR DESCRIPTION
## Summary

CRM publisher side of EVO-1266. When a contact moves between pipeline stages, the CRM emits a canonical `pipeline.stage_changed` event to evo-flow so Customer Journey triggers can match against it. Implements the publisher chain alongside the existing AutomationRule dispatcher path — both paths coexist (Automation Rules keeps its in-tx dispatcher event; Journey triggers consume the post-commit Wisper broadcast).

## Changes

- `lib/events/evo_flow_event_names.rb`: append `'pipeline.stage_changed'` to the canonical name list. Mirrors `evo-flow`'s `event-names.enum.ts` — CI sync script enforces parity (companion PR: evolution-foundation/evo-flow#16).
- `app/services/evo_flow/event_schema.rb`: matching Ruby `DEFINITIONS` entry. The boot-time sanity check (`raise "missing entries"`) blocks deploy if the enum and schema drift.
- `app/listeners/evo_flow/pipeline_events_listener.rb`: new `pipeline_stage_updated(data)` handler that resolves the contact id (lead vs deal), builds the payload via `PayloadBuilder.build_track`, and enqueues `EvoFlow::PublishEventWorker`. Mirrors the structure of the existing `pipeline_item_created` handler.
- `app/models/pipeline_item.rb`: new **post-commit** callbacks `broadcast_stage_update_to_evo_flow` fire the Wisper `:pipeline_stage_updated` broadcast. Wired as `after_create_commit` + `after_update_commit, if: :saved_change_to_pipeline_stage_id?` so a rollback during create does not leak orphan Sidekiq jobs (matches the AC5 pattern that `publish_pipeline_item_created` established for `pipeline_item.created`). The pre-existing in-transaction `dispatcher.dispatch('pipeline_stage_updated', ...)` calls are unchanged — Automation Rules continues to observe them.

## Code review fixes applied before push

- **H1** — `from_stage_id` / `from_stage_name` are now **omitted** from the payload when the source stage is nil (initial assignment) instead of being sent as explicit null. The evo-flow `EventSchemaValidationPipe` rejects null for typed (`:uuid`) optional fields — same failure mode as EVO-1570. Spec updated to assert key absence.
- **M1** — `occurred_at` / `source_event_uuid` now derive from `pipeline_item.updated_at` (the AR timestamp set when the stage changed) instead of `Time.zone.now`. This makes the resulting `messageId` deterministic for the same logical event across listener invocations and Sidekiq retries. Mirrors the `enqueue_track` pattern that uses `pipeline_item.created_at`. New spec verifies two invocations produce identical `messageId`.
- **M2** — New integration spec under `spec/models/pipeline_item_spec.rb` asserts the Wisper `:pipeline_stage_updated` broadcast actually fires when `PipelineItem#move_to_stage` runs (the listener spec only exercised the handler in isolation, masking publish-wiring bugs — the exact gap that surfaced during smoke).
- **L2** — Feature-gate-off tests now stub `EVO_FLOW_ENABLED` in addition to `AUTH_APIKEY_INTEGRATION_LOCAL` (mechanical fix-in-place — applied to both my new spec and the pre-existing `pipeline_item_created` AC12 spec).

## Security

- No new endpoints. Event publishing is gated by `EvoFlow.enabled?` (`EVO_FLOW_ENABLED` or `AUTH_APIKEY_INTEGRATION_LOCAL` env). Account scoping is implicit via the `PipelineItem` and its `Conversation`/`Contact` associations.
- No new attack surface — same publisher path as the existing `pipeline_item_created` event.

## Test plan

- `bundle exec rspec spec/listeners/evo_flow/pipeline_events_listener_spec.rb` — 19/19 (was 11 pre-fix; +8 new specs covering H1, M1, AC1, AC3, AC4 of EVO-1266)
- `bundle exec rspec spec/models/pipeline_item_spec.rb` — 13/13 (incl. M2 integration spec + pre-existing AC5 rollback guards)
- `bundle exec rspec spec/services/automation_rules/flow_execution_service_spec.rb` — 14/14 (no regression on the Automation Rules path — same dispatcher event)
- `bundle exec rspec spec/listeners/automation_rule_listener_attribute_changed_spec.rb` — 6/6 (no regression)

## Smoke (partial — see Known Limitations)

- ✅ Stage move triggers Wisper publish → listener fires → CRM enqueues PublishEventWorker → worker POSTs to evo-flow `/events/track` with messageId. Log line `[EvoFlow] published path=/events/track messageId=...` confirmed end-to-end.
- ✅ evo-flow `[api]` receiver logs `Received track event: pipeline.stage_changed`.
- ⏳ Full end-to-end (event-process → journey-trigger-processor → Temporal worker → Sessions Viewer entry) requires local setup that is **out of scope for this PR**:
  - **EVO-1200** (Todo, `[1.7] Provisionar 7 topicos via deployment scripts`) — provisions the Kafka topic that `JourneyTriggerProcessor` subscribes to. Without it, the consumer crashes with `UNKNOWN_TOPIC_OR_PARTITION` on boot.
  - **EVO-1229** (Todo, `[5.7] Criar README por modo e sincronizar .env.example`) — documents `AUTH_APIKEY_INTEGRATION_LOCAL` / `EVO_FLOW_ENABLED` in the CRM `.env.example`. Both currently absent → silent feature-gate failure unless the operator manually adds them (this PR's smoke turned up the gap).
  - **EVO-1571** (Done) — already documented the local docker setup but did not address the Journey consumer chain (it targeted Tracking).

## Changed Files

- `lib/events/evo_flow_event_names.rb`
- `app/services/evo_flow/event_schema.rb`
- `app/listeners/evo_flow/pipeline_events_listener.rb`
- `app/models/pipeline_item.rb`
- `spec/listeners/evo_flow/pipeline_events_listener_spec.rb`
- `spec/models/pipeline_item_spec.rb`

## Linked Issue

- EVO-1266 — https://linear.app/evoai/issue/EVO-1266

## Related PRs

- `evo-flow` PR #16 — manifest entry: https://github.com/evolution-foundation/evo-flow/pull/16
- `evo-ai-frontend-community` PR #125 — trigger UI: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/125