### PR TITLE
fix(whatsapp): stop dropping Z-API group messages on E.164 validation

### DIFF
--- a/app/services/whatsapp/incoming_message_zapi_service.rb
+++ b/app/services/whatsapp/incoming_message_zapi_service.rb
@@ -74,22 +74,35 @@ class Whatsapp::IncomingMessageZapiService
     message_id = params[:messageId]
     timestamp = params[:momment] || params[:moment] || Time.current.to_i * 1000
 
-    # Use chatLid as source_id and identifier for Z-API
-    source_id = chat_lid.presence || phone
-    identifier = chat_lid.presence
+    # Mirror EVO-1018's Evolution-path handling (EvolutionHandlers::MessagesUpsert#set_group_contact):
+    # a group becomes a contact of type 'group' identified by the group JID, with no phone_number.
+    #
+    # Two Z-API quirks have to be normalized for a group, otherwise the message is silently dropped
+    # (the WhatsappEventsJob rescue swallows the validation error and never reaches Sentry):
+    #   1. params[:phone] is the group JID "<digits>-group", not an E.164 number — forcing
+    #      "+#{phone}" makes Contact#save! raise on the phone E.164 validation.
+    #   2. ContactInbox#source_id is validated against a regex that, for groups, only accepts the
+    #      "<digits>@g.us" shape — "<digits>-group" is rejected. Normalize it the same way the
+    #      Evolution path already produces its group JIDs.
+    if params[:isGroup]
+      group_jid = "#{phone.to_s.sub(/-group\z/, '')}@g.us"
+      source_id = group_jid
+      identifier = group_jid
+      contact_attributes = { name: params[:chatName] || params[:senderName], identifier: identifier, type: 'group' }
+    else
+      source_id = chat_lid.presence || phone
+      identifier = chat_lid.presence
+      contact_attributes = { name: params[:chatName] || params[:senderName], identifier: identifier, phone_number: "+#{phone}" }
+    end
 
     contact_inbox = ContactInboxWithContactBuilder.new(
       inbox: inbox,
       source_id: source_id,
-      contact_attributes: {
-        name: params[:chatName] || params[:senderName],
-        phone_number: "+#{phone}",
-        identifier: identifier
-      }
+      contact_attributes: contact_attributes
     ).perform
 
-    # Fetch contact profile picture if not already set
-    fetch_contact_profile_picture(contact_inbox.contact, "+#{phone}") unless contact_inbox.contact.avatar.attached?
+    # Fetch contact profile picture if not already set (groups have no contact phone number)
+    fetch_contact_profile_picture(contact_inbox.contact, "+#{phone}") unless params[:isGroup] || contact_inbox.contact.avatar.attached?
 
     conversation = find_or_create_conversation(contact_inbox)
 

--- a/spec/services/whatsapp/incoming_message_zapi_service_groups_spec.rb
+++ b/spec/services/whatsapp/incoming_message_zapi_service_groups_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for the Z-API group path. Before this fix a group message was
+# silently dropped (the WhatsappEventsJob rescue swallowed the error) by two validations:
+#   1. phone_number: "+#{params[:phone]}" — params[:phone] is "<digits>-group", not E.164.
+#   2. ContactInbox#source_id — "<digits>-group" fails the source-id regex, which for groups
+#      expects "<digits>@g.us". The fix normalizes the Z-API group JID to that shape.
+# Mirrors spec/services/whatsapp/incoming_message_evolution_service_groups_spec.rb.
+RSpec.describe Whatsapp::IncomingMessageZapiService do
+  let(:inbox) { instance_double(Inbox, id: 1) }
+  let(:contact) { instance_double(Contact, id: 99, avatar: instance_double(ActiveStorage::Attached::One, attached?: true)) }
+  let(:contact_inbox) { instance_double(ContactInbox, id: 7, contact: contact, contact_id: 99) }
+  let(:builder) { instance_double(ContactInboxWithContactBuilder, perform: contact_inbox) }
+
+  # Mirrors the real Z-API group payload: chatLid is nil and phone is the "<digits>-group" JID.
+  let(:group_params) do
+    {
+      type: 'ReceivedCallback', fromMe: false, isGroup: true,
+      phone: '120363403143464221-group', chatLid: nil,
+      chatName: 'My Group', senderName: 'Alice', participantPhone: '5511999999999',
+      messageId: 'msg-1', momment: 1_700_000_000_000, text: { message: 'hi everyone' }
+    }
+  end
+
+  let(:individual_params) do
+    {
+      type: 'ReceivedCallback', fromMe: false, isGroup: false,
+      phone: '5511888888888', chatName: 'Bob', senderName: 'Bob',
+      messageId: 'msg-2', momment: 1_700_000_001_000, text: { message: 'hey' }
+    }
+  end
+
+  before do
+    allow(ContactInboxWithContactBuilder).to receive(:new).and_return(builder)
+  end
+
+  describe '#process_incoming_message (group branch)' do
+    let(:service) { described_class.new(inbox: inbox, params: group_params) }
+
+    before do
+      allow(service).to receive(:find_or_create_conversation).and_return(instance_double(Conversation, id: 5))
+      allow(service).to receive(:process_text_message)
+      allow(service).to receive(:fetch_contact_profile_picture)
+    end
+
+    it 'normalizes the group JID to <digits>@g.us, builds a type group contact, no phone_number' do
+      expect(ContactInboxWithContactBuilder).to receive(:new) do |args|
+        expect(args[:source_id]).to eq('120363403143464221@g.us')
+        expect(args[:contact_attributes]).to include(type: 'group', identifier: '120363403143464221@g.us')
+        expect(args[:contact_attributes]).not_to have_key(:phone_number)
+        builder
+      end
+      service.send(:process_incoming_message)
+    end
+
+    it 'does not try to fetch a profile picture for a group (no contact phone)' do
+      expect(service).not_to receive(:fetch_contact_profile_picture)
+      service.send(:process_incoming_message)
+    end
+  end
+
+  describe '#process_incoming_message (individual branch, regression guard)' do
+    let(:service) { described_class.new(inbox: inbox, params: individual_params) }
+
+    before do
+      allow(service).to receive(:find_or_create_conversation).and_return(instance_double(Conversation, id: 6))
+      allow(service).to receive(:process_text_message)
+      allow(service).to receive(:fetch_contact_profile_picture)
+    end
+
+    it 'still builds the contact with an E.164 phone_number and no group type' do
+      expect(ContactInboxWithContactBuilder).to receive(:new) do |args|
+        expect(args[:contact_attributes]).to include(phone_number: '+5511888888888')
+        expect(args[:contact_attributes]).not_to have_key(:type)
+        builder
+      end
+      service.send(:process_incoming_message)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Incoming **WhatsApp group messages via the Z-API channel** are silently dropped on `main` (and `1.0.0-rc5`). The `Webhooks::WhatsappEventsJob` rescue swallows the error, so it never reaches Sentry. Two validations fail for a group:

1. **Contact phone** — `phone_number: "+#{phone}"`, but in a group `params[:phone]` is the group JID `"<digits>-group"`, not E.164 → `Contact#save!` raises `Phone number should be in e164 format`.
2. **ContactInbox source_id** — `"<digits>-group"` fails the source-id regex, which for groups expects `"<digits>@g.us"`.

EVO-1018 fixed group handling for the **Evolution** path but did not cover the **Z-API** path.

Observed on one production tenant: ~79% of inbound volume (group traffic) was being lost.

## Fix

Mirror EVO-1018's `EvolutionHandlers::MessagesUpsert#set_group_contact` on the Z-API path:
- normalize the Z-API group JID `"<digits>-group"` → `"<digits>@g.us"`,
- use it as both `source_id` and `identifier`,
- build the contact as `type: 'group'` with **no** `phone_number`,
- skip the profile-picture fetch for groups.

1:1 behavior is unchanged.

## Verified in production

After deploying this patch, group conversations ingest correctly (contacts created as `type: 'group'` with `<digits>@g.us` identifiers) and zero group messages were dropped over the observed window.

## Tests

Adds `spec/services/whatsapp/incoming_message_zapi_service_groups_spec.rb`, mirroring `incoming_message_evolution_service_groups_spec.rb`:
- group → JID normalized to `<digits>@g.us`, contact built with `type: 'group'`, no `phone_number`
- group → no profile-picture fetch
- 1:1 regression guard → contact still built with `phone_number: "+<e164>"`, no `type`

## Refs

Fixes the Z-API side of evolution-foundation/evo-crm-community#49
