### PR TITLE
fix(whatsapp): resolve LID addressing on Evolution inbound (use remoteJidAlt)

### DIFF
--- a/app/services/whatsapp/evolution_handlers/helpers.rb
+++ b/app/services/whatsapp/evolution_handlers/helpers.rb
@@ -112,7 +112,12 @@ module Whatsapp::EvolutionHandlers::Helpers
     return jid unless jid.to_s.end_with?('@lid')
 
     alt = @raw_message[:remoteJidAlt] || @raw_message.dig(:key, :remoteJidAlt)
-    alt.presence || jid
+    # Only trust remoteJidAlt when it is a real (non-LID) JID — guards against a
+    # future payload where the alternate is itself LID-style, which would otherwise
+    # be misclassified as 'user'. Falls back to the original LID when unavailable.
+    return alt if alt.present? && !alt.to_s.end_with?('@lid')
+
+    jid
   end
 
   def phone_number_from_jid
@@ -204,7 +209,10 @@ module Whatsapp::EvolutionHandlers::Helpers
   def group_jid
     return nil unless jid_type == 'group'
 
-    @raw_message[:remoteJid] || @raw_message.dig(:key, :remoteJid)
+    # Use the resolved JID for consistency with jid_type/phone_number_from_jid.
+    # Group JIDs are @g.us (never @lid), so this returns the same value today, but
+    # keeps a single source of truth for how the remote JID is interpreted.
+    effective_remote_jid
   end
 
   # Evolution API (v2.3.1) does not include group metadata in the messages.upsert

--- a/app/services/whatsapp/evolution_handlers/helpers.rb
+++ b/app/services/whatsapp/evolution_handlers/helpers.rb
@@ -102,10 +102,23 @@ module Whatsapp::EvolutionHandlers::Helpers
     end
   end
 
+  # WhatsApp "LID addressing mode" (2024+ privacy): remoteJid is an opaque LID like
+  # "256186830074110@lid" instead of the phone JID. Evolution ships the real phone JID
+  # in remoteJidAlt. Without resolving it, jid_type returns 'lid', message_processable?
+  # rejects the message, and it is silently dropped (observed ~99.6% of 1:1 inbound).
+  # Prefer remoteJidAlt whenever the primary JID is a @lid. Refs evolution-foundation/evo-crm-community#49 / #19.
+  def effective_remote_jid
+    jid = @raw_message[:remoteJid] || @raw_message.dig(:key, :remoteJid)
+    return jid unless jid.to_s.end_with?('@lid')
+
+    alt = @raw_message[:remoteJidAlt] || @raw_message.dig(:key, :remoteJidAlt)
+    alt.presence || jid
+  end
+
   def phone_number_from_jid
     # Evolution API format: "5511999999999@s.whatsapp.net" or "5511999999999@c.us"
     # Para messages.update, remoteJid pode vir diretamente no root
-    remote_jid = @raw_message[:remoteJid] || @raw_message.dig(:key, :remoteJid)
+    remote_jid = effective_remote_jid
     return nil unless remote_jid
 
     remote_jid.split('@').first.split(':').first.split('_').first
@@ -161,8 +174,10 @@ module Whatsapp::EvolutionHandlers::Helpers
   end
 
   def jid_type
-    # Para messages.update, remoteJid pode vir diretamente no root
-    jid = @raw_message[:remoteJid] || @raw_message.dig(:key, :remoteJid)
+    # Para messages.update, remoteJid pode vir diretamente no root.
+    # effective_remote_jid resolves LID addressing (@lid -> remoteJidAlt) so a 1:1
+    # message in LID mode is classified as 'user' instead of being dropped as 'lid'.
+    jid = effective_remote_jid
     return 'unknown' unless jid
 
     server = jid.split('@').last

--- a/spec/services/whatsapp/incoming_message_evolution_service_lid_spec.rb
+++ b/spec/services/whatsapp/incoming_message_evolution_service_lid_spec.rb
@@ -55,6 +55,20 @@ RSpec.describe Whatsapp::IncomingMessageEvolutionService do
     end
   end
 
+  context 'when remoteJidAlt is itself a LID (defensive)' do
+    before do
+      service.instance_variable_set(:@raw_message,
+                                    { key: { id: 'msg-2b', fromMe: false,
+                                             remoteJid: '256186830074110@lid', remoteJidAlt: '999000111222@lid' },
+                                      message: { conversation: 'hi' } })
+    end
+
+    it 'does not trust a LID-style remoteJidAlt and keeps lid (stays dropped, no misclassification)' do
+      expect(service.send(:jid_type)).to eq('lid')
+      expect(service.send(:message_processable?)).to be false
+    end
+  end
+
   context 'when a normal 1:1 message arrives (regression guard)' do
     before do
       service.instance_variable_set(:@raw_message,

--- a/spec/services/whatsapp/incoming_message_evolution_service_lid_spec.rb
+++ b/spec/services/whatsapp/incoming_message_evolution_service_lid_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression coverage for WhatsApp "LID addressing mode" on the Evolution path.
+# When a 1:1 message arrives with remoteJid "<id>@lid" (2024+ privacy feature),
+# jid_type returned 'lid', message_processable? rejected it, and the message was
+# silently dropped. Evolution ships the real phone JID in remoteJidAlt, so we
+# resolve it via effective_remote_jid. Refs evolution-foundation/evo-crm-community#49 (LID).
+RSpec.describe Whatsapp::IncomingMessageEvolutionService do
+  let(:channel) { instance_double(Channel::Whatsapp, provider: 'evolution') }
+  let(:inbox) { instance_double(Inbox, id: 1, channel: channel) }
+  let(:service) { described_class.new(inbox: inbox, params: { event: 'messages.upsert', data: {} }) }
+
+  before do
+    service.instance_variable_set(:@inbox, inbox)
+    allow(service).to receive_messages(ignore_message?: false, find_message_by_source_id: false, message_under_process?: false)
+  end
+
+  context 'when a 1:1 message arrives in LID addressing mode' do
+    let(:lid_payload) do
+      {
+        key: { id: 'msg-1', fromMe: false, addressingMode: 'lid',
+               remoteJid: '256186830074110@lid', remoteJidAlt: '5511999999999@s.whatsapp.net' },
+        pushName: 'Alice',
+        message: { conversation: 'hello' }
+      }
+    end
+
+    before { service.instance_variable_set(:@raw_message, lid_payload) }
+
+    it 'resolves the JID type to user via remoteJidAlt (was dropped as lid)' do
+      expect(service.send(:jid_type)).to eq('user')
+    end
+
+    it 'extracts the real phone number from remoteJidAlt, not the LID' do
+      expect(service.send(:phone_number_from_jid)).to eq('5511999999999')
+    end
+
+    it 'is now processable instead of being silently dropped' do
+      expect(service.send(:message_processable?)).to be true
+    end
+  end
+
+  context 'when a LID message has no remoteJidAlt (cannot resolve)' do
+    before do
+      service.instance_variable_set(:@raw_message,
+                                    { key: { id: 'msg-2', fromMe: false, remoteJid: '256186830074110@lid' },
+                                      message: { conversation: 'hi' } })
+    end
+
+    it 'gracefully falls back to lid (no phantom @lid contact gets created)' do
+      expect(service.send(:jid_type)).to eq('lid')
+      expect(service.send(:message_processable?)).to be false
+    end
+  end
+
+  context 'when a normal 1:1 message arrives (regression guard)' do
+    before do
+      service.instance_variable_set(:@raw_message,
+                                    { key: { id: 'msg-3', fromMe: false, remoteJid: '5511888888888@s.whatsapp.net' },
+                                      message: { conversation: 'hey' } })
+    end
+
+    it 'still classifies as user and extracts the phone unchanged' do
+      expect(service.send(:jid_type)).to eq('user')
+      expect(service.send(:phone_number_from_jid)).to eq('5511888888888')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

WhatsApp's **LID addressing mode** (2024+ privacy feature) delivers 1:1 messages with `remoteJid: "<id>@lid"` instead of the phone JID. On the Evolution path:

- `jid_type` (`evolution_handlers/helpers.rb`) returns `'lid'` for `@lid`
- `message_processable?` only accepts `jid_type in %w[user group]`

→ the message is **silently dropped** (no contact, no conversation, no log beyond the event). In one production deployment this was **~99.6% of inbound 1:1 traffic** (1096 `@lid` vs 4 `@s.whatsapp.net` over 30 days). Related to #19 (which covers the outgoing side).

## Fix

Evolution already ships the real phone JID in **`remoteJidAlt`**. Add `effective_remote_jid` that prefers `remoteJidAlt` whenever the primary JID is a `@lid`, and use it from `jid_type` and `phone_number_from_jid`. Falls back to the raw `@lid` when `remoteJidAlt` is absent (no behavior change in that case).

```ruby
def effective_remote_jid
  jid = @raw_message[:remoteJid] || @raw_message.dig(:key, :remoteJid)
  return jid unless jid.to_s.end_with?('@lid')

  alt = @raw_message[:remoteJidAlt] || @raw_message.dig(:key, :remoteJidAlt)
  alt.presence || jid
end
```

## Verified in production

After deploying, 1:1 messages in LID mode now create a contact with the **real** phone number (from `remoteJidAlt`) plus a conversation — instead of being dropped.

## Tests

Adds `spec/services/whatsapp/incoming_message_evolution_service_lid_spec.rb`:
- LID + `remoteJidAlt` → `jid_type == 'user'`, phone extracted from `remoteJidAlt`, `message_processable?` true
- LID without `remoteJidAlt` → graceful fallback to `lid`
- normal `@s.whatsapp.net` → unchanged (regression guard)

## Refs

#19 (LID addressing — outgoing). This addresses the inbound 1:1 side.

## Summary by Sourcery

Handle WhatsApp Evolution inbound messages that use LID addressing by resolving the effective remote JID from remoteJidAlt so 1:1 messages are processed instead of dropped.

Bug Fixes:
- Ensure inbound 1:1 WhatsApp messages addressed via LID are recognized as user messages and no longer silently discarded.

Tests:
- Add specs covering LID inbound scenarios with and without remoteJidAlt and standard @s.whatsapp.net messages to guard the new behavior.