### PR TITLE
feat(crm): notify inbox members on new message in unassigned conversations (EVO-1459)

### DIFF
--- a/app/services/messages/new_message_notification_service.rb
+++ b/app/services/messages/new_message_notification_service.rb
@@ -1,11 +1,14 @@
 class Messages::NewMessageNotificationService
   pattr_initialize [:message!]
 
+  NEW_CONVERSATION_NOTIFICATION_GUARD = 2.minutes
+
   def perform
     return unless message.notifiable?
 
     notify_conversation_assignee
     notify_participating_users
+    notify_inbox_members_if_unassigned
   end
 
   private
@@ -39,6 +42,32 @@ class Messages::NewMessageNotificationService
         secondary_actor: message
       ).perform
     end
+  end
+
+  # An unassigned conversation is invisible to the team, so every inbox member
+  # is notified of new activity. The 2-minute guard skips brand-new conversations
+  # to avoid doubling up with the conversation_created notification.
+  def notify_inbox_members_if_unassigned
+    return if conversation.assignee.present?
+    return if conversation.created_at > NEW_CONVERSATION_NOTIFICATION_GUARD.ago
+
+    conversation.inbox.members.each do |member|
+      next if member == sender
+      next if notified_member_ids.include?(member.id)
+
+      NotificationBuilder.new(
+        notification_type: 'assigned_conversation_new_message',
+        user: member,
+        primary_actor: message.conversation,
+        secondary_actor: message
+      ).perform
+    end
+  end
+
+  # Single query for the whole inbox fan-out instead of one exists? per member —
+  # an unassigned inbox can have many members.
+  def notified_member_ids
+    @notified_member_ids ||= conversation.notifications.where(secondary_actor: message).pluck(:user_id)
   end
 
   # The user could already have been notified via a mention or via assignment

--- a/spec/services/messages/new_message_notification_service_spec.rb
+++ b/spec/services/messages/new_message_notification_service_spec.rb
@@ -17,12 +17,15 @@ RSpec.describe Messages::NewMessageNotificationService do
   let(:sender) { instance_double(User) }
   let(:participants_relation) { instance_double(ActiveRecord::Relation) }
   let(:notifications_relation) { instance_double(ActiveRecord::Relation, exists?: false) }
+  let(:inbox) { instance_double(Inbox, members: []) }
   let(:conversation) do
     instance_double(
       Conversation,
       assignee: assignee,
       conversation_participants: [],
-      notifications: notifications_relation
+      notifications: notifications_relation,
+      created_at: 5.minutes.ago,
+      inbox: inbox
     )
   end
   let(:message) do
@@ -98,6 +101,69 @@ RSpec.describe Messages::NewMessageNotificationService do
         primary_actor: conversation,
         secondary_actor: message
       ).once
+    end
+  end
+
+  describe '#notify_inbox_members_if_unassigned' do
+    let(:member) { instance_double(User, id: 101) }
+    let(:notified_relation) { instance_double(ActiveRecord::Relation, pluck: []) }
+
+    before do
+      allow(conversation).to receive(:assignee).and_return(nil)
+      allow(notifications_relation).to receive(:where).with(secondary_actor: message).and_return(notified_relation)
+    end
+
+    it 'notifies every inbox member of an unassigned conversation except the sender' do
+      allow(inbox).to receive(:members).and_return([member, sender])
+
+      described_class.new(message: message).perform
+
+      expect(NotificationBuilder).to have_received(:new).with(
+        notification_type: 'assigned_conversation_new_message',
+        user: member,
+        primary_actor: conversation,
+        secondary_actor: message
+      ).once
+      expect(NotificationBuilder).not_to have_received(:new).with(hash_including(user: sender))
+    end
+
+    it 'notifies each of several inbox members exactly once' do
+      member_b = instance_double(User, id: 102)
+      allow(inbox).to receive(:members).and_return([member, member_b, sender])
+
+      described_class.new(message: message).perform
+
+      expect(NotificationBuilder).to have_received(:new).with(hash_including(user: member)).once
+      expect(NotificationBuilder).to have_received(:new).with(hash_including(user: member_b)).once
+      expect(NotificationBuilder).not_to have_received(:new).with(hash_including(user: sender))
+    end
+
+    it 'does not notify inbox members when the conversation has an assignee' do
+      allow(conversation).to receive(:assignee).and_return(assignee)
+      allow(notifications_relation).to receive(:exists?).with(user: assignee, secondary_actor: message).and_return(false)
+      allow(inbox).to receive(:members).and_return([member])
+
+      described_class.new(message: message).perform
+
+      expect(NotificationBuilder).not_to have_received(:new).with(hash_including(user: member))
+    end
+
+    it 'does not notify inbox members for a brand-new conversation (2-minute guard)' do
+      allow(conversation).to receive(:created_at).and_return(30.seconds.ago)
+      allow(inbox).to receive(:members).and_return([member])
+
+      described_class.new(message: message).perform
+
+      expect(NotificationBuilder).not_to have_received(:new)
+    end
+
+    it 'skips an inbox member already notified (e.g. as a participant or mention)' do
+      allow(inbox).to receive(:members).and_return([member])
+      allow(notified_relation).to receive(:pluck).with(:user_id).and_return([member.id])
+
+      described_class.new(message: message).perform
+
+      expect(NotificationBuilder).not_to have_received(:new).with(hash_including(user: member))
     end
   end
 end


### PR DESCRIPTION
## Summary
When a new message arrives in a conversation with **no assignee**, notify **all inbox members** (except the sender and anyone already notified), so unassigned conversations are not invisible to the team. Behavior restored from EVO-1419, where it was reverted out into this dedicated card.

- New private `notify_inbox_members_if_unassigned` wired into `Messages::NewMessageNotificationService#perform`.
- 2-minute guard (`NEW_CONVERSATION_NOTIFICATION_GUARD`) skips brand-new conversations to avoid doubling up with the `conversation_created` notification.
- Reuses the `assigned_conversation_new_message` notification type — no `notification_settings` schema change.

## Product decisions (signed off)
- **Notification type:** reuse `assigned_conversation_new_message` (a dedicated type would cascade into a `notification_settings` migration + settings UI).
- **2-minute guard:** kept.
- **Fan-out volume (AC3):** full fan-out accepted for MVP (up to N notifications per message, N = inbox members).

## Security
- No new endpoint and no user input. Fan-out is scoped to `conversation.inbox.members` (tenant isolation via inbox membership). Reuses the existing `NotificationBuilder` guards (blocked-conversation, per-user subscription).

## Test plan
- `evo-ai-crm-community: ruby -c app/services/messages/new_message_notification_service.rb` → Syntax OK
- `evo-ai-crm-community: bundle exec rspec spec/services/messages/new_message_notification_service_spec.rb` → 11 examples, 0 failures
- `evo-ai-crm-community: bundle exec rubocop <changed files>` → no offenses

## Changed Files
- `app/services/messages/new_message_notification_service.rb`
- `spec/services/messages/new_message_notification_service_spec.rb`

## Linked Issue
- EVO-1459

## Summary by Sourcery

Notify inbox members when new messages arrive in unassigned conversations, while avoiding duplicate or redundant notifications.

New Features:
- Send new-message notifications to all members of an inbox for conversations without an assignee, excluding the sender and users already notified.

Enhancements:
- Skip inbox-wide notifications for very recent conversations using a 2-minute guard to prevent duplicate conversation-created and new-message alerts.
- Optimize inbox member notification fan-out by querying already-notified user IDs once per message instead of per member.

Tests:
- Add service specs covering inbox-member notifications for unassigned conversations, including sender exclusion, multiple members, guard timing, assignee presence, and already-notified users.