### PR TITLE
feat(crm): warn on missing canned response in send_canned_response flow action (EVO-1257)

### DIFF
--- a/app/services/automation_rules/message_action_handlers.rb
+++ b/app/services/automation_rules/message_action_handlers.rb
@@ -23,7 +23,10 @@ module AutomationRules
 
       canned_id = params[0].is_a?(Hash) ? (params[0][:canned_response_id] || params[0]['canned_response_id']) : params[0]
       canned = CannedResponse.find_by(id: canned_id)
-      return unless canned
+      unless canned
+        log_canned_response_not_found(canned_id)
+        return
+      end
 
       message_params = {
         content: canned.content,
@@ -37,6 +40,10 @@ module AutomationRules
       end
 
       Messages::MessageBuilder.new(nil, @conversation, message_params).perform
+    end
+
+    def log_canned_response_not_found(canned_id)
+      Rails.logger.warn "Automation Rule #{@rule.id}: Canned response #{canned_id.inspect} not found; skipping send_canned_response for conversation #{@conversation.id}"
     end
 
     def send_template(params)

--- a/spec/services/automation_rules/flow_execution_service_spec.rb
+++ b/spec/services/automation_rules/flow_execution_service_spec.rb
@@ -199,6 +199,16 @@ RSpec.describe AutomationRules::FlowExecutionService do
         expect(Messages::MessageBuilder).not_to receive(:new)
         flow_service.send(:execute_node_action, node)
       end
+
+      it 'logs a warning and skips when canned_response_id does not match any canned response (AC3 / EVO-1257)' do
+        nonexistent_id = SecureRandom.uuid
+        node = { 'type' => 'send-canned-response-node', 'id' => 'n1', 'data' => { 'canned_response_id' => nonexistent_id } }
+
+        expect(Rails.logger).to receive(:warn).with(/Canned response .* not found.*skipping send_canned_response/i)
+        expect(Messages::MessageBuilder).not_to receive(:new)
+
+        flow_service.send(:execute_node_action, node)
+      end
     end
 
     describe 'send-template-node' do


### PR DESCRIPTION
## Summary
- Part of EVO-1257 (Journey "Send Canned Response" node). The flow dispatch + handler for `send-canned-response-node` already exist; this adds the **AC3 resilience**: log a warning when the referenced `CannedResponse` is missing instead of silently skipping.
- `MessageActionHandlers#send_canned_response` is the single source of truth shared by `ActionService` (Automation Rules) and `FlowExecutionService` (Flow canvas), so the improvement applies to both surfaces — preserving parity (AC4).

## Security
- No new endpoint or params. Node config is an id reference resolved via `CannedResponse.find_by` (no injection surface). Behavior change is log-only on an already no-op path.

## Test plan
- `evo-ai-crm-community: ruby -c app/services/automation_rules/message_action_handlers.rb`
- `evo-ai-crm-community: bundle exec rspec spec/services/automation_rules/flow_execution_service_spec.rb -e "send-canned-response-node"` — 3/3
- `evo-ai-crm-community: bundle exec rspec spec/services/automation_rules/` — 37/37 (shared-module change does not regress ActionService specs)

## Changed Files
- `app/services/automation_rules/message_action_handlers.rb`
- `spec/services/automation_rules/flow_execution_service_spec.rb`

## Related PRs
- frontend (node UI): pending link below

## Linked Issue
- EVO-1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add logging when a send-canned-response flow action references a missing canned response, and cover the new behavior with tests.

Bug Fixes:
- Ensure send_canned_response logs a warning and explicitly skips execution when the referenced canned response cannot be found instead of silently no-oping.

Tests:
- Extend flow execution service specs to verify that missing canned responses trigger a warning log and do not attempt to build or send a message.