### PR TITLE
feat(crm): email_team + canned_response show endpoints for the evo-flow journey executor (EVO-1634)

### DIFF
--- a/app/controllers/api/v1/canned_responses_controller.rb
+++ b/app/controllers/api/v1/canned_responses_controller.rb
@@ -3,22 +3,30 @@ class Api::V1::CannedResponsesController < Api::V1::BaseController
 
   require_permissions({
     index: 'canned_responses.read',
+    show: 'canned_responses.read',
     create: 'canned_responses.create',
     update: 'canned_responses.update',
     destroy: 'canned_responses.delete'
   })
 
-  before_action :fetch_canned_response, only: [:update, :destroy]
+  before_action :fetch_canned_response, only: [:show, :update, :destroy]
 
   def index
     @canned_responses = canned_responses
-    
+
     apply_pagination
-    
+
     paginated_response(
       data: CannedResponseSerializer.serialize_collection(@canned_responses),
       collection: @canned_responses,
       message: 'Canned responses retrieved successfully'
+    )
+  end
+
+  def show
+    success_response(
+      data: CannedResponseSerializer.serialize(@canned_response),
+      message: 'Canned response retrieved successfully'
     )
   end
 

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -19,6 +19,7 @@ class Api::V1::ConversationsController < Api::V1::BaseController
     archive: 'conversations.update',
     unarchive: 'conversations.update',
     transcript: 'conversations.export',
+    email_team: 'conversations.update',
     available_for_pipeline: 'conversations.read'
   })
   
@@ -256,6 +257,26 @@ class Api::V1::ConversationsController < Api::V1::BaseController
     success_response(
       data: { email: params[:email] },
       message: 'Transcript email scheduled for delivery'
+    )
+  end
+
+  def email_team
+    if params[:team_ids].blank? || params[:message].blank?
+      return error_response(
+        ApiErrorCodes::VALIDATION_ERROR,
+        'team_ids and message are required',
+        status: :bad_request
+      )
+    end
+
+    teams = Team.where(id: params[:team_ids])
+    teams.each do |team|
+      TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, params[:message])&.deliver_later
+    end
+
+    success_response(
+      data: { team_ids: teams.pluck(:id), message: params[:message] },
+      message: 'Team notification email scheduled for delivery'
     )
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
           post :mute
           post :unmute
           post :transcript
+          post :email_team
           post :toggle_status
           post :toggle_priority
           post :toggle_typing_status
@@ -153,7 +154,7 @@ Rails.application.routes.draw do
         delete :avatar, on: :member
       end
 
-      resources :canned_responses, only: [:index, :create, :update, :destroy], controller: 'canned_responses'
+      resources :canned_responses, only: [:index, :show, :create, :update, :destroy], controller: 'canned_responses'
 
       resources :facebook_comment_moderations, only: [:index, :show], controller: 'facebook_comment_moderations' do
         member do

--- a/spec/requests/api/v1/canned_responses_show_spec.rb
+++ b/spec/requests/api/v1/canned_responses_show_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/canned_responses/:id', type: :request do
+  let(:canned) { CannedResponse.create!(short_code: "cr-#{SecureRandom.hex(3)}", content: 'Hello there') }
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  it 'returns the canned response by id' do
+    get "/api/v1/canned_responses/#{canned.id}", headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response.dig('data', 'id')).to eq(canned.id)
+    expect(json_response.dig('data', 'content')).to eq('Hello there')
+  end
+end

--- a/spec/requests/api/v1/conversations_email_team_spec.rb
+++ b/spec/requests/api/v1/conversations_email_team_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/conversations/:id/email_team', type: :request do
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://emailteam.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Spec Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Spec Contact', email: 'spec@example.com') }
+  let(:contact_inbox) { ContactInbox.create!(contact: contact, inbox: inbox, source_id: SecureRandom.hex(8)) }
+  let(:conversation) do
+    Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+  end
+  let(:team) { Team.create!(name: "Team #{SecureRandom.hex(3)}") }
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  it 'enqueues a team notification mailer for each team' do
+    mailer = double(deliver_later: true)
+    allow(TeamNotifications::AutomationNotificationMailer)
+      .to receive(:conversation_creation).and_return(mailer)
+
+    post "/api/v1/conversations/#{conversation.id}/email_team",
+         params: { team_ids: [team.id], message: 'Heads up' },
+         headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(TeamNotifications::AutomationNotificationMailer)
+      .to have_received(:conversation_creation).with(conversation, team, 'Heads up')
+    expect(mailer).to have_received(:deliver_later)
+  end
+
+  it 'returns 400 when team_ids or message is missing' do
+    post "/api/v1/conversations/#{conversation.id}/email_team",
+         params: { message: 'x' }, headers: headers, as: :json
+
+    expect(response).to have_http_status(:bad_request)
+  end
+end


### PR DESCRIPTION
## Summary
Adds the two CRM endpoints the evo-flow Journey (Temporal) executor needs so Flow Builder action nodes execute their real effect — part of **EVO-1634** (wire palette action nodes into the evo-flow runtime).

- `GET /api/v1/canned_responses/:id` (**show**) — lets `send-canned-response-node` resolve content by id with a single fetch (replaces the previous list-and-scan).
- `POST /api/v1/conversations/:id/email_team` — backs `send-email-team-node`; validates `team_ids` + `message` and notifies each team via `TeamNotifications::AutomationNotificationMailer.conversation_creation(...).deliver_later`.

Both are service-token authenticated (`X-Service-Token` = `EVOAI_CRM_API_TOKEN`), matching the existing evo-flow → CRM calls.

## Validation
- `bundle exec rspec spec/requests/api/v1/conversations_email_team_spec.rb spec/requests/api/v1/canned_responses_show_spec.rb` → 3 examples, 0 failures
- `ruby -c` on the changed controllers

## Changed Files
- `app/controllers/api/v1/canned_responses_controller.rb`
- `app/controllers/api/v1/conversations_controller.rb`
- `config/routes.rb`
- `spec/requests/api/v1/canned_responses_show_spec.rb`
- `spec/requests/api/v1/conversations_email_team_spec.rb`

## Related PRs
- evo-flow#25 — executor node wiring (consumes these endpoints)
- evo-ai-frontend-community — palette parity manifest (link added after open)

## Linked Issue
- EVO-1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add new CRM API endpoints to support evo-flow journey executor actions for emailing teams and fetching canned responses by ID.

New Features:
- Introduce POST /api/v1/conversations/:id/email_team to trigger team notification emails for a conversation.
- Expose GET /api/v1/canned_responses/:id to retrieve a single canned response by ID.

Tests:
- Add request specs covering the canned response show endpoint and the conversations email_team endpoint.