### PR TITLE
fix(automation): execute and record contact-triggered automations (EVO-1635)

### DIFF
--- a/app/jobs/automation_contact_event_job.rb
+++ b/app/jobs/automation_contact_event_job.rb
@@ -11,7 +11,13 @@
 # and double the outbound webhooks already sent via EvoFlow. Instead this job
 # invokes the automation listener directly, in the background, for contacts only.
 class AutomationContactEventJob < ApplicationJob
-  queue_as :critical
+  # Contact create/update is far higher-volume than conversation events (bulk
+  # imports/syncs write thousands of contacts), so this runs on the normal queue
+  # rather than :critical — automation is best-effort background work and must
+  # not starve realtime/critical conversation handling during a mass import.
+  # Contacts with no matching active rule are filtered upstream
+  # (Contact#enqueue_contact_automation) so they never reach this queue at all.
+  queue_as :default
 
   SUPPORTED_EVENTS = %w[contact_created contact_updated].freeze
 

--- a/app/jobs/automation_contact_event_job.rb
+++ b/app/jobs/automation_contact_event_job.rb
@@ -1,0 +1,27 @@
+# Feeds contact_created / contact_updated events to the automation engine ONLY.
+#
+# Contact#dispatch_create_event / #dispatch_update_event (the full sync+async
+# dispatcher path) are intentionally disabled — contacts publish through Wisper
+# (EvoFlow) for integrations. That left AutomationRuleListener, which subscribes
+# to the AsyncDispatcher, with no source of contact events, so contact-triggered
+# automation rules never ran.
+#
+# We deliberately do NOT re-enable the broad dispatch: that would also resurrect
+# the legacy HookListener / WebhookListener / ActionCableListener for contacts
+# and double the outbound webhooks already sent via EvoFlow. Instead this job
+# invokes the automation listener directly, in the background, for contacts only.
+class AutomationContactEventJob < ApplicationJob
+  queue_as :critical
+
+  SUPPORTED_EVENTS = %w[contact_created contact_updated].freeze
+
+  def perform(event_name, contact_id, changed_attributes = {})
+    return unless SUPPORTED_EVENTS.include?(event_name)
+
+    contact = Contact.find_by(id: contact_id)
+    return if contact.nil?
+
+    event = Events::Base.new(event_name, Time.zone.now, { contact: contact, changed_attributes: changed_attributes })
+    AutomationRuleListener.instance.public_send(event_name, event)
+  end
+end

--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -90,18 +90,11 @@ class AutomationRuleListener < BaseListener
     rules = current_account_rules('contact_created', account)
 
     rules.each do |rule|
-      # Para eventos de contato que só têm condições de contato, 
-      # não precisamos de uma conversa
+      # Para eventos de contato que só têm condições de contato (ou nenhuma),
+      # não precisamos de uma conversa. Avalia + executa via execução nativa de
+      # contato, registrando o run no automation_rule_runs (observabilidade).
       if rule_has_only_contact_conditions?(rule)
-        conditions_match = evaluate_contact_conditions(rule, contact, changed_attributes)
-        if conditions_match
-          # Executa ações que não precisam de conversa (como webhooks)
-          if rule.mode == 'flow' && rule.flow_data.present?
-            AutomationRules::FlowExecutionService.new(rule, account, nil, contact).perform
-          else
-            execute_contact_actions(rule, account, contact)
-          end
-        end
+        evaluate_and_execute_contact_rule(rule, contact, changed_attributes)
       else
         # Se tiver condições de conversa, precisa de uma conversa
         conversation = contact.conversations.last
@@ -127,47 +120,42 @@ class AutomationRuleListener < BaseListener
     changed_attributes = event.data[:changed_attributes]
 
     # Evitar loop infinito - múltiplas estratégias de detecção
-    
+
     # 1. Se changed_attributes está vazio, pode ser um evento de automação não detectado
     if changed_attributes.blank? || changed_attributes.empty?
       Rails.logger.info "Automation Rule: Skipping contact_updated for contact #{contact.id} - empty changed_attributes"
       return
     end
-    
+
     # 2. Removido a proteção excessiva de labels - automações podem ser executadas quando labels mudam
-    
+
     # 3. Verificar se há muitos eventos recentes do mesmo contato (proteção contra spam)
     recent_events_key = "contact_updated_#{contact.id}"
     recent_count = Rails.cache.read(recent_events_key) || 0
-    
+
     if recent_count > 5
       Rails.logger.warn "Automation Rule: Skipping contact_updated for contact #{contact.id} - too many recent events (#{recent_count})"
       return
     end
-    
+
     # Incrementar contador de eventos recentes (expira em 30 segundos)
     Rails.cache.write(recent_events_key, recent_count + 1, expires_in: 30.seconds)
 
     # Log para debug das mudanças
-    Rails.logger.debug "Automation Rule: Processing contact_updated for contact #{contact.id} - changed attributes: #{changed_attributes.keys.sort}"
+    Rails.logger.debug do
+      "Automation Rule: Processing contact_updated for contact #{contact.id} - changed attributes: #{changed_attributes.keys.sort}"
+    end
 
     return unless rule_present?('contact_updated', account)
 
     rules = current_account_rules('contact_updated', account)
 
     rules.each do |rule|
-      # Para eventos de contato que só têm condições de contato, 
-      # não precisamos de uma conversa
+      # Para eventos de contato que só têm condições de contato (ou nenhuma),
+      # não precisamos de uma conversa. Avalia + executa via execução nativa de
+      # contato, registrando o run no automation_rule_runs (observabilidade).
       if rule_has_only_contact_conditions?(rule)
-        conditions_match = evaluate_contact_conditions(rule, contact, changed_attributes)
-        if conditions_match
-          # Executa ações que não precisam de conversa (como webhooks)
-          if rule.mode == 'flow' && rule.flow_data.present?
-            AutomationRules::FlowExecutionService.new(rule, account, nil, contact).perform
-          else
-            execute_contact_actions(rule, account, contact)
-          end
-        end
+        evaluate_and_execute_contact_rule(rule, contact, changed_attributes)
       else
         # Se tiver condições de conversa, precisa de uma conversa
         conversation = contact.conversations.last
@@ -214,6 +202,11 @@ class AutomationRuleListener < BaseListener
     recorder.skipped!("Duplicate event for pipeline_item=#{pipeline_item&.id} stage=#{stage_id} within #{PIPELINE_STAGE_DEDUP_WINDOW}s window")
     recorder.persist!
   end
+
+  # When the contact_updated spam circuit breaker trips, record ONE skipped run
+  # per active rule per window (cache-guarded) so the drop is visible in the logs
+  # without flooding automation_rule_runs during a bulk update storm.
+
 
   def pipeline_stage_dedup_key(rule_id, pipeline_item_id, stage_id)
     "automation:pipeline_stage_updated:#{rule_id}:#{pipeline_item_id}:#{stage_id}"
@@ -404,21 +397,49 @@ class AutomationRuleListener < BaseListener
     end
   end
 
-  def execute_contact_actions(rule, account, contact)
-    # Executa apenas ações que não precisam de conversa
-    rule.actions.each do |action|
-      action_name = action['action_name']
-      action_params = action['action_params']
+  # Contact-triggered rule with only-contact (or no) conditions: evaluate and
+  # execute without a conversation, recording the run so it shows up in the
+  # automation logs. Native contact actions (webhook, contact labels) run;
+  # conversation-bound actions are recorded as skipped with a reason by the
+  # ContactActionService.
+  def evaluate_and_execute_contact_rule(rule, contact, changed_attributes)
+    recorder = ::AutomationRules::RunRecorder.new(
+      rule: rule,
+      event_name: rule.event_name,
+      payload: { contact_id: contact&.id, changed_attributes: changed_attributes }
+    )
+    recorder.add_step('Event received', data: { event_name: rule.event_name, changed_attributes: changed_attributes })
 
-      case action_name
-      when 'send_webhook_event'
-        # Webhook pode ser enviado sem conversa
-        webhook_url = action_params[0]
-        if webhook_url.present?
-          WebhookJob.perform_later(webhook_url, contact.webhook_data.merge(event: "contact_#{rule.event_name.split('_').last}"))
-        end
-      # Adicione outras ações que não precisam de conversa aqui
-      end
+    conditions_match = evaluate_contact_conditions(rule, contact, changed_attributes)
+    recorder.add_step(
+      'Conditions evaluated',
+      level: conditions_match ? 'success' : 'info',
+      data: { matched: !!conditions_match, conditions: rule.conditions }
+    )
+
+    unless conditions_match
+      recorder.no_match!
+      recorder.persist!
+      return
     end
+
+    if rule.mode == 'flow' && rule.flow_data.present?
+      recorder.add_step('Executing flow', data: { mode: 'flow' })
+      AutomationRules::FlowExecutionService.new(rule, nil, nil, contact).perform
+    else
+      AutomationRules::ContactActionService.new(rule, contact, recorder: recorder).perform
+    end
+
+    recorder.matched!
+    recorder.persist!
+  rescue StandardError => e
+    Rails.logger.error "[AutomationRuleListener] evaluate_and_execute_contact_rule failed rule=#{rule&.id}: #{e.class}: #{e.message}"
+    recorder.error!(e)
+    recorder.persist!
   end
+
+  # Contact-triggered rule that references conversation attributes: needs the
+  # contact's last conversation. Records the run either way (matched / no_match /
+  # skipped-no-conversation) so it's visible in the logs instead of vanishing.
+
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -74,9 +74,10 @@ class Contact < ApplicationRecord
   before_validation :prepare_contact_attributes, :ensure_location_present
   before_save :ensure_location_present
   # after_create_commit :dispatch_create_event # Disabled - using Wisper events instead
-  after_create_commit :ip_lookup, :publish_contact_created, :assign_to_default_pipeline
+  after_create_commit :ip_lookup, :publish_contact_created, :assign_to_default_pipeline, :trigger_contact_created_automation
   # after_update_commit :dispatch_update_event # Disabled - using Wisper events instead
-  after_update_commit :publish_contact_updated, :publish_custom_attribute_changes, :publish_label_changes
+  after_update_commit :publish_contact_updated, :publish_custom_attribute_changes, :publish_label_changes,
+                      :trigger_contact_updated_automation
   before_save :sync_contact_attributes
   before_destroy :ensure_pipeline_items_cleanup, :publish_contact_deleted
   after_destroy_commit :dispatch_destroy_event
@@ -290,6 +291,25 @@ class Contact < ApplicationRecord
 
   def dispatch_destroy_event
     Rails.configuration.dispatcher.dispatch(CONTACT_DELETED, Time.zone.now, contact: self)
+  end
+
+  # Feeds contact events to automation rules ONLY (see AutomationContactEventJob).
+  # The broad dispatch_*_event path above stays disabled; this is the narrow
+  # bridge that keeps contact-triggered automations working.
+  def trigger_contact_created_automation
+    enqueue_contact_automation('contact_created')
+  end
+
+  def trigger_contact_updated_automation
+    enqueue_contact_automation('contact_updated')
+  end
+
+  # Loop guard: when the contact change was itself made by a running automation
+  # (Current.executed_by is the rule), do not enqueue another automation pass.
+  def enqueue_contact_automation(event_name)
+    return if Current.executed_by.is_a?(AutomationRule)
+
+    AutomationContactEventJob.perform_later(event_name, id, previous_changes.as_json)
   end
 
   # Wisper event publishers

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -306,8 +306,13 @@ class Contact < ApplicationRecord
 
   # Loop guard: when the contact change was itself made by a running automation
   # (Current.executed_by is the rule), do not enqueue another automation pass.
+  #
+  # Rule guard: skip enqueueing entirely when no active rule listens for this
+  # event. Without it, every contact write (including bulk import/sync) spawns an
+  # empty background job that loads the contact only to find nothing to run.
   def enqueue_contact_automation(event_name)
     return if Current.executed_by.is_a?(AutomationRule)
+    return unless AutomationRule.exists?(event_name: event_name, active: true)
 
     AutomationContactEventJob.perform_later(event_name, id, previous_changes.as_json)
   end

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -1,0 +1,97 @@
+# Executes automation-rule actions for contact-triggered events
+# (`contact_created` / `contact_updated`) that have no conversation in scope.
+#
+# Only a subset of actions can run without a conversation: webhooks and
+# contact-level labels operate directly on the contact. Conversation-bound
+# actions (send_message, assign_team, assign_agent, pipeline moves, status
+# changes, …) cannot run here. Instead of silently doing nothing — the previous
+# behaviour of `AutomationRuleListener#execute_contact_actions`, which only
+# handled `send_webhook_event` and left everything else as a no-op — they are
+# recorded on the run as `skipped` with a reason, so the outcome is observable
+# in the automation logs (`automation_rule_runs`).
+class AutomationRules::ContactActionService
+  # Actions that operate on the contact itself and need no conversation.
+  CONTACT_NATIVE_ACTIONS = %w[send_webhook_event add_label remove_label].freeze
+
+  def initialize(rule, contact, recorder: nil)
+    @rule = rule
+    @contact = contact
+    @recorder = recorder
+  end
+
+  def perform
+    # Tag downstream events as performed-by-automation so the listener's loop
+    # guard (`performed_by_automation?`) skips them.
+    Current.executed_by = @rule
+    Array(@rule.actions).each { |action| run_action(action.with_indifferent_access) }
+  ensure
+    Current.reset
+  end
+
+  private
+
+  def run_action(action)
+    action_name = action[:action_name]
+    action_params = action[:action_params]
+
+    return record_skip(action_name) unless CONTACT_NATIVE_ACTIONS.include?(action_name)
+
+    dispatch_native_action(action_name, action_params)
+    @recorder&.add_step("Action: #{action_name}", level: 'success', data: { params: action_params })
+  rescue StandardError => e
+    Rails.logger.error "Automation Rule #{@rule.id}: Error executing contact action #{action_name}: #{e.message}"
+    @recorder&.add_step("Action errored: #{action_name}", level: 'error', data: { error: "#{e.class}: #{e.message}" })
+    EvolutionExceptionTracker.new(e).capture_exception
+  end
+
+  def record_skip(action_name)
+    @recorder&.add_step(
+      "Action skipped: #{action_name}",
+      level: 'warn',
+      data: {
+        action_name: action_name,
+        reason: 'requires a conversation; contact trigger has no conversation in scope'
+      }
+    )
+  end
+
+  # The action_name is constrained to CONTACT_NATIVE_ACTIONS before we get here,
+  # so no arbitrary method can be invoked.
+  def dispatch_native_action(action_name, action_params)
+    case action_name
+    when 'send_webhook_event' then send_webhook_event(action_params)
+    when 'add_label' then add_label(action_params)
+    when 'remove_label' then remove_label(action_params)
+    end
+  end
+
+  def send_webhook_event(action_params)
+    webhook_url = action_params.is_a?(Array) ? action_params[0] : action_params
+    return if webhook_url.blank?
+
+    clean_url = webhook_url.to_s.strip
+    payload = (@contact.webhook_data || {}).merge(event: "contact_#{@rule.event_name.split('_').last}")
+    WebhookJob.perform_later(clean_url, payload)
+    Rails.logger.info "Automation Rule #{@rule.id}: Sent webhook to #{clean_url} for contact #{@contact.id}"
+  end
+
+  def add_label(label_ids)
+    labels = Label.where(id: label_ids)
+    return if labels.empty?
+
+    # Route through the setter so `saved_change_to_label_list?` dirty-tracks the
+    # change and Contact#publish_label_changes fires (mirrors FlowExecutionService).
+    titles = labels.pluck(:title)
+    @contact.update!(label_list: (@contact.label_list + titles).uniq)
+    Rails.logger.info "Automation Rule #{@rule.id}: Added #{labels.count} labels to contact #{@contact.id}"
+  end
+
+  def remove_label(label_ids)
+    labels = Label.where(id: label_ids)
+    return if labels.empty?
+
+    titles = labels.pluck(:title)
+    @contact.update!(label_list: @contact.label_list - titles)
+    Rails.logger.info "Automation Rule #{@rule.id}: Removed #{labels.count} labels from contact #{@contact.id}"
+  end
+end

--- a/spec/jobs/automation_contact_event_job_spec.rb
+++ b/spec/jobs/automation_contact_event_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutomationContactEventJob do
+  let(:contact) { Contact.create!(name: 'Jane', email: "c-#{SecureRandom.hex(4)}@test.com") }
+
+  it 'invokes the automation listener for a supported contact event' do
+    listener = instance_double(AutomationRuleListener, contact_updated: nil)
+    allow(AutomationRuleListener).to receive(:instance).and_return(listener)
+
+    described_class.perform_now('contact_updated', contact.id, { 'name' => %w[a b] })
+
+    expect(listener).to have_received(:contact_updated) do |event|
+      expect(event.data[:contact]).to eq(contact)
+      expect(event.data[:changed_attributes]).to eq({ 'name' => %w[a b] })
+    end
+  end
+
+  it 'ignores unsupported event names' do
+    allow(AutomationRuleListener).to receive(:instance)
+    described_class.perform_now('contact_deleted', contact.id, {})
+    expect(AutomationRuleListener).not_to have_received(:instance)
+  end
+
+  it 'no-ops when the contact no longer exists' do
+    listener = instance_double(AutomationRuleListener, contact_updated: nil)
+    allow(AutomationRuleListener).to receive(:instance).and_return(listener)
+
+    described_class.perform_now('contact_updated', SecureRandom.uuid, {})
+
+    expect(listener).not_to have_received(:contact_updated)
+  end
+end

--- a/spec/listeners/automation_rule_listener_contact_spec.rb
+++ b/spec/listeners/automation_rule_listener_contact_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Integration coverage for contact-triggered automation rules under
+# AutomationRuleListener#contact_updated.
+#
+# Regression: contact_created/contact_updated rules with only-contact (or no)
+# conditions used to run through a webhook-only branch that recorded NOTHING in
+# automation_rule_runs, so every contact automation was invisible in the logs.
+# This spec asserts the run is now persisted (matched / no_match) and that
+# conversation-bound actions are skipped with a recorded reason.
+RSpec.describe AutomationRuleListener do
+  let(:listener) { described_class.instance }
+
+  let(:contact) { Contact.create!(name: 'Jane', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let!(:label) { Label.create!(title: 'vip', color: '#abcdef') }
+
+  ContactEvent = Struct.new(:data) unless defined?(ContactEvent)
+
+  def build_rule(actions:, conditions: [])
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}",
+      event_name: 'contact_updated',
+      active: true,
+      mode: 'simple',
+      conditions: conditions,
+      actions: actions
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  def dispatch(changed_attributes: { 'name' => %w[Old New] })
+    listener.contact_updated(ContactEvent.new({ contact: contact, changed_attributes: changed_attributes }))
+  end
+
+  after { Current.reset }
+
+  describe 'native contact action with NO conditions' do
+    let!(:rule) { build_rule(actions: [{ 'action_name' => 'add_label', 'action_params' => [label.id] }]) }
+
+    it 'executes the action and records a matched run' do
+      expect { dispatch }.to change(AutomationRuleRun, :count).by(1)
+
+      run = AutomationRuleRun.last
+      expect(run.status).to eq('matched')
+      expect(run.event_name).to eq('contact_updated')
+      expect(run.steps.map { |s| s['label'] }).to include('Action: add_label')
+      expect(contact.reload.label_list).to include('vip')
+    end
+  end
+
+  describe 'conversation-bound action on a contact trigger' do
+    let!(:rule) { build_rule(actions: [{ 'action_name' => 'assign_team', 'action_params' => [SecureRandom.uuid] }]) }
+
+    it 'records a matched run with a skip step explaining the missing conversation' do
+      expect { dispatch }.to change(AutomationRuleRun, :count).by(1)
+
+      run = AutomationRuleRun.last
+      expect(run.status).to eq('matched')
+      skip_step = run.steps.find { |s| s['label'] == 'Action skipped: assign_team' }
+      expect(skip_step).to be_present
+      expect(skip_step.dig('data', 'reason')).to include('requires a conversation')
+    end
+  end
+
+  describe 'conditions that do not match' do
+    let!(:rule) do
+      build_rule(
+        actions: [{ 'action_name' => 'add_label', 'action_params' => [label.id] }],
+        conditions: [{ 'attribute_key' => 'name', 'filter_operator' => 'equal_to', 'values' => ['Someone Else'], 'query_operator' => nil }]
+      )
+    end
+
+    it 'records a no_match run and does not execute the action' do
+      expect { dispatch }.to change(AutomationRuleRun, :count).by(1)
+
+      run = AutomationRuleRun.last
+      expect(run.status).to eq('no_match')
+      expect(contact.reload.label_list).not_to include('vip')
+    end
+  end
+
+  describe 'guard: empty changed_attributes' do
+    let!(:rule) { build_rule(actions: [{ 'action_name' => 'add_label', 'action_params' => [label.id] }]) }
+
+    it 'does not record a run (event carries no change)' do
+      expect { dispatch(changed_attributes: {}) }.not_to change(AutomationRuleRun, :count)
+    end
+  end
+end

--- a/spec/models/contact_automation_trigger_spec.rb
+++ b/spec/models/contact_automation_trigger_spec.rb
@@ -8,13 +8,24 @@ RSpec.describe Contact, type: :model do
   before { allow(AutomationContactEventJob).to receive(:perform_later) }
   after { Current.reset }
 
+  # The enqueue guard only fires when an active rule listens for the event, so
+  # the "happy path" specs need one in place.
+  def rule_for(event_name)
+    rule = AutomationRule.new(name: 'r', event_name: event_name, active: true, mode: 'simple', conditions: [], actions: [])
+    rule.save!(validate: false)
+    rule
+  end
+
   it 'enqueues a contact_created automation event on create' do
+    rule_for('contact_created')
+
     contact = Contact.create!(name: 'New', email: "c-#{SecureRandom.hex(4)}@test.com")
 
     expect(AutomationContactEventJob).to have_received(:perform_later).with('contact_created', contact.id, anything)
   end
 
   it 'enqueues a contact_updated automation event on update' do
+    rule_for('contact_updated')
     contact = Contact.create!(name: 'X', email: "c-#{SecureRandom.hex(4)}@test.com")
 
     contact.update!(name: 'Y')
@@ -22,10 +33,31 @@ RSpec.describe Contact, type: :model do
     expect(AutomationContactEventJob).to have_received(:perform_later).with('contact_updated', contact.id, anything)
   end
 
-  it 'does NOT enqueue when the change came from a running automation (loop guard)' do
+  # Seam test (review follow-up): drive a REAL label change through the producer
+  # path instead of injecting changed_attributes by hand, so after_update_commit →
+  # enqueue is actually exercised for the acts-as-taggable-on setter.
+  it 'enqueues a contact_updated automation event when labels change via update!(label_list:)' do
+    rule_for('contact_updated')
     contact = Contact.create!(name: 'X', email: "c-#{SecureRandom.hex(4)}@test.com")
-    rule = AutomationRule.new(name: 'r', event_name: 'contact_updated', active: true, mode: 'simple', conditions: [], actions: [])
-    rule.save!(validate: false)
+
+    contact.update!(label_list: ['vip'])
+
+    expect(AutomationContactEventJob).to have_received(:perform_later).with('contact_updated', contact.id, anything)
+  end
+
+  it 'does NOT enqueue when no active rule listens for the event (rule guard)' do
+    # Only an inactive rule exists → nothing should be enqueued.
+    AutomationRule.new(name: 'off', event_name: 'contact_created', active: false, mode: 'simple', conditions: [],
+                       actions: []).save!(validate: false)
+
+    Contact.create!(name: 'New', email: "c-#{SecureRandom.hex(4)}@test.com")
+
+    expect(AutomationContactEventJob).not_to have_received(:perform_later)
+  end
+
+  it 'does NOT enqueue when the change came from a running automation (loop guard)' do
+    rule = rule_for('contact_updated')
+    contact = Contact.create!(name: 'X', email: "c-#{SecureRandom.hex(4)}@test.com")
     Current.executed_by = rule
 
     contact.update!(name: 'Z')

--- a/spec/models/contact_automation_trigger_spec.rb
+++ b/spec/models/contact_automation_trigger_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Coverage for the narrow bridge that keeps contact-triggered automations alive
+# even though Contact#dispatch_*_event (the broad dispatcher path) stays disabled.
+RSpec.describe Contact, type: :model do
+  before { allow(AutomationContactEventJob).to receive(:perform_later) }
+  after { Current.reset }
+
+  it 'enqueues a contact_created automation event on create' do
+    contact = Contact.create!(name: 'New', email: "c-#{SecureRandom.hex(4)}@test.com")
+
+    expect(AutomationContactEventJob).to have_received(:perform_later).with('contact_created', contact.id, anything)
+  end
+
+  it 'enqueues a contact_updated automation event on update' do
+    contact = Contact.create!(name: 'X', email: "c-#{SecureRandom.hex(4)}@test.com")
+
+    contact.update!(name: 'Y')
+
+    expect(AutomationContactEventJob).to have_received(:perform_later).with('contact_updated', contact.id, anything)
+  end
+
+  it 'does NOT enqueue when the change came from a running automation (loop guard)' do
+    contact = Contact.create!(name: 'X', email: "c-#{SecureRandom.hex(4)}@test.com")
+    rule = AutomationRule.new(name: 'r', event_name: 'contact_updated', active: true, mode: 'simple', conditions: [], actions: [])
+    rule.save!(validate: false)
+    Current.executed_by = rule
+
+    contact.update!(name: 'Z')
+
+    expect(AutomationContactEventJob).not_to have_received(:perform_later).with('contact_updated', contact.id, anything)
+  end
+end

--- a/spec/services/automation_rules/contact_action_service_spec.rb
+++ b/spec/services/automation_rules/contact_action_service_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit coverage for the contact-native action executor used by
+# AutomationRuleListener for contact_created / contact_updated rules that have
+# no conversation in scope.
+RSpec.describe AutomationRules::ContactActionService do
+  let(:contact) { Contact.create!(name: 'Jane', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let!(:label) { Label.create!(title: 'vip', color: '#abcdef') }
+
+  let(:recorder) { instance_double(AutomationRules::RunRecorder, add_step: nil) }
+
+  def build_rule(actions:)
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}",
+      event_name: 'contact_updated',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: actions
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  after { Current.reset }
+
+  describe 'native contact actions' do
+    it 'enqueues a webhook with the contact payload' do
+      allow(WebhookJob).to receive(:perform_later)
+      rule = build_rule(actions: [{ 'action_name' => 'send_webhook_event', 'action_params' => ['https://example.com/hook '] }])
+
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      expect(WebhookJob).to have_received(:perform_later).with(
+        'https://example.com/hook', # whitespace trimmed
+        hash_including(event: 'contact_updated')
+      )
+      expect(recorder).to have_received(:add_step).with('Action: send_webhook_event', hash_including(level: 'success'))
+    end
+
+    it 'adds a label to the contact (not a conversation)' do
+      rule = build_rule(actions: [{ 'action_name' => 'add_label', 'action_params' => [label.id] }])
+
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      expect(contact.reload.label_list).to include('vip')
+    end
+
+    it 'removes a label from the contact' do
+      contact.update!(label_list: ['vip'])
+      rule = build_rule(actions: [{ 'action_name' => 'remove_label', 'action_params' => [label.id] }])
+
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      expect(contact.reload.label_list).not_to include('vip')
+    end
+  end
+
+  describe 'conversation-bound actions' do
+    it 'does NOT execute and records a skip with a reason' do
+      rule = build_rule(actions: [{ 'action_name' => 'assign_team', 'action_params' => [SecureRandom.uuid] }])
+
+      expect_any_instance_of(Conversation).not_to receive(:update!)
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      expect(recorder).to have_received(:add_step).with(
+        'Action skipped: assign_team',
+        hash_including(level: 'warn', data: hash_including(reason: a_string_including('requires a conversation')))
+      )
+    end
+  end
+
+  describe 'robustness' do
+    it 'isolates a failing action so later actions still run' do
+      allow(WebhookJob).to receive(:perform_later)
+      # First action raises (blank label set resolves to empty -> we force an error
+      # by stubbing Label.where to raise on the first call only).
+      rule = build_rule(actions: [
+                          { 'action_name' => 'add_label', 'action_params' => [label.id] },
+                          { 'action_name' => 'send_webhook_event', 'action_params' => ['https://example.com/hook'] }
+                        ])
+      allow(Label).to receive(:where).and_raise(StandardError, 'boom')
+      allow(EvolutionExceptionTracker).to receive(:new).and_return(double(capture_exception: nil))
+
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      # The webhook (second action) still fired despite the first raising.
+      expect(WebhookJob).to have_received(:perform_later)
+      expect(recorder).to have_received(:add_step).with('Action errored: add_label', hash_including(level: 'error'))
+    end
+
+    it 'resets Current.executed_by after running' do
+      rule = build_rule(actions: [{ 'action_name' => 'add_label', 'action_params' => [label.id] }])
+
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      expect(Current.executed_by).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## EVO-1635 — Automações de contato não executam nem aparecem nos logs

**Root cause:** `Contact#dispatch_*_event` desabilitado → eventos de contato nunca chegavam ao `AutomationRuleListener`; e o ramo de contato não gravava run (sem `RunRecorder`) e só rodava webhook.

**Fix:** `AutomationContactEventJob` (ponte só p/ automação), `ContactActionService` (execução nativa de contato + skip observável), callbacks no Contact com guarda de loop, `RunRecorder` no ramo de contato.

**Testes:** 16 specs verdes (service + listener + job + model).

Parte da EVO-1637. Base da stack (1635 → 1640 → 1638).