### PR TITLE
fix(automation): record skipped runs for contact silent drops (EVO-1640)

### DIFF
--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -1,5 +1,9 @@
 class AutomationRuleListener < BaseListener
   PIPELINE_STAGE_DEDUP_WINDOW = (ENV.fetch('AUTOMATION_PIPELINE_STAGE_DEDUP_WINDOW_SECONDS', 5).to_i)
+  # Anti-spam circuit breaker for contact_updated (e.g. bulk imports hammering a
+  # single contact). Both tunable via ENV; threshold high disables it.
+  CONTACT_UPDATED_SPAM_THRESHOLD = (ENV.fetch('AUTOMATION_CONTACT_UPDATED_SPAM_THRESHOLD', 5).to_i)
+  CONTACT_UPDATED_SPAM_WINDOW = (ENV.fetch('AUTOMATION_CONTACT_UPDATED_SPAM_WINDOW_SECONDS', 30).to_i)
 
   def conversation_updated(event)
     process_conversation_event(event, 'conversation_updated')
@@ -96,18 +100,8 @@ class AutomationRuleListener < BaseListener
       if rule_has_only_contact_conditions?(rule)
         evaluate_and_execute_contact_rule(rule, contact, changed_attributes)
       else
-        # Se tiver condições de conversa, precisa de uma conversa
-        conversation = contact.conversations.last
-        next unless conversation
-
-        conditions_match = ::AutomationRules::ConditionsFilterService.new(rule, conversation, { contact: contact, changed_attributes: changed_attributes }).perform
-        if conditions_match.present?
-          if rule.mode == 'flow' && rule.flow_data.present?
-            AutomationRules::FlowExecutionService.new(rule, account, conversation, contact).perform
-          else
-            ::AutomationRules::ActionService.new(rule, account, conversation).perform
-          end
-        end
+        # Condições de conversa exigem uma conversa; avalia/executa registrando o run.
+        evaluate_and_execute_contact_conversation_rule(rule, contact, changed_attributes)
       end
     end
   end
@@ -133,13 +127,14 @@ class AutomationRuleListener < BaseListener
     recent_events_key = "contact_updated_#{contact.id}"
     recent_count = Rails.cache.read(recent_events_key) || 0
 
-    if recent_count > 5
+    if recent_count > CONTACT_UPDATED_SPAM_THRESHOLD
       Rails.logger.warn "Automation Rule: Skipping contact_updated for contact #{contact.id} - too many recent events (#{recent_count})"
+      record_contact_spam_skip(contact, changed_attributes)
       return
     end
 
-    # Incrementar contador de eventos recentes (expira em 30 segundos)
-    Rails.cache.write(recent_events_key, recent_count + 1, expires_in: 30.seconds)
+    # Incrementar contador de eventos recentes (expira na janela configurada)
+    Rails.cache.write(recent_events_key, recent_count + 1, expires_in: CONTACT_UPDATED_SPAM_WINDOW.seconds)
 
     # Log para debug das mudanças
     Rails.logger.debug do
@@ -157,18 +152,8 @@ class AutomationRuleListener < BaseListener
       if rule_has_only_contact_conditions?(rule)
         evaluate_and_execute_contact_rule(rule, contact, changed_attributes)
       else
-        # Se tiver condições de conversa, precisa de uma conversa
-        conversation = contact.conversations.last
-        next unless conversation
-
-        conditions_match = ::AutomationRules::ConditionsFilterService.new(rule, conversation, { contact: contact, changed_attributes: changed_attributes }).perform
-        if conditions_match.present?
-          if rule.mode == 'flow' && rule.flow_data.present?
-            AutomationRules::FlowExecutionService.new(rule, account, conversation, contact).perform
-          else
-            ::AutomationRules::ActionService.new(rule, account, conversation).perform
-          end
-        end
+        # Condições de conversa exigem uma conversa; avalia/executa registrando o run.
+        evaluate_and_execute_contact_conversation_rule(rule, contact, changed_attributes)
       end
     end
   end
@@ -206,7 +191,22 @@ class AutomationRuleListener < BaseListener
   # When the contact_updated spam circuit breaker trips, record ONE skipped run
   # per active rule per window (cache-guarded) so the drop is visible in the logs
   # without flooding automation_rule_runs during a bulk update storm.
+  def record_contact_spam_skip(contact, changed_attributes)
+    flag_key = "automation:contact_updated_spam_recorded:#{contact.id}"
+    return if Rails.cache.read(flag_key)
 
+    Rails.cache.write(flag_key, true, expires_in: CONTACT_UPDATED_SPAM_WINDOW.seconds)
+    current_account_rules('contact_updated').each do |rule|
+      recorder = ::AutomationRules::RunRecorder.new(
+        rule: rule,
+        event_name: 'contact_updated',
+        payload: { contact_id: contact&.id, changed_attributes: changed_attributes }
+      )
+      recorder.add_step('Event received', data: { event_name: 'contact_updated' })
+      recorder.skipped!("Rate-limited: more than #{CONTACT_UPDATED_SPAM_THRESHOLD} contact_updated events within #{CONTACT_UPDATED_SPAM_WINDOW}s")
+      recorder.persist!
+    end
+  end
 
   def pipeline_stage_dedup_key(rule_id, pipeline_item_id, stage_id)
     "automation:pipeline_stage_updated:#{rule_id}:#{pipeline_item_id}:#{stage_id}"
@@ -441,5 +441,48 @@ class AutomationRuleListener < BaseListener
   # Contact-triggered rule that references conversation attributes: needs the
   # contact's last conversation. Records the run either way (matched / no_match /
   # skipped-no-conversation) so it's visible in the logs instead of vanishing.
+  def evaluate_and_execute_contact_conversation_rule(rule, contact, changed_attributes)
+    recorder = ::AutomationRules::RunRecorder.new(
+      rule: rule,
+      event_name: rule.event_name,
+      payload: { contact_id: contact&.id, changed_attributes: changed_attributes }
+    )
+    recorder.add_step('Event received', data: { event_name: rule.event_name, changed_attributes: changed_attributes })
 
+    conversation = contact.conversations.last
+    if conversation.nil?
+      recorder.skipped!('contact has no conversation for conversation-scoped conditions')
+      recorder.persist!
+      return
+    end
+
+    conditions_match = ::AutomationRules::ConditionsFilterService.new(
+      rule, conversation, { contact: contact, changed_attributes: changed_attributes }
+    ).perform
+    recorder.add_step(
+      'Conditions evaluated',
+      level: conditions_match.present? ? 'success' : 'info',
+      data: { matched: conditions_match.present?, conditions: rule.conditions }
+    )
+
+    if conditions_match.blank?
+      recorder.no_match!
+      recorder.persist!
+      return
+    end
+
+    if rule.mode == 'flow' && rule.flow_data.present?
+      recorder.add_step('Executing flow', data: { mode: 'flow' })
+      AutomationRules::FlowExecutionService.new(rule, nil, conversation, contact).perform
+    else
+      AutomationRules::ActionService.new(rule, nil, conversation).perform
+    end
+
+    recorder.matched!
+    recorder.persist!
+  rescue StandardError => e
+    Rails.logger.error "[AutomationRuleListener] evaluate_and_execute_contact_conversation_rule failed rule=#{rule&.id}: #{e.class}: #{e.message}"
+    recorder.error!(e)
+    recorder.persist!
+  end
 end

--- a/spec/listeners/automation_rule_listener_contact_observability_spec.rb
+++ b/spec/listeners/automation_rule_listener_contact_observability_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression (T2 / observabilidade): rule de contato com condição de CONVERSA e
+# contato sem conversa deve gravar um run `skipped` (antes era drop silencioso).
+RSpec.describe AutomationRuleListener do
+  let(:listener) { described_class.instance }
+  let(:contact) { Contact.create!(name: 'Jane', email: "c-#{SecureRandom.hex(4)}@test.com", phone_number: '+5571999998888') }
+  let!(:vip) { Label.create!(title: 'vip', color: '#abcdef') }
+  let!(:gold) { Label.create!(title: 'gold', color: '#ffd700') }
+
+  ContactCondEvent = Struct.new(:data) unless defined?(ContactCondEvent)
+
+  def build_rule(conditions)
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}", event_name: 'contact_updated', active: true, mode: 'simple',
+      conditions: conditions, actions: [{ 'action_name' => 'send_webhook_event', 'action_params' => ['https://e.com/h'] }]
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  def dispatch(changed_attributes)
+    listener.contact_updated(ContactCondEvent.new({ contact: contact, changed_attributes: changed_attributes }))
+  end
+
+  after { Current.reset }
+  before { allow(WebhookJob).to receive(:perform_later) }
+
+  it 'records a skipped run for a conversation-scoped condition when the contact has no conversation (T2)' do
+    # `status` is a conversation attribute -> routes to the conversation branch.
+    build_rule([{ 'attribute_key' => 'status', 'filter_operator' => 'equal_to', 'values' => ['open'], 'query_operator' => nil }])
+    expect { dispatch({ 'name' => %w[a b] }) }.to change(AutomationRuleRun, :count).by(1)
+    run = AutomationRuleRun.last
+    expect(run.status).to eq('skipped')
+    expect(run.steps.map { |s| s['label'] }.join).to include('no conversation')
+  end
+
+end


### PR DESCRIPTION
## EVO-1640 — Observabilidade: drops silenciosos

**Fix:** spam guard de `contact_updated` agora ENV-configurável e grava `skipped` (uma vez por janela); ramo de condição-de-conversa sem conversa grava `skipped`/`no_match`/`matched` (antes era drop silencioso).

**Testes:** 17 specs verdes (base + observability T2).

Parte da EVO-1637. **Stacked sobre** `danilocarneiro/evo-1635-bug-cadastro-de-automacao` (EVO-1635) — merge sequencial.