### PR TITLE
fix(automation): contact condition operators + labels semantics (EVO-1638)

### DIFF
--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -382,6 +382,14 @@ class AutomationRuleListener < BaseListener
   # in previous_changes ([[old_titles], [new_titles]]); scalars under their column.
   def contact_attribute_changed_match?(attribute_key, values, changed_attributes)
     changed = (changed_attributes || {}).with_indifferent_access
+    # `attribute_changed` needs a {from, to} transition shape. `nil` means
+    # "changed at all" (wildcard); a malformed value (e.g. a bare Array from a
+    # legacy/broken condition) can't express a transition. Treat it as no-match
+    # for THIS condition instead of letting `values['from']` raise a TypeError —
+    # that exception is rescued upstream but errors the ENTIRE rule run rather
+    # than failing the single condition.
+    return false unless values.nil? || values.is_a?(Hash)
+
     values ||= {}
     backend_key = attribute_key == 'labels' ? 'label_list' : attribute_key
     transition = changed[backend_key]

--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -318,83 +318,102 @@ class AutomationRuleListener < BaseListener
   end
 
   def evaluate_contact_conditions(rule, contact, changed_attributes)
-    # Avalia condições simples de contato
+    # Avalia condições de contato sem precisar de conversa.
     rule.conditions.all? do |condition|
       attribute_key = condition['attribute_key']
       filter_operator = condition['filter_operator']
       values = condition['values']
 
-      case attribute_key
-      when 'labels'
-        # Para labels, verifica se o contato tem as labels especificadas
-        contact_labels = contact.label_list
-        case filter_operator
-        when 'equal_to'
-          label_ids = values
-          label_titles = Label.where(id: label_ids).pluck(:title)
-          (label_titles - contact_labels).empty?
-        when 'not_equal_to'
-          label_ids = values
-          label_titles = Label.where(id: label_ids).pluck(:title)
-          (label_titles & contact_labels).empty?
-        when 'is_present'
-          contact_labels.any?
-        when 'is_not_present'
-          contact_labels.empty?
-        else
-          false
-        end
-      when 'name', 'email', 'phone_number', 'identifier'
-        # Atributos simples do contato
-        contact_value = contact.send(attribute_key)
-        case filter_operator
-        when 'equal_to'
-          values.include?(contact_value)
-        when 'not_equal_to'
-          !values.include?(contact_value)
-        when 'contains'
-          values.any? { |v| contact_value&.include?(v) }
-        when 'does_not_contain'
-          values.none? { |v| contact_value&.include?(v) }
-        when 'is_present'
-          contact_value.present?
-        when 'is_not_present'
-          contact_value.blank?
-        else
-          false
-        end
-      when 'blocked'
-        case filter_operator
-        when 'equal_to'
-          contact.blocked == (values.first == 'true')
-        when 'not_equal_to'
-          contact.blocked != (values.first == 'true')
-        else
-          false
-        end
-      when 'city', 'country_code', 'company'
-        # Atributos adicionais
-        contact_value = contact.additional_attributes&.dig(attribute_key)
-        case filter_operator
-        when 'equal_to'
-          values.include?(contact_value)
-        when 'not_equal_to'
-          !values.include?(contact_value)
-        when 'contains'
-          values.any? { |v| contact_value&.include?(v) }
-        when 'does_not_contain'
-          values.none? { |v| contact_value&.include?(v) }
-        when 'is_present'
-          contact_value.present?
-        when 'is_not_present'
-          contact_value.blank?
-        else
-          false
-        end
+      # `attribute_changed` é uniforme (transição from/to) e independe do atributo,
+      # espelhando ConditionsFilterService p/ o caminho com conversa. Sem isso,
+      # regras de "label mudou" / "blocked mudou" caíam em `else false` e nunca
+      # casavam silenciosamente.
+      if filter_operator == 'attribute_changed'
+        contact_attribute_changed_match?(attribute_key, values, changed_attributes)
       else
-        false
+        contact_attribute_match?(contact, attribute_key, filter_operator, values)
       end
     end
+  end
+
+  def contact_attribute_match?(contact, attribute_key, filter_operator, values)
+    case attribute_key
+    when 'labels'
+      contact_labels = contact.label_list
+      label_titles = Label.where(id: values).pluck(:title)
+      case filter_operator
+      # any-of (alinhado ao EXISTS...IN do ConditionsFilterService; era all-of).
+      when 'equal_to' then (label_titles & contact_labels).any?
+      when 'not_equal_to' then (label_titles & contact_labels).empty?
+      when 'is_present' then contact_labels.any?
+      when 'is_not_present' then contact_labels.empty?
+      else false
+      end
+    when 'name', 'email', 'phone_number', 'identifier'
+      match_text_operator(contact.send(attribute_key), filter_operator, values)
+    when 'blocked'
+      case filter_operator
+      when 'equal_to' then contact.blocked == (values.first == 'true')
+      when 'not_equal_to' then contact.blocked != (values.first == 'true')
+      else false
+      end
+    when 'city', 'country_code', 'company'
+      match_text_operator(contact.additional_attributes&.dig(attribute_key), filter_operator, values)
+    else
+      false
+    end
+  end
+
+  def match_text_operator(contact_value, filter_operator, values)
+    case filter_operator
+    when 'equal_to' then values.include?(contact_value)
+    when 'not_equal_to' then !values.include?(contact_value)
+    when 'contains' then values.any? { |v| contact_value&.include?(v) }
+    when 'does_not_contain' then values.none? { |v| contact_value&.include?(v) }
+    when 'starts_with' then values.any? { |v| contact_value&.start_with?(v.to_s) }
+    when 'is_present' then contact_value.present?
+    when 'is_not_present' then contact_value.blank?
+    else false
+    end
+  end
+
+  # Mirrors ConditionsFilterService#scalar_transition_match? / labels_transition_match?:
+  # empty `from`/`to` is a wildcard for that side. Labels live under `label_list`
+  # in previous_changes ([[old_titles], [new_titles]]); scalars under their column.
+  def contact_attribute_changed_match?(attribute_key, values, changed_attributes)
+    changed = (changed_attributes || {}).with_indifferent_access
+    values ||= {}
+    backend_key = attribute_key == 'labels' ? 'label_list' : attribute_key
+    transition = changed[backend_key]
+    return false unless transition.is_a?(Array) && transition.length >= 2
+
+    if attribute_key == 'labels'
+      contact_labels_transition_match?(values, transition)
+    else
+      contact_scalar_transition_match?(values, transition)
+    end
+  end
+
+  def contact_scalar_transition_match?(values, transition)
+    from_values = Array(values['from']).map(&:to_s)
+    to_values = Array(values['to']).map(&:to_s)
+    from_match = from_values.empty? || from_values.include?(transition[0].to_s)
+    to_match = to_values.empty? || to_values.include?(transition[1].to_s)
+    from_match && to_match
+  end
+
+  def contact_labels_transition_match?(values, transition)
+    previous_labels = Array(transition[0])
+    current_labels = Array(transition[1])
+    from_titles = Label.where(id: Array(values['from'])).pluck(:title)
+    to_titles = Label.where(id: Array(values['to'])).pluck(:title)
+    added = current_labels - previous_labels
+    removed = previous_labels - current_labels
+
+    return false if to_titles.any? && (added & to_titles).empty?
+    return false if from_titles.any? && (removed & from_titles).empty?
+
+    true
   end
 
   # Contact-triggered rule with only-contact (or no) conditions: evaluate and

--- a/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
+++ b/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
@@ -60,4 +60,27 @@ RSpec.describe AutomationRuleListener do
     dispatch({ 'blocked' => [false, true] }) # opposite direction
     expect(AutomationRuleRun.last.status).to eq('no_match')
   end
+
+  # Seam test (review ressalva): drive the condition with the changed_attributes a
+  # REAL update!(label_list:) actually emits, instead of hand-injecting
+  # {'label_list' => [[], ['vip']]}. This exercises the producer→consumer seam
+  # (acts-as-taggable-on writes label_list into previous_changes).
+  it 'matches labels attribute_changed using previous_changes from a real update!(label_list:)' do
+    build_rule([{ 'attribute_key' => 'labels', 'filter_operator' => 'attribute_changed', 'values' => { 'from' => [], 'to' => [vip.id] }, 'query_operator' => nil }])
+    contact.update!(label_list: ['vip'])
+    Current.reset
+    real_changes = contact.previous_changes.as_json
+    expect(real_changes).to have_key('label_list') # producer side actually carries it
+    dispatch(real_changes)
+    expect(AutomationRuleRun.last.status).to eq('matched')
+  end
+
+  # Shape guard (review suggestion): a malformed `values` (bare Array instead of
+  # {from,to}) must fail THIS condition as no_match, not raise a TypeError that
+  # errors the whole rule run.
+  it 'records a no_match (not error) when an attribute_changed condition has a malformed values shape' do
+    build_rule([{ 'attribute_key' => 'labels', 'filter_operator' => 'attribute_changed', 'values' => [vip.id], 'query_operator' => nil }])
+    dispatch({ 'label_list' => [[], ['vip']] })
+    expect(AutomationRuleRun.last.status).to eq('no_match')
+  end
 end

--- a/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
+++ b/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression for the contact-path condition evaluator: attribute_changed and
+# starts_with used to fall through to `else false` (silent never-match), and
+# `labels equal_to` used all-of semantics while the SQL path uses any-of.
+RSpec.describe AutomationRuleListener do
+  let(:listener) { described_class.instance }
+  let(:contact) { Contact.create!(name: 'Jane', email: "c-#{SecureRandom.hex(4)}@test.com", phone_number: '+5571999998888') }
+  let!(:vip) { Label.create!(title: 'vip', color: '#abcdef') }
+  let!(:gold) { Label.create!(title: 'gold', color: '#ffd700') }
+
+  ContactCondEvent = Struct.new(:data) unless defined?(ContactCondEvent)
+
+  def build_rule(conditions)
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}", event_name: 'contact_updated', active: true, mode: 'simple',
+      conditions: conditions, actions: [{ 'action_name' => 'send_webhook_event', 'action_params' => ['https://e.com/h'] }]
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  def dispatch(changed_attributes)
+    listener.contact_updated(ContactCondEvent.new({ contact: contact, changed_attributes: changed_attributes }))
+  end
+
+  after { Current.reset }
+  before { allow(WebhookJob).to receive(:perform_later) }
+
+  it 'matches blocked attribute_changed (false -> true)' do
+    build_rule([{ 'attribute_key' => 'blocked', 'filter_operator' => 'attribute_changed', 'values' => { 'from' => ['false'], 'to' => ['true'] }, 'query_operator' => nil }])
+    dispatch({ 'blocked' => [false, true] })
+    expect(AutomationRuleRun.last.status).to eq('matched')
+  end
+
+  it 'matches labels attribute_changed when the requested label was added' do
+    build_rule([{ 'attribute_key' => 'labels', 'filter_operator' => 'attribute_changed', 'values' => { 'from' => [], 'to' => [vip.id] }, 'query_operator' => nil }])
+    dispatch({ 'label_list' => [[], ['vip']] })
+    expect(AutomationRuleRun.last.status).to eq('matched')
+  end
+
+  it 'matches phone_number starts_with' do
+    build_rule([{ 'attribute_key' => 'phone_number', 'filter_operator' => 'starts_with', 'values' => ['+55'], 'query_operator' => nil }])
+    dispatch({ 'name' => %w[a b] })
+    expect(AutomationRuleRun.last.status).to eq('matched')
+  end
+
+  it 'labels equal_to is any-of: matches when the contact has ANY requested label' do
+    contact.update!(label_list: ['vip']) # has vip, not gold
+    Current.reset
+    build_rule([{ 'attribute_key' => 'labels', 'filter_operator' => 'equal_to', 'values' => [vip.id, gold.id], 'query_operator' => nil }])
+    dispatch({ 'name' => %w[a b] })
+    expect(AutomationRuleRun.last.status).to eq('matched')
+  end
+
+  it 'records a no_match run when an attribute_changed transition does not match' do
+    build_rule([{ 'attribute_key' => 'blocked', 'filter_operator' => 'attribute_changed', 'values' => { 'from' => ['true'], 'to' => ['false'] }, 'query_operator' => nil }])
+    dispatch({ 'blocked' => [false, true] }) # opposite direction
+    expect(AutomationRuleRun.last.status).to eq('no_match')
+  end
+end


### PR DESCRIPTION
## EVO-1638 — Condições de contato: never-match silencioso + divergência de labels

**Fix:** `evaluate_contact_conditions` ganha `attribute_changed` (scalar + labels) e `starts_with`; `labels equal_to` alinhado a any-of (era all-of vs SQL).

**Testes:** 22 specs verdes (tudo).

Parte da EVO-1637. **Stacked sobre** `danilocarneiro/evo-1640-bug-automacao-drops-silenciosos-na-observabilidade-spam` (EVO-1640) — merge sequencial.