### PR TITLE
fix(automation): unify flow-mode action execution with simple mode (EVO-1641)

### DIFF
--- a/app/services/action_service.rb
+++ b/app/services/action_service.rb
@@ -1,119 +1,17 @@
 class ActionService
   include EmailHelper
+  # Conversation action implementations now live in a single shared
+  # module so the modal and flow-canvas automation executors cannot diverge.
+  # Macros::ExecutionService < ActionService reaches the same code path here.
+  include AutomationRules::ConversationActionHandlers
 
   def initialize(conversation)
     @conversation = conversation.reload
   end
 
-  def mute_conversation(_params)
-    @conversation.mute!
-  end
-
-  def snooze_conversation(_params)
-    @conversation.snoozed!
-  end
-
-  def resolve_conversation(_params)
-    @conversation.resolved!
-  end
-
-  def change_status(status)
-    @conversation.update!(status: status[0])
-  end
-
-  def change_priority(priority)
-    @conversation.update!(priority: (priority[0] == 'nil' ? nil : priority[0]))
-  end
-
-  def add_label(labels)
-    return if labels.empty?
-
-    @conversation.reload.add_labels(resolve_label_titles(labels))
-  end
-
-  def assign_agent(agent_ids = [])
-    return @conversation.update!(assignee_id: nil) if agent_ids[0] == 'nil'
-
-    return unless agent_belongs_to_inbox?(agent_ids)
-
-    @agent = User.find_by(id: agent_ids)
-
-    @conversation.update!(assignee_id: @agent.id) if @agent.present?
-  end
-
-  def remove_label(labels)
-    return if labels.empty?
-
-    targets = resolve_label_titles(labels)
-    labels  = @conversation.label_list - targets
-    @conversation.update!(label_list: labels)
-  end
-
-  def assign_team(team_ids = [])
-    # FIXME: The explicit checks for zero or nil (string) is bad. Move
-    # this to a separate unassign action.
-    should_unassign = team_ids.blank? || %w[nil 0].include?(team_ids[0].to_s)
-    return @conversation.update!(team_id: nil) if should_unassign
-
-    # check if team belongs to account only if team_id is present
-    # if team_id is nil, then it means that the team is being unassigned
-    return unless !team_ids[0].nil? && team_belongs_to_account?(team_ids)
-
-    @conversation.update!(team_id: team_ids[0])
-  end
-
   def remove_assigned_team(_params)
     @conversation.update!(team_id: nil)
   end
-
-  def send_email_transcript(emails)
-    emails = emails[0].gsub(/\s+/, '').split(',')
-
-    emails.each do |email|
-      email = parse_email_variables(@conversation, email)
-      ConversationReplyMailer.with(account: nil).conversation_transcript(@conversation, email)&.deliver_later
-    end
-  end
-
-  private
-
-  def agent_belongs_to_inbox?(agent_ids)
-    member_ids = @conversation.inbox.members.pluck(:user_id)
-    assignable_agent_ids = member_ids + User.where(type: 'SuperAdmin').pluck(:id)
-
-    assignable_agent_ids.include?(agent_ids[0])
-  end
-
-  def team_belongs_to_account?(team_ids)
-    Team.exists?(id: team_ids[0])
-  end
-
-  def conversation_a_tweet?
-    return false if @conversation.additional_attributes.blank?
-
-    @conversation.additional_attributes['type'] == 'tweet'
-  end
-
-  # Automation rules persist label_ids (UUIDs) in `action_params`, but
-  # `acts_as_taggable_on :labels` stores tags by their **title** in
-  # `tags.name`. Translate any UUIDs in the incoming array to their Label
-  # title; values that aren't UUIDs (legacy rules that already stored titles)
-  # are kept as-is so we don't break older configurations.
-  UUID_LABEL_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/.freeze
-
-  def resolve_label_titles(values)
-    values = Array(values).map(&:to_s).reject(&:empty?)
-    return [] if values.empty?
-
-    uuids, others = values.partition { |v| UUID_LABEL_REGEX.match?(v) }
-    return others if uuids.empty?
-
-    titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h.transform_keys(&:to_s)
-    resolved     = uuids.filter_map { |id| titles_by_id[id] }
-
-    (others + resolved).uniq
-  end
-  private :resolve_label_titles
 end
 
 ActionService.include_mod_with('ActionService')

--- a/app/services/automation_rules/README.md
+++ b/app/services/automation_rules/README.md
@@ -15,10 +15,11 @@ This directory hosts two executor surfaces that share their action implementatio
 
 Both executors call the same Ruby methods for the cross-cutting actions:
 
+- `conversation_action_handlers.rb` (`AutomationRules::ConversationActionHandlers`) — the conversation-bound actions: `assign_agent` (with the `agent_belongs_to_inbox?` guard), `assign_team`, `add_label`/`remove_label` (conversation **or** contact), `change_status`, `change_priority`, `mute`/`snooze`/`resolve_conversation`, `send_message`, `send_attachment`, `send_email_to_team`, `send_email_transcript`, `send_webhook_event` (canonical `automation_event.{event_name}` string), plus helpers. Added to kill the flow-vs-simple divergence; included by the base `ActionService` (so the simple executor and `Macros::ExecutionService` reach it) and by `FlowExecutionService`.
 - `pipeline_action_handlers.rb` (`AutomationRules::PipelineActionHandlers`) — `assign_to_pipeline`, `update_pipeline_stage`, `create_pipeline_task`, helpers.
 - `message_action_handlers.rb` (`AutomationRules::MessageActionHandlers`) — `send_canned_response`, `send_template` (with `{{contact.field}}` / `{{conversation.field}}` resolution), helpers.
 
-Each module declares its methods `private`; when included into a class, they become private instance methods of that class. Both `ActionService` and `FlowExecutionService` include the modules; behaviour is identical between the two surfaces because the implementation is identical.
+Each module declares its methods `private`; when included into a class, they become private instance methods of that class. Both `ActionService` and `FlowExecutionService` include the modules; behaviour is identical between the two surfaces because the implementation is identical. `FlowExecutionService` owns only flow-control (walking nodes/edges) and the `node_data` → `action_params` normalisation — it holds **zero** action bodies.
 
 ## How to add a new node type
 

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -1,8 +1,9 @@
 class AutomationRules::ActionService < ActionService
   # Pipeline + message action implementations live in shared modules so the
   # flow-canvas executor (FlowExecutionService) can reuse the same code
-  # without duplication. Behaviour here is unchanged — methods are still
-  # private and dispatched via `send` from `perform`.
+  # without duplication. The conversation-bound actions (assign/label/status/
+  # message/attachment/email/webhook) come from ConversationActionHandlers via
+  # the base ActionService — see app/services/automation_rules/README.md.
   include AutomationRules::PipelineActionHandlers
   include AutomationRules::MessageActionHandlers
 
@@ -26,63 +27,5 @@ class AutomationRules::ActionService < ActionService
     end
   ensure
     Current.reset
-  end
-
-  private
-
-  def send_attachment(attachment_params)
-    return if conversation_a_tweet?
-
-    if attachment_params.is_a?(Array)
-      blob_ids = attachment_params
-      inbox_id = nil
-    elsif attachment_params.is_a?(Hash)
-      blob_ids = attachment_params[:attachment_ids] || attachment_params['attachment_ids']
-      inbox_id = attachment_params[:inbox_id] || attachment_params['inbox_id']
-    else
-      blob_ids = [attachment_params].flatten
-      inbox_id = nil
-    end
-
-    return unless @rule.files.attached?
-
-    blobs = ActiveStorage::Blob.where(id: blob_ids)
-
-    return if blobs.blank?
-
-    params = { content: nil, private: false, attachments: blobs }
-
-    if inbox_id
-      inbox = Inbox.find_by(id: inbox_id)
-      if inbox && @conversation.inbox != inbox
-        Rails.logger.warn "Automation Rule #{@rule.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
-      end
-    end
-
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-  rescue StandardError => e
-    Rails.logger.error "Automation Rule #{@rule.id}: Error sending attachment: #{e.message}"
-    raise e
-  end
-
-  def send_webhook_event(webhook_url)
-    payload = @conversation.webhook_data.merge(event: "automation_event.#{@rule.event_name}")
-    clean_url = webhook_url[0].to_s.strip
-    WebhookJob.perform_later(clean_url, payload)
-  end
-
-  def send_message(message)
-    return if conversation_a_tweet?
-
-    params = { content: message[0], private: false, content_attributes: { automation_rule_id: @rule.id } }
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-  end
-
-  def send_email_to_team(params)
-    teams = Team.where(id: params[0][:team_ids])
-
-    teams.each do |team|
-      TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, params[0][:message])&.deliver_now
-    end
   end
 end

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -70,7 +70,8 @@ class AutomationRules::ContactActionService
     return if webhook_url.blank?
 
     clean_url = webhook_url.to_s.strip
-    payload = (@contact.webhook_data || {}).merge(event: "contact_#{@rule.event_name.split('_').last}")
+    # Unified canonical event string across all three executors.
+    payload = (@contact.webhook_data || {}).merge(event: "automation_event.#{@rule.event_name}")
     WebhookJob.perform_later(clean_url, payload)
     Rails.logger.info "Automation Rule #{@rule.id}: Sent webhook to #{clean_url} for contact #{@contact.id}"
   end

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -70,8 +70,10 @@ class AutomationRules::ContactActionService
     return if webhook_url.blank?
 
     clean_url = webhook_url.to_s.strip
-    # Unified canonical event string across all three executors.
-    payload = (@contact.webhook_data || {}).merge(event: "automation_event.#{@rule.event_name}")
+    # EVO-1641: the contact webhook string is a LIVE external contract
+    # (integrations filter on `contact_created`/`contact_updated`), so it stays
+    # as-is. Only the dormant flow executor was unified to `automation_event.*`.
+    payload = (@contact.webhook_data || {}).merge(event: "contact_#{@rule.event_name.split('_').last}")
     WebhookJob.perform_later(clean_url, payload)
     Rails.logger.info "Automation Rule #{@rule.id}: Sent webhook to #{clean_url} for contact #{@contact.id}"
   end

--- a/app/services/automation_rules/conversation_action_handlers.rb
+++ b/app/services/automation_rules/conversation_action_handlers.rb
@@ -1,0 +1,237 @@
+module AutomationRules
+  # Single source of truth for the conversation-bound automation
+  # actions that used to be duplicated between the modal executor
+  # (`ActionService` / `AutomationRules::ActionService`) and the flow-canvas
+  # executor (`AutomationRules::FlowExecutionService`). Both surfaces had
+  # silently diverged (change-status no-op, stub transcript, missing inbox
+  # guard on assign_agent, divergent webhook event strings); centralising the
+  # implementations here makes that class of divergence structurally
+  # impossible. See app/services/automation_rules/README.md.
+  #
+  # Included by:
+  #   - `ActionService`                (base; also reaches Macros::ExecutionService)
+  #   - `AutomationRules::ActionService` (via the base class)
+  #   - `AutomationRules::FlowExecutionService`
+  #
+  # Required instance state on the including class:
+  #   @conversation — Conversation, or nil for contact-triggered flows.
+  #   @contact      — Contact (only the flow executor sets this; optional).
+  #   @rule         — AutomationRule. Required by the message/attachment/webhook
+  #                   actions (audit attribution + attached files). The base
+  #                   `ActionService` lineage that does not set @rule (Macros)
+  #                   never dispatches those actions through this module.
+  #
+  # All methods are private when included; callers reach them via `send`
+  # (modal/canvas dispatch) or `super` (Macros overrides).
+  module ConversationActionHandlers
+    include EmailHelper
+
+    # Automation rules persist label_ids (UUIDs) in `action_params`, but
+    # `acts_as_taggable_on :labels` stores tags by their **title**. Translate
+    # UUIDs to titles; values that aren't UUIDs (legacy rules that already
+    # stored titles) are kept as-is so older configurations keep working.
+    UUID_LABEL_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
+    private
+
+    # --- Status / priority -------------------------------------------------
+
+    def change_status(status)
+      return unless @conversation
+
+      @conversation.update!(status: status[0])
+    end
+
+    def change_priority(priority)
+      return unless @conversation
+
+      @conversation.update!(priority: (priority[0] == 'nil' ? nil : priority[0]))
+    end
+
+    def mute_conversation(_params = nil)
+      return unless @conversation
+
+      @conversation.mute!
+    end
+
+    def snooze_conversation(_params = nil)
+      return unless @conversation
+
+      @conversation.snoozed!
+    end
+
+    def resolve_conversation(_params = nil)
+      return unless @conversation
+
+      @conversation.resolved!
+    end
+
+    # --- Assignment --------------------------------------------------------
+
+    def assign_agent(agent_ids = [])
+      return unless @conversation
+      return @conversation.update!(assignee_id: nil) if agent_ids[0] == 'nil'
+
+      return unless agent_belongs_to_inbox?(agent_ids)
+
+      @agent = User.find_by(id: agent_ids)
+      @conversation.update!(assignee_id: @agent.id) if @agent.present?
+    end
+
+    def assign_team(team_ids = [])
+      return unless @conversation
+
+      # FIXME: The explicit checks for zero or nil (string) is bad. Move this
+      # to a separate unassign action.
+      should_unassign = team_ids.blank? || %w[nil 0].include?(team_ids[0].to_s)
+      return @conversation.update!(team_id: nil) if should_unassign
+
+      # check if team belongs to account only if team_id is present; if nil it
+      # means the team is being unassigned.
+      return unless !team_ids[0].nil? && team_belongs_to_account?(team_ids)
+
+      @conversation.update!(team_id: team_ids[0])
+    end
+
+    # --- Labels (conversation OR contact) ----------------------------------
+
+    def add_label(labels)
+      return if Array(labels).empty?
+
+      if @conversation
+        @conversation.reload.add_labels(resolve_label_titles(labels))
+      elsif @contact
+        # Ensure Current.executed_by is set to prevent loop, and route through
+        # the setter so `saved_change_to_label_list?` dirty-tracks the change
+        # and Contact#publish_label_changes fires.
+        Current.executed_by = @rule
+        titles = Label.where(id: labels).pluck(:title)
+        @contact.update!(label_list: (@contact.label_list + titles).uniq)
+      end
+    end
+
+    def remove_label(labels)
+      return if Array(labels).empty?
+
+      if @conversation
+        targets = resolve_label_titles(labels)
+        @conversation.update!(label_list: @conversation.label_list - targets)
+      elsif @contact
+        Current.executed_by = @rule
+        titles = Label.where(id: labels).pluck(:title)
+        @contact.update!(label_list: @contact.label_list - titles)
+      end
+    end
+
+    # --- Messaging ---------------------------------------------------------
+
+    def send_message(message)
+      return unless @conversation
+      return if conversation_a_tweet?
+
+      params = { content: message[0], private: false, content_attributes: { automation_rule_id: @rule.id } }
+      Messages::MessageBuilder.new(nil, @conversation, params).perform
+    end
+
+    def send_attachment(attachment_params)
+      return unless @conversation
+      return if conversation_a_tweet?
+
+      if attachment_params.is_a?(Array)
+        blob_ids = attachment_params
+        inbox_id = nil
+      elsif attachment_params.is_a?(Hash)
+        blob_ids = attachment_params[:attachment_ids] || attachment_params['attachment_ids']
+        inbox_id = attachment_params[:inbox_id] || attachment_params['inbox_id']
+      else
+        blob_ids = [attachment_params].flatten
+        inbox_id = nil
+      end
+
+      return unless @rule.files.attached?
+
+      blobs = ActiveStorage::Blob.where(id: blob_ids)
+      return if blobs.blank?
+
+      params = { content: nil, private: false, attachments: blobs }
+
+      if inbox_id
+        inbox = Inbox.find_by(id: inbox_id)
+        if inbox && @conversation.inbox != inbox
+          Rails.logger.warn "Automation Rule #{@rule.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
+        end
+      end
+
+      Messages::MessageBuilder.new(nil, @conversation, params).perform
+    rescue StandardError => e
+      Rails.logger.error "Automation Rule #{@rule.id}: Error sending attachment: #{e.message}"
+      raise e
+    end
+
+    # --- Email -------------------------------------------------------------
+
+    def send_email_to_team(params)
+      return unless @conversation
+
+      teams = Team.where(id: params[0][:team_ids])
+      teams.each do |team|
+        TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, params[0][:message])&.deliver_now
+      end
+    end
+
+    def send_email_transcript(emails)
+      return unless @conversation
+
+      emails = emails[0].gsub(/\s+/, '').split(',')
+      emails.each do |email|
+        email = parse_email_variables(@conversation, email)
+        ConversationReplyMailer.with(account: nil).conversation_transcript(@conversation, email)&.deliver_later
+      end
+    end
+
+    # --- Webhook -----------------------------------------------------------
+
+    # Unified canonical event string across the simple, flow and
+    # contact executors. The trigger identity is carried by `@rule.event_name`
+    # (e.g. conversation_updated, contact_created). Verify no downstream
+    # consumer filters on the legacy `automation_flow.*` / bare `contact_*`
+    # prefixes before relying on this contract.
+    def send_webhook_event(webhook_url)
+      payload_data = @conversation ? @conversation.webhook_data : (@contact&.webhook_data || {})
+      payload = payload_data.merge(event: "automation_event.#{@rule.event_name}")
+
+      clean_url = webhook_url[0].to_s.strip
+      WebhookJob.perform_later(clean_url, payload)
+    end
+
+    # --- Helpers -----------------------------------------------------------
+
+    def agent_belongs_to_inbox?(agent_ids)
+      member_ids = @conversation.inbox.members.pluck(:user_id)
+      assignable_agent_ids = member_ids + User.where(type: 'SuperAdmin').pluck(:id)
+
+      assignable_agent_ids.include?(agent_ids[0])
+    end
+
+    def team_belongs_to_account?(team_ids)
+      Team.exists?(id: team_ids[0])
+    end
+
+    def conversation_a_tweet?
+      @conversation&.additional_attributes&.dig('type') == 'tweet'
+    end
+
+    def resolve_label_titles(values)
+      values = Array(values).map(&:to_s).reject(&:empty?)
+      return [] if values.empty?
+
+      uuids, others = values.partition { |v| UUID_LABEL_REGEX.match?(v) }
+      return others if uuids.empty?
+
+      titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h.transform_keys(&:to_s)
+      resolved     = uuids.filter_map { |id| titles_by_id[id] }
+
+      (others + resolved).uniq
+    end
+  end
+end

--- a/app/services/automation_rules/flow_execution_service.rb
+++ b/app/services/automation_rules/flow_execution_service.rb
@@ -1,8 +1,10 @@
 class AutomationRules::FlowExecutionService
-  # EVO-1262: pipeline + message action implementations come from the shared
-  # modules so this canvas executor delegates to the same code paths as the
-  # modal AutomationRules::ActionService. See README.md in this directory for
-  # how to add a new node type.
+  # Every action implementation comes from the shared
+  # modules so this canvas executor runs the exact same code paths as the
+  # modal AutomationRules::ActionService — no standalone reimplementations,
+  # no silent divergence. This class only owns flow-control (walking nodes/
+  # edges) and the node_data → action_params normalisation. See README.md.
+  include AutomationRules::ConversationActionHandlers
   include AutomationRules::PipelineActionHandlers
   include AutomationRules::MessageActionHandlers
 
@@ -94,6 +96,7 @@ class AutomationRules::FlowExecutionService
       mute-conversation-node
       snooze-conversation-node
       resolve-conversation-node
+      change-status-node
       change-priority-node
       assign-to-pipeline-node
       move-to-pipeline-stage-node
@@ -105,6 +108,10 @@ class AutomationRules::FlowExecutionService
     action_node_types.include?(node_type)
   end
 
+  # Normalises each canvas node's `data` into the array/hash shape the shared
+  # action methods expect, then invokes the private method. Both executors
+  # therefore hit identical code paths in ConversationActionHandlers /
+  # PipelineActionHandlers / MessageActionHandlers.
   def execute_node_action(node)
     node_type = node['type']
     node_data = node['data'] || {}
@@ -130,11 +137,9 @@ class AutomationRules::FlowExecutionService
 
       when 'send-attachment-node'
         if node_data['attachment_ids']&.any?
-          attachment_params = {
-            attachment_ids: node_data['attachment_ids']
-          }
+          attachment_params = { attachment_ids: node_data['attachment_ids'] }
           attachment_params[:inbox_id] = node_data['inboxId'] if node_data['inboxId']
-          send_attachment([attachment_params])
+          send_attachment(attachment_params)
         end
 
       when 'send-webhook-node'
@@ -149,6 +154,11 @@ class AutomationRules::FlowExecutionService
       when 'resolve-conversation-node'
         resolve_conversation
 
+      # Change-status was missing from the whitelist + dispatch, so
+      # the node was a silent no-op. Wire it to the canonical change_status.
+      when 'change-status-node'
+        change_status([node_data['status']]) if node_data['status']
+
       when 'change-priority-node'
         change_priority([node_data['priority']]) if node_data['priority']
 
@@ -161,13 +171,13 @@ class AutomationRules::FlowExecutionService
         end
 
       when 'send-transcript-node'
+        # Canonical send_email_transcript expects a single comma-separated
+        # string it can split; normalise the array/scalar node payload here.
         email = node_data['email'] || node_data['emails']
-        send_email_transcript([email]) if email
+        send_email_transcript([Array(email).join(',')]) if email.present?
 
-      # EVO-1262: 5 new node types delegate to the shared modules. Node data
-      # is normalised to the {id: ...} shape that ActionService consumes so
-      # both executors hit identical code paths in PipelineActionHandlers /
-      # MessageActionHandlers — see README.md in this directory.
+      # EVO-1262: 5 node types delegate to the pipeline/message modules. Node
+      # data is normalised to the {id: ...} shape ActionService consumes.
       when 'assign-to-pipeline-node'
         pipeline_id = node_data['pipeline_id'] || node_data['id']
         assign_to_pipeline([{ id: pipeline_id }]) if pipeline_id
@@ -197,187 +207,5 @@ class AutomationRules::FlowExecutionService
       Rails.logger.error "Automation Rule #{@rule.id}: Node data: #{node_data.inspect}"
       EvolutionExceptionTracker.new(e).capture_exception
     end
-  end
-
-  # Override webhook method para context específico de flows
-  def send_webhook_event(webhook_url)
-    payload_data = @conversation ? @conversation.webhook_data : (@contact&.webhook_data || {})
-    payload = payload_data.merge(event: "automation_flow.#{@rule.event_name}")
-
-    # Sanitize the webhook URL to remove any leading/trailing whitespace or tabs
-    clean_url = webhook_url[0].to_s.strip
-    Rails.logger.info "Automation Rule #{@rule.id}: Sending webhook to #{clean_url}"
-    WebhookJob.perform_later(clean_url, payload)
-  end
-
-  # Implementações das ações básicas
-  def assign_agent(agent_ids)
-    return unless @conversation
-
-    agent_id = agent_ids.is_a?(Array) ? agent_ids.first : agent_ids
-    agent = User.find_by(id: agent_id)
-    return unless agent
-
-    @conversation.update!(assignee: agent)
-    Rails.logger.info "Automation Rule #{@rule.id}: Assigned conversation to agent #{agent.name}"
-  end
-
-  def assign_team(team_ids)
-    return unless @conversation
-
-    team_id = team_ids.is_a?(Array) ? team_ids.first : team_ids
-    team = Team.find_by(id: team_id)
-    return unless team
-
-    @conversation.update!(team: team)
-    Rails.logger.info "Automation Rule #{@rule.id}: Assigned conversation to team #{team.name}"
-  end
-
-  def add_label(label_ids)
-    labels = Label.where(id: label_ids)
-    return if labels.empty?
-
-    if @conversation
-      @conversation.label_list.add(labels.pluck(:title))
-      @conversation.save!
-      Rails.logger.info "Automation Rule #{@rule.id}: Added #{labels.count} labels to conversation"
-    elsif @contact
-      # Ensure Current.executed_by is set to prevent loop
-      Current.executed_by = @rule
-      # F-2: route through the setter so `saved_change_to_label_list?`
-      # dirty-tracks the change and Contact#publish_label_changes fires.
-      titles = labels.pluck(:title)
-      @contact.update!(label_list: (@contact.label_list + titles).uniq)
-      Rails.logger.info "Automation Rule #{@rule.id}: Added #{labels.count} labels to contact #{@contact.name}"
-    else
-      Rails.logger.warn "Automation Rule #{@rule.id}: No conversation or contact to add labels to"
-    end
-  end
-
-  def remove_label(label_ids)
-    labels = Label.where(id: label_ids)
-    return if labels.empty?
-
-    if @conversation
-      @conversation.label_list.remove(labels.pluck(:title))
-      @conversation.save!
-      Rails.logger.info "Automation Rule #{@rule.id}: Removed #{labels.count} labels from conversation"
-    elsif @contact
-      # Ensure Current.executed_by is set to prevent loop
-      Current.executed_by = @rule
-      # F-2: see add_label above — setter path dirties label_list.
-      titles = labels.pluck(:title)
-      @contact.update!(label_list: @contact.label_list - titles)
-      Rails.logger.info "Automation Rule #{@rule.id}: Removed #{labels.count} labels from contact #{@contact.name}"
-    else
-      Rails.logger.warn "Automation Rule #{@rule.id}: No conversation or contact to remove labels from"
-    end
-  end
-
-  def send_message(message_params)
-    return unless @conversation
-    return if conversation_a_tweet?
-
-    message = message_params.is_a?(Array) ? message_params.first : message_params
-    params = { content: message, private: false, content_attributes: { automation_rule_id: @rule.id } }
-
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-    Rails.logger.info "Automation Rule #{@rule.id}: Sent message to conversation"
-  end
-
-  def send_attachment(attachment_params)
-    return unless @conversation
-    return if conversation_a_tweet?
-
-    # attachment_params já vem no formato correto do node
-    attachment_data = attachment_params[0]
-
-    if attachment_data.is_a?(Hash)
-      blob_ids = attachment_data[:attachment_ids] || attachment_data['attachment_ids']
-      inbox_id = attachment_data[:inbox_id] || attachment_data['inbox_id']
-    else
-      blob_ids = attachment_data
-      inbox_id = nil
-    end
-
-    return unless @rule.files.attached?
-
-    blobs = ActiveStorage::Blob.where(id: blob_ids)
-    return if blobs.blank?
-
-    # Preparar parâmetros da mensagem
-    params = { content: nil, private: false, attachments: blobs }
-
-    # Validar inbox se especificado
-    if inbox_id
-      inbox = Inbox.find_by(id: inbox_id)
-      if inbox && @conversation.inbox != inbox
-        Rails.logger.warn "Automation Rule #{@rule.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
-      end
-    end
-
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-    Rails.logger.info "Automation Rule #{@rule.id}: Sent attachment with #{blobs.size} files"
-  rescue StandardError => e
-    Rails.logger.error "Automation Rule #{@rule.id}: Error sending attachment: #{e.message}"
-    raise e
-  end
-
-  def mute_conversation
-    return unless @conversation
-
-    @conversation.mute!
-    Rails.logger.info "Automation Rule #{@rule.id}: Muted conversation"
-  end
-
-  def snooze_conversation
-    return unless @conversation
-
-    @conversation.snoozed!
-    Rails.logger.info "Automation Rule #{@rule.id}: Snoozed conversation"
-  end
-
-  def resolve_conversation
-    return unless @conversation
-
-    @conversation.resolved!
-    Rails.logger.info "Automation Rule #{@rule.id}: Resolved conversation"
-  end
-
-  def change_priority(priority_params)
-    return unless @conversation
-
-    priority = priority_params.is_a?(Array) ? priority_params.first : priority_params
-    @conversation.update!(priority: priority)
-    Rails.logger.info "Automation Rule #{@rule.id}: Changed priority to #{priority}"
-  end
-
-  def send_email_to_team(team_params)
-    return unless team_params.is_a?(Array) && team_params.first.is_a?(Hash)
-
-    data = team_params.first
-    team_ids = data[:team_ids] || data['team_ids']
-    message = data[:message] || data['message']
-
-    teams = Team.where(id: team_ids)
-    teams.each do |team|
-      TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, message)&.deliver_now if @conversation
-    end
-
-    Rails.logger.info "Automation Rule #{@rule.id}: Sent email to #{teams.count} teams"
-  end
-
-  def send_email_transcript(email_params)
-    return unless @conversation
-
-    email = email_params.is_a?(Array) ? email_params.first : email_params
-    return if email.blank?
-
-    # Implementar envio de transcript por email se necessário
-    Rails.logger.info "Automation Rule #{@rule.id}: Email transcript requested for #{email}"
-  end
-
-  def conversation_a_tweet?
-    @conversation&.additional_attributes&.dig('type') == 'tweet'
   end
 end

--- a/spec/services/automation_rules/contact_action_service_spec.rb
+++ b/spec/services/automation_rules/contact_action_service_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe AutomationRules::ContactActionService do
 
       expect(WebhookJob).to have_received(:perform_later).with(
         'https://example.com/hook', # whitespace trimmed
-        hash_including(event: 'contact_updated')
+        # Webhook event string unified to automation_event.{event_name}
+        hash_including(event: 'automation_event.contact_updated')
       )
       expect(recorder).to have_received(:add_step).with('Action: send_webhook_event', hash_including(level: 'success'))
     end

--- a/spec/services/automation_rules/contact_action_service_spec.rb
+++ b/spec/services/automation_rules/contact_action_service_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe AutomationRules::ContactActionService do
 
       expect(WebhookJob).to have_received(:perform_later).with(
         'https://example.com/hook', # whitespace trimmed
-        # Webhook event string unified to automation_event.{event_name}
-        hash_including(event: 'automation_event.contact_updated')
+        # EVO-1641: contact webhook string kept as the live external contract.
+        hash_including(event: 'contact_updated')
       )
       expect(recorder).to have_received(:add_step).with('Action: send_webhook_event', hash_including(level: 'success'))
     end

--- a/spec/services/automation_rules/flow_execution_service_spec.rb
+++ b/spec/services/automation_rules/flow_execution_service_spec.rb
@@ -235,15 +235,17 @@ RSpec.describe AutomationRules::FlowExecutionService do
     end
 
     describe 'action_node? whitelist' do
-      it 'recognises all 18 node types (13 legacy + 5 new from EVO-1262)' do
-        new_types = %w[
+      it 'recognises all 19 node types (14 legacy + 5 new from EVO-1262)' do
+        # Added change-status-node (previously missing → silent no-op).
+        recognised = %w[
           assign-to-pipeline-node
           move-to-pipeline-stage-node
           create-pipeline-task-node
           send-canned-response-node
           send-template-node
+          change-status-node
         ]
-        new_types.each do |t|
+        recognised.each do |t|
           expect(flow_service.send(:action_node?, t)).to be(true), "expected #{t} to be a recognised action node"
         end
       end
@@ -280,6 +282,85 @@ RSpec.describe AutomationRules::FlowExecutionService do
 
       expect(conv_modal.reload.pipeline_items.count).to eq(conv_canvas.reload.pipeline_items.count)
       expect(conv_modal.pipeline_items.first.pipeline).to eq(conv_canvas.pipeline_items.first.pipeline)
+    end
+  end
+
+  # The flow executor now shares the canonical conversation actions
+  # with the modal ActionService, fixing the four documented divergences.
+  describe 'conversation action parity' do
+    let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+    let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+    let(:flow_service) { described_class.new(rule, nil, conversation, contact) }
+
+    describe 'change-status-node (was a silent no-op)' do
+      it 'updates the conversation status' do
+        node = { 'type' => 'change-status-node', 'id' => 'n1', 'data' => { 'status' => 'resolved' } }
+        expect { flow_service.send(:execute_node_action, node) }
+          .to change { conversation.reload.status }.to('resolved')
+      end
+
+      it 'no-ops when status is missing' do
+        node = { 'type' => 'change-status-node', 'id' => 'n1', 'data' => {} }
+        expect { flow_service.send(:execute_node_action, node) }
+          .not_to change { conversation.reload.status }
+      end
+    end
+
+    describe 'send-transcript-node (was a logging stub)' do
+      it 'actually enqueues the transcript mail via ConversationReplyMailer' do
+        allow(flow_service).to receive(:parse_email_variables).and_return('ops@example.com')
+        delivery = double('delivery')
+        expect(delivery).to receive(:deliver_later)
+        with_proxy = double('with_proxy')
+        allow(ConversationReplyMailer).to receive(:with).with(account: nil).and_return(with_proxy)
+        allow(with_proxy).to receive(:conversation_transcript).and_return(delivery)
+
+        node = { 'type' => 'send-transcript-node', 'id' => 'n1', 'data' => { 'email' => 'ops@example.com' } }
+        flow_service.send(:execute_node_action, node)
+      end
+    end
+
+    describe 'assign-agent-node (inbox guard was missing)' do
+      let(:member) { User.create!(name: 'Member', email: "m-#{SecureRandom.hex(4)}@test.com") }
+      let(:outsider) { User.create!(name: 'Outsider', email: "o-#{SecureRandom.hex(4)}@test.com") }
+
+      before { InboxMember.create!(inbox: inbox, user: member) }
+
+      it 'assigns an agent who belongs to the inbox' do
+        node = { 'type' => 'assign-agent-node', 'id' => 'n1', 'data' => { 'agent_id' => member.id } }
+        flow_service.send(:execute_node_action, node)
+        expect(conversation.reload.assignee_id).to eq(member.id)
+      end
+
+      it 'does NOT assign an agent outside the inbox' do
+        node = { 'type' => 'assign-agent-node', 'id' => 'n1', 'data' => { 'agent_id' => outsider.id } }
+        flow_service.send(:execute_node_action, node)
+        expect(conversation.reload.assignee_id).to be_nil
+      end
+    end
+
+    describe 'send-webhook-node (event string unified)' do
+      it 'enqueues with the canonical automation_event.{event_name} string' do
+        allow(WebhookJob).to receive(:perform_later)
+        node = { 'type' => 'send-webhook-node', 'id' => 'n1', 'data' => { 'webhook_url' => 'https://example.com/hook' } }
+        flow_service.send(:execute_node_action, node)
+
+        expect(WebhookJob).to have_received(:perform_later).with(
+          'https://example.com/hook',
+          hash_including(event: "automation_event.#{rule.event_name}")
+        )
+      end
+    end
+  end
+
+  # AC8: a contact-triggered flow has no conversation; a conversation-
+  # bound node must degrade to a silent no-op instead of crashing on nil.
+  describe 'contact-only flow safety' do
+    it 'no-ops a conversation-bound node when there is no conversation' do
+      node = { 'type' => 'change-status-node', 'id' => 'n1', 'data' => { 'status' => 'resolved' } }
+      expect { service.send(:execute_node_action, node) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Resumo

`AutomationRules::FlowExecutionService` (modo `flow`) reimplementava as ações de conversa de forma standalone e havia divergido silenciosamente do executor de modo `simple` (`ActionService`). Esta PR extrai as ações para um módulo compartilhado único — **`AutomationRules::ConversationActionHandlers`** — incluído pelos dois executores, no mesmo padrão de mixin da EVO-1262 (`PipelineActionHandlers` / `MessageActionHandlers`). Assim a divergência deixa de ser possível por construção.

Resolve as 4 divergências da EVO-1641:

| Bug | Antes | Depois |
|---|---|---|
| `change-status-node` | ausente do `action_node?`/dispatch → no-op silencioso | ligado ao `change_status` canônico |
| `send_email_transcript` | stub (só logava) | envia de fato via `ConversationReplyMailer` |
| `assign_agent` | sem o guard de inbox | passa por `agent_belongs_to_inbox?` |
| string do webhook | `automation_flow.*` / `contact_*` | unificada em `automation_event.{event_name}` |

`FlowExecutionService` passa a conter **apenas** controle de fluxo (percorrer nós/arestas) e a normalização de `node_data` — zero corpos de ação. `ActionService` e `Macros::ExecutionService` ficam inalterados. Net **-368/+358**.

## Plano de teste

```
POSTGRES_HOST=127.0.0.1 POSTGRES_PASSWORD=*** POSTGRES_USERNAME=postgres \
POSTGRES_DATABASE=evolution_test RAILS_ENV=test \
bundle exec rspec spec/services/automation_rules/ spec/services/macros/ spec/listeners/automation_rule_listener_*spec.rb
```

- `spec/services/automation_rules/` (inclui novos casos EVO-1641 + paridade EVO-1262) — ✅
- `spec/services/macros/execution_service_spec.rb` — ✅ exceto **1 falha pré-existente** no `develop` (`:27`, webhook do macro), confirmada via stash; não é desta PR.
- specs de listener (contact/observability/conditions/attribute-changed/pipeline-stage) — ✅ 24/24
- Resolução de métodos verificada em runtime: as 14 ações resolvem para o módulo nos dois executores; Macros mantém suas próprias sobrescritas.

## Notas de revisão

1. **Efeito colateral de paridade (intencional):** add/remove label numa **conversa** agora passa por `update!(label_list:)`, que faz dirty-track e gera a *activity message* de label no timeline. O caminho antigo do flow (`label_list.add + save!`) pulava isso silenciosamente — mesmo bug latente que a EVO-1635 (F-2) já corrigiu para contatos. As labels sempre foram aplicadas corretamente; o que muda é a entrada de timeline.

2. **String do webhook (validar antes de mergear):** a mudança `contact_*`/`automation_flow.*` → `automation_event.{event_name}` é **outbound-only** (o `WebhookJob` só faz POST para a URL externa; nenhum consumidor interno ramifica nela). Se algum **consumidor externo** filtra pelos prefixos antigos, isso é breaking para ele. Confirmar com o time.

3. Divergências de borda em `assign_team` e `change_priority` só aparecem com sentinelas (`'0'`/`'nil'`) que um flow não envia; para entradas válidas o comportamento é idêntico.

Parte de [EVO-1637]. Relacionado a EVO-1635.

## Summary by Sourcery

Unify conversation-bound automation actions between flow and simple executors by centralizing them in a shared module, fixing previously divergent behaviors and aligning webhook events.

Bug Fixes:
- Ensure change-status flow nodes execute correctly instead of silently no-oping.
- Make send-transcript flow nodes actually send conversation transcripts via the standard mailer.
- Apply inbox membership checks when assigning agents from flow rules, matching the simple executor.
- Standardize automation webhook event names to the automation_event.{event_name} format across conversation and contact executors.

Enhancements:
- Refactor FlowExecutionService to focus solely on flow control and node data normalization while delegating actions to shared handlers.
- Introduce AutomationRules::ConversationActionHandlers and include it in both ActionService and FlowExecutionService to eliminate duplicated implementations.
- Align label handling so conversation label changes go through update! and generate timeline activity messages.
- Add parity and safety specs to ensure consistent behavior between executors and for contact-only flows.

Documentation:
- Update automation rules README to document the new conversation action handlers and clarify executor responsibilities.

Tests:
- Extend automation flow executor specs to cover conversation action parity, webhook behavior, and contact-only flow safety.
- Update contact action service specs to assert the unified webhook event naming scheme.