### PR TITLE
refactor(automation): contact-capable conditions filter + shadow-compare (EVO-1642)

### DIFF
--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -336,6 +336,26 @@ class AutomationRuleListener < BaseListener
     end
   end
 
+  # EVO-1642 (shadow phase): run the SQL ConditionsFilterService alongside the
+  # authoritative Ruby evaluator and log any disagreement, so we can prove prod
+  # parity before retiring the Ruby path. Behaviour is unchanged — Ruby stays
+  # authoritative — and a failing shadow must never break the live run.
+  def shadow_compare_contact_conditions(rule, contact, changed_attributes, ruby_match)
+    sql_match = ::AutomationRules::ConditionsFilterService.new(
+      rule, nil, { contact: contact, changed_attributes: changed_attributes }
+    ).perform
+
+    # Both evaluators already return booleans; compare directly.
+    return if sql_match == ruby_match
+
+    Rails.logger.warn(
+      "[ConditionsParity] rule=#{rule.id} event=#{rule.event_name} ruby=#{ruby_match} " \
+      "sql=#{sql_match} conditions=#{rule.conditions.inspect}"
+    )
+  rescue StandardError => e
+    Rails.logger.warn("[ConditionsParity] rule=#{rule&.id} event=#{rule&.event_name} sql_error=#{e.class}: #{e.message}")
+  end
+
   def contact_attribute_match?(contact, attribute_key, filter_operator, values)
     case attribute_key
     when 'labels'
@@ -438,6 +458,7 @@ class AutomationRuleListener < BaseListener
     recorder.add_step('Event received', data: { event_name: rule.event_name, changed_attributes: changed_attributes })
 
     conditions_match = evaluate_contact_conditions(rule, contact, changed_attributes)
+    shadow_compare_contact_conditions(rule, contact, changed_attributes, conditions_match)
     recorder.add_step(
       'Conditions evaluated',
       level: conditions_match ? 'success' : 'info',

--- a/app/services/action_service.rb
+++ b/app/services/action_service.rb
@@ -1,119 +1,17 @@
 class ActionService
   include EmailHelper
+  # Conversation action implementations now live in a single shared
+  # module so the modal and flow-canvas automation executors cannot diverge.
+  # Macros::ExecutionService < ActionService reaches the same code path here.
+  include AutomationRules::ConversationActionHandlers
 
   def initialize(conversation)
     @conversation = conversation.reload
   end
 
-  def mute_conversation(_params)
-    @conversation.mute!
-  end
-
-  def snooze_conversation(_params)
-    @conversation.snoozed!
-  end
-
-  def resolve_conversation(_params)
-    @conversation.resolved!
-  end
-
-  def change_status(status)
-    @conversation.update!(status: status[0])
-  end
-
-  def change_priority(priority)
-    @conversation.update!(priority: (priority[0] == 'nil' ? nil : priority[0]))
-  end
-
-  def add_label(labels)
-    return if labels.empty?
-
-    @conversation.reload.add_labels(resolve_label_titles(labels))
-  end
-
-  def assign_agent(agent_ids = [])
-    return @conversation.update!(assignee_id: nil) if agent_ids[0] == 'nil'
-
-    return unless agent_belongs_to_inbox?(agent_ids)
-
-    @agent = User.find_by(id: agent_ids)
-
-    @conversation.update!(assignee_id: @agent.id) if @agent.present?
-  end
-
-  def remove_label(labels)
-    return if labels.empty?
-
-    targets = resolve_label_titles(labels)
-    labels  = @conversation.label_list - targets
-    @conversation.update!(label_list: labels)
-  end
-
-  def assign_team(team_ids = [])
-    # FIXME: The explicit checks for zero or nil (string) is bad. Move
-    # this to a separate unassign action.
-    should_unassign = team_ids.blank? || %w[nil 0].include?(team_ids[0].to_s)
-    return @conversation.update!(team_id: nil) if should_unassign
-
-    # check if team belongs to account only if team_id is present
-    # if team_id is nil, then it means that the team is being unassigned
-    return unless !team_ids[0].nil? && team_belongs_to_account?(team_ids)
-
-    @conversation.update!(team_id: team_ids[0])
-  end
-
   def remove_assigned_team(_params)
     @conversation.update!(team_id: nil)
   end
-
-  def send_email_transcript(emails)
-    emails = emails[0].gsub(/\s+/, '').split(',')
-
-    emails.each do |email|
-      email = parse_email_variables(@conversation, email)
-      ConversationReplyMailer.with(account: nil).conversation_transcript(@conversation, email)&.deliver_later
-    end
-  end
-
-  private
-
-  def agent_belongs_to_inbox?(agent_ids)
-    member_ids = @conversation.inbox.members.pluck(:user_id)
-    assignable_agent_ids = member_ids + User.where(type: 'SuperAdmin').pluck(:id)
-
-    assignable_agent_ids.include?(agent_ids[0])
-  end
-
-  def team_belongs_to_account?(team_ids)
-    Team.exists?(id: team_ids[0])
-  end
-
-  def conversation_a_tweet?
-    return false if @conversation.additional_attributes.blank?
-
-    @conversation.additional_attributes['type'] == 'tweet'
-  end
-
-  # Automation rules persist label_ids (UUIDs) in `action_params`, but
-  # `acts_as_taggable_on :labels` stores tags by their **title** in
-  # `tags.name`. Translate any UUIDs in the incoming array to their Label
-  # title; values that aren't UUIDs (legacy rules that already stored titles)
-  # are kept as-is so we don't break older configurations.
-  UUID_LABEL_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/.freeze
-
-  def resolve_label_titles(values)
-    values = Array(values).map(&:to_s).reject(&:empty?)
-    return [] if values.empty?
-
-    uuids, others = values.partition { |v| UUID_LABEL_REGEX.match?(v) }
-    return others if uuids.empty?
-
-    titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h.transform_keys(&:to_s)
-    resolved     = uuids.filter_map { |id| titles_by_id[id] }
-
-    (others + resolved).uniq
-  end
-  private :resolve_label_titles
 end
 
 ActionService.include_mod_with('ActionService')

--- a/app/services/automation_rules/README.md
+++ b/app/services/automation_rules/README.md
@@ -15,10 +15,11 @@ This directory hosts two executor surfaces that share their action implementatio
 
 Both executors call the same Ruby methods for the cross-cutting actions:
 
+- `conversation_action_handlers.rb` (`AutomationRules::ConversationActionHandlers`) — the conversation-bound actions: `assign_agent` (with the `agent_belongs_to_inbox?` guard), `assign_team`, `add_label`/`remove_label` (conversation **or** contact), `change_status`, `change_priority`, `mute`/`snooze`/`resolve_conversation`, `send_message`, `send_attachment`, `send_email_to_team`, `send_email_transcript`, `send_webhook_event` (canonical `automation_event.{event_name}` string), plus helpers. Added to kill the flow-vs-simple divergence; included by the base `ActionService` (so the simple executor and `Macros::ExecutionService` reach it) and by `FlowExecutionService`.
 - `pipeline_action_handlers.rb` (`AutomationRules::PipelineActionHandlers`) — `assign_to_pipeline`, `update_pipeline_stage`, `create_pipeline_task`, helpers.
 - `message_action_handlers.rb` (`AutomationRules::MessageActionHandlers`) — `send_canned_response`, `send_template` (with `{{contact.field}}` / `{{conversation.field}}` resolution), helpers.
 
-Each module declares its methods `private`; when included into a class, they become private instance methods of that class. Both `ActionService` and `FlowExecutionService` include the modules; behaviour is identical between the two surfaces because the implementation is identical.
+Each module declares its methods `private`; when included into a class, they become private instance methods of that class. Both `ActionService` and `FlowExecutionService` include the modules; behaviour is identical between the two surfaces because the implementation is identical. `FlowExecutionService` owns only flow-control (walking nodes/edges) and the `node_data` → `action_params` normalisation — it holds **zero** action bodies.
 
 ## How to add a new node type
 

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -1,8 +1,9 @@
 class AutomationRules::ActionService < ActionService
   # Pipeline + message action implementations live in shared modules so the
   # flow-canvas executor (FlowExecutionService) can reuse the same code
-  # without duplication. Behaviour here is unchanged — methods are still
-  # private and dispatched via `send` from `perform`.
+  # without duplication. The conversation-bound actions (assign/label/status/
+  # message/attachment/email/webhook) come from ConversationActionHandlers via
+  # the base ActionService — see app/services/automation_rules/README.md.
   include AutomationRules::PipelineActionHandlers
   include AutomationRules::MessageActionHandlers
 
@@ -26,63 +27,5 @@ class AutomationRules::ActionService < ActionService
     end
   ensure
     Current.reset
-  end
-
-  private
-
-  def send_attachment(attachment_params)
-    return if conversation_a_tweet?
-
-    if attachment_params.is_a?(Array)
-      blob_ids = attachment_params
-      inbox_id = nil
-    elsif attachment_params.is_a?(Hash)
-      blob_ids = attachment_params[:attachment_ids] || attachment_params['attachment_ids']
-      inbox_id = attachment_params[:inbox_id] || attachment_params['inbox_id']
-    else
-      blob_ids = [attachment_params].flatten
-      inbox_id = nil
-    end
-
-    return unless @rule.files.attached?
-
-    blobs = ActiveStorage::Blob.where(id: blob_ids)
-
-    return if blobs.blank?
-
-    params = { content: nil, private: false, attachments: blobs }
-
-    if inbox_id
-      inbox = Inbox.find_by(id: inbox_id)
-      if inbox && @conversation.inbox != inbox
-        Rails.logger.warn "Automation Rule #{@rule.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
-      end
-    end
-
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-  rescue StandardError => e
-    Rails.logger.error "Automation Rule #{@rule.id}: Error sending attachment: #{e.message}"
-    raise e
-  end
-
-  def send_webhook_event(webhook_url)
-    payload = @conversation.webhook_data.merge(event: "automation_event.#{@rule.event_name}")
-    clean_url = webhook_url[0].to_s.strip
-    WebhookJob.perform_later(clean_url, payload)
-  end
-
-  def send_message(message)
-    return if conversation_a_tweet?
-
-    params = { content: message[0], private: false, content_attributes: { automation_rule_id: @rule.id } }
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-  end
-
-  def send_email_to_team(params)
-    teams = Team.where(id: params[0][:team_ids])
-
-    teams.each do |team|
-      TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, params[0][:message])&.deliver_now
-    end
   end
 end

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -15,6 +15,9 @@ class AutomationRules::ConditionsFilterService < FilterService
     super([], nil)
     @rule = rule
     @conversation = conversation
+    # EVO-1642: contact-triggered rules with only-contact conditions run with
+    # no conversation in scope; the base relation falls back to the contact.
+    @contact = options[:contact]
 
     # setup filters from json file
     file = File.read('./lib/filters/filter_keys.yml')
@@ -124,11 +127,15 @@ class AutomationRules::ConditionsFilterService < FilterService
   # resolved) and Ruby's `Array.in?([])` is always false, so the rule never
   # fires.
   def scalar_transition_match?(filter, changed_attribute)
-    from_values = Array(filter['values']['from'])
-    to_values = Array(filter['values']['to'])
+    # EVO-1642: coerce both sides to String before comparing. Condition values
+    # are stored as strings (e.g. 'true'), but changed_attribute can carry the
+    # native type (e.g. boolean false for `blocked`), so `false.in?(['false'])`
+    # was silently never matching. Mirrors the Ruby contact evaluator.
+    from_values = Array(filter['values']['from']).map(&:to_s)
+    to_values = Array(filter['values']['to']).map(&:to_s)
 
-    from_match = from_values.empty? || changed_attribute[0].in?(from_values)
-    to_match = to_values.empty? || changed_attribute[1].in?(to_values)
+    from_match = from_values.empty? || changed_attribute[0].to_s.in?(from_values)
+    to_match = to_values.empty? || changed_attribute[1].to_s.in?(to_values)
 
     from_match && to_match
   end
@@ -260,23 +267,37 @@ class AutomationRules::ConditionsFilterService < FilterService
   # of conversation- and contact-level tags.
   def labels_query_fragment(query_hash, current_index, query_operator)
     filter_operator = query_hash[:filter_operator] || query_hash['filter_operator']
-    negate = filter_operator == 'not_equal_to'
+    # EVO-1642: is_present / is_not_present ask "does the record have ANY label"
+    # — there are no specific titles to match, so the `name IN (...)` clause is
+    # dropped. Without this they degraded to `IN (<empty>)` and never matched.
+    presence = %w[is_present is_not_present].include?(filter_operator)
+    negate = %w[not_equal_to is_not_present].include?(filter_operator)
 
     existence = negate ? 'NOT EXISTS' : 'EXISTS'
+
+    # EVO-1642: with a conversation the "label" is the union of conversation-
+    # and contact-level tags; for a contact-only rule (no conversation in the
+    # base relation) only the contact's own tags exist.
+    taggable_match =
+      if @conversation.present?
+        "(lbl_tg.taggable_type = 'Conversation' AND lbl_tg.taggable_id = conversations.id) " \
+          "OR (lbl_tg.taggable_type = 'Contact' AND lbl_tg.taggable_id = contacts.id)"
+      else
+        "lbl_tg.taggable_type = 'Contact' AND lbl_tg.taggable_id = contacts.id"
+      end
+
+    name_clause = presence ? '' : "AND lbl_t.name IN (:value_#{current_index})"
 
     subquery = <<~SQL.squish
       SELECT 1
         FROM taggings AS lbl_tg
         JOIN tags    AS lbl_t ON lbl_t.id = lbl_tg.tag_id
        WHERE lbl_tg.context = 'labels'
-         AND (
-              (lbl_tg.taggable_type = 'Conversation' AND lbl_tg.taggable_id = conversations.id)
-           OR (lbl_tg.taggable_type = 'Contact'      AND lbl_tg.taggable_id = contacts.id)
-         )
-         AND lbl_t.name IN (:value_#{current_index})
+         AND (#{taggable_match})
+         #{name_clause}
     SQL
 
-    @filter_values["value_#{current_index}"] = Array(query_hash['values'])
+    @filter_values["value_#{current_index}"] = Array(query_hash['values']) unless presence
 
     " #{existence} (#{subquery}) #{query_operator} "
   end
@@ -290,6 +311,12 @@ class AutomationRules::ConditionsFilterService < FilterService
   end
 
   def build_query_string(filters, query_hash, current_index)
+    # EVO-1642: some keys (e.g. country_code, labels) live in BOTH the
+    # conversations and contacts filter sections. With no conversation in the
+    # base relation, resolve them against contacts — otherwise the query would
+    # reference the absent `conversations` table and error out.
+    return contact_query_string(filters[:contact], query_hash.with_indifferent_access, current_index) if @conversation.nil? && filters[:contact]
+
     if filters[:conversation]
       conversation_query_string('conversations', filters[:conversation], query_hash.with_indifferent_access, current_index)
     elsif filters[:contact]
@@ -318,6 +345,12 @@ class AutomationRules::ConditionsFilterService < FilterService
   end
 
   def base_relation
+    # EVO-1642: contact-only rules (no conversation) match directly against the
+    # contact row. Only contacts.* columns and the labels EXISTS subquery are
+    # referenced for these rules (see rule_has_only_contact_conditions?), so no
+    # conversation/message/pipeline JOIN is needed.
+    return Contact.where(id: @contact.id) if @conversation.nil? && @contact.present?
+
     records = Conversation.where(id: @conversation.id).joins(
       'LEFT OUTER JOIN contacts on conversations.contact_id = contacts.id'
     ).joins(

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -10,6 +10,13 @@
 # recorded on the run as `skipped` with a reason, so the outcome is observable
 # in the automation logs (`automation_rule_runs`).
 class AutomationRules::ContactActionService
+  # EVO-1642: contact-level labels are the canonical implementations in the
+  # shared module — included here so this executor stops hand-rolling its own
+  # add_label/remove_label. `@contact` is set and `@conversation` is nil, so
+  # they take the contact branch. `send_webhook_event` stays local because the
+  # contact webhook event string is a live external contract (see below).
+  include AutomationRules::ConversationActionHandlers
+
   # Actions that operate on the contact itself and need no conversation.
   CONTACT_NATIVE_ACTIONS = %w[send_webhook_event add_label remove_label].freeze
 
@@ -65,36 +72,17 @@ class AutomationRules::ContactActionService
     end
   end
 
+  # Kept local (not delegated to the shared module): the contact webhook event
+  # string is a LIVE external contract — integrations filter on
+  # `contact_created`/`contact_updated`. Only the dormant flow executor was
+  # unified to `automation_event.*` (EVO-1641 review). Also guards a blank URL.
   def send_webhook_event(action_params)
     webhook_url = action_params.is_a?(Array) ? action_params[0] : action_params
     return if webhook_url.blank?
 
     clean_url = webhook_url.to_s.strip
-    # EVO-1641: the contact webhook string is a LIVE external contract
-    # (integrations filter on `contact_created`/`contact_updated`), so it stays
-    # as-is. Only the dormant flow executor was unified to `automation_event.*`.
     payload = (@contact.webhook_data || {}).merge(event: "contact_#{@rule.event_name.split('_').last}")
     WebhookJob.perform_later(clean_url, payload)
     Rails.logger.info "Automation Rule #{@rule.id}: Sent webhook to #{clean_url} for contact #{@contact.id}"
-  end
-
-  def add_label(label_ids)
-    labels = Label.where(id: label_ids)
-    return if labels.empty?
-
-    # Route through the setter so `saved_change_to_label_list?` dirty-tracks the
-    # change and Contact#publish_label_changes fires (mirrors FlowExecutionService).
-    titles = labels.pluck(:title)
-    @contact.update!(label_list: (@contact.label_list + titles).uniq)
-    Rails.logger.info "Automation Rule #{@rule.id}: Added #{labels.count} labels to contact #{@contact.id}"
-  end
-
-  def remove_label(label_ids)
-    labels = Label.where(id: label_ids)
-    return if labels.empty?
-
-    titles = labels.pluck(:title)
-    @contact.update!(label_list: @contact.label_list - titles)
-    Rails.logger.info "Automation Rule #{@rule.id}: Removed #{labels.count} labels from contact #{@contact.id}"
   end
 end

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -70,7 +70,8 @@ class AutomationRules::ContactActionService
     return if webhook_url.blank?
 
     clean_url = webhook_url.to_s.strip
-    payload = (@contact.webhook_data || {}).merge(event: "contact_#{@rule.event_name.split('_').last}")
+    # Unified canonical event string across all three executors.
+    payload = (@contact.webhook_data || {}).merge(event: "automation_event.#{@rule.event_name}")
     WebhookJob.perform_later(clean_url, payload)
     Rails.logger.info "Automation Rule #{@rule.id}: Sent webhook to #{clean_url} for contact #{@contact.id}"
   end

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -70,8 +70,10 @@ class AutomationRules::ContactActionService
     return if webhook_url.blank?
 
     clean_url = webhook_url.to_s.strip
-    # Unified canonical event string across all three executors.
-    payload = (@contact.webhook_data || {}).merge(event: "automation_event.#{@rule.event_name}")
+    # EVO-1641: the contact webhook string is a LIVE external contract
+    # (integrations filter on `contact_created`/`contact_updated`), so it stays
+    # as-is. Only the dormant flow executor was unified to `automation_event.*`.
+    payload = (@contact.webhook_data || {}).merge(event: "contact_#{@rule.event_name.split('_').last}")
     WebhookJob.perform_later(clean_url, payload)
     Rails.logger.info "Automation Rule #{@rule.id}: Sent webhook to #{clean_url} for contact #{@contact.id}"
   end

--- a/app/services/automation_rules/conversation_action_handlers.rb
+++ b/app/services/automation_rules/conversation_action_handlers.rb
@@ -1,0 +1,237 @@
+module AutomationRules
+  # Single source of truth for the conversation-bound automation
+  # actions that used to be duplicated between the modal executor
+  # (`ActionService` / `AutomationRules::ActionService`) and the flow-canvas
+  # executor (`AutomationRules::FlowExecutionService`). Both surfaces had
+  # silently diverged (change-status no-op, stub transcript, missing inbox
+  # guard on assign_agent, divergent webhook event strings); centralising the
+  # implementations here makes that class of divergence structurally
+  # impossible. See app/services/automation_rules/README.md.
+  #
+  # Included by:
+  #   - `ActionService`                (base; also reaches Macros::ExecutionService)
+  #   - `AutomationRules::ActionService` (via the base class)
+  #   - `AutomationRules::FlowExecutionService`
+  #
+  # Required instance state on the including class:
+  #   @conversation — Conversation, or nil for contact-triggered flows.
+  #   @contact      — Contact (only the flow executor sets this; optional).
+  #   @rule         — AutomationRule. Required by the message/attachment/webhook
+  #                   actions (audit attribution + attached files). The base
+  #                   `ActionService` lineage that does not set @rule (Macros)
+  #                   never dispatches those actions through this module.
+  #
+  # All methods are private when included; callers reach them via `send`
+  # (modal/canvas dispatch) or `super` (Macros overrides).
+  module ConversationActionHandlers
+    include EmailHelper
+
+    # Automation rules persist label_ids (UUIDs) in `action_params`, but
+    # `acts_as_taggable_on :labels` stores tags by their **title**. Translate
+    # UUIDs to titles; values that aren't UUIDs (legacy rules that already
+    # stored titles) are kept as-is so older configurations keep working.
+    UUID_LABEL_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
+    private
+
+    # --- Status / priority -------------------------------------------------
+
+    def change_status(status)
+      return unless @conversation
+
+      @conversation.update!(status: status[0])
+    end
+
+    def change_priority(priority)
+      return unless @conversation
+
+      @conversation.update!(priority: (priority[0] == 'nil' ? nil : priority[0]))
+    end
+
+    def mute_conversation(_params = nil)
+      return unless @conversation
+
+      @conversation.mute!
+    end
+
+    def snooze_conversation(_params = nil)
+      return unless @conversation
+
+      @conversation.snoozed!
+    end
+
+    def resolve_conversation(_params = nil)
+      return unless @conversation
+
+      @conversation.resolved!
+    end
+
+    # --- Assignment --------------------------------------------------------
+
+    def assign_agent(agent_ids = [])
+      return unless @conversation
+      return @conversation.update!(assignee_id: nil) if agent_ids[0] == 'nil'
+
+      return unless agent_belongs_to_inbox?(agent_ids)
+
+      @agent = User.find_by(id: agent_ids)
+      @conversation.update!(assignee_id: @agent.id) if @agent.present?
+    end
+
+    def assign_team(team_ids = [])
+      return unless @conversation
+
+      # FIXME: The explicit checks for zero or nil (string) is bad. Move this
+      # to a separate unassign action.
+      should_unassign = team_ids.blank? || %w[nil 0].include?(team_ids[0].to_s)
+      return @conversation.update!(team_id: nil) if should_unassign
+
+      # check if team belongs to account only if team_id is present; if nil it
+      # means the team is being unassigned.
+      return unless !team_ids[0].nil? && team_belongs_to_account?(team_ids)
+
+      @conversation.update!(team_id: team_ids[0])
+    end
+
+    # --- Labels (conversation OR contact) ----------------------------------
+
+    def add_label(labels)
+      return if Array(labels).empty?
+
+      if @conversation
+        @conversation.reload.add_labels(resolve_label_titles(labels))
+      elsif @contact
+        # Ensure Current.executed_by is set to prevent loop, and route through
+        # the setter so `saved_change_to_label_list?` dirty-tracks the change
+        # and Contact#publish_label_changes fires.
+        Current.executed_by = @rule
+        titles = Label.where(id: labels).pluck(:title)
+        @contact.update!(label_list: (@contact.label_list + titles).uniq)
+      end
+    end
+
+    def remove_label(labels)
+      return if Array(labels).empty?
+
+      if @conversation
+        targets = resolve_label_titles(labels)
+        @conversation.update!(label_list: @conversation.label_list - targets)
+      elsif @contact
+        Current.executed_by = @rule
+        titles = Label.where(id: labels).pluck(:title)
+        @contact.update!(label_list: @contact.label_list - titles)
+      end
+    end
+
+    # --- Messaging ---------------------------------------------------------
+
+    def send_message(message)
+      return unless @conversation
+      return if conversation_a_tweet?
+
+      params = { content: message[0], private: false, content_attributes: { automation_rule_id: @rule.id } }
+      Messages::MessageBuilder.new(nil, @conversation, params).perform
+    end
+
+    def send_attachment(attachment_params)
+      return unless @conversation
+      return if conversation_a_tweet?
+
+      if attachment_params.is_a?(Array)
+        blob_ids = attachment_params
+        inbox_id = nil
+      elsif attachment_params.is_a?(Hash)
+        blob_ids = attachment_params[:attachment_ids] || attachment_params['attachment_ids']
+        inbox_id = attachment_params[:inbox_id] || attachment_params['inbox_id']
+      else
+        blob_ids = [attachment_params].flatten
+        inbox_id = nil
+      end
+
+      return unless @rule.files.attached?
+
+      blobs = ActiveStorage::Blob.where(id: blob_ids)
+      return if blobs.blank?
+
+      params = { content: nil, private: false, attachments: blobs }
+
+      if inbox_id
+        inbox = Inbox.find_by(id: inbox_id)
+        if inbox && @conversation.inbox != inbox
+          Rails.logger.warn "Automation Rule #{@rule.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
+        end
+      end
+
+      Messages::MessageBuilder.new(nil, @conversation, params).perform
+    rescue StandardError => e
+      Rails.logger.error "Automation Rule #{@rule.id}: Error sending attachment: #{e.message}"
+      raise e
+    end
+
+    # --- Email -------------------------------------------------------------
+
+    def send_email_to_team(params)
+      return unless @conversation
+
+      teams = Team.where(id: params[0][:team_ids])
+      teams.each do |team|
+        TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, params[0][:message])&.deliver_now
+      end
+    end
+
+    def send_email_transcript(emails)
+      return unless @conversation
+
+      emails = emails[0].gsub(/\s+/, '').split(',')
+      emails.each do |email|
+        email = parse_email_variables(@conversation, email)
+        ConversationReplyMailer.with(account: nil).conversation_transcript(@conversation, email)&.deliver_later
+      end
+    end
+
+    # --- Webhook -----------------------------------------------------------
+
+    # Unified canonical event string across the simple, flow and
+    # contact executors. The trigger identity is carried by `@rule.event_name`
+    # (e.g. conversation_updated, contact_created). Verify no downstream
+    # consumer filters on the legacy `automation_flow.*` / bare `contact_*`
+    # prefixes before relying on this contract.
+    def send_webhook_event(webhook_url)
+      payload_data = @conversation ? @conversation.webhook_data : (@contact&.webhook_data || {})
+      payload = payload_data.merge(event: "automation_event.#{@rule.event_name}")
+
+      clean_url = webhook_url[0].to_s.strip
+      WebhookJob.perform_later(clean_url, payload)
+    end
+
+    # --- Helpers -----------------------------------------------------------
+
+    def agent_belongs_to_inbox?(agent_ids)
+      member_ids = @conversation.inbox.members.pluck(:user_id)
+      assignable_agent_ids = member_ids + User.where(type: 'SuperAdmin').pluck(:id)
+
+      assignable_agent_ids.include?(agent_ids[0])
+    end
+
+    def team_belongs_to_account?(team_ids)
+      Team.exists?(id: team_ids[0])
+    end
+
+    def conversation_a_tweet?
+      @conversation&.additional_attributes&.dig('type') == 'tweet'
+    end
+
+    def resolve_label_titles(values)
+      values = Array(values).map(&:to_s).reject(&:empty?)
+      return [] if values.empty?
+
+      uuids, others = values.partition { |v| UUID_LABEL_REGEX.match?(v) }
+      return others if uuids.empty?
+
+      titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h.transform_keys(&:to_s)
+      resolved     = uuids.filter_map { |id| titles_by_id[id] }
+
+      (others + resolved).uniq
+    end
+  end
+end

--- a/app/services/automation_rules/flow_execution_service.rb
+++ b/app/services/automation_rules/flow_execution_service.rb
@@ -1,8 +1,10 @@
 class AutomationRules::FlowExecutionService
-  # EVO-1262: pipeline + message action implementations come from the shared
-  # modules so this canvas executor delegates to the same code paths as the
-  # modal AutomationRules::ActionService. See README.md in this directory for
-  # how to add a new node type.
+  # Every action implementation comes from the shared
+  # modules so this canvas executor runs the exact same code paths as the
+  # modal AutomationRules::ActionService — no standalone reimplementations,
+  # no silent divergence. This class only owns flow-control (walking nodes/
+  # edges) and the node_data → action_params normalisation. See README.md.
+  include AutomationRules::ConversationActionHandlers
   include AutomationRules::PipelineActionHandlers
   include AutomationRules::MessageActionHandlers
 
@@ -94,6 +96,7 @@ class AutomationRules::FlowExecutionService
       mute-conversation-node
       snooze-conversation-node
       resolve-conversation-node
+      change-status-node
       change-priority-node
       assign-to-pipeline-node
       move-to-pipeline-stage-node
@@ -105,6 +108,10 @@ class AutomationRules::FlowExecutionService
     action_node_types.include?(node_type)
   end
 
+  # Normalises each canvas node's `data` into the array/hash shape the shared
+  # action methods expect, then invokes the private method. Both executors
+  # therefore hit identical code paths in ConversationActionHandlers /
+  # PipelineActionHandlers / MessageActionHandlers.
   def execute_node_action(node)
     node_type = node['type']
     node_data = node['data'] || {}
@@ -130,11 +137,9 @@ class AutomationRules::FlowExecutionService
 
       when 'send-attachment-node'
         if node_data['attachment_ids']&.any?
-          attachment_params = {
-            attachment_ids: node_data['attachment_ids']
-          }
+          attachment_params = { attachment_ids: node_data['attachment_ids'] }
           attachment_params[:inbox_id] = node_data['inboxId'] if node_data['inboxId']
-          send_attachment([attachment_params])
+          send_attachment(attachment_params)
         end
 
       when 'send-webhook-node'
@@ -149,6 +154,11 @@ class AutomationRules::FlowExecutionService
       when 'resolve-conversation-node'
         resolve_conversation
 
+      # Change-status was missing from the whitelist + dispatch, so
+      # the node was a silent no-op. Wire it to the canonical change_status.
+      when 'change-status-node'
+        change_status([node_data['status']]) if node_data['status']
+
       when 'change-priority-node'
         change_priority([node_data['priority']]) if node_data['priority']
 
@@ -161,13 +171,13 @@ class AutomationRules::FlowExecutionService
         end
 
       when 'send-transcript-node'
+        # Canonical send_email_transcript expects a single comma-separated
+        # string it can split; normalise the array/scalar node payload here.
         email = node_data['email'] || node_data['emails']
-        send_email_transcript([email]) if email
+        send_email_transcript([Array(email).join(',')]) if email.present?
 
-      # EVO-1262: 5 new node types delegate to the shared modules. Node data
-      # is normalised to the {id: ...} shape that ActionService consumes so
-      # both executors hit identical code paths in PipelineActionHandlers /
-      # MessageActionHandlers — see README.md in this directory.
+      # EVO-1262: 5 node types delegate to the pipeline/message modules. Node
+      # data is normalised to the {id: ...} shape ActionService consumes.
       when 'assign-to-pipeline-node'
         pipeline_id = node_data['pipeline_id'] || node_data['id']
         assign_to_pipeline([{ id: pipeline_id }]) if pipeline_id
@@ -197,187 +207,5 @@ class AutomationRules::FlowExecutionService
       Rails.logger.error "Automation Rule #{@rule.id}: Node data: #{node_data.inspect}"
       EvolutionExceptionTracker.new(e).capture_exception
     end
-  end
-
-  # Override webhook method para context específico de flows
-  def send_webhook_event(webhook_url)
-    payload_data = @conversation ? @conversation.webhook_data : (@contact&.webhook_data || {})
-    payload = payload_data.merge(event: "automation_flow.#{@rule.event_name}")
-
-    # Sanitize the webhook URL to remove any leading/trailing whitespace or tabs
-    clean_url = webhook_url[0].to_s.strip
-    Rails.logger.info "Automation Rule #{@rule.id}: Sending webhook to #{clean_url}"
-    WebhookJob.perform_later(clean_url, payload)
-  end
-
-  # Implementações das ações básicas
-  def assign_agent(agent_ids)
-    return unless @conversation
-
-    agent_id = agent_ids.is_a?(Array) ? agent_ids.first : agent_ids
-    agent = User.find_by(id: agent_id)
-    return unless agent
-
-    @conversation.update!(assignee: agent)
-    Rails.logger.info "Automation Rule #{@rule.id}: Assigned conversation to agent #{agent.name}"
-  end
-
-  def assign_team(team_ids)
-    return unless @conversation
-
-    team_id = team_ids.is_a?(Array) ? team_ids.first : team_ids
-    team = Team.find_by(id: team_id)
-    return unless team
-
-    @conversation.update!(team: team)
-    Rails.logger.info "Automation Rule #{@rule.id}: Assigned conversation to team #{team.name}"
-  end
-
-  def add_label(label_ids)
-    labels = Label.where(id: label_ids)
-    return if labels.empty?
-
-    if @conversation
-      @conversation.label_list.add(labels.pluck(:title))
-      @conversation.save!
-      Rails.logger.info "Automation Rule #{@rule.id}: Added #{labels.count} labels to conversation"
-    elsif @contact
-      # Ensure Current.executed_by is set to prevent loop
-      Current.executed_by = @rule
-      # F-2: route through the setter so `saved_change_to_label_list?`
-      # dirty-tracks the change and Contact#publish_label_changes fires.
-      titles = labels.pluck(:title)
-      @contact.update!(label_list: (@contact.label_list + titles).uniq)
-      Rails.logger.info "Automation Rule #{@rule.id}: Added #{labels.count} labels to contact #{@contact.name}"
-    else
-      Rails.logger.warn "Automation Rule #{@rule.id}: No conversation or contact to add labels to"
-    end
-  end
-
-  def remove_label(label_ids)
-    labels = Label.where(id: label_ids)
-    return if labels.empty?
-
-    if @conversation
-      @conversation.label_list.remove(labels.pluck(:title))
-      @conversation.save!
-      Rails.logger.info "Automation Rule #{@rule.id}: Removed #{labels.count} labels from conversation"
-    elsif @contact
-      # Ensure Current.executed_by is set to prevent loop
-      Current.executed_by = @rule
-      # F-2: see add_label above — setter path dirties label_list.
-      titles = labels.pluck(:title)
-      @contact.update!(label_list: @contact.label_list - titles)
-      Rails.logger.info "Automation Rule #{@rule.id}: Removed #{labels.count} labels from contact #{@contact.name}"
-    else
-      Rails.logger.warn "Automation Rule #{@rule.id}: No conversation or contact to remove labels from"
-    end
-  end
-
-  def send_message(message_params)
-    return unless @conversation
-    return if conversation_a_tweet?
-
-    message = message_params.is_a?(Array) ? message_params.first : message_params
-    params = { content: message, private: false, content_attributes: { automation_rule_id: @rule.id } }
-
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-    Rails.logger.info "Automation Rule #{@rule.id}: Sent message to conversation"
-  end
-
-  def send_attachment(attachment_params)
-    return unless @conversation
-    return if conversation_a_tweet?
-
-    # attachment_params já vem no formato correto do node
-    attachment_data = attachment_params[0]
-
-    if attachment_data.is_a?(Hash)
-      blob_ids = attachment_data[:attachment_ids] || attachment_data['attachment_ids']
-      inbox_id = attachment_data[:inbox_id] || attachment_data['inbox_id']
-    else
-      blob_ids = attachment_data
-      inbox_id = nil
-    end
-
-    return unless @rule.files.attached?
-
-    blobs = ActiveStorage::Blob.where(id: blob_ids)
-    return if blobs.blank?
-
-    # Preparar parâmetros da mensagem
-    params = { content: nil, private: false, attachments: blobs }
-
-    # Validar inbox se especificado
-    if inbox_id
-      inbox = Inbox.find_by(id: inbox_id)
-      if inbox && @conversation.inbox != inbox
-        Rails.logger.warn "Automation Rule #{@rule.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
-      end
-    end
-
-    Messages::MessageBuilder.new(nil, @conversation, params).perform
-    Rails.logger.info "Automation Rule #{@rule.id}: Sent attachment with #{blobs.size} files"
-  rescue StandardError => e
-    Rails.logger.error "Automation Rule #{@rule.id}: Error sending attachment: #{e.message}"
-    raise e
-  end
-
-  def mute_conversation
-    return unless @conversation
-
-    @conversation.mute!
-    Rails.logger.info "Automation Rule #{@rule.id}: Muted conversation"
-  end
-
-  def snooze_conversation
-    return unless @conversation
-
-    @conversation.snoozed!
-    Rails.logger.info "Automation Rule #{@rule.id}: Snoozed conversation"
-  end
-
-  def resolve_conversation
-    return unless @conversation
-
-    @conversation.resolved!
-    Rails.logger.info "Automation Rule #{@rule.id}: Resolved conversation"
-  end
-
-  def change_priority(priority_params)
-    return unless @conversation
-
-    priority = priority_params.is_a?(Array) ? priority_params.first : priority_params
-    @conversation.update!(priority: priority)
-    Rails.logger.info "Automation Rule #{@rule.id}: Changed priority to #{priority}"
-  end
-
-  def send_email_to_team(team_params)
-    return unless team_params.is_a?(Array) && team_params.first.is_a?(Hash)
-
-    data = team_params.first
-    team_ids = data[:team_ids] || data['team_ids']
-    message = data[:message] || data['message']
-
-    teams = Team.where(id: team_ids)
-    teams.each do |team|
-      TeamNotifications::AutomationNotificationMailer.conversation_creation(@conversation, team, message)&.deliver_now if @conversation
-    end
-
-    Rails.logger.info "Automation Rule #{@rule.id}: Sent email to #{teams.count} teams"
-  end
-
-  def send_email_transcript(email_params)
-    return unless @conversation
-
-    email = email_params.is_a?(Array) ? email_params.first : email_params
-    return if email.blank?
-
-    # Implementar envio de transcript por email se necessário
-    Rails.logger.info "Automation Rule #{@rule.id}: Email transcript requested for #{email}"
-  end
-
-  def conversation_a_tweet?
-    @conversation&.additional_attributes&.dig('type') == 'tweet'
   end
 end

--- a/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
+++ b/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
@@ -83,4 +83,30 @@ RSpec.describe AutomationRuleListener do
     dispatch({ 'label_list' => [[], ['vip']] })
     expect(AutomationRuleRun.last.status).to eq('no_match')
   end
+
+  # EVO-1642: the SQL ConditionsFilterService runs in shadow next to the
+  # authoritative Ruby evaluator. It must (a) log on disagreement, (b) never
+  # change behaviour, (c) never break the run if it raises.
+  describe 'shadow-compare (EVO-1642)' do
+    it 'logs [ConditionsParity] on disagreement but behaviour follows Ruby' do
+      build_rule([{ 'attribute_key' => 'name', 'filter_operator' => 'equal_to', 'values' => ['Jane'], 'query_operator' => nil }])
+      # Ruby matches (name == Jane); force the SQL shadow to disagree.
+      allow_any_instance_of(AutomationRules::ConditionsFilterService).to receive(:perform).and_return(false)
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      dispatch({ 'name' => %w[a b] })
+
+      expect(Rails.logger).to have_received(:warn).with(/\[ConditionsParity\].*ruby=true sql=false/)
+      # Behaviour follows Ruby (authoritative): the rule still matched + ran.
+      expect(AutomationRuleRun.last.status).to eq('matched')
+    end
+
+    it 'never breaks the live run when the SQL shadow raises' do
+      build_rule([{ 'attribute_key' => 'name', 'filter_operator' => 'equal_to', 'values' => ['Jane'], 'query_operator' => nil }])
+      allow_any_instance_of(AutomationRules::ConditionsFilterService).to receive(:perform).and_raise(StandardError, 'boom')
+
+      expect { dispatch({ 'name' => %w[a b] }) }.not_to raise_error
+      expect(AutomationRuleRun.last.status).to eq('matched')
+    end
+  end
 end

--- a/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1642: ConditionsFilterService can now evaluate contact-only rules WITHOUT
+# a conversation (base_relation falls back to Contact.where(id:)). This spec
+# proves two things at once:
+#   1. the SQL evaluator returns the correct boolean for every contact operator;
+#   2. it is at PARITY with the hand-rolled Ruby evaluator
+#      (AutomationRuleListener#evaluate_contact_conditions) it will replace.
+# The parity assertion is the regression net that lets Phase 2 delete the Ruby
+# path as a pure deletion. Operators covered match the contact whitelist in
+# AutomationRuleListener#rule_has_only_contact_conditions? and the operator sets
+# in lib/filters/filter_keys.yml (the only combos the frontend can produce).
+RSpec.describe AutomationRules::ConditionsFilterService do
+  let(:listener) { AutomationRuleListener.instance }
+  let!(:vip) { Label.create!(title: "vip-#{SecureRandom.hex(3)}", color: '#abcdef') }
+  let!(:gold) { Label.create!(title: "gold-#{SecureRandom.hex(3)}", color: '#ffd700') }
+  let(:contact) do
+    c = Contact.create!(name: 'Jane', email: "jane-#{SecureRandom.hex(4)}@test.com", phone_number: "+55#{rand(10**10)}")
+    c.update!(additional_attributes: { 'city' => 'SP', 'company' => 'Acme', 'country_code' => 'BR' }, label_list: [vip.title])
+    Current.reset
+    c.reload
+  end
+  let(:bare_contact) { Contact.create!(name: 'Bare', email: "bare-#{SecureRandom.hex(4)}@test.com", phone_number: "+55#{rand(10**10)}") }
+
+  after { Current.reset }
+
+  def build_rule(conditions)
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}", event_name: 'contact_updated', active: true, mode: 'simple',
+      conditions: conditions, actions: []
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  # Drives both evaluators for the same rule and asserts they agree AND match
+  # the expected boolean.
+  def expect_parity(conditions, expected:, changed: {}, on: nil)
+    target = on || contact
+    rule = build_rule(conditions)
+    ruby = listener.send(:evaluate_contact_conditions, rule, target.reload, changed)
+    sql  = described_class.new(rule, nil, contact: target.reload, changed_attributes: changed).perform
+    aggregate_failures do
+      expect(ruby).to eq(expected), "ruby evaluator: expected #{expected}, got #{ruby.inspect}"
+      expect(sql).to  eq(expected), "sql evaluator: expected #{expected}, got #{sql.inspect}"
+    end
+  end
+
+  describe 'text attributes (name/email/phone)' do
+    it('name equal_to matches')        { expect_parity([cond('name', 'equal_to', ['Jane'])], expected: true) }
+    it('name equal_to mismatches')     { expect_parity([cond('name', 'equal_to', ['Bob'])], expected: false) }
+    it('name not_equal_to matches')    { expect_parity([cond('name', 'not_equal_to', ['Bob'])], expected: true) }
+    it('email contains matches')       { expect_parity([cond('email', 'contains', ['@test.com'])], expected: true) }
+    it('name does_not_contain')        { expect_parity([cond('name', 'does_not_contain', ['Bob'])], expected: true) }
+    it('phone_number starts_with')     { expect_parity([cond('phone_number', 'starts_with', ['+55'])], expected: true) }
+  end
+
+  describe 'additional_attributes (city/company/country_code)' do
+    it('city equal_to matches')        { expect_parity([cond('city', 'equal_to', ['SP'])], expected: true) }
+    it('company contains matches')     { expect_parity([cond('company', 'contains', ['Acm'])], expected: true) }
+    it('country_code not_equal_to')    { expect_parity([cond('country_code', 'not_equal_to', ['US'])], expected: true) }
+  end
+
+  describe 'blocked (boolean)' do
+    it('blocked equal_to false')       { expect_parity([cond('blocked', 'equal_to', ['false'])], expected: true) }
+    it('blocked equal_to true (miss)') { expect_parity([cond('blocked', 'equal_to', ['true'])], expected: false) }
+  end
+
+  describe 'labels' do
+    it 'equal_to is any-of (matches when the contact has ANY listed label)' do
+      expect_parity([cond('labels', 'equal_to', [vip.id, gold.id])], expected: true)
+    end
+    it 'not_equal_to matches only when the contact has NONE of the listed labels' do
+      expect_parity([cond('labels', 'not_equal_to', [gold.id])], expected: true)
+      expect_parity([cond('labels', 'not_equal_to', [vip.id])], expected: false)
+    end
+    it 'is_present matches a contact with labels, not a bare contact' do
+      expect_parity([cond('labels', 'is_present', [])], expected: true)
+      expect_parity([cond('labels', 'is_present', [])], expected: false, on: bare_contact)
+    end
+    it 'is_not_present matches a bare contact, not a labelled one' do
+      expect_parity([cond('labels', 'is_not_present', [])], expected: true, on: bare_contact)
+      expect_parity([cond('labels', 'is_not_present', [])], expected: false)
+    end
+  end
+
+  describe 'attribute_changed transitions' do
+    it 'scalar boolean transition (blocked false -> true)' do
+      expect_parity([cond('blocked', 'attribute_changed', { 'from' => ['false'], 'to' => ['true'] })],
+                    changed: { 'blocked' => [false, true] }, expected: true)
+    end
+    it 'scalar transition mismatch (opposite direction)' do
+      expect_parity([cond('blocked', 'attribute_changed', { 'from' => ['true'], 'to' => ['false'] })],
+                    changed: { 'blocked' => [false, true] }, expected: false)
+    end
+    it 'scalar empty from is a wildcard' do
+      expect_parity([cond('blocked', 'attribute_changed', { 'from' => [], 'to' => ['true'] })],
+                    changed: { 'blocked' => [false, true] }, expected: true)
+    end
+    it 'labels transition when the requested label was added' do
+      expect_parity([cond('labels', 'attribute_changed', { 'from' => [], 'to' => [vip.id] })],
+                    changed: { 'label_list' => [[], [vip.title]] }, expected: true)
+    end
+    it 'labels transition when the watched label was NOT in the diff' do
+      expect_parity([cond('labels', 'attribute_changed', { 'from' => [], 'to' => [gold.id] })],
+                    changed: { 'label_list' => [[], [vip.title]] }, expected: false)
+    end
+  end
+
+  describe 'no conditions' do
+    it('an empty condition set matches (vacuous truth)') { expect_parity([], expected: true) }
+  end
+
+  def cond(key, operator, values, query_operator = nil)
+    { 'attribute_key' => key, 'filter_operator' => operator, 'values' => values, 'query_operator' => query_operator }
+  end
+end

--- a/spec/services/automation_rules/contact_action_service_spec.rb
+++ b/spec/services/automation_rules/contact_action_service_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe AutomationRules::ContactActionService do
 
       expect(WebhookJob).to have_received(:perform_later).with(
         'https://example.com/hook', # whitespace trimmed
-        hash_including(event: 'contact_updated')
+        # Webhook event string unified to automation_event.{event_name}
+        hash_including(event: 'automation_event.contact_updated')
       )
       expect(recorder).to have_received(:add_step).with('Action: send_webhook_event', hash_including(level: 'success'))
     end

--- a/spec/services/automation_rules/contact_action_service_spec.rb
+++ b/spec/services/automation_rules/contact_action_service_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe AutomationRules::ContactActionService do
 
       expect(WebhookJob).to have_received(:perform_later).with(
         'https://example.com/hook', # whitespace trimmed
-        # Webhook event string unified to automation_event.{event_name}
-        hash_including(event: 'automation_event.contact_updated')
+        # EVO-1641: contact webhook string kept as the live external contract.
+        hash_including(event: 'contact_updated')
       )
       expect(recorder).to have_received(:add_step).with('Action: send_webhook_event', hash_including(level: 'success'))
     end

--- a/spec/services/automation_rules/flow_execution_service_spec.rb
+++ b/spec/services/automation_rules/flow_execution_service_spec.rb
@@ -235,15 +235,17 @@ RSpec.describe AutomationRules::FlowExecutionService do
     end
 
     describe 'action_node? whitelist' do
-      it 'recognises all 18 node types (13 legacy + 5 new from EVO-1262)' do
-        new_types = %w[
+      it 'recognises all 19 node types (14 legacy + 5 new from EVO-1262)' do
+        # Added change-status-node (previously missing → silent no-op).
+        recognised = %w[
           assign-to-pipeline-node
           move-to-pipeline-stage-node
           create-pipeline-task-node
           send-canned-response-node
           send-template-node
+          change-status-node
         ]
-        new_types.each do |t|
+        recognised.each do |t|
           expect(flow_service.send(:action_node?, t)).to be(true), "expected #{t} to be a recognised action node"
         end
       end
@@ -280,6 +282,85 @@ RSpec.describe AutomationRules::FlowExecutionService do
 
       expect(conv_modal.reload.pipeline_items.count).to eq(conv_canvas.reload.pipeline_items.count)
       expect(conv_modal.pipeline_items.first.pipeline).to eq(conv_canvas.pipeline_items.first.pipeline)
+    end
+  end
+
+  # The flow executor now shares the canonical conversation actions
+  # with the modal ActionService, fixing the four documented divergences.
+  describe 'conversation action parity' do
+    let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+    let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+    let(:flow_service) { described_class.new(rule, nil, conversation, contact) }
+
+    describe 'change-status-node (was a silent no-op)' do
+      it 'updates the conversation status' do
+        node = { 'type' => 'change-status-node', 'id' => 'n1', 'data' => { 'status' => 'resolved' } }
+        expect { flow_service.send(:execute_node_action, node) }
+          .to change { conversation.reload.status }.to('resolved')
+      end
+
+      it 'no-ops when status is missing' do
+        node = { 'type' => 'change-status-node', 'id' => 'n1', 'data' => {} }
+        expect { flow_service.send(:execute_node_action, node) }
+          .not_to change { conversation.reload.status }
+      end
+    end
+
+    describe 'send-transcript-node (was a logging stub)' do
+      it 'actually enqueues the transcript mail via ConversationReplyMailer' do
+        allow(flow_service).to receive(:parse_email_variables).and_return('ops@example.com')
+        delivery = double('delivery')
+        expect(delivery).to receive(:deliver_later)
+        with_proxy = double('with_proxy')
+        allow(ConversationReplyMailer).to receive(:with).with(account: nil).and_return(with_proxy)
+        allow(with_proxy).to receive(:conversation_transcript).and_return(delivery)
+
+        node = { 'type' => 'send-transcript-node', 'id' => 'n1', 'data' => { 'email' => 'ops@example.com' } }
+        flow_service.send(:execute_node_action, node)
+      end
+    end
+
+    describe 'assign-agent-node (inbox guard was missing)' do
+      let(:member) { User.create!(name: 'Member', email: "m-#{SecureRandom.hex(4)}@test.com") }
+      let(:outsider) { User.create!(name: 'Outsider', email: "o-#{SecureRandom.hex(4)}@test.com") }
+
+      before { InboxMember.create!(inbox: inbox, user: member) }
+
+      it 'assigns an agent who belongs to the inbox' do
+        node = { 'type' => 'assign-agent-node', 'id' => 'n1', 'data' => { 'agent_id' => member.id } }
+        flow_service.send(:execute_node_action, node)
+        expect(conversation.reload.assignee_id).to eq(member.id)
+      end
+
+      it 'does NOT assign an agent outside the inbox' do
+        node = { 'type' => 'assign-agent-node', 'id' => 'n1', 'data' => { 'agent_id' => outsider.id } }
+        flow_service.send(:execute_node_action, node)
+        expect(conversation.reload.assignee_id).to be_nil
+      end
+    end
+
+    describe 'send-webhook-node (event string unified)' do
+      it 'enqueues with the canonical automation_event.{event_name} string' do
+        allow(WebhookJob).to receive(:perform_later)
+        node = { 'type' => 'send-webhook-node', 'id' => 'n1', 'data' => { 'webhook_url' => 'https://example.com/hook' } }
+        flow_service.send(:execute_node_action, node)
+
+        expect(WebhookJob).to have_received(:perform_later).with(
+          'https://example.com/hook',
+          hash_including(event: "automation_event.#{rule.event_name}")
+        )
+      end
+    end
+  end
+
+  # AC8: a contact-triggered flow has no conversation; a conversation-
+  # bound node must degrade to a silent no-op instead of crashing on nil.
+  describe 'contact-only flow safety' do
+    it 'no-ops a conversation-bound node when there is no conversation' do
+      node = { 'type' => 'change-status-node', 'id' => 'n1', 'data' => { 'status' => 'resolved' } }
+      expect { service.send(:execute_node_action, node) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
> **Stacked sobre #120 (EVO-1641).** Base desta PR é a branch da 1641 porque o módulo `ConversationActionHandlers` ainda não está no `develop`. Quando #120 mergear, rebasear esta branch em `origin/develop` e retargetar a base para `develop`. O diff abaixo é só da EVO-1642.

## Resumo

Fase 1 da unificação dos executores + avaliadores de condição da automação (EVO-1642). Duas frentes:

**Condições — `ConditionsFilterService` agora roda sem conversa:**
- `base_relation` cai para `Contact.where(id:)` quando não há conversa (regras contact-only) → o avaliador SQL passa a fazer o trabalho que o avaliador Ruby hand-rolled existia para fazer.
- `labels_query_fragment` é base-aware (EXISTS só em `contacts.id` sem conversa) e agora trata `is_present`/`is_not_present` (valores vazios derrubavam o `IN` e nunca casavam).
- `scalar_transition_match?` coage os dois lados para String → transições booleanas (`blocked false->true`) casam em vez de silenciosamente nunca casar.
- `build_query_string` resolve chaves que existem nas DUAS seções (`country_code`, `labels`) contra `contacts` quando não há conversa, em vez de referenciar a tabela `conversations` ausente.

**Shadow-compare (zero mudança de comportamento):** `evaluate_and_execute_contact_rule` roda o serviço SQL ao lado do avaliador Ruby (autoritativo) e loga `[ConditionsParity] ...` em qualquer divergência; um shadow que levanta é resgatado e nunca quebra o run vivo.

**Ações:** `ContactActionService` foldado em `ConversationActionHandlers` (último executor que ainda duplicava `add_label`/`remove_label`/`send_webhook_event`). Mantido só um override fino de `send_webhook_event` para preservar o skip de URL blank.

## Plano de teste

```
POSTGRES_HOST=127.0.0.1 POSTGRES_PASSWORD=*** POSTGRES_USERNAME=postgres \
POSTGRES_DATABASE=evolution_test RAILS_ENV=test \
bundle exec rspec spec/services/automation_rules/ spec/listeners/automation_rule_listener_*spec.rb
```

- Novo `conditions_filter_service_contact_spec.rb`: assere `ruby == sql == esperado` para **todo** operador de contato (name/email/phone/identifier, city/company/country_code, blocked, labels equal_to any-of / not_equal_to / is_present / is_not_present, attribute_changed escalar+labels+wildcard). Essa é a rede de regressão que torna a Fase 2 uma deleção pura.
- Testes de shadow: divergência loga `[ConditionsParity]` e comportamento segue o Ruby; shadow que levanta não quebra o run.
- Regressão de conversa (`conditions_filter_service_spec`, `..._attribute_changed_spec`) e o fold (`contact_action_service_spec`): verdes.
- Falhas pré-existentes (macros webhook, evo_flow listeners) reproduzidas no `develop` — não são desta PR.

## Notas de revisão

1. **Achados pelo shadow durante o dev:** três divergências SQL↔Ruby reais foram encontradas e corrigidas aqui (boolean `attribute_changed`, labels presence, routing de `country_code`). Sem isso o retire direto teria regredido esses casos — valida a abordagem shadow-then-retire.
2. **Monitoramento em prod (entre Fase 1 e 2):** `grep '[ConditionsParity]'` nos logs. Zero divergência numa janela representativa = sinal verde para a Fase 2 (deletar `evaluate_contact_conditions` + 5 helpers; SQL vira autoritativo).
3. **Custo transitório:** a Fase 1 adiciona uma query SQL extra por avaliação de regra de contato (o shadow). Removida na Fase 2.
4. `rule_has_only_contact_conditions?` permanece — roteia a AÇÃO (nativa vs conversation-bound), independente do avaliador.

Parte de [EVO-1637]. Relacionado a EVO-1635.

## Summary by Sourcery

Unify contact-only automation condition evaluation with the SQL-based ConditionsFilterService and introduce a shadow comparison path to validate parity with the existing Ruby evaluator before deprecating it.

Bug Fixes:
- Ensure attribute_changed conditions correctly match boolean transitions by coercing both sides to strings before comparison.
- Fix label presence conditions (is_present/is_not_present) so they match based on the existence of any labels instead of generating empty IN clauses that never match.
- Route shared keys like country_code and labels to the contact scope when no conversation is present to avoid invalid queries against the conversations table.

Enhancements:
- Allow ConditionsFilterService to evaluate contact-only rules without a conversation by targeting the contact as the base relation and adjusting label queries accordingly.
- Refactor contact automation actions to reuse the shared ConversationActionHandlers implementations, keeping only a thin local guard for blank webhook URLs.
- Add a shadow comparison of SQL vs Ruby contact condition evaluation that logs parity differences and swallows SQL errors without affecting live behaviour.

Tests:
- Add tests covering contact-only SQL condition evaluation to assert parity with the Ruby evaluator across contact attributes and label operators.
- Add listener specs to verify that shadow comparison logs [ConditionsParity] on disagreement and never breaks or alters the live rule execution flow.