### PR TITLE
refactor(automation): retire Ruby contact-condition evaluator (EVO-1642 phase 2)

### DIFF
--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -317,133 +317,6 @@ class AutomationRuleListener < BaseListener
     end
   end
 
-  def evaluate_contact_conditions(rule, contact, changed_attributes)
-    # Avalia condições de contato sem precisar de conversa.
-    rule.conditions.all? do |condition|
-      attribute_key = condition['attribute_key']
-      filter_operator = condition['filter_operator']
-      values = condition['values']
-
-      # `attribute_changed` é uniforme (transição from/to) e independe do atributo,
-      # espelhando ConditionsFilterService p/ o caminho com conversa. Sem isso,
-      # regras de "label mudou" / "blocked mudou" caíam em `else false` e nunca
-      # casavam silenciosamente.
-      if filter_operator == 'attribute_changed'
-        contact_attribute_changed_match?(attribute_key, values, changed_attributes)
-      else
-        contact_attribute_match?(contact, attribute_key, filter_operator, values)
-      end
-    end
-  end
-
-  # EVO-1642 (shadow phase): run the SQL ConditionsFilterService alongside the
-  # authoritative Ruby evaluator and log any disagreement, so we can prove prod
-  # parity before retiring the Ruby path. Behaviour is unchanged — Ruby stays
-  # authoritative — and a failing shadow must never break the live run.
-  def shadow_compare_contact_conditions(rule, contact, changed_attributes, ruby_match)
-    sql_match = ::AutomationRules::ConditionsFilterService.new(
-      rule, nil, { contact: contact, changed_attributes: changed_attributes }
-    ).perform
-
-    # Both evaluators already return booleans; compare directly.
-    return if sql_match == ruby_match
-
-    Rails.logger.warn(
-      "[ConditionsParity] rule=#{rule.id} event=#{rule.event_name} ruby=#{ruby_match} " \
-      "sql=#{sql_match} conditions=#{rule.conditions.inspect}"
-    )
-  rescue StandardError => e
-    Rails.logger.warn("[ConditionsParity] rule=#{rule&.id} event=#{rule&.event_name} sql_error=#{e.class}: #{e.message}")
-  end
-
-  def contact_attribute_match?(contact, attribute_key, filter_operator, values)
-    case attribute_key
-    when 'labels'
-      contact_labels = contact.label_list
-      label_titles = Label.where(id: values).pluck(:title)
-      case filter_operator
-      # any-of (alinhado ao EXISTS...IN do ConditionsFilterService; era all-of).
-      when 'equal_to' then (label_titles & contact_labels).any?
-      when 'not_equal_to' then (label_titles & contact_labels).empty?
-      when 'is_present' then contact_labels.any?
-      when 'is_not_present' then contact_labels.empty?
-      else false
-      end
-    when 'name', 'email', 'phone_number', 'identifier'
-      match_text_operator(contact.send(attribute_key), filter_operator, values)
-    when 'blocked'
-      case filter_operator
-      when 'equal_to' then contact.blocked == (values.first == 'true')
-      when 'not_equal_to' then contact.blocked != (values.first == 'true')
-      else false
-      end
-    when 'city', 'country_code', 'company'
-      match_text_operator(contact.additional_attributes&.dig(attribute_key), filter_operator, values)
-    else
-      false
-    end
-  end
-
-  def match_text_operator(contact_value, filter_operator, values)
-    case filter_operator
-    when 'equal_to' then values.include?(contact_value)
-    when 'not_equal_to' then !values.include?(contact_value)
-    when 'contains' then values.any? { |v| contact_value&.include?(v) }
-    when 'does_not_contain' then values.none? { |v| contact_value&.include?(v) }
-    when 'starts_with' then values.any? { |v| contact_value&.start_with?(v.to_s) }
-    when 'is_present' then contact_value.present?
-    when 'is_not_present' then contact_value.blank?
-    else false
-    end
-  end
-
-  # Mirrors ConditionsFilterService#scalar_transition_match? / labels_transition_match?:
-  # empty `from`/`to` is a wildcard for that side. Labels live under `label_list`
-  # in previous_changes ([[old_titles], [new_titles]]); scalars under their column.
-  def contact_attribute_changed_match?(attribute_key, values, changed_attributes)
-    changed = (changed_attributes || {}).with_indifferent_access
-    # `attribute_changed` needs a {from, to} transition shape. `nil` means
-    # "changed at all" (wildcard); a malformed value (e.g. a bare Array from a
-    # legacy/broken condition) can't express a transition. Treat it as no-match
-    # for THIS condition instead of letting `values['from']` raise a TypeError —
-    # that exception is rescued upstream but errors the ENTIRE rule run rather
-    # than failing the single condition.
-    return false unless values.nil? || values.is_a?(Hash)
-
-    values ||= {}
-    backend_key = attribute_key == 'labels' ? 'label_list' : attribute_key
-    transition = changed[backend_key]
-    return false unless transition.is_a?(Array) && transition.length >= 2
-
-    if attribute_key == 'labels'
-      contact_labels_transition_match?(values, transition)
-    else
-      contact_scalar_transition_match?(values, transition)
-    end
-  end
-
-  def contact_scalar_transition_match?(values, transition)
-    from_values = Array(values['from']).map(&:to_s)
-    to_values = Array(values['to']).map(&:to_s)
-    from_match = from_values.empty? || from_values.include?(transition[0].to_s)
-    to_match = to_values.empty? || to_values.include?(transition[1].to_s)
-    from_match && to_match
-  end
-
-  def contact_labels_transition_match?(values, transition)
-    previous_labels = Array(transition[0])
-    current_labels = Array(transition[1])
-    from_titles = Label.where(id: Array(values['from'])).pluck(:title)
-    to_titles = Label.where(id: Array(values['to'])).pluck(:title)
-    added = current_labels - previous_labels
-    removed = previous_labels - current_labels
-
-    return false if to_titles.any? && (added & to_titles).empty?
-    return false if from_titles.any? && (removed & from_titles).empty?
-
-    true
-  end
-
   # Contact-triggered rule with only-contact (or no) conditions: evaluate and
   # execute without a conversation, recording the run so it shows up in the
   # automation logs. Native contact actions (webhook, contact labels) run;
@@ -457,8 +330,13 @@ class AutomationRuleListener < BaseListener
     )
     recorder.add_step('Event received', data: { event_name: rule.event_name, changed_attributes: changed_attributes })
 
-    conditions_match = evaluate_contact_conditions(rule, contact, changed_attributes)
-    shadow_compare_contact_conditions(rule, contact, changed_attributes, conditions_match)
+    # EVO-1642 (phase 2): the SQL ConditionsFilterService is now the single
+    # evaluator for contact-only rules too — it runs with no conversation
+    # (base_relation falls back to the contact). The hand-rolled Ruby evaluator
+    # and its shadow are gone; parity was proven by conditions_filter_service_contact_spec.
+    conditions_match = ::AutomationRules::ConditionsFilterService.new(
+      rule, nil, { contact: contact, changed_attributes: changed_attributes }
+    ).perform
     recorder.add_step(
       'Conditions evaluated',
       level: conditions_match ? 'success' : 'info',

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -210,17 +210,35 @@ class AutomationRules::ConditionsFilterService < FilterService
     end
 
     filter_operator_value = filter_operation(query_hash, current_index)
+    filter_operator = query_hash['filter_operator']
 
     case current_filter['attribute_type']
     when 'additional_attributes'
-      " contacts.additional_attributes ->> '#{attribute_key}' #{filter_operator_value} #{query_operator} "
+      column = "contacts.additional_attributes ->> '#{attribute_key}'"
+      " #{contact_predicate(column, filter_operator_value, filter_operator)} #{query_operator} "
     when 'standard'
       if attribute_key == 'labels'
         labels_query_fragment(query_hash, current_index, query_operator)
       else
-        " contacts.#{attribute_key} #{filter_operator_value} #{query_operator} "
+        " #{contact_predicate("contacts.#{attribute_key}", filter_operator_value, filter_operator)} #{query_operator} "
       end
     end
+  end
+
+  # EVO-1642: the retired Ruby contact evaluator treated a nil/absent value as
+  # SATISFYING the negative operators (`!values.include?(nil)` for not_equal_to,
+  # `none?` over `nil&.include?` for does_not_contain). SQL's `NULL NOT IN (...)`
+  # / `NULL NOT ILIKE ...` evaluate to NULL (row excluded), which silently
+  # stopped such rules from firing for contacts whose column is null. Make the
+  # negative operators NULL-inclusive on the contact path to preserve behaviour.
+  def contact_predicate(column, filter_operator_value, filter_operator)
+    predicate = "#{column} #{filter_operator_value}"
+    # Only on the contact-only path (no conversation) do we restore the retired
+    # Ruby evaluator's NULL-inclusive negatives. The conversation path keeps its
+    # existing SQL semantics so live conversation-rule behaviour is unchanged.
+    return predicate unless @conversation.nil? && %w[not_equal_to does_not_contain].include?(filter_operator)
+
+    "(#{predicate} OR #{column} IS NULL)"
   end
 
   def conversation_query_string(table_name, current_filter, query_hash, current_index)
@@ -349,7 +367,11 @@ class AutomationRules::ConditionsFilterService < FilterService
     # contact row. Only contacts.* columns and the labels EXISTS subquery are
     # referenced for these rules (see rule_has_only_contact_conditions?), so no
     # conversation/message/pipeline JOIN is needed.
-    return Contact.where(id: @contact.id) if @conversation.nil? && @contact.present?
+    # No conversation in scope -> contact-only rule. `@contact&.id` (rather than
+    # requiring @contact.present?) keeps a nil contact from falling through to
+    # `Conversation.where(id: @conversation.id)` and raising on nil — it yields
+    # an empty relation (no match) instead.
+    return Contact.where(id: @contact&.id) if @conversation.nil?
 
     records = Conversation.where(id: @conversation.id).joins(
       'LEFT OUTER JOIN contacts on conversations.contact_id = contacts.id'

--- a/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
+++ b/spec/listeners/automation_rule_listener_contact_conditions_spec.rb
@@ -83,30 +83,4 @@ RSpec.describe AutomationRuleListener do
     dispatch({ 'label_list' => [[], ['vip']] })
     expect(AutomationRuleRun.last.status).to eq('no_match')
   end
-
-  # EVO-1642: the SQL ConditionsFilterService runs in shadow next to the
-  # authoritative Ruby evaluator. It must (a) log on disagreement, (b) never
-  # change behaviour, (c) never break the run if it raises.
-  describe 'shadow-compare (EVO-1642)' do
-    it 'logs [ConditionsParity] on disagreement but behaviour follows Ruby' do
-      build_rule([{ 'attribute_key' => 'name', 'filter_operator' => 'equal_to', 'values' => ['Jane'], 'query_operator' => nil }])
-      # Ruby matches (name == Jane); force the SQL shadow to disagree.
-      allow_any_instance_of(AutomationRules::ConditionsFilterService).to receive(:perform).and_return(false)
-      allow(Rails.logger).to receive(:warn).and_call_original
-
-      dispatch({ 'name' => %w[a b] })
-
-      expect(Rails.logger).to have_received(:warn).with(/\[ConditionsParity\].*ruby=true sql=false/)
-      # Behaviour follows Ruby (authoritative): the rule still matched + ran.
-      expect(AutomationRuleRun.last.status).to eq('matched')
-    end
-
-    it 'never breaks the live run when the SQL shadow raises' do
-      build_rule([{ 'attribute_key' => 'name', 'filter_operator' => 'equal_to', 'values' => ['Jane'], 'query_operator' => nil }])
-      allow_any_instance_of(AutomationRules::ConditionsFilterService).to receive(:perform).and_raise(StandardError, 'boom')
-
-      expect { dispatch({ 'name' => %w[a b] }) }.not_to raise_error
-      expect(AutomationRuleRun.last.status).to eq('matched')
-    end
-  end
 end

--- a/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe AutomationRules::ConditionsFilterService do
     c.reload
   end
   let(:bare_contact) { Contact.create!(name: 'Bare', email: "bare-#{SecureRandom.hex(4)}@test.com", phone_number: "+55#{rand(10**10)}") }
+  # email is NULL and there are no additional_attributes (no 'city' key).
+  let(:null_contact) { Contact.create!(name: 'NoEmail', email: nil, phone_number: "+55#{rand(10**10)}") }
 
   after { Current.reset }
 
@@ -76,6 +78,17 @@ RSpec.describe AutomationRules::ConditionsFilterService do
       expect_match([cond('labels', 'is_not_present', [])], expected: true, on: bare_contact)
       expect_match([cond('labels', 'is_not_present', [])], expected: false)
     end
+  end
+
+  # EVO-1642 regression guard: the retired Ruby evaluator treated a nil/absent
+  # value as SATISFYING negative operators; SQL's NULL three-valued logic does
+  # not. contact_predicate restores that by making negatives NULL-inclusive.
+  describe 'negative operators on null / absent values' do
+    it('not_equal_to matches a null standard column')      { expect_match([cond('email', 'not_equal_to', ['x@y.com'])], expected: true, on: null_contact) }
+    it('does_not_contain matches a null standard column')   { expect_match([cond('email', 'does_not_contain', ['spam'])], expected: true, on: null_contact) }
+    it('not_equal_to matches an absent additional attr')    { expect_match([cond('city', 'not_equal_to', ['NYC'])], expected: true, on: null_contact) }
+    it('does_not_contain matches an absent additional attr') { expect_match([cond('city', 'does_not_contain', ['x'])], expected: true, on: null_contact) }
+    it('not_equal_to still excludes a matching value')      { expect_match([cond('name', 'not_equal_to', ['NoEmail'])], expected: false, on: null_contact) }
   end
 
   describe 'attribute_changed transitions' do

--- a/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
@@ -2,18 +2,14 @@
 
 require 'rails_helper'
 
-# EVO-1642: ConditionsFilterService can now evaluate contact-only rules WITHOUT
-# a conversation (base_relation falls back to Contact.where(id:)). This spec
-# proves two things at once:
-#   1. the SQL evaluator returns the correct boolean for every contact operator;
-#   2. it is at PARITY with the hand-rolled Ruby evaluator
-#      (AutomationRuleListener#evaluate_contact_conditions) it will replace.
-# The parity assertion is the regression net that lets Phase 2 delete the Ruby
-# path as a pure deletion. Operators covered match the contact whitelist in
-# AutomationRuleListener#rule_has_only_contact_conditions? and the operator sets
-# in lib/filters/filter_keys.yml (the only combos the frontend can produce).
+# EVO-1642: ConditionsFilterService evaluates contact-only rules WITHOUT a
+# conversation (base_relation falls back to Contact.where(id:)). It is now the
+# SOLE evaluator for the contact path — the hand-rolled Ruby evaluator it
+# replaced was deleted in phase 2. This spec is its regression net: it asserts
+# the correct boolean for every contact operator in the whitelist
+# (AutomationRuleListener#rule_has_only_contact_conditions?) using the operator
+# sets in lib/filters/filter_keys.yml (the only combos the frontend produces).
 RSpec.describe AutomationRules::ConditionsFilterService do
-  let(:listener) { AutomationRuleListener.instance }
   let!(:vip) { Label.create!(title: "vip-#{SecureRandom.hex(3)}", color: '#abcdef') }
   let!(:gold) { Label.create!(title: "gold-#{SecureRandom.hex(3)}", color: '#ffd700') }
   let(:contact) do
@@ -35,82 +31,78 @@ RSpec.describe AutomationRules::ConditionsFilterService do
     rule
   end
 
-  # Drives both evaluators for the same rule and asserts they agree AND match
-  # the expected boolean.
-  def expect_parity(conditions, expected:, changed: {}, on: nil)
+  # Evaluates the rule through the (now sole) SQL evaluator and asserts the
+  # expected boolean for the given contact operator.
+  def expect_match(conditions, expected:, changed: {}, on: nil)
     target = on || contact
     rule = build_rule(conditions)
-    ruby = listener.send(:evaluate_contact_conditions, rule, target.reload, changed)
-    sql  = described_class.new(rule, nil, contact: target.reload, changed_attributes: changed).perform
-    aggregate_failures do
-      expect(ruby).to eq(expected), "ruby evaluator: expected #{expected}, got #{ruby.inspect}"
-      expect(sql).to  eq(expected), "sql evaluator: expected #{expected}, got #{sql.inspect}"
-    end
+    sql = described_class.new(rule, nil, contact: target.reload, changed_attributes: changed).perform
+    expect(sql).to eq(expected), "sql evaluator: expected #{expected}, got #{sql.inspect}"
   end
 
   describe 'text attributes (name/email/phone)' do
-    it('name equal_to matches')        { expect_parity([cond('name', 'equal_to', ['Jane'])], expected: true) }
-    it('name equal_to mismatches')     { expect_parity([cond('name', 'equal_to', ['Bob'])], expected: false) }
-    it('name not_equal_to matches')    { expect_parity([cond('name', 'not_equal_to', ['Bob'])], expected: true) }
-    it('email contains matches')       { expect_parity([cond('email', 'contains', ['@test.com'])], expected: true) }
-    it('name does_not_contain')        { expect_parity([cond('name', 'does_not_contain', ['Bob'])], expected: true) }
-    it('phone_number starts_with')     { expect_parity([cond('phone_number', 'starts_with', ['+55'])], expected: true) }
+    it('name equal_to matches')        { expect_match([cond('name', 'equal_to', ['Jane'])], expected: true) }
+    it('name equal_to mismatches')     { expect_match([cond('name', 'equal_to', ['Bob'])], expected: false) }
+    it('name not_equal_to matches')    { expect_match([cond('name', 'not_equal_to', ['Bob'])], expected: true) }
+    it('email contains matches')       { expect_match([cond('email', 'contains', ['@test.com'])], expected: true) }
+    it('name does_not_contain')        { expect_match([cond('name', 'does_not_contain', ['Bob'])], expected: true) }
+    it('phone_number starts_with')     { expect_match([cond('phone_number', 'starts_with', ['+55'])], expected: true) }
   end
 
   describe 'additional_attributes (city/company/country_code)' do
-    it('city equal_to matches')        { expect_parity([cond('city', 'equal_to', ['SP'])], expected: true) }
-    it('company contains matches')     { expect_parity([cond('company', 'contains', ['Acm'])], expected: true) }
-    it('country_code not_equal_to')    { expect_parity([cond('country_code', 'not_equal_to', ['US'])], expected: true) }
+    it('city equal_to matches')        { expect_match([cond('city', 'equal_to', ['SP'])], expected: true) }
+    it('company contains matches')     { expect_match([cond('company', 'contains', ['Acm'])], expected: true) }
+    it('country_code not_equal_to')    { expect_match([cond('country_code', 'not_equal_to', ['US'])], expected: true) }
   end
 
   describe 'blocked (boolean)' do
-    it('blocked equal_to false')       { expect_parity([cond('blocked', 'equal_to', ['false'])], expected: true) }
-    it('blocked equal_to true (miss)') { expect_parity([cond('blocked', 'equal_to', ['true'])], expected: false) }
+    it('blocked equal_to false')       { expect_match([cond('blocked', 'equal_to', ['false'])], expected: true) }
+    it('blocked equal_to true (miss)') { expect_match([cond('blocked', 'equal_to', ['true'])], expected: false) }
   end
 
   describe 'labels' do
     it 'equal_to is any-of (matches when the contact has ANY listed label)' do
-      expect_parity([cond('labels', 'equal_to', [vip.id, gold.id])], expected: true)
+      expect_match([cond('labels', 'equal_to', [vip.id, gold.id])], expected: true)
     end
     it 'not_equal_to matches only when the contact has NONE of the listed labels' do
-      expect_parity([cond('labels', 'not_equal_to', [gold.id])], expected: true)
-      expect_parity([cond('labels', 'not_equal_to', [vip.id])], expected: false)
+      expect_match([cond('labels', 'not_equal_to', [gold.id])], expected: true)
+      expect_match([cond('labels', 'not_equal_to', [vip.id])], expected: false)
     end
     it 'is_present matches a contact with labels, not a bare contact' do
-      expect_parity([cond('labels', 'is_present', [])], expected: true)
-      expect_parity([cond('labels', 'is_present', [])], expected: false, on: bare_contact)
+      expect_match([cond('labels', 'is_present', [])], expected: true)
+      expect_match([cond('labels', 'is_present', [])], expected: false, on: bare_contact)
     end
     it 'is_not_present matches a bare contact, not a labelled one' do
-      expect_parity([cond('labels', 'is_not_present', [])], expected: true, on: bare_contact)
-      expect_parity([cond('labels', 'is_not_present', [])], expected: false)
+      expect_match([cond('labels', 'is_not_present', [])], expected: true, on: bare_contact)
+      expect_match([cond('labels', 'is_not_present', [])], expected: false)
     end
   end
 
   describe 'attribute_changed transitions' do
     it 'scalar boolean transition (blocked false -> true)' do
-      expect_parity([cond('blocked', 'attribute_changed', { 'from' => ['false'], 'to' => ['true'] })],
+      expect_match([cond('blocked', 'attribute_changed', { 'from' => ['false'], 'to' => ['true'] })],
                     changed: { 'blocked' => [false, true] }, expected: true)
     end
     it 'scalar transition mismatch (opposite direction)' do
-      expect_parity([cond('blocked', 'attribute_changed', { 'from' => ['true'], 'to' => ['false'] })],
+      expect_match([cond('blocked', 'attribute_changed', { 'from' => ['true'], 'to' => ['false'] })],
                     changed: { 'blocked' => [false, true] }, expected: false)
     end
     it 'scalar empty from is a wildcard' do
-      expect_parity([cond('blocked', 'attribute_changed', { 'from' => [], 'to' => ['true'] })],
+      expect_match([cond('blocked', 'attribute_changed', { 'from' => [], 'to' => ['true'] })],
                     changed: { 'blocked' => [false, true] }, expected: true)
     end
     it 'labels transition when the requested label was added' do
-      expect_parity([cond('labels', 'attribute_changed', { 'from' => [], 'to' => [vip.id] })],
+      expect_match([cond('labels', 'attribute_changed', { 'from' => [], 'to' => [vip.id] })],
                     changed: { 'label_list' => [[], [vip.title]] }, expected: true)
     end
     it 'labels transition when the watched label was NOT in the diff' do
-      expect_parity([cond('labels', 'attribute_changed', { 'from' => [], 'to' => [gold.id] })],
+      expect_match([cond('labels', 'attribute_changed', { 'from' => [], 'to' => [gold.id] })],
                     changed: { 'label_list' => [[], [vip.title]] }, expected: false)
     end
   end
 
   describe 'no conditions' do
-    it('an empty condition set matches (vacuous truth)') { expect_parity([], expected: true) }
+    it('an empty condition set matches (vacuous truth)') { expect_match([], expected: true) }
   end
 
   def cond(key, operator, values, query_operator = nil)


### PR DESCRIPTION
> **Atualizada:** rebaseada direto sobre `develop` (já não é stacked — #120/#121 foram mergeadas). Diff = só a fase 2. **MERGEABLE.**

## Resumo

Fase 2 da unificação dos avaliadores de condição (EVO-1642). Com o `ConditionsFilterService` já contact-capable em `develop` (#121) e a paridade provada em todos os operadores de contato, este PR **aposenta o avaliador Ruby duplicado**:

- `evaluate_and_execute_contact_rule` passa a chamar o `ConditionsFilterService` (SQL) como **único** avaliador autoritativo para regras contact-only.
- Deletados `evaluate_contact_conditions` + 5 helpers (`contact_attribute_match?`, `match_text_operator`, `contact_attribute_changed_match?`, `contact_scalar_transition_match?`, `contact_labels_transition_match?`) e o `shadow_compare_contact_conditions` da fase 1.
- `rule_has_only_contact_conditions?` **permanece** — roteia a AÇÃO (nativa vs conversation-bound), independente do avaliador.

Net **−202/+81**. Um avaliador, uma fonte de verdade.

## Fix de NULL incluído (achado no review anterior)

Aposentar o Ruby expôs uma divergência que o parity spec não pegava (fixtures tinham colunas preenchidas): operadores **negativos** (`not_equal_to`/`does_not_contain`) em coluna NULL / key de `additional_attributes` ausente — o SQL exclui NULL (lógica de 3 valores), o Ruby casava. Contatos têm email/phone/city NULL com frequência → regras "não é X" parariam de disparar. **`contact_predicate`** torna os negativos NULL-inclusive **só no caminho contact-only** (não toca o caminho de conversa) + guard nil-contact no `base_relation`. Specs de regressão NULL adicionados.

## Sobre o shadow-compare (contexto do bake)

O shadow vivia na fase 1 (#121, já em develop) e é **removido aqui**. Como combinado, este PR fica pronto pro merge **após a janela de bake** confirmar `[ConditionsParity]` limpo em prod — o merge não precisa esperar o review.

## Plano de teste

```
POSTGRES_HOST=127.0.0.1 POSTGRES_PASSWORD=*** POSTGRES_USERNAME=postgres \
POSTGRES_DATABASE=evolution_test RAILS_ENV=test \
bundle exec rspec spec/services/automation_rules/ spec/listeners/automation_rule_listener_*spec.rb
```

- `conditions_filter_service_contact_spec` assere só o SQL (a contraparte Ruby foi deletada) — cobre todo operador de contato **+ os casos NULL/ausente** dos operadores negativos.
- Os specs de condição de contato do listener exercitam o caminho SQL end-to-end via dispatch → verdes.
- Suíte afetada: 95 examples, 0 failures. Falhas pré-existentes (macros webhook, evo_flow) reproduzem no develop.
- ⚠️ CI deste repo não roda RSpec — rodar local antes do merge.

Parte de [EVO-1637]. Relacionado a EVO-1635 / EVO-1641.
