### PR TITLE
feat(crm): validate SendGrid key and register event webhook on channel save (EVO-1249)

### DIFF
--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -5,6 +5,10 @@ module Api
       class InboxesController < Api::V1::BaseController
         include Api::V1::InboxesHelper
         include Api::V1::ResourceLimitsHelper
+
+        rescue_from Sendgrid::InvalidApiKeyError, with: :handle_sendgrid_invalid_key
+        rescue_from Sendgrid::ServiceUnavailableError, with: :handle_sendgrid_unavailable
+
         before_action :fetch_inbox, except: %i[index create]
         before_action :fetch_agent_bot, only: [:set_agent_bot]
         before_action :validate_limit, only: [:create]
@@ -760,6 +764,22 @@ module Api
           @agent_bot = AgentBot.find(params[:agent_bot]) if params[:agent_bot]
         rescue ActiveRecord::RecordNotFound
           @agent_bot = nil
+        end
+
+        def handle_sendgrid_invalid_key(exception)
+          error_response(
+            ApiErrorCodes::VALIDATION_ERROR,
+            exception.message.presence || 'SendGrid API key is invalid',
+            status: :unprocessable_entity
+          )
+        end
+
+        def handle_sendgrid_unavailable(exception)
+          error_response(
+            ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
+            exception.message.presence || 'SendGrid is currently unavailable',
+            status: :service_unavailable
+          )
         end
 
         def create_channel

--- a/app/models/channel/sendgrid.rb
+++ b/app/models/channel/sendgrid.rb
@@ -65,18 +65,35 @@ class Channel::Sendgrid < ApplicationRecord
     Sendgrid::AdminClient.new(api_key).smoke_test!
   end
 
-  # update_column skips validations/callbacks on purpose: writing the status
-  # through a normal save would re-fire this after_commit and loop.
   def register_event_webhook
-    Sendgrid::AdminClient.new(api_key).upsert_event_webhook!(callback_url: webhook_callback_url)
-    update_column(:webhook_registration_status, 'active') # rubocop:disable Rails/SkipsModelValidations
+    url = webhook_callback_url
+    unless absolute_url?(url)
+      return mark_webhook_status('failed',
+                                 "callback URL is not absolute (#{url.inspect}); set SENDGRID_WEBHOOK_URL or FRONTEND_URL")
+    end
+
+    Sendgrid::AdminClient.new(api_key).upsert_event_webhook!(callback_url: url)
+    mark_webhook_status('active')
   rescue Sendgrid::ApiError => e
-    Rails.logger.error("Channel::Sendgrid#register_event_webhook failed: #{e.message}")
-    update_column(:webhook_registration_status, 'failed') # rubocop:disable Rails/SkipsModelValidations
+    mark_webhook_status('failed', e.message)
+  end
+
+  # update_column skips validations/callbacks on purpose: writing the status
+  # through a normal save would re-fire the after_save callback and loop.
+  def mark_webhook_status(status, error = nil)
+    Rails.logger.error("Channel::Sendgrid#register_event_webhook: #{error}") if error
+    update_column(:webhook_registration_status, status) # rubocop:disable Rails/SkipsModelValidations
   end
 
   def webhook_callback_url
     ENV.fetch('SENDGRID_WEBHOOK_URL') { "#{ENV.fetch('FRONTEND_URL', '')}/webhooks/sendgrid" }
+  end
+
+  def absolute_url?(url)
+    uri = URI.parse(url.to_s)
+    uri.is_a?(URI::HTTP) && uri.host.present?
+  rescue URI::InvalidURIError
+    false
   end
 
   def encrypt_api_key(value)

--- a/app/models/channel/sendgrid.rb
+++ b/app/models/channel/sendgrid.rb
@@ -2,14 +2,15 @@
 #
 # Table name: channel_sendgrid
 #
-#  id                :uuid             not null, primary key
-#  api_key_encrypted :text             not null
-#  from_email        :string           not null
-#  from_name         :string
-#  reply_to          :string
-#  sender_domain     :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
+#  id                          :uuid             not null, primary key
+#  api_key_encrypted           :text             not null
+#  from_email                  :string           not null
+#  from_name                   :string
+#  reply_to                    :string
+#  sender_domain               :string
+#  webhook_registration_status :string           default("pending"), not null
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
 #
 # Indexes
 #
@@ -25,10 +26,22 @@ class Channel::Sendgrid < ApplicationRecord
 
   DOMAIN_FORMAT = /\A[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+\z/i
 
+  WEBHOOK_STATUSES = %w[pending active failed].freeze
+
   validates :api_key, presence: true
   validates :from_email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :reply_to, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
   validates :sender_domain, format: { with: DOMAIN_FORMAT }, allow_blank: true
+  validates :webhook_registration_status, inclusion: { in: WEBHOOK_STATUSES }
+
+  # The smoke test (401/403) must gate persistence, so it runs before save and
+  # lets Sendgrid::InvalidApiKeyError propagate out of create!/update! to the
+  # controller. Webhook registration runs after save (rescued) so a SendGrid
+  # outage marks the channel `failed` instead of aborting a valid key. The
+  # webhook is account-global (keyed to the API key), so registering inside the
+  # transaction is safe — a later rollback only leaves a benign extra setting.
+  before_save :verify_remote_api_key, if: :will_save_change_to_api_key_encrypted?
+  after_save :register_event_webhook, if: :saved_change_to_api_key_encrypted?
 
   def name
     'SendGrid'
@@ -47,6 +60,24 @@ class Channel::Sendgrid < ApplicationRecord
   end
 
   private
+
+  def verify_remote_api_key
+    Sendgrid::AdminClient.new(api_key).smoke_test!
+  end
+
+  # update_column skips validations/callbacks on purpose: writing the status
+  # through a normal save would re-fire this after_commit and loop.
+  def register_event_webhook
+    Sendgrid::AdminClient.new(api_key).upsert_event_webhook!(callback_url: webhook_callback_url)
+    update_column(:webhook_registration_status, 'active') # rubocop:disable Rails/SkipsModelValidations
+  rescue Sendgrid::ApiError => e
+    Rails.logger.error("Channel::Sendgrid#register_event_webhook failed: #{e.message}")
+    update_column(:webhook_registration_status, 'failed') # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def webhook_callback_url
+    ENV.fetch('SENDGRID_WEBHOOK_URL') { "#{ENV.fetch('FRONTEND_URL', '')}/webhooks/sendgrid" }
+  end
 
   def encrypt_api_key(value)
     Fernet.generate(InstallationConfig.encryption_key, value)

--- a/app/serializers/inbox_serializer.rb
+++ b/app/serializers/inbox_serializer.rb
@@ -69,6 +69,7 @@ module InboxSerializer
         result['reply_to'] = inbox.channel.reply_to
         result['sender_domain'] = inbox.channel.sender_domain
         result['api_key_present'] = inbox.channel.api_key.present?
+        result['webhook_registration_status'] = inbox.channel.webhook_registration_status
       end
 
       # WebWidget specific fields

--- a/app/services/sendgrid/admin_client.rb
+++ b/app/services/sendgrid/admin_client.rb
@@ -1,0 +1,81 @@
+module Sendgrid
+  # Isolated HTTP client for the SendGrid admin API (credential smoke test +
+  # event webhook registration). Mirrors app/services/evo_flow/client.rb
+  # (HTTParty + custom error + handle_response + redacted logging).
+  class AdminClient
+    include HTTParty
+
+    DEFAULT_BASE_URL = 'https://api.sendgrid.com/v3'.freeze
+    REDACTED_4XX = '[redacted: 4xx body]'.freeze
+    MAX_LOGGED_BODY = 500
+
+    # Events forwarded to the CRM webhook (story 9.2 scope).
+    WEBHOOK_EVENTS = %w[
+      bounce click deferred delivered dropped group_resubscribe
+      group_unsubscribe open processed spam_report unsubscribe
+    ].freeze
+
+    def initialize(api_key, base_url: ENV.fetch('SENDGRID_API_BASE_URL', DEFAULT_BASE_URL), timeout: 10)
+      @api_key = api_key.to_s
+      @base_url = base_url
+      @timeout = timeout
+    end
+
+    # GET /v3/scopes — authentication smoke test. 401/403 means the key is bad;
+    # any other non-2xx or a network error means SendGrid could not confirm it.
+    def smoke_test!
+      response = request(:get, '/scopes')
+      return true if success?(response)
+      raise InvalidApiKeyError.new('SendGrid API key is invalid', response.code, response) if invalid_key?(response)
+
+      raise ServiceUnavailableError.new(
+        "SendGrid smoke test failed: #{response.code} - #{safe_body(response)}", response.code, response
+      )
+    end
+
+    # PATCH /v3/user/webhooks/event/settings — single event-webhook config per
+    # account; enables the CRM callback URL with the scoped event list.
+    def upsert_event_webhook!(callback_url:)
+      payload = WEBHOOK_EVENTS.each_with_object({ enabled: true, url: callback_url }) do |event, acc|
+        acc[event] = true
+      end
+      response = request(:patch, '/user/webhooks/event/settings', payload)
+      return response.parsed_response if success?(response)
+
+      msg = "SendGrid webhook registration failed: #{response.code} - #{safe_body(response)}"
+      Rails.logger.error(msg)
+      raise ServiceUnavailableError.new(msg, response.code, response)
+    end
+
+    private
+
+    def request(verb, path, payload = nil)
+      options = { headers: request_headers, timeout: @timeout }
+      options[:body] = payload.to_json if payload
+      self.class.public_send(verb, "#{@base_url}#{path}", options)
+    rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError, OpenSSL::SSL::SSLError => e
+      raise ServiceUnavailableError.new("SendGrid request failed: #{e.message}", nil, nil)
+    end
+
+    def success?(response)
+      (200..299).cover?(response.code)
+    end
+
+    def invalid_key?(response)
+      [401, 403].include?(response.code)
+    end
+
+    def request_headers
+      { 'Authorization' => "Bearer #{@api_key}", 'Content-Type' => 'application/json' }
+    end
+
+    # 4xx bodies can echo the key or input, so the whole 4xx class is redacted;
+    # 5xx bodies are length-bounded.
+    def safe_body(response)
+      return REDACTED_4XX if (400..499).cover?(response.code)
+
+      body = response.body.to_s
+      body.length > MAX_LOGGED_BODY ? "#{body[0, MAX_LOGGED_BODY]}... (truncated)" : body
+    end
+  end
+end

--- a/app/services/sendgrid/api_error.rb
+++ b/app/services/sendgrid/api_error.rb
@@ -1,0 +1,12 @@
+module Sendgrid
+  # Base error for any non-2xx SendGrid admin response or network failure.
+  class ApiError < StandardError
+    attr_reader :code, :response
+
+    def initialize(message = nil, code = nil, response = nil)
+      @code = code
+      @response = response
+      super(message)
+    end
+  end
+end

--- a/app/services/sendgrid/invalid_api_key_error.rb
+++ b/app/services/sendgrid/invalid_api_key_error.rb
@@ -1,0 +1,5 @@
+module Sendgrid
+  # SendGrid rejected the API key (401/403). Surfaced by the controller as a 422
+  # so the channel is not persisted with an unusable key.
+  class InvalidApiKeyError < ApiError; end
+end

--- a/app/services/sendgrid/service_unavailable_error.rb
+++ b/app/services/sendgrid/service_unavailable_error.rb
@@ -1,0 +1,6 @@
+module Sendgrid
+  # SendGrid was unreachable or returned 5xx — distinct from an invalid key so
+  # the smoke test answers 503 instead of 422, and webhook registration can mark
+  # the channel `failed` for later retry.
+  class ServiceUnavailableError < ApiError; end
+end

--- a/db/migrate/20260609120000_add_webhook_registration_status_to_channel_sendgrid.rb
+++ b/db/migrate/20260609120000_add_webhook_registration_status_to_channel_sendgrid.rb
@@ -1,0 +1,5 @@
+class AddWebhookRegistrationStatusToChannelSendgrid < ActiveRecord::Migration[7.1]
+  def change
+    add_column :channel_sendgrid, :webhook_registration_status, :string, null: false, default: 'pending'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_08_194533) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -271,6 +271,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_08_194533) do
     t.string "from_name"
     t.string "reply_to"
     t.string "sender_domain"
+    t.string "webhook_registration_status", default: "pending", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["from_email"], name: "index_channel_sendgrid_on_from_email"

--- a/spec/models/channel/sendgrid_spec.rb
+++ b/spec/models/channel/sendgrid_spec.rb
@@ -130,5 +130,19 @@ RSpec.describe Channel::Sendgrid, type: :model do
 
       expect(channel.reload.webhook_registration_status).to eq('failed')
     end
+
+    it 'marks the webhook failed without calling SendGrid when no absolute callback URL is configured' do
+      original = ENV.values_at('SENDGRID_WEBHOOK_URL', 'FRONTEND_URL')
+      ENV.delete('SENDGRID_WEBHOOK_URL')
+      ENV.delete('FRONTEND_URL')
+
+      channel = described_class.create!(valid_attrs)
+
+      expect(channel.reload.webhook_registration_status).to eq('failed')
+      expect(a_request(:patch, webhook_url)).not_to have_been_made
+    ensure
+      ENV['SENDGRID_WEBHOOK_URL'] = original[0]
+      ENV['FRONTEND_URL'] = original[1]
+    end
   end
 end

--- a/spec/models/channel/sendgrid_spec.rb
+++ b/spec/models/channel/sendgrid_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'webmock/rspec'
 
 RSpec.describe Channel::Sendgrid, type: :model do
   let(:valid_attrs) do
@@ -10,6 +11,14 @@ RSpec.describe Channel::Sendgrid, type: :model do
       from_name: 'Test Sender',
       sender_domain: 'example.com'
     }
+  end
+
+  let(:scopes_url) { 'https://api.sendgrid.com/v3/scopes' }
+  let(:webhook_url) { 'https://api.sendgrid.com/v3/user/webhooks/event/settings' }
+
+  before do
+    stub_request(:get, scopes_url).to_return(status: 200, body: '{}')
+    stub_request(:patch, webhook_url).to_return(status: 200, body: '{}')
   end
 
   describe 'api_key encryption at rest' do
@@ -76,6 +85,50 @@ RSpec.describe Channel::Sendgrid, type: :model do
   describe '#name' do
     it 'returns SendGrid' do
       expect(described_class.new.name).to eq('SendGrid')
+    end
+  end
+
+  describe 'api key smoke test on save' do
+    it 'persists and marks the webhook active when SendGrid accepts the key' do
+      channel = described_class.create!(valid_attrs)
+
+      expect(channel.reload.webhook_registration_status).to eq('active')
+    end
+
+    it 'raises and does not persist when SendGrid rejects the key' do
+      stub_request(:get, scopes_url).to_return(status: 401, body: '{}')
+
+      expect { described_class.create!(valid_attrs) }.to raise_error(Sendgrid::InvalidApiKeyError)
+      expect(described_class.count).to eq(0)
+    end
+
+    it 'skips the smoke test and webhook when the api_key is unchanged' do
+      channel = described_class.create!(valid_attrs)
+      WebMock.reset_executed_requests!
+
+      channel.update!(from_name: 'Renamed')
+
+      expect(a_request(:get, scopes_url)).not_to have_been_made
+      expect(a_request(:patch, webhook_url)).not_to have_been_made
+    end
+
+    it 're-runs the smoke test when the api_key is rotated' do
+      channel = described_class.create!(valid_attrs)
+      WebMock.reset_executed_requests!
+
+      channel.update!(api_key: 'SG.rotated')
+
+      expect(a_request(:get, scopes_url)).to have_been_made.once
+    end
+  end
+
+  describe 'webhook registration failure' do
+    it 'persists the channel and marks the webhook failed on a SendGrid 5xx' do
+      stub_request(:patch, webhook_url).to_return(status: 500, body: 'oops')
+
+      channel = described_class.create!(valid_attrs)
+
+      expect(channel.reload.webhook_registration_status).to eq('failed')
     end
   end
 end

--- a/spec/requests/api/v1/inboxes_sendgrid_spec.rb
+++ b/spec/requests/api/v1/inboxes_sendgrid_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'webmock/rspec'
 
 RSpec.describe 'SendGrid channel via /api/v1/inboxes', type: :request do
   let(:service_token) { 'spec-service-token' }
   let(:headers) { { 'X-Service-Token' => service_token } }
+  let(:scopes_url) { 'https://api.sendgrid.com/v3/scopes' }
+  let(:webhook_url) { 'https://api.sendgrid.com/v3/user/webhooks/event/settings' }
   let(:valid_payload) do
     {
       name: 'SendGrid Inbox',
@@ -18,7 +21,11 @@ RSpec.describe 'SendGrid channel via /api/v1/inboxes', type: :request do
     }
   end
 
-  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+  before do
+    ENV['EVOAI_CRM_API_TOKEN'] = service_token
+    stub_request(:get, scopes_url).to_return(status: 200, body: '{}')
+    stub_request(:patch, webhook_url).to_return(status: 200, body: '{}')
+  end
 
   after do
     ENV.delete('EVOAI_CRM_API_TOKEN')
@@ -49,6 +56,60 @@ RSpec.describe 'SendGrid channel via /api/v1/inboxes', type: :request do
       post '/api/v1/inboxes',
            params: valid_payload.deep_merge(channel: { from_email: 'not-an-email' }),
            headers: headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'registers the SendGrid webhook and reports it active' do
+      post '/api/v1/inboxes', params: valid_payload, headers: headers, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['data']['webhook_registration_status']).to eq('active')
+      expect(a_request(:patch, webhook_url)).to have_been_made
+    end
+
+    it 'returns 422 and does not persist the channel when the api_key is rejected' do
+      stub_request(:get, scopes_url).to_return(status: 401, body: '{}')
+
+      expect do
+        post '/api/v1/inboxes', params: valid_payload, headers: headers, as: :json
+      end.not_to change(Channel::Sendgrid, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'persists the channel with a failed webhook status when registration errors' do
+      stub_request(:patch, webhook_url).to_return(status: 500, body: 'oops')
+
+      post '/api/v1/inboxes', params: valid_payload, headers: headers, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['data']['webhook_registration_status']).to eq('failed')
+    end
+  end
+
+  describe 'PATCH /api/v1/inboxes/:id' do
+    def create_inbox
+      post '/api/v1/inboxes', params: valid_payload, headers: headers, as: :json
+      response.parsed_body['data']['id']
+    end
+
+    it 're-runs the smoke test when the api_key is rotated' do
+      inbox_id = create_inbox
+      WebMock.reset_executed_requests!
+
+      patch "/api/v1/inboxes/#{inbox_id}",
+            params: { channel: { api_key: 'SG.rotated-key' } }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(a_request(:get, scopes_url)).to have_been_made.once
+    end
+
+    it 'returns 422 when the rotated api_key is rejected' do
+      inbox_id = create_inbox
+      stub_request(:get, scopes_url).to_return(status: 403, body: '{}')
+
+      patch "/api/v1/inboxes/#{inbox_id}",
+            params: { channel: { api_key: 'SG.bad-key' } }, headers: headers, as: :json
 
       expect(response).to have_http_status(:unprocessable_entity)
     end

--- a/spec/serializers/inbox_serializer_sendgrid_spec.rb
+++ b/spec/serializers/inbox_serializer_sendgrid_spec.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'webmock/rspec'
 
 RSpec.describe InboxSerializer do
   describe '.serialize with a SendGrid channel' do
+    before do
+      stub_request(:get, 'https://api.sendgrid.com/v3/scopes').to_return(status: 200, body: '{}')
+      stub_request(:patch, 'https://api.sendgrid.com/v3/user/webhooks/event/settings').to_return(status: 200, body: '{}')
+    end
+
     let(:channel) do
       Channel::Sendgrid.create!(
         api_key: 'SG.secret-xyz',

--- a/spec/services/sendgrid/admin_client_spec.rb
+++ b/spec/services/sendgrid/admin_client_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Sendgrid::AdminClient do
+  subject(:client) { described_class.new(api_key) }
+
+  let(:api_key) { 'SG.test-key' }
+  let(:scopes_url) { 'https://api.sendgrid.com/v3/scopes' }
+  let(:webhook_url) { 'https://api.sendgrid.com/v3/user/webhooks/event/settings' }
+  let(:callback_url) { 'https://crm.example.com/webhooks/sendgrid' }
+
+  describe '#smoke_test!' do
+    it 'returns true and sends the key as a Bearer token when SendGrid accepts it' do
+      stub = stub_request(:get, scopes_url)
+             .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+             .to_return(status: 200, body: { scopes: ['mail.send'] }.to_json)
+
+      expect(client.smoke_test!).to be(true)
+      expect(stub).to have_been_requested
+    end
+
+    [401, 403].each do |code|
+      it "raises InvalidApiKeyError on #{code}" do
+        stub_request(:get, scopes_url).to_return(status: code, body: '{}')
+
+        expect { client.smoke_test! }.to raise_error(Sendgrid::InvalidApiKeyError)
+      end
+    end
+
+    it 'raises ServiceUnavailableError on a 5xx' do
+      stub_request(:get, scopes_url).to_return(status: 503, body: 'down')
+
+      expect { client.smoke_test! }.to raise_error(Sendgrid::ServiceUnavailableError)
+    end
+
+    it 'raises ServiceUnavailableError on a network failure' do
+      stub_request(:get, scopes_url).to_timeout
+
+      expect { client.smoke_test! }.to raise_error(Sendgrid::ServiceUnavailableError)
+    end
+  end
+
+  describe '#upsert_event_webhook!' do
+    it 'enables the callback url with exactly the eleven scoped events' do
+      stub_request(:patch, webhook_url).to_return(status: 200, body: '{}')
+
+      client.upsert_event_webhook!(callback_url: callback_url)
+
+      expect(
+        a_request(:patch, webhook_url).with do |req|
+          body = JSON.parse(req.body)
+          body['enabled'] == true && body['url'] == callback_url &&
+            described_class::WEBHOOK_EVENTS.all? { |event| body[event] == true }
+        end
+      ).to have_been_made
+    end
+
+    it 'raises ServiceUnavailableError on a 5xx' do
+      stub_request(:patch, webhook_url).to_return(status: 500, body: 'oops')
+
+      expect { client.upsert_event_webhook!(callback_url: callback_url) }
+        .to raise_error(Sendgrid::ServiceUnavailableError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Story **[9.2] EVO-1249** — closes the loop after 9.1 (SendGridChannel CRUD): when a SendGrid channel is created or its `api_key` is rotated, the CRM now (a) **smoke-tests the key** against `GET /v3/scopes` (401/403 → **422**, channel not persisted; 5xx/network → **503**) and (b) **registers the SendGrid event webhook** (`PATCH /v3/user/webhooks/event/settings`) pointing at `POST /webhooks/sendgrid` with the 11 scoped events. A registration failure persists the channel with `webhook_registration_status = 'failed'` and logs it.

- `Sendgrid::AdminClient` (HTTParty, isolated; mirrors `EvoFlow::Client`): `smoke_test!` + `upsert_event_webhook!`, with `InvalidApiKeyError` (401/403) / `ServiceUnavailableError` (5xx/network). Errors split into their own files for Zeitwerk.
- `Channel::Sendgrid`: `before_save` smoke gate + `after_save` webhook registration, both guarded on `api_key` change; `webhook_registration_status` column (`pending`/`active`/`failed`).
- `InboxesController`: `rescue_from` → 422 (invalid key) / 503 (SendGrid down).
- `InboxSerializer`: exposes `webhook_registration_status` (never the key).

> **Note — endpoint:** the card text references `POST /api/v1/notificame/channels`, but 9.1 was delivered on the Chatwoot-style inbox architecture, so this hooks into the real path `POST/PATCH /api/v1/inboxes` (`Channel::Sendgrid` via `InboxesController`).

## Security

- API key never logged (4xx bodies redacted in the client) and never serialized (only `api_key_present` + status).
- HTTPS to `api.sendgrid.com`; base URL configurable via `SENDGRID_API_BASE_URL`. Callback URL via `SENDGRID_WEBHOOK_URL` (fallback `FRONTEND_URL`); a non-absolute URL short-circuits to `failed` instead of registering a bad endpoint (review fix M2).
- Endpoint already scoped by `require_permissions` (`inboxes.create` / `inboxes.update`).

## Test plan

- `evo-ai-crm-community: bundle exec rubocop` (authored files clean)
- `evo-ai-crm-community: bundle exec rspec spec/services/sendgrid/admin_client_spec.rb spec/models/channel/sendgrid_spec.rb spec/requests/api/v1/inboxes_sendgrid_spec.rb spec/serializers/inbox_serializer_sendgrid_spec.rb` — **34 examples, 0 failures**
- Manual smoke (Rails dev + mocked SendGrid via `SENDGRID_API_BASE_URL`):
  - valid key → `201` + `webhook_registration_status: active`, webhook PATCH carried the 11 events to the absolute URL, key not leaked
  - invalid key → `422` `{ code: VALIDATION_ERROR, message: "SendGrid API key is invalid" }`

## Changed Files

- `app/services/sendgrid/admin_client.rb`, `api_error.rb`, `invalid_api_key_error.rb`, `service_unavailable_error.rb`
- `app/models/channel/sendgrid.rb`
- `app/controllers/api/v1/inboxes_controller.rb`
- `app/serializers/inbox_serializer.rb`
- `db/migrate/20260609120000_add_webhook_registration_status_to_channel_sendgrid.rb`, `db/schema.rb`
- specs: `spec/services/sendgrid/admin_client_spec.rb` (+ extended model / request / serializer specs)

## Deferred / notes

- **M1 (accepted, documented):** smoke + webhook run inside the create transaction (testability under transactional fixtures); acceptable for a low-frequency admin operation.
- **Pre-existing (not in scope):** `spec/models/channel/whatsapp_spec.rb:61` makes a real `graph.facebook.com` call and fails under any WebMock-loading spec (reproduced without this change via `evo_auth_service_spec`). Recommend a follow-up to stub it.

## Linked Issue

- EVO-1249

cc @daniel.paes

🤖 Generated with [Claude Code](https://claude.com/claude-code)