### PR TITLE
feat(crm): persist AI→human handoff as a timeline activity message (EVO-1560)

### DIFF
--- a/app/models/concerns/activity_message_handler.rb
+++ b/app/models/concerns/activity_message_handler.rb
@@ -4,6 +4,7 @@ module ActivityMessageHandler
   include PriorityActivityMessageHandler
   include LabelActivityMessageHandler
   include TeamActivityMessageHandler
+  include BotHandoffActivityMessageHandler
 
   private
 

--- a/app/models/concerns/bot_handoff_activity_message_handler.rb
+++ b/app/models/concerns/bot_handoff_activity_message_handler.rb
@@ -9,6 +9,10 @@ module BotHandoffActivityMessageHandler
   private
 
   def create_bot_handoff_activity
+    # Only log a real transition: skip when bot_handoff! runs on an
+    # already-open conversation (open! is then a no-op).
+    return unless saved_change_to_status?
+
     content = I18n.t('conversations.activity.bot_handoff')
     params = activity_message_params(content).merge(content_attributes: { handoff_type: 'bot_to_human' })
     ::Conversations::ActivityMessageJob.perform_later(self, params)

--- a/app/models/concerns/bot_handoff_activity_message_handler.rb
+++ b/app/models/concerns/bot_handoff_activity_message_handler.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Persists the AI→human handoff as a timeline activity message (EVO-1560), so
+# the transition is durable and renders in the conversation history alongside
+# the existing status/assignee/label activities.
+module BotHandoffActivityMessageHandler
+  extend ActiveSupport::Concern
+
+  private
+
+  def create_bot_handoff_activity
+    content = I18n.t('conversations.activity.bot_handoff')
+    params = activity_message_params(content).merge(content_attributes: { handoff_type: 'bot_to_human' })
+    ::Conversations::ActivityMessageJob.perform_later(self, params)
+  end
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -166,6 +166,7 @@ class Conversation < ApplicationRecord
 
   def bot_handoff!
     open!
+    create_bot_handoff_activity
     dispatcher_dispatch(CONVERSATION_BOT_HANDOFF)
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
         removed: '%{user_name} removed %{labels}'
       muted: '%{user_name} has muted the conversation'
       unmuted: '%{user_name} has unmuted the conversation'
+      bot_handoff: 'The bot handed off the conversation to an agent'
       auto_resolution_message: 'Resolving the conversation as it has been inactive for a while. Please start a new conversation if you need further assistance.'
     templates:
       greeting_message_body: '%{account_name} typically replies in a few hours.'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -159,6 +159,7 @@ pt:
         removed: '%{user_name} removeu a %{labels}'
       muted: '%{user_name} bloqueou a conversa'
       unmuted: '%{user_name} reativou a conversa'
+      bot_handoff: 'O bot encaminhou a conversa para um atendente'
       auto_resolution_message: 'Resolving the conversation as it has been inactive for a while. Please start a new conversation if you need further assistance.'
     templates:
       greeting_message_body: '%{account_name} normalmente responde em poucas horas.'

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -177,6 +177,7 @@ pt_BR:
         removed: '%{user_name} removeu %{labels}'
       muted: '%{user_name} silenciou a conversa'
       unmuted: '%{user_name} reativou a conversa'
+      bot_handoff: 'O bot encaminhou a conversa para um atendente'
       auto_resolution_message: 'Resolvendo a conversa dado que está inativa por um tempo. Por favor, inicie uma nova conversa se precisar de mais ajuda.'
     templates:
       greeting_message_body: '%{account_name} normalmente responde em algumas horas.'

--- a/spec/models/conversation_bot_handoff_spec.rb
+++ b/spec/models/conversation_bot_handoff_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe 'Conversation#bot_handoff! activity', type: :model do
   let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
   let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
   let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
-  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :pending) }
+  let(:conversation) do
+    conv = Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+    # Bypass the callback that auto-opens new conversations to set up a real
+    # pending -> open handoff transition.
+    conv.update_column(:status, Conversation.statuses[:pending]) # rubocop:disable Rails/SkipsModelValidations
+    conv.reload
+  end
 
   def captured_activity_params
     captured = []
@@ -29,6 +35,15 @@ RSpec.describe 'Conversation#bot_handoff! activity', type: :model do
     expect(handoff).to be_present
     expect(handoff[:message_type]).to eq(:activity)
     expect(handoff[:content]).to eq(I18n.t('conversations.activity.bot_handoff'))
+  end
+
+  it 'does not log a handoff activity when the conversation is already open' do
+    open_conversation = Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :open)
+    params = captured_activity_params
+
+    open_conversation.bot_handoff!
+
+    expect(params.any? { |p| p.dig(:content_attributes, :handoff_type) == 'bot_to_human' }).to be(false)
   end
 
   it 'opens the conversation' do

--- a/spec/models/conversation_bot_handoff_spec.rb
+++ b/spec/models/conversation_bot_handoff_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1560 — the AI→human handoff must leave a durable, renderable timeline
+# item. bot_handoff! previously only dispatched an event; it now also persists
+# an activity message (reusing the existing activity-message mechanism).
+RSpec.describe 'Conversation#bot_handoff! activity', type: :model do
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox, status: :pending) }
+
+  def captured_activity_params
+    captured = []
+    allow(Conversations::ActivityMessageJob).to receive(:perform_later) do |_record, params|
+      captured << params
+    end
+    captured
+  end
+
+  it 'persists a bot-handoff activity message tagged bot_to_human' do
+    params = captured_activity_params
+
+    conversation.bot_handoff!
+
+    handoff = params.find { |p| p.dig(:content_attributes, :handoff_type) == 'bot_to_human' }
+    expect(handoff).to be_present
+    expect(handoff[:message_type]).to eq(:activity)
+    expect(handoff[:content]).to eq(I18n.t('conversations.activity.bot_handoff'))
+  end
+
+  it 'opens the conversation' do
+    captured_activity_params
+
+    conversation.bot_handoff!
+
+    expect(conversation.reload).to be_open
+  end
+
+  it 'persists a valid activity Message row with the handoff metadata' do
+    params = conversation.send(:activity_message_params, I18n.t('conversations.activity.bot_handoff'))
+                         .merge(content_attributes: { handoff_type: 'bot_to_human' })
+
+    expect { conversation.messages.create!(params) }.to change(conversation.messages, :count).by(1)
+
+    msg = conversation.messages.last
+    expect(msg.message_type).to eq('activity')
+    expect(msg.content).to eq(I18n.t('conversations.activity.bot_handoff'))
+    expect(msg.content_attributes['handoff_type']).to eq('bot_to_human')
+  end
+
+  it 'localizes the handoff content in en and pt-BR' do
+    expect(I18n.t('conversations.activity.bot_handoff', locale: :en))
+      .to eq('The bot handed off the conversation to an agent')
+    expect(I18n.t('conversations.activity.bot_handoff', locale: :pt_BR))
+      .to eq('O bot encaminhou a conversa para um atendente')
+  end
+end


### PR DESCRIPTION
## Summary

When the bot hands a conversation off to a human, `Conversation#bot_handoff!` previously only dispatched the `CONVERSATION_BOT_HANDOFF` event (a notification + a reporting metric) — leaving **no durable, user-visible record** of the transition. It now also persists an **activity message**, reusing the existing activity-message mechanism, so the handoff renders in the conversation timeline alongside the status/assignee/label activities.

- `BotHandoffActivityMessageHandler` concern (mirrors the existing per-category activity handlers: priority/label/team), included into `ActivityMessageHandler`. Creates `message_type: :activity`, `content_attributes: { handoff_type: 'bot_to_human' }`, guarded on a real status transition (`saved_change_to_status?`) so a no-op call on an already-open conversation does not log a spurious handoff.
- i18n key `conversations.activity.bot_handoff` (en + pt-BR + pt).
- **No new table, no migration, no API/serializer change** — the frontend already renders activity messages via `SystemMessage` (the content is server-localized).

## Scope / deferred

- **Delivered (the gap the card identified):** persist + render the **bot→human** handoff.
- **`[fulano] assumiu a conversa`** already exists via the assignee-change activity (unchanged).
- **Deferred (no trigger exists in the code):** **human→bot** ("devolvido ao bot") would require a new return-to-bot feature. Optional separator/metrics also out of v1 (a `reporting_event` for `conversation_bot_handoff` already exists).

## Security

- No new endpoint, input, or secret. The activity message is internal, scoped by conversation/inbox like every other activity. No authz change.

## Test plan

- `evo-ai-crm-community: bundle exec rspec spec/models/conversation_bot_handoff_spec.rb` — **5 examples, 0 failures** (enqueue params, no-op guard, opens, real Message persistence, en/pt-BR localization)
- `evo-ai-crm-community: bundle exec rubocop` — clean on the authored files

## Changed Files

- `app/models/concerns/bot_handoff_activity_message_handler.rb` (new)
- `app/models/concerns/activity_message_handler.rb` (include)
- `app/models/conversation.rb` (`bot_handoff!`)
- `config/locales/en.yml`, `config/locales/pt_BR.yml`, `config/locales/pt.yml`
- `spec/models/conversation_bot_handoff_spec.rb` (new)

## Deferred ACs

- human→bot ("devolvido ao bot") — no return-to-bot trigger exists in the codebase; deferred to a future feature (accepted by reporter).

## Linked Issue

- EVO-1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Persist the AI-to-human bot handoff as a timeline activity message when a conversation is handed over to an agent.

New Features:
- Record bot-to-human handoffs as activity messages in the conversation timeline.
- Localize the bot handoff activity message in English and Portuguese variants.

Tests:
- Add model specs to verify bot handoff activity creation, no-op behavior, and localization.