### PR TITLE
feat(templates): decouple message templates from channel for global menu (EVO-1231)

### DIFF
--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -348,13 +348,22 @@ module Api
 
         # Generic message templates (for all channel types)
         def message_templates
-          authorize @inbox, :message_templates?
+          # Global (channel-less) mode is gated by the require_permissions
+          # before_action; the inbox is irrelevant so skip the inbox policy.
+          authorize @inbox, :message_templates? unless global_template_request?
 
           case request.method
           when 'GET'
             # List templates
             begin
-              @templates = @inbox.channel&.message_templates&.active || MessageTemplate.none
+              @templates =
+                if global_template_request?
+                  # Only channel-less (global) templates, and only active ones
+                  # to mirror the per-channel listing semantics.
+                  MessageTemplate.where(channel_id: nil).active
+                else
+                  @inbox.channel&.message_templates&.active || MessageTemplate.none
+                end
 
               @templates = @templates.by_category(params[:category]) if params[:category].present?
               @templates = @templates.by_type(params[:template_type]) if params[:template_type].present?
@@ -411,14 +420,24 @@ module Api
               # template approval (Api, Email, etc.), fall back to the
               # local-only path so behaviour is unchanged.
               template =
-                if @inbox.channel.respond_to?(:create_template)
+                if global_template_request?
+                  # Global template: not tied to any channel. A self-reported
+                  # `provider == whatsapp_cloud` is rejected by the model, since
+                  # a WhatsApp Cloud template must be bound to its channel.
+                  MessageTemplate.create!(
+                    template_params.to_h.merge(
+                      channel: nil,
+                      intended_provider: params.dig(:message_template, :provider)
+                    )
+                  )
+                elsif @inbox.channel.respond_to?(:create_template)
                   @inbox.channel.create_template(template_params.to_h.stringify_keys)
                 else
                   @inbox.channel.create_message_template(template_params)
                 end
 
               # Reload channel to clear any cached associations
-              @inbox.channel.reload
+              @inbox.channel.reload unless global_template_request?
 
               success_response(
                 data: template.serialized,
@@ -431,6 +450,14 @@ module Api
                 ApiErrorCodes::VALIDATION_ERROR,
                 e.message,
                 details: format_validation_errors(e.record.errors),
+                status: :unprocessable_entity
+              )
+            rescue ActiveRecord::RecordNotUnique => e
+              # Partial unique index race for global template names.
+              Rails.logger.error "Template uniqueness conflict: #{e.message}"
+              error_response(
+                ApiErrorCodes::VALIDATION_ERROR,
+                'A template with this name already exists',
                 status: :unprocessable_entity
               )
             rescue StandardError => e
@@ -494,7 +521,7 @@ module Api
           Rails.logger.info "Params: #{params.inspect}"
           Rails.logger.info "Template ID: #{params[:template_id]}"
 
-          authorize @inbox, :update_message_template?
+          authorize @inbox, :update_message_template? unless global_template_request?
           Rails.logger.info 'Authorization passed'
 
           Rails.logger.info 'Channel type validation passed'
@@ -511,13 +538,24 @@ module Api
             Rails.logger.info "Template params keys: #{template_params.keys}"
             Rails.logger.info "Calling update_message_template with ID: #{template_id}"
 
-            updated_template = @inbox.channel.update_message_template(template_id, template_params)
+            updated_template =
+              if global_template_request?
+                # Global template: update the channel-less record directly.
+                # Scoping to channel_id: nil prevents reaching channel-bound
+                # templates through the global endpoint.
+                template = MessageTemplate.where(channel_id: nil).find(template_id)
+                template.intended_provider = params.dig(:message_template, :provider)
+                template.update!(template_params)
+                template
+              else
+                @inbox.channel.update_message_template(template_id, template_params)
+              end
             Rails.logger.info "Template updated successfully"
             Rails.logger.info "Updated template ID: #{updated_template.id}"
             Rails.logger.info "Updated template attributes: #{updated_template.attributes.inspect}"
 
             # Reload channel to clear any cached associations
-            @inbox.channel.reload
+            @inbox.channel.reload unless global_template_request?
 
             success_response(
               data: { template: updated_template.serialized },
@@ -536,6 +574,14 @@ module Api
               ApiErrorCodes::VALIDATION_ERROR,
               e.message,
               details: format_validation_errors(e.record.errors),
+              status: :unprocessable_entity
+            )
+          rescue ActiveRecord::RecordNotUnique => e
+            # Partial unique index race for global template names.
+            Rails.logger.error "Template uniqueness conflict: #{e.message}"
+            error_response(
+              ApiErrorCodes::VALIDATION_ERROR,
+              'A template with this name already exists',
               status: :unprocessable_entity
             )
           rescue StandardError => e
@@ -558,7 +604,7 @@ module Api
           Rails.logger.info "Params: #{params.inspect}"
           Rails.logger.info "Template ID or Name: #{params[:template_id] || params[:template_name]}"
 
-          authorize @inbox, :delete_message_template?
+          authorize @inbox, :delete_message_template? unless global_template_request?
           Rails.logger.info 'Authorization passed'
 
           Rails.logger.info 'Channel type validation passed'
@@ -571,7 +617,13 @@ module Api
 
             if template_id.present?
               # Delete by ID (new way)
-              @inbox.channel.delete_message_template(template_id)
+              if global_template_request?
+                # Scope to channel_id: nil so the global endpoint cannot delete
+                # channel-bound templates.
+                MessageTemplate.where(channel_id: nil).find(template_id).destroy!
+              else
+                @inbox.channel.delete_message_template(template_id)
+              end
               Rails.logger.info "Template deleted successfully by ID: #{template_id}"
             elsif template_name.present?
               # Delete by name (legacy support)
@@ -589,7 +641,7 @@ module Api
             end
 
             # Reload channel to clear any cached associations
-            @inbox.channel.reload
+            @inbox.channel.reload unless global_template_request?
 
             success_response(
               data: nil,
@@ -598,6 +650,13 @@ module Api
           rescue ActiveRecord::RecordNotFound
             Rails.logger.error "Template not found"
             render_template_not_found_error
+          rescue ActiveRecord::RecordNotDestroyed => e
+            Rails.logger.error "Template could not be destroyed: #{e.message}"
+            error_response(
+              ApiErrorCodes::VALIDATION_ERROR,
+              'Template could not be deleted',
+              status: :unprocessable_entity
+            )
           rescue StandardError => e
             Rails.logger.error "Error in delete_message_template: #{e.message}"
             Rails.logger.error "Error backtrace: #{e.backtrace.join("\n")}"
@@ -1025,6 +1084,11 @@ module Api
               }
             ]
           )
+        end
+
+        # Global (channel-less) template mode toggle: `?global=true`.
+        def global_template_request?
+          ActiveModel::Type::Boolean.new.cast(params[:global])
         end
 
         def extract_message_template_params

--- a/app/models/message_template.rb
+++ b/app/models/message_template.rb
@@ -7,7 +7,7 @@
 #  id            :uuid             not null, primary key
 #  active        :boolean          default(TRUE)
 #  category      :string
-#  channel_type  :string           not null
+#  channel_type  :string
 #  components    :jsonb
 #  content       :text             not null
 #  language      :string           default("pt_BR")
@@ -20,10 +20,11 @@
 #  variables     :jsonb
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  channel_id    :uuid             not null
+#  channel_id    :uuid
 #
 # Indexes
 #
+#  idx_message_templates_global_name   (name) UNIQUE WHERE (channel_id IS NULL)
 #  idx_templates_active_by_channel     (channel_type,channel_id,active)
 #  idx_templates_by_category           (category)
 #  idx_templates_by_name               (name)
@@ -33,13 +34,23 @@
 #
 
 class MessageTemplate < ApplicationRecord
-  belongs_to :channel, polymorphic: true
+  # Channel is optional so templates can exist as global (channel-less) records.
+  # WhatsApp Cloud templates still require a channel (enforced below).
+  belongs_to :channel, polymorphic: true, optional: true
+
+  # Non-persisted hint used by the global create path to flag WhatsApp Cloud
+  # intent for a channel-less template, so the conditional validation can fire.
+  attr_accessor :intended_provider
 
   validates :name, presence: true
   validates :content, presence: true
+  # When channel_type/channel_id are nil this scopes uniqueness to the global
+  # (nil, nil) bucket, i.e. global template names are unique.
   validates :name, uniqueness: { scope: [:channel_type, :channel_id] }
   validates :language, presence: true
   validates :media_type, inclusion: { in: %w[image video document audio] }, allow_nil: true
+
+  validate :channel_required_for_whatsapp_cloud
 
   before_save :extract_variables_from_content
   after_initialize :set_defaults
@@ -175,6 +186,14 @@ class MessageTemplate < ApplicationRecord
   end
 
   private
+
+  # WhatsApp Cloud requires a Meta-approved template tied to its channel, so a
+  # channel-less template flagged as WhatsApp Cloud is invalid.
+  def channel_required_for_whatsapp_cloud
+    return if channel.present?
+
+    errors.add(:channel, 'is required for WhatsApp Cloud templates') if intended_provider == 'whatsapp_cloud'
+  end
 
   def set_defaults
     self.language ||= 'pt_BR'

--- a/db/migrate/20260609140000_decouple_message_templates_channel.rb
+++ b/db/migrate/20260609140000_decouple_message_templates_channel.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# EVO-1231 [6.2]: decouple message templates from channel so they can exist as
+# global (channel-less) records. Channel link becomes optional; a partial unique
+# index guarantees global template names are unique among channel-less rows.
+class DecoupleMessageTemplatesChannel < ActiveRecord::Migration[7.1]
+  def up
+    change_column_null :message_templates, :channel_type, true
+    change_column_null :message_templates, :channel_id, true
+
+    add_index :message_templates, :name,
+              unique: true,
+              where: 'channel_id IS NULL',
+              name: 'idx_message_templates_global_name'
+  end
+
+  def down
+    # Restoring NOT NULL is impossible once global (channel-less) templates exist.
+    if select_value('SELECT 1 FROM message_templates WHERE channel_id IS NULL LIMIT 1')
+      raise ActiveRecord::IrreversibleMigration,
+            'Cannot restore NOT NULL on message_templates.channel_*: global (channel-less) templates exist'
+    end
+
+    remove_index :message_templates, name: 'idx_message_templates_global_name'
+    change_column_null :message_templates, :channel_id, false
+    change_column_null :message_templates, :channel_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_09_130000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_09_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -695,8 +695,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_09_130000) do
   end
 
   create_table "message_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "channel_type", null: false
-    t.uuid "channel_id", null: false
+    t.string "channel_type"
+    t.uuid "channel_id"
     t.string "name", null: false
     t.text "content", null: false
     t.string "language", default: "pt_BR"
@@ -715,6 +715,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_09_130000) do
     t.index ["channel_type", "channel_id", "active"], name: "idx_templates_active_by_channel"
     t.index ["channel_type", "channel_id"], name: "index_message_templates_on_channel"
     t.index ["name", "channel_type", "channel_id"], name: "idx_templates_lookup"
+    t.index ["name"], name: "idx_message_templates_global_name", unique: true, where: "(channel_id IS NULL)"
     t.index ["name"], name: "idx_templates_by_name"
     t.index ["template_type"], name: "idx_templates_by_type"
   end

--- a/spec/models/message_template_spec.rb
+++ b/spec/models/message_template_spec.rb
@@ -52,4 +52,60 @@ RSpec.describe MessageTemplate, type: :model do
       expect(serialized['settings']).to eq({ 'status' => 'PENDING', 'source' => 'meta_api' })
     end
   end
+
+  # EVO-1231 [6.2]: templates can exist as global (channel-less) records;
+  # WhatsApp Cloud templates still require a channel.
+  describe 'channel decoupling' do
+    def whatsapp_channel(provider:)
+      channel = Channel::Whatsapp.new(provider: provider, phone_number: "+1555#{SecureRandom.hex(3)}")
+      channel.save!(validate: false)
+      channel
+    end
+
+    it 'persists a global (channel-less) template' do
+      template = described_class.create!(name: "global-#{SecureRandom.hex(4)}", content: 'Hello')
+
+      expect(template.channel_id).to be_nil
+      expect(template.channel_type).to be_nil
+    end
+
+    it 'is invalid as a channel-less WhatsApp Cloud template' do
+      template = described_class.new(
+        name: "wac-#{SecureRandom.hex(4)}", content: 'Hello', intended_provider: 'whatsapp_cloud'
+      )
+
+      expect(template).not_to be_valid
+      expect(template.errors[:channel]).to include('is required for WhatsApp Cloud templates')
+    end
+
+    it 'is valid as a WhatsApp Cloud template when a channel is present' do
+      template = described_class.new(
+        name: "wac-#{SecureRandom.hex(4)}", content: 'Hello',
+        channel: whatsapp_channel(provider: 'whatsapp_cloud'), intended_provider: 'whatsapp_cloud'
+      )
+
+      expect(template).to be_valid
+    end
+
+    it 'enforces a unique name among global templates' do
+      name = "dup-#{SecureRandom.hex(4)}"
+      described_class.create!(name: name, content: 'first')
+
+      duplicate = described_class.new(name: name, content: 'second')
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:name]).to be_present
+    end
+
+    it 'allows a channel-bound template to reuse a global template name' do
+      name = "shared-#{SecureRandom.hex(4)}"
+      described_class.create!(name: name, content: 'global')
+
+      bound = described_class.new(
+        name: name, content: 'bound', channel: whatsapp_channel(provider: 'evolution')
+      )
+
+      expect(bound).to be_valid
+    end
+  end
 end

--- a/spec/requests/api/v1/message_templates_spec.rb
+++ b/spec/requests/api/v1/message_templates_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1231 [6.2]: global (channel-less) message-template CRUD exposed via the
+# existing per-inbox endpoints with the `?global=true` toggle.
+RSpec.describe 'Api::V1::Inboxes message templates (global mode)', type: :request do
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+  let(:channel) { Channel::Api.create!(hmac_mandatory: false) }
+  let(:inbox) { Inbox.create!(channel: channel, name: "Inbox #{SecureRandom.hex(3)}") }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  describe 'POST /api/v1/inboxes/:id/message_templates?global=true' do
+    it 'creates a channel-less template (AC1)' do
+      post "/api/v1/inboxes/#{inbox.id}/message_templates?global=true",
+           params: { message_template: { name: "g-#{SecureRandom.hex(4)}", content: 'Hello' } },
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:created)
+      created = MessageTemplate.find(json_response['data']['id'])
+      expect(created.channel_id).to be_nil
+      expect(created.channel_type).to be_nil
+    end
+
+    it 'rejects a WhatsApp Cloud template without a channel (AC5)' do
+      post "/api/v1/inboxes/#{inbox.id}/message_templates?global=true",
+           params: { message_template: { name: "wac-#{SecureRandom.hex(4)}", content: 'Hello', provider: 'whatsapp_cloud' } },
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'GET /api/v1/inboxes/:id/message_templates?global=true (AC2)' do
+    it 'lists global templates' do
+      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Hi')
+
+      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data'].map { |t| t['name'] }).to include(template.name)
+    end
+  end
+
+  describe 'PUT /api/v1/inboxes/:id/message_templates/:template_id?global=true (AC3)' do
+    it 'updates a global template' do
+      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Old')
+
+      put "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}?global=true",
+          params: { message_template: { content: 'New' } },
+          headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(template.reload.content).to eq('New')
+    end
+  end
+
+  describe 'DELETE /api/v1/inboxes/:id/message_templates/:template_id?global=true (AC4)' do
+    it 'deletes a global template' do
+      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Bye')
+
+      delete "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}?global=true",
+             headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(MessageTemplate.exists?(template.id)).to be(false)
+    end
+  end
+
+  describe 'global scoping (excludes channel-bound and inactive templates)' do
+    def whatsapp_channel
+      ch = Channel::Whatsapp.new(provider: 'evolution', phone_number: "+1555#{SecureRandom.hex(3)}")
+      ch.save!(validate: false)
+      ch
+    end
+
+    it 'GET does not leak channel-bound templates' do
+      global = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'global')
+      bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: whatsapp_channel)
+
+      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", headers: headers, as: :json
+
+      names = json_response['data'].map { |t| t['name'] }
+      expect(names).to include(global.name)
+      expect(names).not_to include(bound.name)
+    end
+
+    it 'GET does not return inactive global templates' do
+      inactive = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'hidden', active: false)
+
+      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", headers: headers, as: :json
+
+      expect(json_response['data'].map { |t| t['name'] }).not_to include(inactive.name)
+    end
+
+    it 'PUT cannot reach a channel-bound template' do
+      bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: whatsapp_channel)
+
+      put "/api/v1/inboxes/#{inbox.id}/message_templates/#{bound.id}?global=true",
+          params: { message_template: { content: 'hacked' } },
+          headers: headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(bound.reload.content).to eq('bound')
+    end
+
+    it 'DELETE cannot reach a channel-bound template' do
+      bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: whatsapp_channel)
+
+      delete "/api/v1/inboxes/#{inbox.id}/message_templates/#{bound.id}?global=true",
+             headers: headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(MessageTemplate.exists?(bound.id)).to be(true)
+    end
+  end
+
+  describe 'permission enforcement (AC6)' do
+    let(:forbidden_user) { User.create!(name: 'No Perm', email: "noperm-#{SecureRandom.hex(4)}@example.com") }
+
+    before do
+      # Authenticate as a user (not a service token) so the require_permissions
+      # gate evaluates the remote permission, which we deny.
+      allow_any_instance_of(Api::V1::InboxesController)
+        .to receive(:authenticate_request!) { Current.user = forbidden_user }
+      allow_any_instance_of(EvoAuthService).to receive(:check_user_permission).and_return(false)
+    end
+
+    it 'returns 403 when the user lacks inboxes.message_templates' do
+      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

EVO-1231 [6.2] — re-scoped from *create* to **extend/decouple** (the 6.1 investigation / EVO-1230 proved a full `MessageTemplate` system already exists, hard-coupled to a channel).

Makes `MessageTemplate` channel-optional so templates can exist as **global (channel-less)** records, exposed through the existing per-inbox endpoints via a `?global=true` toggle. WhatsApp Cloud templates still require a channel. No `account_id` (this CRM is single-tenant).

- **Migration** — `channel_type`/`channel_id` nullable + partial unique index `(name) WHERE channel_id IS NULL`; explicit `up`/`down` with an `IrreversibleMigration` guard when global rows exist.
- **Model** — `belongs_to :channel, optional: true`, `intended_provider` virtual attr, `channel_required_for_whatsapp_cloud` validation.
- **Controller** — global branches in `message_templates` / `update_message_template` / `delete_message_template`, scoped to `channel_id: nil` so the global endpoint **cannot reach channel-bound templates**; `RecordNotUnique` / `RecordNotDestroyed` handled; in-action Pundit `authorize @inbox` skipped in global mode (the `require_permissions` before_action remains the gate).

### Endpoints (existing routes, `?global=true`)
- `GET    /api/v1/inboxes/:id/message_templates?global=true` — list active global templates
- `POST   /api/v1/inboxes/:id/message_templates?global=true` — create channel-less
- `PUT    /api/v1/inboxes/:id/message_templates/:template_id?global=true`
- `DELETE /api/v1/inboxes/:id/message_templates/:template_id?global=true`

## Test plan

- `bundle exec rspec spec/models/message_template_spec.rb spec/requests/api/v1/message_templates_spec.rb` → **24 examples, 0 failures** (incl. negative scoping + 403 auth).
- Migration: `db:migrate` → `db:rollback` → `db:migrate` verified clean.
- `rubocop` on new files clean; no new offense types on the controller.

## Notes

- Went through an adversarial review pass: 10 findings, 9 fixed (incl. two High-severity: cross-channel tampering via global PUT/DELETE, and a global-GET data leak — both now scoped to `channel_id: nil` and covered by negative specs), 1 confirmed no-defect (authorization not weakened).
- **WhatsApp Cloud** intent uses a self-reported `provider` + virtual attribute (a global/channel-less template is by definition not WA Cloud); deeper enforcement would need a persisted provider — deferred.
- **For 6.4 (UI):** the global menu currently lists **channel-less, active** templates only — confirm with product whether it should also surface channel-bound ones.
- Out of scope (tracked separately): UI (EVO-1233), call-site migration (EVO-1235), channel-link logic (EVO-1232), SendGrid concern gap (D4).