### PR TITLE
feat(crm): move_conversation endpoint for Journey Move to Pipeline Stage (EVO-1272)

### DIFF
--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -395,6 +395,38 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
   end
   # rubocop:enable Metrics/MethodLength
 
+  # Moves a conversation to a target stage by resolving its current pipeline
+  # placement server-side: same-pipeline -> move_to_stage; different pipeline ->
+  # cross-pipeline relocate (leaves the previous pipeline); none -> assign.
+  # Consumed by the evo-flow Journey "Move to Pipeline Stage" node so its output
+  # matches the Automation Rules pipeline action (10.B parity). A deleted target
+  # stage degrades to a logged skip rather than an error.
+  def move_conversation
+    stage = @pipeline.pipeline_stages.find_by(id: params[:pipeline_stage_id])
+    return skip_missing_target_stage if stage.nil?
+
+    conversation = Conversation.find_by(id: params[:conversation_id]) ||
+                   Conversation.find_by(display_id: params[:conversation_id])
+    return error_response(ApiErrorCodes::CONVERSATION_NOT_FOUND, 'Conversation not found') if conversation.nil?
+
+    movement_type, success = relocate_conversation(conversation, stage)
+
+    unless success
+      return error_response(
+        ApiErrorCodes::OPERATION_FAILED,
+        'Failed to move conversation',
+        status: :unprocessable_entity
+      )
+    end
+
+    dispatch_conversation_updated_event(conversation)
+
+    success_response(
+      data: { moved: true, movement_type: movement_type, pipeline_id: @pipeline.id, stage_id: stage.id },
+      message: 'Conversation moved successfully'
+    )
+  end
+
   def stats
     @stats = {
       total_conversations: @pipeline_items.count,
@@ -468,6 +500,31 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
   end
 
   private
+
+  def skip_missing_target_stage
+    Rails.logger.warn(
+      "PipelineItems#move_conversation: stage #{params[:pipeline_stage_id].inspect} " \
+      "not found in pipeline #{@pipeline.id}; skipping"
+    )
+    success_response(
+      data: { moved: false, skipped: true, reason: 'stage_not_found' },
+      message: 'Target stage not found; move skipped'
+    )
+  end
+
+  def relocate_conversation(conversation, stage)
+    service = Pipelines::ConversationService.new(pipeline: @pipeline, user: Current.user)
+    current_item = conversation.pipeline_items.active.find_by(pipeline_id: @pipeline.id) ||
+                   conversation.pipeline_items.active.first
+
+    if current_item.nil?
+      ['assigned', service.add_conversation(conversation, stage: stage)]
+    elsif current_item.pipeline_id == @pipeline.id
+      ['same_pipeline', service.move_to_stage(current_item, stage)]
+    else
+      ['cross_pipeline', service.move_to_pipeline_stage(current_item, stage)]
+    end
+  end
 
   def dispatch_conversation_updated_event(conversation)
     # Update conversation timestamp to ensure frontend gets the update (only for deals, not leads)

--- a/app/services/pipelines/conversation_service.rb
+++ b/app/services/pipelines/conversation_service.rb
@@ -46,6 +46,24 @@ class Pipelines::ConversationService
     false
   end
 
+  # Relocates an existing pipeline_item to a stage in a DIFFERENT pipeline,
+  # in place (preserving the row + history), so the conversation leaves the
+  # previous pipeline. Mirrors Pipelines::StageAutomationService#move_to_pipeline
+  # for parity; same-pipeline moves use #move_to_stage.
+  def move_to_pipeline_stage(pipeline_item, target_stage)
+    return false if pipeline_item.pipeline_id == target_stage.pipeline_id
+
+    old_stage = pipeline_item.pipeline_stage
+    pipeline_item.update!(pipeline_id: target_stage.pipeline_id, pipeline_stage_id: target_stage.id)
+    record_cross_pipeline_movement(pipeline_item, old_stage, target_stage)
+    notify_conversation_moved(pipeline_item, old_stage, target_stage)
+    execute_stage_automation(pipeline_item, target_stage)
+    true
+  rescue StandardError => e
+    Rails.logger.error "Failed to move conversation across pipelines: #{e.message}"
+    false
+  end
+
   def bulk_move_conversations(conversation_ids, new_stage, notes: nil)
     results = { success: 0, failed: 0, errors: [] }
 
@@ -133,6 +151,18 @@ class Pipelines::ConversationService
   def add_notes_to_movement(pipeline_item, notes)
     latest_movement = pipeline_item.stage_movements.last
     latest_movement.update!(notes: notes)
+  end
+
+  def record_cross_pipeline_movement(pipeline_item, old_stage, target_stage)
+    pipeline_item.stage_movements.create!(
+      from_stage: old_stage,
+      to_stage: target_stage,
+      moved_by: @user,
+      movement_type: 'cross_pipeline',
+      notes: "Moved from pipeline '#{old_stage&.pipeline&.name}' to '#{target_stage.pipeline.name}'"
+    )
+  rescue StandardError => e
+    Rails.logger.error "Failed to record cross-pipeline movement: #{e.message}"
   end
 
   def execute_stage_automation(pipeline_item, stage)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -562,6 +562,7 @@ Rails.application.routes.draw do
           end
           collection do
             patch :bulk_move
+            patch :move_conversation
             get :stats
             get :available_conversations
             get :available_contacts

--- a/spec/controllers/api/v1/pipeline_items_controller_spec.rb
+++ b/spec/controllers/api/v1/pipeline_items_controller_spec.rb
@@ -128,4 +128,93 @@ RSpec.describe Api::V1::PipelineItemsController, type: :controller do
       end
     end
   end
+
+  # EVO-1272 [10.14]: endpoint consumed by the evo-flow Journey "Move to
+  # Pipeline Stage" node. Resolves the conversation's current placement
+  # server-side (same-pipeline / cross-pipeline / assign) so the Journey
+  # node output matches the Automation Rules pipeline action (10.B parity).
+  describe 'PATCH #move_conversation' do
+    let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+    let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+    context 'when the conversation is already active in the target pipeline (same-pipeline, AC1)' do
+      before do
+        Pipelines::ConversationService.new(pipeline: pipeline, user: user).add_conversation(conversation, stage: stage_one)
+      end
+
+      it 'moves the existing item to the target stage' do
+        patch :move_conversation, params: {
+          pipeline_id: pipeline.id,
+          conversation_id: conversation.id,
+          pipeline_stage_id: stage_two.id
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig('data', 'movement_type')).to eq('same_pipeline')
+        item = conversation.pipeline_items.active.find_by(pipeline: pipeline)
+        expect(item.pipeline_stage_id).to eq(stage_two.id)
+      end
+    end
+
+    context 'when the conversation is active in a different pipeline (cross-pipeline, AC2)' do
+      let(:other_pipeline) { Pipeline.create!(name: 'Support', pipeline_type: 'sales', created_by: user) }
+      let!(:other_stage) { PipelineStage.create!(pipeline: other_pipeline, name: 'Triage', position: 1) }
+
+      before do
+        Pipelines::ConversationService.new(pipeline: other_pipeline, user: user).add_conversation(conversation, stage: other_stage)
+      end
+
+      it 'relocates the item to the target pipeline/stage and removes it from the previous pipeline' do
+        patch :move_conversation, params: {
+          pipeline_id: pipeline.id,
+          conversation_id: conversation.id,
+          pipeline_stage_id: stage_two.id
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig('data', 'movement_type')).to eq('cross_pipeline')
+        expect(conversation.pipeline_items.active.where(pipeline: other_pipeline)).to be_empty
+        moved = conversation.pipeline_items.active.find_by(pipeline: pipeline)
+        expect(moved.pipeline_stage_id).to eq(stage_two.id)
+      end
+    end
+
+    context 'when the conversation is not in any pipeline (auto-assign)' do
+      it 'creates a pipeline_item in the target pipeline at the target stage' do
+        expect do
+          patch :move_conversation, params: {
+            pipeline_id: pipeline.id,
+            conversation_id: conversation.id,
+            pipeline_stage_id: stage_two.id
+          }
+        end.to change { conversation.pipeline_items.active.count }.from(0).to(1)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig('data', 'movement_type')).to eq('assigned')
+        expect(conversation.pipeline_items.active.first.pipeline_stage_id).to eq(stage_two.id)
+      end
+    end
+
+    context 'when the target stage does not exist (deleted stage, AC3)' do
+      before do
+        Pipelines::ConversationService.new(pipeline: pipeline, user: user).add_conversation(conversation, stage: stage_one)
+      end
+
+      it 'degrades to a logged skip without moving the item' do
+        patch :move_conversation, params: {
+          pipeline_id: pipeline.id,
+          conversation_id: conversation.id,
+          pipeline_stage_id: SecureRandom.uuid
+        }
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body.dig('data', 'skipped')).to be(true)
+        expect(body.dig('data', 'reason')).to eq('stage_not_found')
+        expect(conversation.pipeline_items.active.find_by(pipeline: pipeline).pipeline_stage_id).to eq(stage_one.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Backend for the evo-flow Journey **Move to Pipeline Stage** node (EVO-1272).

Adds `PATCH /api/v1/pipelines/:pipeline_id/pipeline_items/move_conversation` (`{conversation_id, pipeline_stage_id}`), which resolves the conversation's current placement server-side and routes it:

- **same pipeline** → `Pipelines::ConversationService#move_to_stage`
- **different pipeline** → `#move_to_pipeline_stage` (relocates in place, leaves the previous pipeline, records a `cross_pipeline` stage_movement) — AC2 "remove from previous"
- **not in any pipeline** → `#add_conversation` (auto-assign)
- **deleted/invalid target stage** → logged skip `{ skipped: true, reason: 'stage_not_found' }` instead of an error (AC3)

## Acceptance Criteria

- [x] AC1 same-pipeline move to target stage
- [x] AC2 cross-pipeline move (removes from previous)
- [x] AC3 invalid stage → warn + skip
- [x] AC4 parity — same-pipeline & invalid-stage identical to Automation Rules. **Note:** cross-pipeline intentionally removes from the previous pipeline (AC2), which the current Automation Rules handler does not; full byte-parity there would require changing Automations (out of scope for this Journey card).

## Tests

Request specs for all four paths (`spec/controllers/api/v1/pipeline_items_controller_spec.rb`). Also validated with a live HTTP smoke (real service-token auth) across same / cross / skip / auto-assign — all green.

## Scope

Does **not** modify the existing `move_to_stage` service. The cross-pipeline `conversation_id` plumbing into Journey trigger events (so the node has a conversation to act on at runtime) is Journey-infra (EVO-1634), tracked separately.

Part of EVO-1272 — paired with evo-flow and frontend PRs.

## Summary by Sourcery

Add a new API endpoint to move a conversation into a specific pipeline stage by resolving its current pipeline placement server-side, including cross-pipeline moves and graceful handling of missing stages.

New Features:
- Introduce PATCH /api/v1/pipelines/:pipeline_id/pipeline_items/move_conversation to move conversations into a target pipeline stage based on their current pipeline placement.
- Support cross-pipeline relocation of conversations that removes them from the previous pipeline and records a cross-pipeline movement.

Enhancements:
- Extend Pipelines::ConversationService with cross-pipeline move support while preserving movement history and triggering automations as appropriate.

Tests:
- Add controller request specs covering same-pipeline moves, cross-pipeline moves, auto-assignment when not in a pipeline, and skips when the target stage is missing.