### PR TITLE
feat(crm): SendGrid event webhook receiver (EVO-1250)

### DIFF
--- a/app/controllers/webhooks/sendgrid_controller.rb
+++ b/app/controllers/webhooks/sendgrid_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Webhooks::SendgridController < ApplicationController
+  skip_before_action :authenticate_user!, raise: false
+
+  # SendGrid posts an array of event objects. Each event is deduped and
+  # processed independently; a single bad event never fails the batch.
+  # Always returns 200 so SendGrid does not retry the whole payload.
+  def create
+    events = parse_events
+    events.each { |event| process_event(event) }
+    render json: { received: events.size }, status: :ok
+  end
+
+  private
+
+  def parse_events
+    raw_body = request.body.read
+    request.body.rewind
+    parsed = JSON.parse(raw_body)
+    parsed.is_a?(Array) ? parsed : [parsed]
+  rescue JSON::ParserError => e
+    Rails.logger.warn("[SENDGRID_WEBHOOK] invalid JSON payload: #{e.message}")
+    []
+  end
+
+  def process_event(event)
+    Sendgrid::EventProcessor.new(event).process
+    true
+  rescue StandardError => e
+    Rails.logger.error("[SENDGRID_WEBHOOK] event processing failed: #{e.class}: #{e.message}")
+    false
+  end
+end

--- a/app/services/sendgrid/event_processor.rb
+++ b/app/services/sendgrid/event_processor.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+module Sendgrid
+  # Processes a single SendGrid event-webhook entry: dedups by sg_event_id,
+  # resolves message context from custom_args, maps the event to an internal
+  # Message status (reusing Messages::StatusUpdateService so the
+  # :message_status_changed broadcast and EvoFlow tracking stay on one path)
+  # and updates Contact email-suppression flags for negative terminal events.
+  #
+  # `unsubscribe` has no delivery-status equivalent, so it is handled as a
+  # suppression-only event (no message-status transition).
+  class EventProcessor
+    DEDUP_TTL = 24.hours.to_i
+    REQUIRED_ARGS = %w[contact_id message_id campaign_id].freeze
+
+    EVENT_STATUS_MAP = {
+      'delivered' => 'delivered',
+      'open' => 'read',
+      'click' => 'read',
+      'bounce' => 'failed',
+      'dropped' => 'failed',
+      'spam_report' => 'failed'
+    }.freeze
+
+    SUPPRESSION_EVENTS = %w[bounce dropped spam_report unsubscribe].freeze
+
+    METRIC_TOTAL = 'sendgrid:events:total'
+    METRIC_DUPLICATE = 'sendgrid:events:duplicate_drops'
+    METRIC_MISSING_ARGS = 'sendgrid:events:missing_args_drops'
+
+    def initialize(event)
+      @event = (event || {}).with_indifferent_access
+    end
+
+    # Returns a result symbol describing the outcome:
+    # :processed | :duplicate | :missing_args | :ignored
+    def process
+      Redis::Alfred.incr(METRIC_TOTAL)
+
+      return drop_duplicate unless claim_event
+
+      Redis::Alfred.incr("sendgrid:events:type:#{event_type}")
+
+      return drop_missing_args unless custom_args_present?
+
+      handle_event
+      :processed
+    end
+
+    private
+
+    attr_reader :event
+
+    def handle_event
+      apply_status_change
+      apply_suppression
+    rescue StandardError
+      # Release the dedup claim so a SendGrid resend can be retried — a
+      # transient write failure must not permanently swallow the event.
+      release_claim
+      raise
+    end
+
+    def claim_event
+      if sg_event_id.blank?
+        Rails.logger.warn("[SENDGRID_WEBHOOK] event without sg_event_id; processing without dedup event=#{event_type.inspect}")
+        return true
+      end
+
+      Redis::Alfred.set(dedup_key, 1, nx: true, ex: DEDUP_TTL)
+    end
+
+    def release_claim
+      return if sg_event_id.blank?
+
+      Redis::Alfred.delete(dedup_key)
+    end
+
+    def drop_duplicate
+      Redis::Alfred.incr(METRIC_DUPLICATE)
+      :duplicate
+    end
+
+    def drop_missing_args
+      Redis::Alfred.incr(METRIC_MISSING_ARGS)
+      Rails.logger.warn(
+        '[SENDGRID_WEBHOOK] dropping event with missing custom_args ' \
+        "sg_event_id=#{sg_event_id.inspect} event=#{event_type.inspect} payload=#{event.to_h.inspect}"
+      )
+      :missing_args
+    end
+
+    def apply_status_change
+      status = EVENT_STATUS_MAP[event_type]
+      return if status.nil?
+
+      message = Message.find_by(id: custom_args[:message_id])
+      return warn_missing('message', custom_args[:message_id]) unless message
+
+      Messages::StatusUpdateService.new(message, status, external_error).perform
+    end
+
+    def apply_suppression
+      return unless SUPPRESSION_EVENTS.include?(event_type)
+
+      contact = Contact.find_by(id: custom_args[:contact_id])
+      return warn_missing('contact', custom_args[:contact_id]) unless contact
+
+      contact.update!(email_suppressed: true, email_suppression_reason: event_type)
+    end
+
+    def external_error
+      return nil unless EVENT_STATUS_MAP[event_type] == 'failed'
+
+      event[:reason].presence || event_type
+    end
+
+    def custom_args_present?
+      REQUIRED_ARGS.all? { |key| custom_args[key].present? }
+    end
+
+    def custom_args
+      @custom_args ||= (event[:custom_args] || {}).with_indifferent_access
+    end
+
+    def event_type
+      event[:event].to_s
+    end
+
+    def sg_event_id
+      event[:sg_event_id].to_s
+    end
+
+    def dedup_key
+      "sendgrid:event:#{sg_event_id}"
+    end
+
+    def warn_missing(kind, id)
+      Rails.logger.warn(
+        "[SENDGRID_WEBHOOK] #{kind} not found for sg_event_id=#{sg_event_id.inspect} #{kind}_id=#{id.inspect}"
+      )
+      nil
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -711,6 +711,7 @@ Rails.application.routes.draw do
   post 'webhooks/telegram/:bot_token', to: 'webhooks/telegram#process_payload'
   post 'webhooks/sms/:phone_number', to: 'webhooks/sms#process_payload'
   post 'webhooks/gmail/pubsub', to: 'webhooks/gmail#pubsub'
+  post 'webhooks/sendgrid', to: 'webhooks/sendgrid#create'
   get 'webhooks/whatsapp', to: 'webhooks/whatsapp#verify'
   post 'webhooks/whatsapp', to: 'webhooks/whatsapp#process_payload'
   get 'webhooks/whatsapp/:phone_number', to: 'webhooks/whatsapp#verify'

--- a/db/migrate/20260609130000_add_email_suppression_to_contacts.rb
+++ b/db/migrate/20260609130000_add_email_suppression_to_contacts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEmailSuppressionToContacts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :contacts, :email_suppressed, :boolean, default: false, null: false
+    add_column :contacts, :email_suppression_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_09_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_09_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -398,6 +398,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_09_120000) do
     t.string "tax_id", limit: 14
     t.string "website"
     t.string "industry"
+    t.boolean "email_suppressed", default: false, null: false
+    t.string "email_suppression_reason"
     t.index ["blocked"], name: "index_contacts_on_blocked"
     t.index ["email"], name: "uniq_email_per_account_contact", unique: true
     t.index ["id"], name: "idx_contacts_with_identity", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"

--- a/spec/requests/webhooks/sendgrid_spec.rb
+++ b/spec/requests/webhooks/sendgrid_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Webhooks::Sendgrid', type: :request do
+  let(:fake_redis) { {} }
+
+  def post_events(events)
+    post '/webhooks/sendgrid', params: events.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+  end
+
+  def event(sg_event_id:, type: 'delivered', args: { contact_id: 'c-1', message_id: 'm-1', campaign_id: 'camp-1' })
+    { 'sg_event_id' => sg_event_id, 'event' => type, 'email' => 'a@b.com', 'custom_args' => args }
+  end
+
+  before do
+    allow(Redis::Alfred).to receive(:get) { |k| fake_redis[k] }
+    allow(Redis::Alfred).to receive(:incr) { |k| fake_redis[k] = (fake_redis[k].to_i + 1).to_s }
+    allow(Redis::Alfred).to receive(:set) do |k, v, **opts|
+      next false if opts[:nx] && fake_redis.key?(k)
+
+      fake_redis[k] = v.to_s
+      true
+    end
+    # Status update and contact lookup are exercised in the unit spec; here we
+    # only assert the controller contract, so keep them as cheap no-ops.
+    allow(Message).to receive(:find_by).and_return(nil)
+    allow(Contact).to receive(:find_by).and_return(nil)
+  end
+
+  describe 'POST /webhooks/sendgrid' do
+    it 'returns 200 and claims the dedup key for a new event (AC1)' do
+      post_events([event(sg_event_id: 'evt-new')])
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['received']).to eq(1)
+      expect(fake_redis['sendgrid:event:evt-new']).to eq('1')
+    end
+
+    it 'drops a duplicate event on the second identical post (AC2)' do
+      post_events([event(sg_event_id: 'evt-dup')])
+      post_events([event(sg_event_id: 'evt-dup')])
+
+      expect(response).to have_http_status(:ok)
+      expect(fake_redis['sendgrid:events:duplicate_drops']).to eq('1')
+    end
+
+    it 'returns 200 and drops the event when custom_args are missing (AC4)' do
+      allow(Rails.logger).to receive(:warn)
+      post '/webhooks/sendgrid',
+           params: [{ 'sg_event_id' => 'evt-noargs', 'event' => 'bounce' }].to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(response).to have_http_status(:ok)
+      expect(fake_redis['sendgrid:events:missing_args_drops']).to eq('1')
+    end
+
+    it 'handles an array mixing new and duplicate events and returns 200 (AC5)' do
+      post_events([event(sg_event_id: 'evt-a'), event(sg_event_id: 'evt-a'), event(sg_event_id: 'evt-b')])
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['received']).to eq(3)
+    end
+
+    it 'returns 200 even when an event raises during processing (AC5 resilience)' do
+      allow(Sendgrid::EventProcessor).to receive(:new).and_raise(StandardError, 'boom')
+
+      post_events([event(sg_event_id: 'evt-boom')])
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'suppresses a real Contact and fires the status update on a bounce (AC3, end-to-end)' do
+      # Exercise the real Redis::Alfred (MockRedis-backed in test) and a real
+      # Contact DB write; only the heavy Message graph is doubled.
+      allow(Redis::Alfred).to receive(:set).and_call_original
+      allow(Redis::Alfred).to receive(:incr).and_call_original
+      allow(Contact).to receive(:find_by).and_call_original
+
+      contact = Contact.create!(name: 'SG Smoke', email: "sg-#{SecureRandom.hex(4)}@example.com")
+      message = instance_double(Message)
+      status_service = instance_double(Messages::StatusUpdateService, perform: true)
+      allow(Message).to receive(:find_by).and_return(message)
+      allow(Messages::StatusUpdateService).to receive(:new).and_return(status_service)
+
+      post_events([event(sg_event_id: "evt-e2e-#{SecureRandom.hex(4)}", type: 'bounce',
+                          args: { contact_id: contact.id, message_id: 'm-1', campaign_id: 'camp-1' })])
+
+      expect(response).to have_http_status(:ok)
+      expect(Messages::StatusUpdateService).to have_received(:new).with(message, 'failed', anything)
+      contact.reload
+      expect(contact.email_suppressed).to be(true)
+      expect(contact.email_suppression_reason).to eq('bounce')
+    end
+
+    it 'accepts a single JSON object (non-array) payload and returns 200' do
+      post '/webhooks/sendgrid',
+           params: event(sg_event_id: 'evt-single').to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['received']).to eq(1)
+    end
+  end
+end

--- a/spec/services/sendgrid/event_processor_spec.rb
+++ b/spec/services/sendgrid/event_processor_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Sendgrid::EventProcessor do
+  subject(:processor) { described_class.new(event) }
+
+  let(:fake_redis) { {} }
+  let(:message) { instance_double(Message) }
+  let(:contact) { instance_double(Contact, update!: true) }
+  let(:status_service) { instance_double(Messages::StatusUpdateService, perform: true) }
+
+  let(:custom_args) { { 'contact_id' => 'c-1', 'message_id' => 'm-1', 'campaign_id' => 'camp-1' } }
+  let(:event) { { 'sg_event_id' => 'evt-1', 'event' => 'delivered', 'email' => 'a@b.com', 'custom_args' => custom_args } }
+
+  before do
+    # In-memory Redis::Alfred stub with NX/EX-aware #set (repo convention,
+    # mirrors spec/workers/evo_flow/backfill_contact_events_worker_spec.rb).
+    allow(Redis::Alfred).to receive(:get) { |k| fake_redis[k] }
+    allow(Redis::Alfred).to receive(:incr) { |k| fake_redis[k] = (fake_redis[k].to_i + 1).to_s }
+    allow(Redis::Alfred).to receive(:delete) { |k| fake_redis.delete(k) }
+    allow(Redis::Alfred).to receive(:set) do |k, v, **opts|
+      next false if opts[:nx] && fake_redis.key?(k)
+
+      fake_redis[k] = v.to_s
+      true
+    end
+
+    allow(Message).to receive(:find_by).and_return(message)
+    allow(Contact).to receive(:find_by).and_return(contact)
+    allow(Messages::StatusUpdateService).to receive(:new).and_return(status_service)
+  end
+
+  describe 'deduplication (AC1, AC2)' do
+    it 'claims the sg_event_id with a 24h TTL on first sight and processes once' do
+      expect(processor.process).to eq(:processed)
+      expect(Redis::Alfred).to have_received(:set).with('sendgrid:event:evt-1', 1, nx: true, ex: 24.hours.to_i)
+    end
+
+    it 'drops the second identical event and increments the duplicate metric' do
+      described_class.new(event).process
+      expect(described_class.new(event).process).to eq(:duplicate)
+      expect(fake_redis['sendgrid:events:duplicate_drops']).to eq('1')
+    end
+
+    it 'does not re-run the status update for a duplicate event' do
+      described_class.new(event).process
+      described_class.new(event).process
+      expect(Messages::StatusUpdateService).to have_received(:new).once
+    end
+  end
+
+  describe 'missing custom_args (AC4)' do
+    %w[contact_id message_id campaign_id].each do |missing_key|
+      it "drops the event when #{missing_key} is missing and logs + increments metric" do
+        event['custom_args'] = custom_args.except(missing_key)
+        allow(Rails.logger).to receive(:warn)
+
+        expect(processor.process).to eq(:missing_args)
+        expect(fake_redis['sendgrid:events:missing_args_drops']).to eq('1')
+        expect(Rails.logger).to have_received(:warn).with(/missing custom_args/)
+        expect(Messages::StatusUpdateService).not_to have_received(:new)
+      end
+    end
+
+    it 'drops the event when custom_args is absent entirely' do
+      event.delete('custom_args')
+      expect(processor.process).to eq(:missing_args)
+    end
+  end
+
+  describe 'event -> status mapping (AC6)' do
+    {
+      'delivered' => 'delivered',
+      'open' => 'read',
+      'click' => 'read',
+      'bounce' => 'failed',
+      'dropped' => 'failed',
+      'spam_report' => 'failed'
+    }.each do |sendgrid_event, internal_status|
+      it "maps #{sendgrid_event} -> #{internal_status} via Messages::StatusUpdateService" do
+        event['event'] = sendgrid_event
+        processor.process
+        expect(Messages::StatusUpdateService).to have_received(:new).with(message, internal_status, anything)
+      end
+    end
+
+    it 'increments the per-type metric for each processed event' do
+      event['event'] = 'open'
+      processor.process
+      expect(fake_redis['sendgrid:events:type:open']).to eq('1')
+    end
+
+    it 'passes the bounce reason as external_error for failed statuses' do
+      event['event'] = 'bounce'
+      event['reason'] = '550 mailbox unavailable'
+      processor.process
+      expect(Messages::StatusUpdateService).to have_received(:new).with(message, 'failed', '550 mailbox unavailable')
+    end
+
+    it 'skips the status update when the message cannot be resolved' do
+      allow(Message).to receive(:find_by).and_return(nil)
+      allow(Rails.logger).to receive(:warn)
+      expect(processor.process).to eq(:processed)
+      expect(Messages::StatusUpdateService).not_to have_received(:new)
+    end
+  end
+
+  describe 'contact suppression (AC3)' do
+    %w[bounce dropped spam_report unsubscribe].each do |negative_event|
+      it "suppresses the contact email on #{negative_event}" do
+        event['event'] = negative_event
+        processor.process
+        expect(contact).to have_received(:update!).with(email_suppressed: true, email_suppression_reason: negative_event)
+      end
+    end
+
+    it 'does not suppress the contact on positive events' do
+      event['event'] = 'delivered'
+      processor.process
+      expect(contact).not_to have_received(:update!)
+    end
+  end
+
+  describe 'unsubscribe (suppression-only, no status transition)' do
+    it 'suppresses the contact but does not call the status update service' do
+      event['event'] = 'unsubscribe'
+      processor.process
+      expect(contact).to have_received(:update!).with(email_suppressed: true, email_suppression_reason: 'unsubscribe')
+      expect(Messages::StatusUpdateService).not_to have_received(:new)
+    end
+  end
+
+  describe 'transient failure (M1)' do
+    it 'releases the dedup claim so a resend can be retried when processing raises' do
+      event['event'] = 'bounce'
+      allow(Contact).to receive(:find_by).and_raise(StandardError, 'db down')
+
+      expect { processor.process }.to raise_error(StandardError)
+      expect(fake_redis).not_to have_key('sendgrid:event:evt-1')
+    end
+  end
+
+  describe 'missing sg_event_id (L1)' do
+    it 'processes without dedup and logs a warning' do
+      event.delete('sg_event_id')
+      allow(Rails.logger).to receive(:warn)
+
+      expect(processor.process).to eq(:processed)
+      expect(Rails.logger).to have_received(:warn).with(/without sg_event_id/)
+      expect(Redis::Alfred).not_to have_received(:set)
+    end
+  end
+
+  describe 'metrics' do
+    it 'always increments the total counter' do
+      processor.process
+      expect(fake_redis['sendgrid:events:total']).to eq('1')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Implements story 9.3 (SendGrid Email Channel epic): a public webhook endpoint that ingests SendGrid event notifications and wires them into the CRM's existing message-status + contact-suppression flows.

- `POST /webhooks/sendgrid` (public scope, no `account_id` — single-tenant), thin controller delegating to a service.
- `Sendgrid::EventProcessor`: dedup by `sg_event_id` via Redis `SET NX` (24h TTL); resolves context from `custom_args` (`contact_id`, `message_id`, `campaign_id`); maps events to internal `Message` status and reuses `Messages::StatusUpdateService` so the `:message_status_changed` Wisper broadcast + EvoFlow tracking stay on one path.
- Negative terminal events (`bounce`, `dropped`, `spam_report`, `unsubscribe`) set `Contact#email_suppressed` + `email_suppression_reason`. `unsubscribe` is suppression-only (no delivery-status transition).
- Redis counters: total, per-type, duplicate-drops, missing-args-drops.

### Event → status mapping
`delivered → delivered` · `open/click → read` · `bounce/dropped/spam_report → failed` · `unsubscribe → suppression only`

## Security
- Endpoint is public and unauthenticated, consistent with the other inbound webhooks. **Signature validation is intentionally out of scope for 9.3** (per the card). Because the endpoint mutates message status and suppresses contacts by client-supplied IDs, the deferred SendGrid signed-event-webhook validation should be treated as a production-hardening prerequisite before public exposure. Risk accepted for now and documented here (no separate card filed by decision).
- Always returns `200` so SendGrid does not retry; dedup `SET NX` is atomic (race-safe across Puma workers); per-event rescue keeps one bad event from failing the batch. On a transient processing failure the dedup claim is released so a resend can be retried.

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/requests/webhooks/sendgrid_spec.rb spec/services/sendgrid/event_processor_spec.rb` — 32 examples, 0 failures (includes a real-DB end-to-end Contact suppression case).
- `evo-ai-crm-community: bundle exec rubocop` on the new files — clean.
- Smoke: `curl -X POST .../webhooks/sendgrid -d '[{"sg_event_id":"t1","event":"bounce","custom_args":{...}}]'` returns `200`; second identical post is deduped.

## Notes
- Metric counters are written but not yet surfaced via `/metrics`; exposing them belongs to the Observability epic (5.x) — left out of this PR by decision.

## Changed Files
- `app/controllers/webhooks/sendgrid_controller.rb` (new)
- `app/services/sendgrid/event_processor.rb` (new)
- `db/migrate/20260609130000_add_email_suppression_to_contacts.rb` (new) + `db/schema.rb`
- `config/routes.rb`
- `spec/requests/webhooks/sendgrid_spec.rb`, `spec/services/sendgrid/event_processor_spec.rb` (new)

## Linked Issue
- EVO-1250
