### PR TITLE
feat(crm): pipeline_tasks#for_conversation endpoint for Journey Create Pipeline Task (EVO-1273)

### DIFF
--- a/app/controllers/api/v1/pipeline_tasks_controller.rb
+++ b/app/controllers/api/v1/pipeline_tasks_controller.rb
@@ -301,10 +301,27 @@ class Api::V1::PipelineTasksController < Api::V1::BaseController
       description: params[:description],
       task_type: params[:task_type].presence || 'call',
       priority: params[:priority].presence || 'low',
-      assigned_to_id: params[:assigned_to_id],
+      assigned_to_id: resolve_assignee_id(params[:assigned_to_id]),
       due_date: calculate_due_date(params[:due_in]),
       created_by: creator
     )
+  end
+
+  # assigned_to has no DB foreign key and the belongs_to is optional, so a stale
+  # assignee id (e.g. a deleted user) would be silently stored as a dangling
+  # reference. Drop it and create the task unassigned rather than fail the whole
+  # automation step.
+  def resolve_assignee_id(assigned_to_id)
+    return nil if assigned_to_id.blank?
+    return assigned_to_id if User.exists?(id: assigned_to_id)
+
+    Rails.logger.warn(
+      "PipelineTasks#for_conversation: assigned_to_id #{assigned_to_id.inspect} " \
+      'is not a known user; creating task unassigned'
+    )
+    nil
+  rescue StandardError
+    nil
   end
 
   def skip_task(reason, conversation)

--- a/app/controllers/api/v1/pipeline_tasks_controller.rb
+++ b/app/controllers/api/v1/pipeline_tasks_controller.rb
@@ -264,7 +264,78 @@ class Api::V1::PipelineTasksController < Api::V1::BaseController
   end
   # rubocop:enable Metrics/AbcSize
 
+  # Creates a PipelineTask on a conversation's active pipeline_item. Consumed by
+  # the evo-flow Journey "Create Pipeline Task" node. A conversation with no
+  # active pipeline_item degrades to a logged skip. created_by falls back through
+  # the conversation/item owners because the Journey call is service-authenticated
+  # (no Current.user) and the Community fork has no SuperAdmin system user.
+  def for_conversation
+    conversation = find_conversation(params[:conversation_id])
+    return error_response(ApiErrorCodes::CONVERSATION_NOT_FOUND, 'Conversation not found') if conversation.nil?
+
+    pipeline_item = conversation.pipeline_items.active.first
+    return skip_task('no_pipeline_item', conversation) if pipeline_item.nil?
+
+    creator = resolve_task_creator(conversation, pipeline_item)
+    return skip_task('no_creator', conversation) if creator.nil?
+
+    task = create_conversation_task(pipeline_item, creator)
+    success_response(
+      data: { created: true, task_id: task.id },
+      message: 'Pipeline task created successfully',
+      status: :created
+    )
+  rescue ActiveRecord::RecordInvalid => e
+    error_response(ApiErrorCodes::VALIDATION_ERROR, e.message, details: e.record.errors.as_json)
+  end
+
   private
+
+  def find_conversation(ref)
+    Conversation.find_by(id: ref) || Conversation.find_by(display_id: ref)
+  end
+
+  def create_conversation_task(pipeline_item, creator)
+    pipeline_item.tasks.create!(
+      title: params[:title],
+      description: params[:description],
+      task_type: params[:task_type].presence || 'call',
+      priority: params[:priority].presence || 'low',
+      assigned_to_id: params[:assigned_to_id],
+      due_date: calculate_due_date(params[:due_in]),
+      created_by: creator
+    )
+  end
+
+  def skip_task(reason, conversation)
+    Rails.logger.warn(
+      "PipelineTasks#for_conversation: conversation #{conversation.id} skipped (#{reason})"
+    )
+    success_response(
+      data: { created: false, skipped: true, reason: reason },
+      message: 'Pipeline task skipped'
+    )
+  end
+
+  def resolve_task_creator(conversation, pipeline_item)
+    Current.user || conversation.assignee || pipeline_item.assigned_by ||
+      User.order(:created_at).first
+  end
+
+  DUE_DATE_UNITS = %w[minutes hours days weeks months].freeze
+
+  def calculate_due_date(due_in)
+    return nil if due_in.blank?
+    return Time.zone.parse(due_in) if due_in.is_a?(String) && due_in.match?(/^\d{4}-\d{2}-\d{2}/)
+
+    value, unit = due_in.to_s.split('.')
+    return nil unless value.present? && DUE_DATE_UNITS.include?(unit)
+
+    value.to_i.public_send(unit).from_now
+  rescue StandardError => e
+    Rails.logger.error "Error parsing due_date: #{e.message}"
+    nil
+  end
 
   def set_pipeline_item
     @pipeline = Pipeline.find(params[:pipeline_id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -533,6 +533,8 @@ Rails.application.routes.draw do
         end
       end
 
+      post 'pipeline_tasks/for_conversation', to: 'pipeline_tasks#for_conversation'
+
       resources :pipelines, controller: 'pipelines' do
         collection do
           get :stats
@@ -768,5 +770,4 @@ Rails.application.routes.draw do
   # extension point. No-op in the community release — the registry is empty
   # unless a consumer gem registers a plugin. See EXTENSION_POINTS.md §3.
   EvoExtensionPoints::PluginLoader.draw_routes(self)
-
 end

--- a/spec/controllers/api/v1/pipeline_tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/pipeline_tasks_controller_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe Api::V1::PipelineTasksController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity).or have_http_status(:bad_request)
         expect(conversation.pipeline_items.first.tasks.count).to eq(0)
       end
+
+      it 'creates the task unassigned when the assignee does not exist (invalid assignee)' do
+        post :for_conversation, params: {
+          conversation_id: conversation.id,
+          title: 'Unassignable task',
+          assigned_to_id: SecureRandom.uuid
+        }
+
+        expect(response).to have_http_status(:created)
+        expect(conversation.pipeline_items.first.tasks.first.assigned_to_id).to be_nil
+      end
     end
 
     context 'when the conversation has no active pipeline_item (AC3)' do

--- a/spec/controllers/api/v1/pipeline_tasks_controller_spec.rb
+++ b/spec/controllers/api/v1/pipeline_tasks_controller_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::PipelineTasksController, type: :controller do
+  let(:user) { User.create!(email: "pt-spec-#{SecureRandom.hex(4)}@example.com", name: 'Spec User') }
+  let(:pipeline) { Pipeline.create!(name: 'Sales', pipeline_type: 'sales', created_by: user) }
+  let!(:stage) { PipelineStage.create!(pipeline: pipeline, name: 'Lead', position: 1) }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Jane', email: "jane-#{SecureRandom.hex(4)}@example.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  before do
+    Current.user = user
+    Current.service_authenticated = true
+    Current.authentication_method = 'service_token'
+
+    allow(controller).to receive(:authenticate_request!).and_return(true)
+    allow(controller).to receive(:authorize).and_return(true)
+    allow(controller).to receive(:pundit_user).and_return({ user: user, account_user: nil })
+  end
+
+  after { Current.reset }
+
+  describe 'POST #for_conversation' do
+    context 'when the conversation has an active pipeline_item' do
+      before do
+        Pipelines::ConversationService.new(pipeline: pipeline, user: user).add_conversation(conversation, stage: stage)
+      end
+
+      it 'creates a task with all provided values (AC1)' do
+        assignee = User.create!(email: "assignee-#{SecureRandom.hex(4)}@example.com", name: 'Assignee')
+
+        expect do
+          post :for_conversation, params: {
+            conversation_id: conversation.id,
+            title: 'Follow up with {contact.name}',
+            description: 'Call the lead',
+            task_type: 'call',
+            priority: 'high',
+            assigned_to_id: assignee.id,
+            due_in: '2.hours'
+          }
+        end.to change { conversation.pipeline_items.first.tasks.count }.from(0).to(1)
+
+        expect(response).to have_http_status(:created)
+        task = conversation.pipeline_items.first.tasks.first
+        expect(task.title).to eq('Follow up with {contact.name}')
+        expect(task.task_type).to eq('call')
+        expect(task.priority).to eq('high')
+        expect(task.assigned_to_id).to eq(assignee.id)
+        expect(task.due_date).to be_within(1.minute).of(2.hours.from_now)
+      end
+
+      it 'creates a task with defaults when only the title is given (AC2)' do
+        post :for_conversation, params: { conversation_id: conversation.id, title: 'Minimal task' }
+
+        expect(response).to have_http_status(:created)
+        task = conversation.pipeline_items.first.tasks.first
+        expect(task.task_type).to eq('call')
+        expect(task.priority).to eq('low')
+        expect(task.due_date).to be_nil
+      end
+
+      it 'falls back to the conversation assignee for created_by when Current.user is absent' do
+        agent = User.create!(email: "agent-#{SecureRandom.hex(4)}@example.com", name: 'Agent')
+        conversation.update!(assignee: agent)
+        Current.user = nil
+
+        post :for_conversation, params: { conversation_id: conversation.id, title: 'Owned task' }
+
+        expect(response).to have_http_status(:created)
+        expect(conversation.pipeline_items.first.tasks.first.created_by_id).to eq(agent.id)
+      end
+
+      it 'returns a validation error when the title is missing' do
+        post :for_conversation, params: { conversation_id: conversation.id, description: 'no title' }
+
+        expect(response).to have_http_status(:unprocessable_entity).or have_http_status(:bad_request)
+        expect(conversation.pipeline_items.first.tasks.count).to eq(0)
+      end
+    end
+
+    context 'when the conversation has no active pipeline_item (AC3)' do
+      it 'degrades to a logged skip without creating a task' do
+        post :for_conversation, params: { conversation_id: conversation.id, title: 'Orphan task' }
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body.dig('data', 'skipped')).to be(true)
+        expect(body.dig('data', 'reason')).to eq('no_pipeline_item')
+      end
+    end
+
+    context 'when the conversation does not exist' do
+      it 'returns a not-found error' do
+        post :for_conversation, params: { conversation_id: SecureRandom.uuid, title: 'x' }
+
+        expect(response).not_to have_http_status(:created)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Backend for the evo-flow Journey **Create Pipeline Task** node (EVO-1273, last of the 3 P1 pipeline nodes).

Adds `POST /api/v1/pipeline_tasks/for_conversation` (`{conversation_id, title, description, task_type, priority, assigned_to_id, due_in}`): finds the conversation's active `pipeline_item` and creates a `PipelineTask` on it. A conversation with no active item degrades to a logged skip.

## Notes
- `created_by` falls back `Current.user → conversation.assignee → pipeline_item.assigned_by → oldest User` (the Journey call is service-authenticated and the Community fork has no SuperAdmin).
- Invalid `assigned_to_id` (no FK on that column) is dropped to unassigned with a warning instead of stored as a dangling ref.
- Relative due dates (`"2.hours"`) parse via a unit allowlist (no arbitrary `send`).

## Acceptance Criteria
- [x] AC1 full config → task with all values
- [x] AC2 minimal (title only) → defaults (task_type=call, priority=low)
- [x] AC3 no pipeline_item → logged skip
- [x] AC4 parity — same `pipeline_item.tasks.create!` fields as the Automation Rules action (created_by is more robust here)

## Security
No tenant scoping needed (single-tenant). No `authorize` on the endpoint — relies on authentication; consistent with the sibling move endpoint.

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/controllers/api/v1/pipeline_tasks_controller_spec.rb` — 7 examples (full / defaults / created_by fallback / invalid assignee / missing title / no-item skip / not-found)
- `evo-ai-crm-community: bundle exec rubocop` — clean on changed files

## Linked Issue
- EVO-1273

## Related PRs
- evolution-foundation/evo-flow (node runtime)
- evolution-foundation/evo-ai-frontend-community (Flow Builder node)

## Summary by Sourcery

Add a new API endpoint to create pipeline tasks for a conversation’s active pipeline item, including robust creator/assignee resolution and due-date handling.

New Features:
- Expose POST /api/v1/pipeline_tasks/for_conversation to create a pipeline task linked to a conversation’s active pipeline item.
- Support relative and absolute due date inputs and sensible defaults for task type and priority when omitted.

Enhancements:
- Implement safeguards for invalid or missing assignees and creators, falling back to safe defaults or skipping task creation with structured responses and logging.

Tests:
- Add controller specs covering successful task creation, defaulting behavior, creator fallback, invalid assignee handling, validation errors, and skip/not-found scenarios.