### PR TITLE
feat(templates): link channel to template and sync WhatsApp Cloud approval (EVO-1232)

### DIFF
--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -30,6 +30,7 @@ module Api
           avatar: 'inboxes.update',
           message_templates: 'inboxes.message_templates',
           sync_message_templates: 'inboxes.message_templates',
+          sync_template_with_whatsapp_cloud: 'inboxes.message_templates',
           update_message_template: 'inboxes.update_message_template',
           delete_message_template: 'inboxes.delete_message_template',
           facebook_posts: 'inboxes.read'
@@ -514,6 +515,36 @@ module Api
           ensure
             Rails.logger.info '=== SYNC MESSAGE TEMPLATES END ==='
           end
+        end
+
+        # Pushes a single template up to Meta (WhatsApp Cloud) for approval. The
+        # inbox :id is a routing placeholder; the template's OWN channel supplies
+        # the WABA, so the template must already be bound to a WhatsApp Cloud
+        # channel. Async — enqueues the sync job and returns 202. (EVO-1232)
+        # Authorization is enforced by the `require_permissions` before_action
+        # (inboxes.message_templates). We deliberately do NOT call the in-action
+        # `authorize @inbox, :message_templates?`: under service-token auth there is
+        # no Pundit user, so it would raise. Mirrors EVO-1231's global path. (F7)
+        def sync_template_with_whatsapp_cloud
+          template = MessageTemplate.find(params[:template_id])
+          channel = template.channel
+
+          unless channel.is_a?(Channel::Whatsapp) && channel.provider == 'whatsapp_cloud'
+            return error_response(
+              ApiErrorCodes::VALIDATION_ERROR,
+              'Template must reference a WhatsApp Cloud channel to sync',
+              status: :unprocessable_entity
+            )
+          end
+
+          SyncMessageTemplateWithWhatsappCloudJob.perform_later(template)
+          success_response(
+            data: { template: template.serialized },
+            message: 'WhatsApp Cloud template sync enqueued',
+            status: :accepted
+          )
+        rescue ActiveRecord::RecordNotFound
+          error_response(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Message template not found', status: :not_found)
         end
 
         def update_message_template

--- a/app/jobs/sync_message_template_with_whatsapp_cloud_job.rb
+++ b/app/jobs/sync_message_template_with_whatsapp_cloud_job.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Pushes a MessageTemplate up to Meta (WhatsApp Cloud) for approval and lets the
+# existing create_template -> sync_templates path write back the Meta template id
+# (metadata['external_id']) and approval status (settings['status'] = 'PENDING')
+# onto the same record. (EVO-1232)
+class SyncMessageTemplateWithWhatsappCloudJob < ApplicationJob
+  queue_as :low
+
+  def perform(message_template)
+    channel = message_template.channel
+
+    unless channel.is_a?(Channel::Whatsapp) && channel.provider == 'whatsapp_cloud'
+      Rails.logger.warn(
+        "[EVO-1232] sync skipped for template #{message_template.id}: not bound to a WhatsApp Cloud channel"
+      )
+      return
+    end
+
+    # channel.create_template pushes to Meta and then re-syncs, landing
+    # metadata['external_id'] + settings['status']='PENDING' on this record.
+    channel.create_template(
+      'name' => message_template.name,
+      'category' => message_template.category,
+      'language' => message_template.language,
+      'components' => meta_components(message_template)
+    )
+  rescue StandardError => e
+    # Publishing to Meta is non-idempotent (a template name can only be created
+    # once), so we do NOT re-raise: a Sidekiq retry would re-publish and error on
+    # the duplicate name. The action is user-triggered and re-runnable, so log and
+    # stop. (EVO-1232 / adversarial review F14)
+    Rails.logger.error(
+      "[EVO-1232] WhatsApp Cloud template sync failed for #{message_template.id}: #{e.message}"
+    )
+  end
+
+  private
+
+  # Persisted components are stored either as Meta's Array-of-components (when the
+  # template was authored via the API/global menu) or as a Hash keyed by
+  # lowercase type (when pulled back from Meta by sync_template_to_database).
+  # Whatsapp::Providers::WhatsappCloudService#process_template_components expects
+  # the Array form, so normalize. (EVO-1232 / adversarial review F2)
+  def meta_components(message_template)
+    components = message_template.components
+    return components if components.is_a?(Array)
+    return components.values if components.is_a?(Hash)
+
+    []
+  end
+end

--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -25,7 +25,8 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
   def sync_event?(params)
     # WhatsApp Cloud sync events
     whatsapp_cloud_field = params.dig(:entry, 0, :changes, 0, :field)
-    whatsapp_cloud_sync_fields = %w[smb_app_state_sync smb_message_echoes history account_update user_id_update]
+    whatsapp_cloud_sync_fields = %w[smb_app_state_sync smb_message_echoes history account_update user_id_update
+                                    message_template_status_update]
 
     # Evolution API sync events
     evolution_event = params[:event]
@@ -72,9 +73,53 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
       handle_account_update(channel, params)
     when 'user_id_update'
       handle_user_id_update(channel, params)
+    when 'message_template_status_update'
+      handle_message_template_status_update(channel, params)
     else
       Rails.logger.warn "Unknown WhatsApp Cloud sync event field: #{field}"
     end
+  end
+
+  # Meta pushes a template's approval status here after review. We persist the
+  # raw status onto the matching template's settings['status'] (and the rejection
+  # reason onto metadata), keyed by the Meta template id we stored at sync time in
+  # metadata['external_id']. (EVO-1232)
+  #
+  # Real Meta payload (entry[0].changes[0].value):
+  #   { event: 'APPROVED'|'REJECTED'|'PENDING'|'PAUSED'|'FLAGGED',
+  #     message_template_id: <int>, message_template_name: <str>,
+  #     message_template_language: <str>, reason: <str|null> }
+  def handle_message_template_status_update(channel, params)
+    # Defensive: ensure indifferent access even if the queue adapter handed us a
+    # string-keyed hash. (adversarial review F4)
+    params = params.with_indifferent_access
+    value = params.dig(:entry, 0, :changes, 0, :value)
+    return unless value.is_a?(Hash)
+
+    external_id = value[:message_template_id].to_s
+    new_status = value[:event]
+    reason = value[:reason]
+    return if external_id.blank? || new_status.blank?
+
+    template = channel.message_templates.find_by("metadata ->> 'external_id' = ?", external_id)
+    if template.nil?
+      Rails.logger.warn "[WHATSAPP] template_status_update: no template for external_id #{external_id}"
+      return
+    end
+
+    new_settings = template.settings.to_h.merge('status' => new_status)
+    new_metadata = template.metadata.to_h
+    new_metadata['rejected_reason'] = reason if reason.present?
+
+    # update_columns skips before_save/validations: a webhook status write must
+    # not be rejected by the WhatsApp Cloud channel validation nor re-run
+    # extract_variables_from_content. (adversarial review F9)
+    # rubocop:disable Rails/SkipsModelValidations
+    template.update_columns(settings: new_settings, metadata: new_metadata, updated_at: Time.current)
+    # rubocop:enable Rails/SkipsModelValidations
+    Rails.logger.info "[WHATSAPP] template #{template.id} status → #{new_status}"
+  rescue StandardError => e
+    Rails.logger.error "[WHATSAPP] message_template_status_update failed: #{e.message}"
   end
 
   def handle_account_update(channel, params)
@@ -348,10 +393,36 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
 
     channel = try_find_channel_from_business_payload(params) ||
               try_find_channel_by_phone_number_id(params) ||
-              try_find_channel_by_phone_number(params)
+              try_find_channel_by_phone_number(params) ||
+              try_find_channel_by_waba_id(params)
 
     log_channel_search_result(channel, params)
     channel
+  end
+
+  # WABA-scoped events (e.g. message_template_status_update) carry only the WABA
+  # id in entry[0].id and no phone metadata, so the phone-centric resolvers above
+  # return nil. Resolve the WhatsApp Cloud channel by its WABA id as a fallback.
+  # (EVO-1232 / adversarial review F3)
+  def try_find_channel_by_waba_id(params)
+    return nil unless params[:object] == 'whatsapp_business_account'
+
+    waba_id = params.dig(:entry, 0, :id)
+    return nil if waba_id.blank?
+
+    channel = find_channel_by_waba_id(waba_id)
+    Rails.logger.info "Channel search via WABA id #{waba_id}: #{channel ? "found #{channel.phone_number}" : 'not found'}"
+    channel
+  end
+
+  def find_channel_by_waba_id(waba_id)
+    Channel::Whatsapp.joins(:inbox)
+                     .where(provider: 'whatsapp_cloud')
+                     .where(
+                       "provider_config ->> 'waba_id' = :id OR provider_config ->> 'business_account_id' = :id",
+                       id: waba_id.to_s
+                     )
+                     .first
   end
 
   def try_find_channel_from_business_payload(params)

--- a/app/models/message_template.rb
+++ b/app/models/message_template.rb
@@ -42,6 +42,19 @@ class MessageTemplate < ApplicationRecord
   # intent for a channel-less template, so the conditional validation can fire.
   attr_accessor :intended_provider
 
+  # Maps Meta's raw template approval status (stored verbatim in
+  # settings['status']) onto a normalized lowercase vocabulary. The raw value is
+  # kept in settings['status'] for backward compatibility; `approval_status` is
+  # the normalized read view. (EVO-1232)
+  META_APPROVAL_STATUS = {
+    'APPROVED' => 'approved',
+    'REJECTED' => 'rejected',
+    'PENDING' => 'pending',
+    'PENDING_QUALITY_CHECK' => 'pending',
+    'PAUSED' => 'paused',
+    'FLAGGED' => 'flagged'
+  }.freeze
+
   validates :name, presence: true
   validates :content, presence: true
   # When channel_type/channel_id are nil this scopes uniqueness to the global
@@ -161,6 +174,21 @@ class MessageTemplate < ApplicationRecord
     )
   end
 
+  # Meta WhatsApp Cloud template id, persisted by the sync path in
+  # metadata['external_id']. Read-only view. (EVO-1232)
+  def external_template_id
+    metadata.is_a?(Hash) ? metadata['external_id'] : nil
+  end
+
+  # Normalized approval status derived from the raw Meta status in
+  # settings['status']; 'draft' when the template was never synced. (EVO-1232)
+  def approval_status
+    raw = settings.is_a?(Hash) ? settings['status'] : nil
+    return 'draft' if raw.blank?
+
+    META_APPROVAL_STATUS.fetch(raw.to_s.upcase, raw.to_s.downcase)
+  end
+
   def serialized
     {
       'id' => id,
@@ -169,7 +197,11 @@ class MessageTemplate < ApplicationRecord
       'language' => language,
       'category' => category,
       'template_type' => template_type,
+      # 'status' is Meta's raw value (e.g. 'APPROVED'); 'approval_status' is the
+      # normalized lowercase view ('approved'). Both intentionally exposed.
       'status' => settings.is_a?(Hash) ? settings['status'] : nil,
+      'approval_status' => approval_status,
+      'external_template_id' => external_template_id,
       'settings' => settings,
       'components' => components,
       'variables' => variables,
@@ -187,12 +219,24 @@ class MessageTemplate < ApplicationRecord
 
   private
 
-  # WhatsApp Cloud requires a Meta-approved template tied to its channel, so a
-  # channel-less template flagged as WhatsApp Cloud is invalid.
+  # WhatsApp Cloud requires a Meta-approved template tied to a WhatsApp Cloud
+  # channel (WABA + namespace). A channel-less or wrong-type channel is invalid
+  # for a WhatsApp Cloud template. (EVO-1232 strengthens EVO-1231's presence-only
+  # rule to also enforce channel type + provider.)
+  # A template is "WhatsApp Cloud" when the global create path flags it via
+  # intended_provider, or when it is already bound to a WhatsApp Cloud channel.
   def channel_required_for_whatsapp_cloud
-    return if channel.present?
+    return unless intended_provider == 'whatsapp_cloud' || whatsapp_cloud_channel?(channel)
 
-    errors.add(:channel, 'is required for WhatsApp Cloud templates') if intended_provider == 'whatsapp_cloud'
+    if channel.blank?
+      errors.add(:channel, 'is required for WhatsApp Cloud templates')
+    elsif !whatsapp_cloud_channel?(channel)
+      errors.add(:channel, 'must reference a WhatsApp Cloud channel')
+    end
+  end
+
+  def whatsapp_cloud_channel?(channel)
+    channel.is_a?(Channel::Whatsapp) && channel.provider == 'whatsapp_cloud'
   end
 
   def set_defaults

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,8 @@ Rails.application.routes.draw do
         post 'message_templates/sync', action: :sync_message_templates, on: :member
         put 'message_templates/:template_id', action: :update_message_template, on: :member
         delete 'message_templates/:template_id', action: :delete_message_template, on: :member
+        post 'message_templates/:template_id/sync_with_whatsapp_cloud',
+             action: :sync_template_with_whatsapp_cloud, on: :member
       end
 
       resources :conversations, only: [:index, :create, :show, :update, :destroy], controller: 'conversations' do

--- a/spec/jobs/sync_message_template_with_whatsapp_cloud_job_spec.rb
+++ b/spec/jobs/sync_message_template_with_whatsapp_cloud_job_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SyncMessageTemplateWithWhatsappCloudJob, type: :job do
+  def whatsapp_channel(provider:)
+    channel = Channel::Whatsapp.new(provider: provider, phone_number: "+1555#{SecureRandom.hex(3)}")
+    channel.save!(validate: false)
+    channel
+  end
+
+  let(:channel) { whatsapp_channel(provider: 'whatsapp_cloud') }
+  let(:template) do
+    t = MessageTemplate.new(
+      name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', category: 'UTILITY', language: 'pt_BR',
+      components: [{ 'type' => 'BODY', 'text' => 'Hi' }]
+    )
+    allow(t).to receive(:channel).and_return(channel)
+    t
+  end
+
+  it 'pushes the template to Meta via channel.create_template with the expected payload' do
+    expect(channel).to receive(:create_template).with(
+      hash_including(
+        'name' => template.name,
+        'category' => 'UTILITY',
+        'language' => 'pt_BR',
+        'components' => [{ 'type' => 'BODY', 'text' => 'Hi' }]
+      )
+    )
+
+    described_class.new.perform(template)
+  end
+
+  it 'normalizes Hash-shaped components into Meta array form (adversarial review F2)' do
+    template.components = { 'body' => { 'type' => 'BODY', 'text' => 'Hi' } }
+
+    expect(channel).to receive(:create_template).with(
+      hash_including('components' => [{ 'type' => 'BODY', 'text' => 'Hi' }])
+    )
+
+    described_class.new.perform(template)
+  end
+
+  it 'lands a pending status + external id on the same record (via the re-sync writeback)' do
+    allow(channel).to receive(:create_template) do
+      template.settings = { 'status' => 'PENDING' }
+      template.metadata = { 'external_id' => '777' }
+    end
+
+    described_class.new.perform(template)
+
+    expect(template.approval_status).to eq('pending')
+    expect(template.external_template_id).to eq('777')
+  end
+
+  it 'skips and does not call create_template when the channel is not WhatsApp Cloud' do
+    baileys = whatsapp_channel(provider: 'baileys')
+    allow(template).to receive(:channel).and_return(baileys)
+
+    expect(baileys).not_to receive(:create_template)
+
+    expect { described_class.new.perform(template) }.not_to raise_error
+  end
+
+  it 'logs and does not re-raise when Meta publish fails (adversarial review F14)' do
+    allow(channel).to receive(:create_template).and_raise(StandardError, 'meta down')
+
+    expect(Rails.logger).to receive(:error).with(/sync failed/)
+    expect { described_class.new.perform(template) }.not_to raise_error
+  end
+end

--- a/spec/jobs/webhooks/whatsapp_events_job_spec.rb
+++ b/spec/jobs/webhooks/whatsapp_events_job_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1232 [6.3]: Meta pushes template approval status to the WhatsApp webhook;
+# WhatsappEventsJob ingests `message_template_status_update` and updates the
+# matching template's settings['status'] (keyed by metadata['external_id']).
+RSpec.describe Webhooks::WhatsappEventsJob, type: :job do
+  let(:waba_id) { "waba-#{SecureRandom.hex(4)}" }
+
+  let(:channel) do
+    ch = Channel::Whatsapp.new(
+      provider: 'whatsapp_cloud',
+      phone_number: "+1555#{SecureRandom.hex(3)}",
+      provider_config: { 'waba_id' => waba_id }
+    )
+    ch.save!(validate: false)
+    ch
+  end
+
+  let!(:template) do
+    MessageTemplate.create!(
+      name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', channel: channel,
+      metadata: { 'external_id' => '12345' }, settings: { 'status' => 'PENDING' }
+    )
+  end
+
+  # find_channel_by_waba_id joins(:inbox), so the channel needs an inbox.
+  before { Inbox.create!(channel: channel, name: "Inbox #{SecureRandom.hex(3)}") }
+
+  def payload(event:, message_template_id: '12345', reason: nil)
+    {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: waba_id,
+          changes: [
+            {
+              field: 'message_template_status_update',
+              value: {
+                event: event,
+                message_template_id: message_template_id,
+                message_template_name: template.name,
+                reason: reason
+              }
+            }
+          ]
+        }
+      ]
+    }.with_indifferent_access
+  end
+
+  it 'detects the event as a sync event (so it is not misrouted to messages)' do
+    expect(described_class.new.send(:sync_event?, payload(event: 'APPROVED'))).to be(true)
+  end
+
+  it 'resolves the WhatsApp Cloud channel by WABA id (adversarial review F3)' do
+    resolved = described_class.new.send(:find_channel, payload(event: 'APPROVED'))
+    expect(resolved).to eq(channel)
+  end
+
+  it 'updates the template status to APPROVED (approval_status approved)' do
+    described_class.new.perform(payload(event: 'APPROVED'))
+
+    template.reload
+    expect(template.settings['status']).to eq('APPROVED')
+    expect(template.approval_status).to eq('approved')
+  end
+
+  it 'records the rejection reason on REJECTED' do
+    described_class.new.perform(payload(event: 'REJECTED', reason: 'INVALID_FORMAT'))
+
+    template.reload
+    expect(template.settings['status']).to eq('REJECTED')
+    expect(template.approval_status).to eq('rejected')
+    expect(template.metadata['rejected_reason']).to eq('INVALID_FORMAT')
+  end
+
+  it 'is a no-op (no error) when no template matches the external id' do
+    expect do
+      described_class.new.perform(payload(event: 'APPROVED', message_template_id: 'does-not-exist'))
+    end.not_to raise_error
+
+    expect(template.reload.settings['status']).to eq('PENDING')
+  end
+end

--- a/spec/models/message_template_spec.rb
+++ b/spec/models/message_template_spec.rb
@@ -108,4 +108,110 @@ RSpec.describe MessageTemplate, type: :model do
       expect(bound).to be_valid
     end
   end
+
+  # EVO-1232 [6.3]: a WhatsApp Cloud template must be bound to a channel that is
+  # actually a WhatsApp Cloud channel (type + provider), not merely present.
+  describe 'WhatsApp Cloud channel type enforcement' do
+    def whatsapp_channel(provider:)
+      channel = Channel::Whatsapp.new(provider: provider, phone_number: "+1555#{SecureRandom.hex(3)}")
+      channel.save!(validate: false)
+      channel
+    end
+
+    it 'is invalid when the channel is a WhatsApp channel of another provider' do
+      template = described_class.new(
+        name: "wac-#{SecureRandom.hex(4)}", content: 'Hi',
+        channel: whatsapp_channel(provider: 'baileys'), intended_provider: 'whatsapp_cloud'
+      )
+
+      expect(template).not_to be_valid
+      expect(template.errors[:channel]).to include('must reference a WhatsApp Cloud channel')
+    end
+
+    it 'is invalid when the channel is not a WhatsApp channel at all' do
+      template = described_class.new(
+        name: "wac-#{SecureRandom.hex(4)}", content: 'Hi',
+        channel: Channel::Api.create!(hmac_mandatory: false), intended_provider: 'whatsapp_cloud'
+      )
+
+      expect(template).not_to be_valid
+      expect(template.errors[:channel]).to include('must reference a WhatsApp Cloud channel')
+    end
+
+    it 'treats a template bound to a WhatsApp Cloud channel as WhatsApp Cloud even without intended_provider' do
+      template = described_class.new(
+        name: "wac-#{SecureRandom.hex(4)}", content: 'Hi',
+        channel: whatsapp_channel(provider: 'whatsapp_cloud')
+      )
+
+      expect(template).to be_valid
+    end
+  end
+
+  # EVO-1232 [6.3]: Meta sync data is read through normalized accessors over the
+  # canonical JSONB (settings['status'] + metadata['external_id']).
+  describe '#approval_status' do
+    subject(:template) { described_class.new(name: 'n', content: 'c') }
+
+    it 'is draft when never synced (blank status)' do
+      template.settings = {}
+      expect(template.approval_status).to eq('draft')
+    end
+
+    it 'normalizes Meta APPROVED to approved' do
+      template.settings = { 'status' => 'APPROVED' }
+      expect(template.approval_status).to eq('approved')
+    end
+
+    it 'normalizes PENDING_QUALITY_CHECK to pending' do
+      template.settings = { 'status' => 'PENDING_QUALITY_CHECK' }
+      expect(template.approval_status).to eq('pending')
+    end
+
+    it 'normalizes PAUSED and FLAGGED' do
+      template.settings = { 'status' => 'PAUSED' }
+      expect(template.approval_status).to eq('paused')
+      template.settings = { 'status' => 'FLAGGED' }
+      expect(template.approval_status).to eq('flagged')
+    end
+
+    it 'falls back to a downcased value for unknown statuses' do
+      template.settings = { 'status' => 'SOMETHING_NEW' }
+      expect(template.approval_status).to eq('something_new')
+    end
+
+    it 'is draft when settings is not a Hash (defensive)' do
+      template.settings = 'malformed'
+      expect(template.approval_status).to eq('draft')
+    end
+  end
+
+  describe '#external_template_id' do
+    subject(:template) { described_class.new(name: 'n', content: 'c') }
+
+    it 'reads metadata external_id' do
+      template.metadata = { 'external_id' => '12345' }
+      expect(template.external_template_id).to eq('12345')
+    end
+
+    it 'is nil when metadata lacks external_id' do
+      template.metadata = { 'namespace' => 'ns' }
+      expect(template.external_template_id).to be_nil
+    end
+  end
+
+  describe '#serialized (EVO-1232 fields)' do
+    it 'exposes approval_status and external_template_id' do
+      template = described_class.new(
+        name: 'n', content: 'c',
+        settings: { 'status' => 'APPROVED' }, metadata: { 'external_id' => '999' }
+      )
+
+      serialized = template.serialized
+      expect(serialized['approval_status']).to eq('approved')
+      expect(serialized['external_template_id']).to eq('999')
+      # Raw Meta status is still exposed for backward compatibility.
+      expect(serialized['status']).to eq('APPROVED')
+    end
+  end
 end

--- a/spec/requests/api/v1/message_templates_spec.rb
+++ b/spec/requests/api/v1/message_templates_spec.rb
@@ -143,4 +143,69 @@ RSpec.describe 'Api::V1::Inboxes message templates (global mode)', type: :reques
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  # EVO-1232 [6.3]: push a single template up to Meta (WhatsApp Cloud) for
+  # approval via POST .../message_templates/:template_id/sync_with_whatsapp_cloud.
+  describe 'POST /api/v1/inboxes/:id/message_templates/:template_id/sync_with_whatsapp_cloud' do
+    def whatsapp_cloud_channel
+      ch = Channel::Whatsapp.new(provider: 'whatsapp_cloud', phone_number: "+1555#{SecureRandom.hex(3)}")
+      ch.save!(validate: false)
+      ch
+    end
+
+    it 'enqueues the sync job and returns 202 for a WhatsApp Cloud template (AC4)' do
+      template = MessageTemplate.create!(name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', channel: whatsapp_cloud_channel)
+
+      expect(SyncMessageTemplateWithWhatsappCloudJob).to receive(:perform_later).with(an_instance_of(MessageTemplate))
+
+      post "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}/sync_with_whatsapp_cloud",
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:accepted)
+      expect(json_response['data']['template']['id']).to eq(template.id)
+    end
+
+    it 'returns 422 and does not enqueue for a channel-less template (AC5)' do
+      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Hi')
+
+      expect(SyncMessageTemplateWithWhatsappCloudJob).not_to receive(:perform_later)
+
+      post "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}/sync_with_whatsapp_cloud",
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 for a template bound to a non-WhatsApp-Cloud channel (AC5)' do
+      bound = Channel::Whatsapp.new(provider: 'baileys', phone_number: "+1555#{SecureRandom.hex(3)}")
+      bound.save!(validate: false)
+      template = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'Hi', channel: bound)
+
+      expect(SyncMessageTemplateWithWhatsappCloudJob).not_to receive(:perform_later)
+
+      post "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}/sync_with_whatsapp_cloud",
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 404 for an unknown template id' do
+      post "/api/v1/inboxes/#{inbox.id}/message_templates/#{SecureRandom.uuid}/sync_with_whatsapp_cloud",
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns 403 without the inboxes.message_templates permission' do
+      template = MessageTemplate.create!(name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', channel: whatsapp_cloud_channel)
+      forbidden_user = User.create!(name: 'No Perm', email: "noperm-#{SecureRandom.hex(4)}@example.com")
+      allow_any_instance_of(Api::V1::InboxesController)
+        .to receive(:authenticate_request!) { Current.user = forbidden_user }
+      allow_any_instance_of(EvoAuthService).to receive(:check_user_permission).and_return(false)
+
+      post "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}/sync_with_whatsapp_cloud", as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Implements **EVO-1232 [6.3]** — binds a `MessageTemplate` to a WhatsApp Cloud channel, pushes it to Meta for approval, and ingests Meta's template status-update webhook. Builds directly on EVO-1231 (#127); **no migration** — reuses the existing JSONB convention (`metadata['external_id']` + `settings['status']`) that the `create_template → sync_templates` path already writes.

The ticket as written assumed work that doesn't match the codebase (new columns/enum, a flat `/api/v1/message_templates` controller, a from-scratch Meta client). This was scoped down to an **extend + wire-up** of the existing infrastructure. Intended deviations, all confirmed:

- **No DB columns / no enum** — `external_template_id` and `approval_status` are read-accessors over the canonical JSONB; `approval_status` normalizes Meta's `APPROVED/PENDING/REJECTED/PAUSED` to lowercase (default `draft`). Single source of truth, nothing for 1233/1255 to re-plumb.
- **Member route under inboxes** (`POST /inboxes/:id/message_templates/:template_id/sync_with_whatsapp_cloud`), consistent with 1231 — not a new flat controller. Inbox `:id` is a routing placeholder; the template's own channel supplies the WABA.
- **Webhook keyed on Meta's real payload** (`value[:event]`, `value[:message_template_id]`), matched against `metadata['external_id']`.

### Changes
- **Model** (`message_template.rb`): `external_template_id` / `approval_status` accessors + `serialized` exposure; WhatsApp Cloud validation strengthened from presence-only to require a `Channel::Whatsapp` with `provider == 'whatsapp_cloud'` (rejects incompatible channel types with 422).
- **Endpoint** (`routes.rb`, `inboxes_controller.rb`): `sync_template_with_whatsapp_cloud` → enqueues `SyncMessageTemplateWithWhatsappCloudJob`, returns `202`. Permission `inboxes.message_templates`.
- **Job** (`sync_message_template_with_whatsapp_cloud_job.rb`, new): reuses `channel.create_template` (push to Meta + re-sync writeback of `metadata['external_id']` + `settings['status']='PENDING'`); normalizes Hash-shaped `components` to Meta's array form; logs without re-raising (the publish is non-idempotent).
- **Webhook** (`whatsapp_events_job.rb`): handles `message_template_status_update` — registered in both the sync-event allow-list and the dispatch `case`; resolves the channel by **WABA id** (these payloads carry no phone metadata); updates `settings['status']` (+ rejection reason) via `update_columns`.

## Test plan
- `spec/models/message_template_spec.rb` — accessors, normalization (incl. PAUSED/FLAGGED/unknown), channel type+provider validation.
- `spec/requests/api/v1/message_templates_spec.rb` — sync endpoint: 202 + enqueue, 422 (channel-less / wrong type), 404, 403.
- `spec/jobs/sync_message_template_with_whatsapp_cloud_job_spec.rb` — payload, components normalization, pending writeback, non-WA-Cloud guard, error-swallow.
- `spec/jobs/webhooks/whatsapp_events_job_spec.rb` — WABA-id resolution, approve/reject status update by external_id, no-match safety, sync-event detection.

```
48 examples, 0 failures
```
New files rubocop-clean; no new offense types in touched legacy files.

## Notas
- **Coordinate with EVO-7.4a** — it also edits `app/jobs/webhooks/whatsapp_events_job.rb` (separate `message_status_update` branch; no logical conflict, possible merge conflict).
- Out of scope: approval UI (EVO-1233), send-template node (EVO-1236/1255), call-site migration (EVO-1234/1235).