### PR TITLE
fix(crm): allow service-token reads on per-inbox message templates (EVO-1255)

### DIFF
--- a/app/policies/inbox_policy.rb
+++ b/app/policies/inbox_policy.rb
@@ -96,6 +96,12 @@ class InboxPolicy < ApplicationPolicy
 
   # Generic message templates (for all channel types)
   def message_templates?
+    # s2s callers (evo-flow journey nodes, EVO-1255) list an inbox's templates
+    # with the service token — the same trust level that already allows global
+    # template CRUD via ?global=true. Without this, pundit_user carries a nil
+    # user and the call 500s.
+    return true if service_authenticated?
+
     @user.administrator? || @user.has_permission?('inboxes.message_templates')
   end
 

--- a/spec/requests/api/v1/message_templates_service_token_spec.rb
+++ b/spec/requests/api/v1/message_templates_service_token_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1255: evo-flow journey nodes list an inbox's templates server-side with
+# the service token. The per-inbox path runs InboxPolicy#message_templates?
+# (unlike ?global=true, which skips authorize), so the policy must honor
+# service authentication instead of dereferencing a nil user.
+RSpec.describe 'Api::V1::Inboxes message templates (service token, per-inbox)', type: :request do
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+  let(:channel) { Channel::Api.create!(hmac_mandatory: false) }
+  let(:inbox) { Inbox.create!(channel: channel, name: "Inbox #{SecureRandom.hex(3)}") }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  it 'lists the inbox templates with a valid service token' do
+    template = MessageTemplate.create!(
+      name: "ch-#{SecureRandom.hex(4)}",
+      content: 'Olá {{first_name}}',
+      channel: channel
+    )
+
+    get "/api/v1/inboxes/#{inbox.id}/message_templates?active=true&per_page=-1",
+        headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    names = response.parsed_body['data'].map { |t| t['name'] }
+    expect(names).to include(template.name)
+  end
+
+  it 'rejects the call without a service token or user' do
+    get "/api/v1/inboxes/#{inbox.id}/message_templates", as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end


### PR DESCRIPTION
## Summary
- `InboxPolicy#message_templates?` now honors `service_authenticated?`: s2s callers (evo-flow journey Send Message template mode) list an inbox's templates with `X-Service-Token`. The per-inbox path runs `authorize` (unlike `?global=true`, which skips it), and the policy dereferenced a nil user → 500.
- Same trust level the service token already has for global template CRUD (EVO-1231 spec suite).

## Security
- Scope limited to the `message_templates?` action (list/create dispatch); `update_message_template?`/`delete_message_template?` unchanged — still admin/permission only.
- Token validated via the existing `secure_compare` concern; no new surface.

## Test plan
- `bundle exec rspec spec/requests/api/v1/message_templates_service_token_spec.rb` — new per-inbox service-token coverage (200 with token, 401 without)
- `bundle exec rspec spec/requests/api/v1/message_templates_spec.rb` — global-mode regression green (17 examples total)

## Changed Files
- `app/policies/inbox_policy.rb`
- `spec/requests/api/v1/message_templates_service_token_spec.rb` (new)

## Related PRs
- evo-flow: https://github.com/evolution-foundation/evo-flow/pull/50 (consumer — merge this one first)
- evo-ai-frontend-community: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/154

## Linked Issue
- EVO-1255

## Summary by Sourcery

Allow service-token authenticated callers to access per-inbox message templates without requiring a user-bound permission check.

Bug Fixes:
- Prevent 500 errors when service-token based s2s callers list per-inbox message templates by permitting access when service authentication is present.

Tests:
- Add request specs covering per-inbox message template access with and without a valid service token to ensure correct 200/401 behavior.