### PR TITLE
fix(crm): validate contact identifier format before using as WhatsApp destination (EVO-1682)

### DIFF
--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -179,10 +179,13 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
       end
     # For Evolution Go provider, identifier prioritizes over phone_number
     elsif channel.provider == 'evolution_go'
-      # If contact has identifier, use it (covers new and updated contacts)
-      if contact.identifier.present?
-        Rails.logger.info "WhatsApp Send: Using identifier #{contact.identifier}"
-        contact.identifier
+      # Use identifier ONLY when it looks like a valid number/JID (Evolution Go SenderAlt).
+      # A non-numeric identifier (e.g. imported lead label "samambaia-090") is an external ID,
+      # never a WhatsApp destination — fall back to phone_number / source_id.
+      if contact.identifier.present? && valid_wa_destination?(contact.identifier)
+        target = contact.identifier.delete_prefix('+')
+        Rails.logger.info "WhatsApp Send: Using identifier #{target}"
+        target
       # If contact_inbox source_id is an identifier (e.g., 96426461769841@lid), use it
       elsif contact_inbox.source_id&.include?('@lid')
         Rails.logger.info "WhatsApp Send: Using source_id identifier #{contact_inbox.source_id}"
@@ -212,6 +215,16 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
         source_id
       end
     end
+  end
+
+  # A valid Evolution Go destination is a numeric JID (@lid / @s.whatsapp.net, or
+  # @g.us with the optional legacy hyphen) or a digits-only string with an optional
+  # leading +. Deliberately stricter than RegexHelper::WHATSAPP_CHANNEL_REGEX, which
+  # validates inbound source_ids (1-digit numbers, BSUIDs) and lacks @s.whatsapp.net:
+  # here a false positive sends a message to a wrong destination (EVO-1682).
+  def valid_wa_destination?(value)
+    value.to_s.match?(/\A\+?\d+(?:-\d+)?@(?:lid|s\.whatsapp\.net|g\.us)\z/) ||
+      value.to_s.match?(/\A\+?\d{8,15}\z/)
   end
 
   def template_params

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -72,6 +72,122 @@ RSpec.describe Whatsapp::SendOnWhatsappService do
     end
   end
 
+  # EVO-1682: identifier is only a valid Evolution Go destination when it looks like
+  # a number/JID; non-numeric identifiers (imported lead labels) must fall back to
+  # phone_number / source_id instead of being sent as the recipient.
+  describe '#determine_target_number_for_sending — evolution_go identifier validation' do
+    let(:provider) { 'evolution_go' }
+    let(:additional_attributes) { nil }
+
+    context 'when identifier is a non-numeric imported label' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: 'samambaia-090', phone_number: '+5561993372804') }
+      let(:contact_inbox_source_id) { '5561993372804' }
+
+      it 'ignores the identifier and uses the cleaned phone_number' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804')
+      end
+    end
+
+    context 'when identifier is a @lid JID (Evolution Go SenderAlt)' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: '96426461769841@lid', phone_number: '+5561993372804') }
+      let(:contact_inbox_source_id) { '5561993372804' }
+
+      it 'uses the identifier' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('96426461769841@lid')
+      end
+    end
+
+    context 'when identifier is a digits-only number' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: '5561993372804', phone_number: nil) }
+      let(:contact_inbox_source_id) { 'whatever' }
+
+      it 'uses the identifier' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804')
+      end
+    end
+
+    context 'when identifier is a number with a leading +' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: '+5561993372804', phone_number: nil) }
+      let(:contact_inbox_source_id) { 'whatever' }
+
+      it 'uses the identifier stripped of the leading + (consistent with the phone_number path)' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804')
+      end
+    end
+
+    context 'when identifier is a @s.whatsapp.net JID' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: '5561993372804@s.whatsapp.net', phone_number: nil) }
+      let(:contact_inbox_source_id) { 'whatever' }
+
+      it 'uses the identifier' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804@s.whatsapp.net')
+      end
+    end
+
+    context 'when identifier is a legacy group JID (hyphenated)' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: '553184455827-1593702061@g.us', phone_number: nil) }
+      let(:contact_inbox_source_id) { 'whatever' }
+
+      it 'uses the identifier' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('553184455827-1593702061@g.us')
+      end
+    end
+
+    context 'when identifier is a non-numeric label with a JID suffix' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: 'samambaia-090@lid', phone_number: '+5561993372804') }
+      let(:contact_inbox_source_id) { '5561993372804' }
+
+      it 'rejects it and uses the cleaned phone_number' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804')
+      end
+    end
+
+    context 'when identifier has + signs in the middle' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: '55+61+993372804', phone_number: '+5561993372804') }
+      let(:contact_inbox_source_id) { '5561993372804' }
+
+      it 'rejects it and uses the cleaned phone_number' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804')
+      end
+    end
+
+    context 'when identifier is invalid, source_id is a @lid JID and phone_number is present' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: 'samambaia-090', phone_number: '+5561993372804') }
+      let(:contact_inbox_source_id) { '96426461769841@lid' }
+
+      it 'prefers the source_id JID over the phone_number (branch order)' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('96426461769841@lid')
+      end
+    end
+
+    context 'when identifier is invalid and source_id is a @lid JID' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: 'samambaia-090', phone_number: nil) }
+      let(:contact_inbox_source_id) { '96426461769841@lid' }
+
+      it 'falls back to the source_id JID' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('96426461769841@lid')
+      end
+    end
+
+    context 'when contact only has phone_number (no identifier)' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: nil, phone_number: '+5561993372804') }
+      let(:contact_inbox_source_id) { '5561993372804' }
+
+      it 'uses the cleaned phone_number' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804')
+      end
+    end
+
+    context 'when identifier is invalid and there is no phone_number' do
+      let(:contact) { instance_double(Contact, id: 1, identifier: 'samambaia-090', phone_number: nil) }
+      let(:contact_inbox_source_id) { '5561993372804' }
+
+      it 'falls back to source_id as last resort' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5561993372804')
+      end
+    end
+  end
+
   # AC6: when the provider rejects a send, the failure path must
   # go through Messages::StatusUpdateService so that the canonical Wisper
   # :message_status_changed event is published. Previously these two sites


### PR DESCRIPTION
## Summary
- `Whatsapp::SendOnWhatsappService#determine_target_number_for_sending` (evolution_go branch): `contact.identifier` is now used as the send destination only when it passes the new `valid_wa_destination?` check — a numeric JID (`@lid` / `@s.whatsapp.net` / `@g.us`, optional legacy hyphen) or a digits-only number (8–15 digits, optional leading `+`, stripped on return).
- Non-numeric identifiers (imported lead labels such as `samambaia-090`) no longer get sent as the recipient; the service falls back to `phone_number` / `source_id`, restoring delivery for imported bases (125/130 contacts unreachable in the report).
- Evolution Go SenderAlt is preserved: a valid JID/number in `identifier` still takes priority.
- The helper is intentionally stricter than `RegexHelper::WHATSAPP_CHANNEL_REGEX` (which validates inbound source_ids and lacks `@s.whatsapp.net`) — rationale documented inline.

## Validation
- `evo-ai-crm-community: ruby -c app/services/whatsapp/send_on_whatsapp_service.rb` — Syntax OK
- `evo-ai-crm-community: bundle exec rspec spec/services/whatsapp/send_on_whatsapp_service_spec.rb` — 19 examples, 0 failures (12 new examples covering the card's ACs and review edge cases)
- `evo-ai-crm-community: bundle exec rubocop <changed files>` — 10 offenses, identical to baseline (none introduced)
- In-app smoke via `rails runner` exercising the real method with the reporter's data: 7/7 PASS (label+phone → phone; `@lid` identifier kept; label with `@lid` suffix rejected; `+` normalized; fallbacks intact)

## Changed Files
- `app/services/whatsapp/send_on_whatsapp_service.rb`
- `spec/services/whatsapp/send_on_whatsapp_service_spec.rb`

## Notes
- The sibling `zapi` branch of the same method still uses `contact.identifier` without format validation when `phone_number` is blank (same bug class). Left untouched here — out of this card's scope (EVO-1682 is evolution_go-specific).

## Linked Issue
- EVO-1682 — https://linear.app/evoai/issue/EVO-1682/rc5-envio-outbound-usa-contactidentifier-como-numero-de-whatsapp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate Evolution Go WhatsApp destinations before using contact identifiers, falling back to phone number or source_id when invalid.

Bug Fixes:
- Prevent non-numeric contact identifiers (e.g., imported labels) from being used as WhatsApp recipients for Evolution Go, restoring correct delivery routing.

Tests:
- Add comprehensive service specs covering valid/invalid identifier formats, JID handling, plus normalization, and fallback precedence between identifier, phone_number, and source_id.