### PR TITLE
feat(templates): migrate channel-coupled templates into global flow (EVO-1234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,45 @@ docker-compose up backend worker
 
 ---
 
+## Maintenance tasks
+
+### Legacy template migration (EVO-1234)
+
+Ports channel-coupled message templates (rows with `channel_id NOT NULL`) into the
+global/independent flow introduced by EVO-1231, creating a channel-less
+(`channel_id IS NULL`) counterpart for each. WhatsApp Cloud templates are
+intentionally **not** migrated — Meta requires an approved template tied to a WABA
+channel, so they stay channel-bound.
+
+```bash
+# 1. Preview — logs the counts that would migrate, writes nothing
+DRY_RUN=true bundle exec rake templates:migrate_legacy
+
+# 2. (Recommended) back up the table before applying in production
+pg_dump -t message_templates "$DATABASE_URL" > message_templates_backup.sql
+
+# 3. Apply — idempotent, safe to rerun (provenance tracked via external_legacy_id)
+bundle exec rake templates:migrate_legacy
+
+# Rollback — deletes ONLY migrated globals (external_legacy_id IS NOT NULL);
+# channel-bound originals and admin-created globals are untouched.
+bundle exec rake templates:rollback_legacy_migration
+```
+
+Notes:
+
+- **Idempotent:** rerunning never duplicates (each copy carries
+  `external_legacy_id = "message_template:<source_id>"`, backed by a partial
+  unique index).
+- **Rollback caveat:** rollback also discards any admin edits made to migrated
+  templates after the migration ran.
+- Best run **after** the template menu UI (EVO-1233) is available so an admin can
+  visually validate the migrated globals.
+- The migration emits Prometheus counters (`templates_migrated_total{source}`,
+  `templates_migrated_skipped{reason}`), but the authoritative result is the
+  summary printed by the rake task and the structured log lines — the counters
+  increment in the worker process and are not exposed to the web `/metrics` scrape.
+
 ## Documentation
 
 | Resource | Link |

--- a/app/jobs/migrate_legacy_templates_to_message_template_job.rb
+++ b/app/jobs/migrate_legacy_templates_to_message_template_job.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+# EVO-1234 [6.5] Migrate channel-coupled message templates into the global /
+# independent (channel-less) flow introduced by EVO-1231.
+#
+# Premise note: the ticket's literal "old models" (per-channel JSONB columns,
+# email_templates table) were already migrated AND dropped in Dec 2025
+# (20251201132657 et al.). The real remaining gap is that those Dec-migrated
+# rows live channel-coupled (channel_id NOT NULL) and therefore never surface in
+# the global template menu. This job creates a global (channel_id: nil)
+# counterpart for each non-WhatsApp-Cloud channel-coupled template.
+#
+# Idempotency: each global copy carries
+#   external_legacy_id = "message_template:<source_id>"
+# backed by a partial unique index, so reruns never duplicate.
+#
+# Source of truth for results = the returned summary Hash + the structured log.
+# Prometheus counters are best-effort instrumentation ONLY: they increment in
+# the Sidekiq worker process, are not visible to the web /metrics scrape, and
+# reset per process. Specs/ACs assert on the summary Hash, never on the counters.
+class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
+  queue_as :low
+
+  BATCH_SIZE = 100
+  LEGACY_KEY_PREFIX = 'message_template'
+
+  # channel_type => Prometheus `source` label (also used for the summary buckets)
+  SOURCE_LABELS = {
+    'Channel::Whatsapp' => 'whatsapp_legacy_template',
+    'Channel::Instagram' => 'instagram_legacy_template',
+    'Channel::FacebookPage' => 'facebook_legacy_template',
+    'Channel::Telegram' => 'telegram_legacy_template',
+    'Channel::TwilioSms' => 'twilio_sms_legacy_template',
+    'Channel::Line' => 'line_legacy_template'
+  }.freeze
+  DEFAULT_SOURCE_LABEL = 'other_legacy_template'
+
+  # Skip reasons. The four below are the documented taxonomy; specs/ACs assert on
+  # these exact keys. `:invalid` (built copy failed validation, e.g. a stray
+  # media_type) and `:error` (unexpected exception) are diagnostic buckets.
+  REASON_WHATSAPP_CLOUD = :whatsapp_cloud
+  REASON_INVALID_CONTENT = :invalid_content
+  REASON_ALREADY_MIGRATED = :already_migrated
+  REASON_DUPLICATE_NAME = :duplicate_name
+
+  def perform(dry_run: false)
+    summary = { migrated: Hash.new(0), skipped: Hash.new(0), dry_run: dry_run }
+    # In-run dedup state so dry-run predicts the SAME counts a real run produces
+    # (nothing is committed in dry-run, so we cannot rely on DB lookups alone).
+    ctx = {
+      dry_run: dry_run,
+      summary: summary,
+      seen_keys: Set.new,    # external_legacy_id keys produced this run
+      all_names: Set.new,    # every global name produced this run (downcased)
+      legacy_names: Set.new  # global names produced by THIS migration this run (downcased)
+    }
+
+    MessageTemplate.where.not(channel_id: nil).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+      batch.each do |source|
+        migrate_one(source, ctx)
+      rescue StandardError => e
+        Rails.logger.error(
+          "[migrate_legacy_templates] source_id=#{source.id} error=#{e.class}: #{e.message}"
+        )
+        summary[:skipped][:error] += 1
+      end
+    end
+
+    Rails.logger.info(
+      "[migrate_legacy_templates] done dry_run=#{dry_run} " \
+      "migrated=#{summary[:migrated].to_h} skipped=#{summary[:skipped].to_h}"
+    )
+    summary
+  end
+
+  private
+
+  def migrate_one(source, ctx)
+    # 1. WhatsApp Cloud (or an unverifiable WhatsApp channel) stays channel-bound:
+    #    Meta requires an approved template tied to a WABA channel (EVO-1232).
+    return skip(ctx, REASON_WHATSAPP_CLOUD, source, 'kept channel-bound (WhatsApp)') if keep_channel_bound?(source)
+
+    # 2. Blank content cannot satisfy the model's presence validation.
+    return skip(ctx, REASON_INVALID_CONTENT, source, 'blank content') if source.content.blank?
+
+    # 3. Idempotency: skip rows already migrated (committed) or seen this run.
+    key = legacy_key(source)
+    if ctx[:seen_keys].include?(key) || MessageTemplate.exists?(external_legacy_id: key)
+      return skip(ctx, REASON_ALREADY_MIGRATED, source, 'already migrated')
+    end
+
+    # 4. Resolve the global name (dedupe vs other legacy rows, suffix vs admin globals).
+    target_name = resolve_name(source, ctx)
+    return skip(ctx, REASON_DUPLICATE_NAME, source, 'another legacy row already owns this name') if target_name == :duplicate
+
+    attrs = build_attrs(source, key, target_name)
+
+    if ctx[:dry_run]
+      candidate = MessageTemplate.new(attrs)
+      unless candidate.valid?
+        return skip(ctx, :invalid, source, candidate.errors.full_messages.join('; '))
+      end
+    else
+      MessageTemplate.create!(attrs)
+      increment_migrated_metric(source_label(source))
+    end
+
+    record_success(ctx, source, target_name, key)
+  end
+
+  # WhatsApp Cloud detection. A WhatsApp-typed row whose channel record is gone
+  # is treated conservatively as "keep channel-bound": we cannot read its
+  # provider, so we refuse to risk globalizing a former Cloud template (F12).
+  def keep_channel_bound?(source)
+    return false unless source.channel_type == 'Channel::Whatsapp'
+
+    channel = source.channel
+    return true if channel.nil? # provider unverifiable -> conservative
+
+    channel.provider == 'whatsapp_cloud'
+  end
+
+  # Returns the global name to use, or :duplicate when another legacy migration
+  # row already owns this base name (one global per legacy name is enough).
+  def resolve_name(source, ctx)
+    base = source.name
+    base_key = base.downcase
+
+    # Owned by a legacy migration already (this run OR committed) -> duplicate.
+    return :duplicate if ctx[:legacy_names].include?(base_key) || legacy_global_exists?(base)
+
+    # Free among all globals -> use as-is.
+    return base unless global_name_taken?(base, ctx)
+
+    # Collides with a genuine pre-existing (admin-created) global -> suffix.
+    suffixed = "#{base} (legacy)"
+    return suffixed unless global_name_taken?(suffixed, ctx)
+
+    "#{base} (legacy #{source.id})"
+  end
+
+  def legacy_global_exists?(name)
+    MessageTemplate.where(channel_id: nil, name: name).where.not(external_legacy_id: nil).exists?
+  end
+
+  def global_name_taken?(name, ctx)
+    ctx[:all_names].include?(name.downcase) ||
+      MessageTemplate.where(channel_id: nil, name: name).exists?
+  end
+
+  def build_attrs(source, key, name)
+    {
+      channel: nil,
+      name: name,
+      external_legacy_id: key,
+      content: source.content,
+      language: source.language,
+      category: source.category,
+      template_type: normalized_template_type(source.template_type),
+      components: deep_dup(source.components),
+      # NOTE (F5): the model's before_save re-derives `variables` from {{tokens}}
+      # in `content`. Legacy rows carry synthetic component-derived var names
+      # (var_1, var_2...) that are NOT present in content, so they are dropped on
+      # save and the copy's variables reflect the real content tokens. This copy
+      # only survives for vars whose names actually appear in content.
+      variables: deep_dup(source.variables),
+      media_url: source.media_url,
+      media_type: source.media_type.presence, # '' -> nil so inclusion+allow_nil passes (F6)
+      settings: deep_dup(source.settings),
+      metadata: deep_dup(source.metadata)
+    }
+  end
+
+  # The Dec-2025 migration only ever wrote text/media/interactive (all valid enum
+  # keys). Guard defensively anyway: an out-of-enum value raises ArgumentError at
+  # assignment, so fall back to the model default (set_defaults => 'text').
+  def normalized_template_type(value)
+    MessageTemplate.template_types.key?(value) ? value : nil
+  end
+
+  def record_success(ctx, source, name, key)
+    ctx[:all_names] << name.downcase
+    ctx[:legacy_names] << name.downcase
+    ctx[:seen_keys] << key
+    ctx[:summary][:migrated][source_label(source)] += 1
+  end
+
+  def skip(ctx, reason, source, detail)
+    Rails.logger.info(
+      "[migrate_legacy_templates] skip reason=#{reason} source_id=#{source.id} " \
+      "name=#{source.name.inspect} detail=#{detail}"
+    )
+    ctx[:summary][:skipped][reason] += 1
+    increment_skipped_metric(reason) unless ctx[:dry_run]
+    nil
+  end
+
+  def legacy_key(source)
+    "#{LEGACY_KEY_PREFIX}:#{source.id}"
+  end
+
+  def source_label(source)
+    SOURCE_LABELS.fetch(source.channel_type, DEFAULT_SOURCE_LABEL)
+  end
+
+  def deep_dup(value)
+    value.respond_to?(:deep_dup) ? value.deep_dup : value
+  end
+
+  # Best-effort metrics. Guarded so a missing constant or registry hiccup never
+  # aborts a migration row.
+  def increment_migrated_metric(label)
+    return unless defined?(EVO_AI_CRM_TEMPLATES_MIGRATED_COUNTER)
+
+    EVO_AI_CRM_TEMPLATES_MIGRATED_COUNTER.increment(labels: { source: label })
+  rescue StandardError => e
+    Rails.logger.warn("[migrate_legacy_templates] migrated metric failed: #{e.message}")
+  end
+
+  def increment_skipped_metric(reason)
+    return unless defined?(EVO_AI_CRM_TEMPLATES_MIGRATED_SKIPPED_COUNTER)
+
+    EVO_AI_CRM_TEMPLATES_MIGRATED_SKIPPED_COUNTER.increment(labels: { reason: reason.to_s })
+  rescue StandardError => e
+    Rails.logger.warn("[migrate_legacy_templates] skipped metric failed: #{e.message}")
+  end
+end

--- a/app/models/message_template.rb
+++ b/app/models/message_template.rb
@@ -8,8 +8,9 @@
 #  active        :boolean          default(TRUE)
 #  category      :string
 #  channel_type  :string
-#  components    :jsonb
-#  content       :text             not null
+#  components         :jsonb
+#  content            :text             not null
+#  external_legacy_id :string
 #  language      :string           default("pt_BR")
 #  media_type    :string
 #  media_url     :string
@@ -24,6 +25,7 @@
 #
 # Indexes
 #
+#  idx_message_templates_external_legacy_id  (external_legacy_id) UNIQUE WHERE (external_legacy_id IS NOT NULL)
 #  idx_message_templates_global_name   (name) UNIQUE WHERE (channel_id IS NULL)
 #  idx_templates_active_by_channel     (channel_type,channel_id,active)
 #  idx_templates_by_category           (category)
@@ -62,6 +64,8 @@ class MessageTemplate < ApplicationRecord
   validates :name, uniqueness: { scope: [:channel_type, :channel_id] }
   validates :language, presence: true
   validates :media_type, inclusion: { in: %w[image video document audio] }, allow_nil: true
+  # Provenance/idempotency key for rows ported into the global flow (EVO-1234).
+  validates :external_legacy_id, uniqueness: true, allow_nil: true
 
   validate :channel_required_for_whatsapp_cloud
 

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -12,3 +12,23 @@ unless defined?(EVO_AI_CRM_CONCURRENT_USERS_GAUGE)
     docstring: 'Concurrent CRM users in the current presence window'
   )
 end
+
+# EVO-1234 [6.5] Legacy-template migration counters. Best-effort instrumentation:
+# they increment in the Sidekiq worker process and are NOT visible to the web
+# /metrics scrape (and reset per process). The migration's source of truth is its
+# returned summary Hash + structured log, not these counters.
+unless defined?(EVO_AI_CRM_TEMPLATES_MIGRATED_COUNTER)
+  EVO_AI_CRM_TEMPLATES_MIGRATED_COUNTER = Prometheus::Client.registry.counter(
+    :templates_migrated_total,
+    docstring: 'Legacy channel-coupled templates migrated into the global flow',
+    labels: [:source]
+  )
+end
+
+unless defined?(EVO_AI_CRM_TEMPLATES_MIGRATED_SKIPPED_COUNTER)
+  EVO_AI_CRM_TEMPLATES_MIGRATED_SKIPPED_COUNTER = Prometheus::Client.registry.counter(
+    :templates_migrated_skipped,
+    docstring: 'Legacy templates skipped during migration to the global flow',
+    labels: [:reason]
+  )
+end

--- a/db/migrate/20260611120000_add_external_legacy_id_to_message_templates.rb
+++ b/db/migrate/20260611120000_add_external_legacy_id_to_message_templates.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# EVO-1234 [6.5]: provenance + idempotency key for templates ported from the
+# channel-coupled records into the global/independent (channel-less) flow.
+# The partial unique index gives DB-level rerun safety: a second migration run
+# can never insert a duplicate global counterpart for the same source row.
+class AddExternalLegacyIdToMessageTemplates < ActiveRecord::Migration[7.1]
+  def change
+    add_column :message_templates, :external_legacy_id, :string
+
+    add_index :message_templates, :external_legacy_id,
+              unique: true,
+              where: 'external_legacy_id IS NOT NULL',
+              name: 'idx_message_templates_external_legacy_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_09_140000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -711,9 +711,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_09_140000) do
     t.boolean "active", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "external_legacy_id"
     t.index ["category"], name: "idx_templates_by_category"
     t.index ["channel_type", "channel_id", "active"], name: "idx_templates_active_by_channel"
     t.index ["channel_type", "channel_id"], name: "index_message_templates_on_channel"
+    t.index ["external_legacy_id"], name: "idx_message_templates_external_legacy_id", unique: true, where: "(external_legacy_id IS NOT NULL)"
     t.index ["name", "channel_type", "channel_id"], name: "idx_templates_lookup"
     t.index ["name"], name: "idx_message_templates_global_name", unique: true, where: "(channel_id IS NULL)"
     t.index ["name"], name: "idx_templates_by_name"

--- a/lib/tasks/templates.rake
+++ b/lib/tasks/templates.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# EVO-1234 [6.5] Operator tasks for porting channel-coupled message templates
+# into the global/independent flow.
+#
+# Usage:
+#   DRY_RUN=true bundle exec rake templates:migrate_legacy   # preview, no writes
+#   bundle exec rake templates:migrate_legacy                # apply (idempotent)
+#   bundle exec rake templates:rollback_legacy_migration     # delete migrated globals
+#
+# The migration is idempotent (safe to rerun). The job runs inline via
+# perform_now so the operator watches the log stream and gets the summary back.
+namespace :templates do
+  desc 'Migrate channel-coupled templates into the global flow (DRY_RUN=true to preview)'
+  task migrate_legacy: :environment do
+    dry_run = ENV['DRY_RUN'] == 'true'
+    summary = MigrateLegacyTemplatesToMessageTemplateJob.perform_now(dry_run: dry_run)
+    puts "[templates:migrate_legacy] dry_run=#{dry_run} #{summary.except(:dry_run).inspect}"
+    puts '[templates:migrate_legacy] DRY RUN — no rows were written. Re-run without DRY_RUN to apply.' if dry_run
+  end
+
+  desc 'Rollback: delete every global template created by the legacy migration'
+  task rollback_legacy_migration: :environment do
+    # Only rows carrying a provenance key are deleted; channel-bound originals
+    # and admin-created globals (external_legacy_id IS NULL) are never touched.
+    scope = MessageTemplate.where.not(external_legacy_id: nil)
+    count = scope.count
+    scope.delete_all
+    puts "[templates:rollback_legacy_migration] deleted #{count} migrated global templates"
+  end
+end

--- a/spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb
+++ b/spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MigrateLegacyTemplatesToMessageTemplateJob, type: :job do
+  # Channels are built without validation, mirroring the EVO-1232 job spec.
+  def whatsapp_channel(provider:)
+    channel = Channel::Whatsapp.new(provider: provider, phone_number: "+1555#{SecureRandom.hex(3)}")
+    channel.save!(validate: false)
+    channel
+  end
+
+  # A channel-coupled (channel_id NOT NULL) template — the migration source shape.
+  def coupled_template(channel:, name:, content: 'Hello {{name}}', **attrs)
+    MessageTemplate.create!(channel: channel, name: name, content: content, language: 'pt_BR', **attrs)
+  end
+
+  def globals
+    MessageTemplate.where(channel_id: nil)
+  end
+
+  let(:baileys) { whatsapp_channel(provider: 'baileys') }
+
+  describe 'dry run (AC1)' do
+    it 'writes nothing and reports the count that would migrate per source/skip reason' do
+      coupled_template(channel: baileys, name: 'Promo A')
+      coupled_template(channel: baileys, name: 'Promo B')
+
+      expect do
+        @summary = described_class.new.perform(dry_run: true)
+      end.not_to change(globals, :count)
+
+      expect(@summary[:dry_run]).to be(true)
+      expect(@summary[:migrated]['whatsapp_legacy_template']).to eq(2)
+      expect(@summary[:skipped]).to be_empty
+    end
+
+    it 'predicts the SAME count a real run produces for same-named sources (F1 regression)' do
+      c2 = whatsapp_channel(provider: 'baileys')
+      coupled_template(channel: baileys, name: 'Shared', content: 'A')
+      coupled_template(channel: c2, name: 'Shared', content: 'B')
+
+      summary = described_class.new.perform(dry_run: true)
+
+      # One global would be created; the second same-named row is a duplicate —
+      # exactly what a real run yields. Dry run must not double-count.
+      migrated_total = summary[:migrated].values.sum
+      expect(migrated_total).to eq(1)
+      expect(summary[:skipped][:duplicate_name]).to eq(1)
+      expect(globals.count).to eq(0)
+    end
+  end
+
+  describe 'normal run (AC2)' do
+    it 'creates a channel-less global counterpart and leaves the original untouched' do
+      source = coupled_template(channel: baileys, name: 'Welcome', content: 'Hi {{name}}', category: 'UTILITY')
+
+      described_class.new.perform
+
+      copy = MessageTemplate.find_by(external_legacy_id: "message_template:#{source.id}")
+      expect(copy).to be_present
+      expect(copy.channel_id).to be_nil
+      expect(copy.content).to eq('Hi {{name}}')
+      expect(copy.category).to eq('UTILITY')
+      expect(copy.variables.map { |v| v['name'] }).to include('name')
+
+      source.reload
+      expect(source.channel_id).to eq(baileys.id)
+      expect(source.external_legacy_id).to be_nil
+    end
+  end
+
+  describe 'idempotency (AC3)' do
+    it 'creates nothing on a second run' do
+      coupled_template(channel: baileys, name: 'Once')
+
+      described_class.new.perform
+      expect do
+        @summary = described_class.new.perform
+      end.not_to change(globals, :count)
+
+      expect(@summary[:skipped][:already_migrated]).to eq(1)
+      expect(@summary[:migrated]).to be_empty
+    end
+  end
+
+  describe 'invalid content (AC4)' do
+    it 'skips a blank-content row under :invalid_content' do
+      blank = MessageTemplate.new(channel: baileys, name: 'Blank', content: '', language: 'pt_BR')
+      blank.save!(validate: false)
+
+      summary = described_class.new.perform
+
+      expect(summary[:skipped][:invalid_content]).to eq(1)
+      expect(globals.count).to eq(0)
+    end
+  end
+
+  describe 'WhatsApp Cloud (AC5)' do
+    it 'keeps Cloud templates channel-bound and creates no global' do
+      cloud = whatsapp_channel(provider: 'whatsapp_cloud')
+      source = coupled_template(channel: cloud, name: 'Cloud One', category: 'UTILITY',
+                                components: [{ 'type' => 'BODY', 'text' => 'Hi' }])
+
+      summary = described_class.new.perform
+
+      expect(summary[:skipped][:whatsapp_cloud]).to eq(1)
+      expect(globals.count).to eq(0)
+      expect(source.reload.channel_id).to eq(cloud.id)
+    end
+  end
+
+  describe 'name collisions (AC6)' do
+    it 'suffixes "(legacy)" when a genuine admin global already owns the name' do
+      MessageTemplate.create!(channel: nil, name: 'Offer', content: 'admin copy') # admin global, no legacy id
+      source = coupled_template(channel: baileys, name: 'Offer', content: 'legacy copy')
+
+      described_class.new.perform
+
+      copy = MessageTemplate.find_by(external_legacy_id: "message_template:#{source.id}")
+      expect(copy.name).to eq('Offer (legacy)')
+      expect(globals.find_by(name: 'Offer').external_legacy_id).to be_nil # admin row intact
+    end
+
+    it 'creates exactly one global when two legacy rows share a name' do
+      c2 = whatsapp_channel(provider: 'baileys')
+      coupled_template(channel: baileys, name: 'Dup', content: 'A')
+      coupled_template(channel: c2, name: 'Dup', content: 'B')
+
+      summary = described_class.new.perform
+
+      expect(globals.where(name: 'Dup').count).to eq(1)
+      expect(summary[:skipped][:duplicate_name]).to eq(1)
+    end
+  end
+
+  describe 'rollback scope (AC7)' do
+    it 'deletes only migrated globals, leaving originals and admin globals' do
+      admin = MessageTemplate.create!(channel: nil, name: 'Kept', content: 'admin')
+      source = coupled_template(channel: baileys, name: 'Migrated')
+      described_class.new.perform
+
+      # Mirrors lib/tasks/templates.rake rollback_legacy_migration.
+      MessageTemplate.where.not(external_legacy_id: nil).delete_all
+
+      expect(MessageTemplate.exists?(admin.id)).to be(true)
+      expect(MessageTemplate.exists?(source.id)).to be(true)
+      expect(globals.where.not(external_legacy_id: nil).count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Porta os `message_templates` **channel-coupled** (`channel_id NOT NULL`) para o fluxo **global/independente** (channel-less) introduzido pela EVO-1231 [6.2], encerrando a divergência entre o novo menu de templates e os registros legados channel-bound.

> **Re-escopo da premissa:** o enunciado literal da EVO-1234 ("migrar dos modelos antigos" — colunas JSONB por canal, tabela `email_templates`) está **obsoleto**: essas fontes já foram migradas **e dropadas** em Dez/2025 (`20251201132657` et al.). O gap real são as linhas hoje channel-coupled que não aparecem no menu global. Confirmado com a investigação 6.1 (EVO-1230, D5).

### O que entra
- **`external_legacy_id`** (coluna string + índice único parcial) → idempotência rerun-safe (`key = "message_template:<source_id>"`).
- **`MigrateLegacyTemplatesToMessageTemplateJob`** (`ApplicationJob`, `queue_as :low`, `find_in_batches(100)`, `perform(dry_run:)`) → cria um global (`channel_id: nil`) por template channel-coupled elegível; retorna um **summary Hash** (fonte de verdade testável).
- **Skip rules:** `whatsapp_cloud` (mantido channel-bound — Meta exige template aprovado em canal WABA, EVO-1232), `invalid_content` (blank), `already_migrated`; colisão de nome → sufixo `(legacy)` vs globais admin.
- **Rake:** `templates:migrate_legacy` (`DRY_RUN=true`) e `templates:rollback_legacy_migration`.
- **Métricas Prometheus** `templates_migrated_total{source}` / `templates_migrated_skipped{reason}` (best-effort — incrementam no worker, **não** são a superfície de AC).
- **README:** seção de manutenção (dry-run, backup `pg_dump`, rollback + caveat).

### Fora de escopo
- Migrar `canned_responses` (6.1/D3 mantém separado).
- Relink de campanha (`whatsapp_template_id` → `message_template_id`) — **N/A**: não há tabela `campaigns` nem coluna `*whatsapp_template_id*` no schema.
- Remover os originais channel-bound (cleanup é story futura — coexistência intencional).
- Globalizar templates WhatsApp Cloud.

## Test plan
- `bundle exec rspec spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb` → **9 examples, 0 failures** (rodado no container de teste sobre `evolution_test`).
- Cobertura: dry-run (zero escrita + contagem), **fidelidade dry-run vs run real para nomes repetidos** (regressão de review adversarial), run normal (counterpart global com `external_legacy_id`/`channel_id: nil`, original intacto), idempotência, skip de conteúdo em branco, skip de WhatsApp Cloud, colisão de nome (sufixo + duplicate), escopo de rollback.
- Manual: seed de templates channel-coupled (baileys/instagram/WA Cloud/blank) → `DRY_RUN=true rake templates:migrate_legacy` → `rake templates:migrate_legacy` → rerun (idempotência) → `rake templates:rollback_legacy_migration`.

## Notas
- **Base:** branch criada a partir de `origin/develop` fresca (já contém 1231 e 1232 squash-merged). Sem rebase pendente — os arquivos tocados eram idênticos entre o branch de referência e a develop; `schema.rb` diff = só `external_legacy_id` + bump de versão.
- **F5 (variables):** a migration de Dez/2025 gravou nomes sintéticos `var_N` que não estão no `content`; o `before_save :extract_variables_from_content` os re-deriva a partir dos `{{tokens}}` do content. A cópia de `variables` só sobrevive para tokens reais — documentado no código.
- **Prometheus:** counters incrementam no processo Sidekiq e não são visíveis no scrape web `/metrics` (resetam por processo). A superfície operacional é o **log estruturado + summary Hash**.

## Summary by Sourcery

Migrate legacy channel-coupled message templates into the new global, channel-less template flow with provenance tracking and operational tooling.

New Features:
- Add a background job and rake tasks to migrate channel-bound message templates into global templates, with dry-run support and rollback.
- Introduce an external_legacy_id field and unique index on message_templates to track provenance and ensure idempotent migrations.
- Expose Prometheus counters to track migrated and skipped legacy templates during the migration process.

Enhancements:
- Document the legacy template migration operational procedure in the README, including backup, rollout, and rollback guidance.

Tests:
- Add job specs covering migration behavior, dry-run parity, name collision handling, skip rules, idempotency, and rollback scope.