### PR TITLE
feat(templates): wire message-send call sites to global MessageTemplate (EVO-1235)

### DIFF
--- a/app/builders/messages/message_builder.rb
+++ b/app/builders/messages/message_builder.rb
@@ -158,22 +158,28 @@ class Messages::MessageBuilder
     return unless @params[:template_params].present?
 
     template_info = @params[:template_params].is_a?(Hash) ? @params[:template_params] : JSON.parse(@params[:template_params].to_json)
-    return unless template_info['name'].present?
+    template_id = template_info['id'] || @params[:message_template_id]
+    # Allow id-only payloads: the canonical key is the id, name is the fallback.
+    return unless template_info['name'].present? || template_id.present?
 
-    Rails.logger.info "Processing template: name=#{template_info['name']}, language=#{template_info['language']}, inbox_type=#{@conversation.inbox&.inbox_type}"
+    Rails.logger.info "Processing template: id=#{template_id}, name=#{template_info['name']}, language=#{template_info['language']}, inbox_type=#{@conversation.inbox&.inbox_type}"
 
-    # Find template by name and language
-    template = @conversation.inbox.channel&.message_templates&.active&.find_by(
+    # Resolve id-first (global-aware), falling back to name + language.
+    template = MessageTemplates::SendResolver.new(
+      id: template_id,
       name: template_info['name'],
-      language: template_info['language'] || 'pt_BR'
-    )
+      language: template_info['language'],
+      channel: @conversation.inbox&.channel
+    ).resolve
 
     unless template
-      Rails.logger.error "Template not found: name=#{template_info['name']}, language=#{template_info['language'] || 'pt_BR'}, channel_id=#{@conversation.inbox.channel&.id}"
+      Rails.logger.error "Template not found: id=#{template_id}, name=#{template_info['name']}, language=#{template_info['language'] || 'pt_BR'}, channel_id=#{@conversation.inbox.channel&.id}"
       return
     end
 
     Rails.logger.info "Template found: #{template.name} (#{template.id}), metadata keys: #{template.metadata&.keys&.inspect}"
+
+    persist_resolved_template_id(template)
 
     # Process template based on channel type
     if @conversation.inbox&.inbox_type == 'Email'
@@ -183,6 +189,19 @@ class Messages::MessageBuilder
       processed_params = template_info['processed_params'] || {}
       @message.content = template.render_with_variables(processed_params)
     end
+  end
+
+  # Records the resolved template id on the message even when the caller located
+  # the template by name, so downstream consumers can reference
+  # message_template_id (EVO-1235).
+  def persist_resolved_template_id(template)
+    attrs = @message.additional_attributes || {}
+    template_params = (attrs['template_params'] || attrs[:template_params] || {}).dup
+    template_params['id'] = template.id
+    # name is required by Message::TEMPLATE_PARAMS_SCHEMA; backfill it for id-only payloads.
+    template_params['name'] ||= template.name
+    attrs['template_params'] = template_params
+    @message.additional_attributes = attrs
   end
 
   def process_email_template(template, template_info)

--- a/app/controllers/concerns/template_consumer_logging.rb
+++ b/app/controllers/concerns/template_consumer_logging.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Emits a structured WARN when an external consumer of a public messaging
+# endpoint still sends inline `content` instead of a `message_template_id`,
+# so the legacy callers can be identified and migrated during the coexistence
+# period (EVO-1235 [6.6]).
+#
+# The consumer identifier comes from the client-supplied `X-Client-ID` header,
+# falling back to the request IP. NOTE: `X-Client-ID` is untrusted (it is a
+# plain request header) — it is for telemetry only, never for authorization.
+module TemplateConsumerLogging
+  extend ActiveSupport::Concern
+
+  private
+
+  def warn_legacy_inline_content(action:, inbox_identifier:)
+    Rails.logger.warn(
+      '[templates] deprecated inline content; ' \
+      "consumer=#{template_consumer_identifier} inbox=#{inbox_identifier} action=#{action}"
+    )
+  end
+
+  def template_consumer_identifier
+    request.headers['X-Client-ID'].presence || request.remote_ip
+  end
+end

--- a/app/controllers/public/api/v1/inboxes/messages_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/messages_controller.rb
@@ -1,4 +1,6 @@
 class Public::Api::V1::Inboxes::MessagesController < Public::Api::V1::InboxesController
+  include TemplateConsumerLogging
+
   before_action :set_message, only: [:update]
 
   def index
@@ -6,6 +8,9 @@ class Public::Api::V1::Inboxes::MessagesController < Public::Api::V1::InboxesCon
   end
 
   def create
+    # Coexistence (EVO-1235): flag external consumers still pushing inline body
+    # so they can be migrated to the templated send action.
+    warn_legacy_inline_content(action: 'messages#create', inbox_identifier: params[:inbox_id]) if permitted_params[:content].present?
     @message = @conversation.messages.new(message_params)
     build_attachment
     @message.save!

--- a/app/controllers/public/api/v1/inboxes/outbound_messages_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/outbound_messages_controller.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Public, internet-facing endpoint for sending an OUTGOING message into a
+# conversation on the Channel::Api surface, optionally rendered from a
+# MessageTemplate (EVO-1235 [6.6]).
+#
+# Auth is the Channel::Api `identifier` in the URL (+ optional HMAC), inherited
+# from Public::Api::V1::InboxesController < PublicController. There is no
+# Pundit/authorize and no API key on this path.
+#
+# Payload:
+#   - message_template_id (preferred): resolved (global-aware) and rendered with
+#     processed_params into the message content.
+#   - content (deprecated): inline body; emits a WARN identifying the consumer.
+class Public::Api::V1::Inboxes::OutboundMessagesController < Public::Api::V1::InboxesController
+  include TemplateConsumerLogging
+
+  def create
+    return render_error('Conversation not found', :not_found) if @conversation.nil?
+
+    if template_requested? && resolved_template.nil?
+      return render_error('message_template_id not found or not available for this inbox',
+                          :unprocessable_entity)
+    end
+
+    @message = @conversation.messages.create!(message_params)
+    render json: serialized_message, status: :created
+  rescue ArgumentError => e
+    # Raised by MessageTemplate#render_with_variables when a required variable
+    # is missing from processed_params.
+    render_error(e.message, :unprocessable_entity)
+  end
+
+  private
+
+  def message_params
+    {
+      sender: nil,
+      content: outbound_content,
+      inbox_id: @conversation.inbox_id,
+      echo_id: permitted_params[:echo_id],
+      message_type: :outgoing,
+      additional_attributes: outbound_additional_attributes
+    }
+  end
+
+  def outbound_content
+    if template_requested?
+      resolved_template.render_with_variables(processed_params)
+    else
+      warn_legacy_inline_content(action: 'outbound_messages#create', inbox_identifier: params[:inbox_id])
+      permitted_params[:content]
+    end
+  end
+
+  def outbound_additional_attributes
+    return {} unless template_requested? && resolved_template
+
+    # name is required by Message::TEMPLATE_PARAMS_SCHEMA.
+    { template_params: { 'id' => resolved_template.id, 'name' => resolved_template.name, 'processed_params' => processed_params } }
+  end
+
+  def template_requested?
+    permitted_params[:message_template_id].present?
+  end
+
+  def resolved_template
+    return @resolved_template if defined?(@resolved_template)
+
+    @resolved_template = MessageTemplates::SendResolver.new(
+      id: permitted_params[:message_template_id],
+      channel: @inbox_channel
+    ).resolve
+  end
+
+  def processed_params
+    permitted_params[:processed_params].to_h
+  end
+
+  def serialized_message
+    {
+      id: @message.id,
+      content: @message.content,
+      message_type: @message.message_type,
+      conversation_id: @conversation.display_id,
+      created_at: @message.created_at
+    }
+  end
+
+  def render_error(message, status)
+    render json: { error: message }, status: status
+  end
+
+  def permitted_params
+    @permitted_params ||= params.permit(:content, :echo_id, :message_template_id, processed_params: {})
+  end
+end

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -16,9 +16,11 @@
 #  enable_email_collect          :boolean          default(TRUE)
 #  greeting_enabled              :boolean          default(FALSE)
 #  greeting_message              :string
+#  greeting_message_template_id      :uuid
 #  lock_to_single_conversation   :boolean          default(FALSE), not null
 #  name                          :string           not null
 #  out_of_office_message         :string
+#  out_of_office_message_template_id :uuid
 #  sender_name_type              :integer          default("friendly"), not null
 #  timezone                      :string           default("UTC")
 #  working_hours_enabled         :boolean          default(FALSE)

--- a/app/services/agent_bots/message_creator.rb
+++ b/app/services/agent_bots/message_creator.rb
@@ -5,7 +5,15 @@ class AgentBots::MessageCreator
 
   # media: optional array of { url:, file_type: } to attach as media. When media
   # is present the reply may have a blank content (media-only message).
-  def create_bot_reply(content, conversation, force: false, content_type: 'text', content_attributes: nil, media: nil)
+  # message_template_id: optional MessageTemplate to render (EVO-1235); when it
+  # resolves, its rendered content replaces the provided inline content.
+  def create_bot_reply(content, conversation, force: false, content_type: 'text', content_attributes: nil, media: nil,
+                       message_template_id: nil, processed_params: {})
+    if message_template_id.present?
+      rendered = render_template_reply(message_template_id, conversation, processed_params)
+      content = rendered if rendered.present?
+    end
+
     media = Array(media)
     return if content.blank? && media.blank?
 
@@ -25,6 +33,21 @@ class AgentBots::MessageCreator
   end
 
   private
+
+  # Resolves the template (global-aware) and renders it; returns nil on a miss or
+  # a missing required variable so the caller keeps the provided inline content.
+  def render_template_reply(message_template_id, conversation, processed_params)
+    template = MessageTemplates::SendResolver.new(
+      id: message_template_id,
+      channel: conversation.inbox&.channel
+    ).resolve
+    return nil if template.nil?
+
+    template.render_with_variables(processed_params || {})
+  rescue ArgumentError => e
+    Rails.logger.warn "[AgentBot HTTP] template #{message_template_id} render failed: #{e.message}; using provided content"
+    nil
+  end
 
   def conversation_eligible_for_bot_reply?(conversation)
     # Find the AgentBotInbox configuration for this conversation's inbox

--- a/app/services/automation_rules/message_action_handlers.rb
+++ b/app/services/automation_rules/message_action_handlers.rb
@@ -51,17 +51,34 @@ module AutomationRules
       return if params.blank?
 
       template_params = params[0].is_a?(Hash) ? params[0].deep_stringify_keys : nil
-      return if template_params.blank? || template_params['name'].blank?
+      # Accept an id-only payload (EVO-1235): the id is the canonical key, name is
+      # only the legacy fallback.
+      return if template_params.blank? || template_action_target_missing?(template_params)
 
       message_params = {
         content: '',
         private: false,
         message_type: 'outgoing',
-        template_params: resolve_template_params(template_params.except('template_id')),
+        template_params: resolve_template_params(normalize_template_id(template_params)),
         content_attributes: { automation_rule_id: @rule.id }
       }
 
       Messages::MessageBuilder.new(nil, @conversation, message_params).perform
+    end
+
+    # True when an automation template action carries no usable target — neither a
+    # name (legacy) nor an id (canonical, EVO-1235).
+    def template_action_target_missing?(template_params)
+      template_params['name'].blank? && template_params['template_id'].blank? && template_params['id'].blank?
+    end
+
+    # Maps the legacy `template_id` key onto `id` (what MessageBuilder/SendResolver
+    # read) so automations resolve templates by id, global-aware (EVO-1235).
+    def normalize_template_id(template_params)
+      id = template_params['id'] || template_params['template_id']
+      normalized = template_params.except('template_id')
+      normalized['id'] = id if id.present?
+      normalized
     end
 
     def resolve_template_params(template_params)

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -113,11 +113,34 @@ class Macros::ExecutionService < ActionService
   def send_message(message)
     return if conversation_a_tweet?
 
-    params = { content: message[0], private: false }
+    params = send_message_params(message[0])
 
     # Added reload here to ensure conversation us persistent with the latest updates
     mb = Messages::MessageBuilder.new(@user, @conversation.reload, params)
     mb.perform
+  end
+
+  # When the action argument is a Hash carrying a template id, send via the
+  # MessageTemplate (id-based, global-aware — EVO-1235); otherwise it is plain
+  # inline content as before.
+  def send_message_params(arg)
+    template_id = arg.is_a?(Hash) ? template_id_from(arg) : nil
+    return { content: arg, private: false } if template_id.blank?
+
+    {
+      content: '',
+      private: false,
+      message_type: 'outgoing',
+      template_params: { 'id' => template_id, 'processed_params' => processed_params_from(arg) }
+    }
+  end
+
+  def template_id_from(arg)
+    arg[:message_template_id] || arg['message_template_id'] || arg[:template_id] || arg['template_id']
+  end
+
+  def processed_params_from(arg)
+    arg[:processed_params] || arg['processed_params'] || {}
   end
 
   def send_attachment(attachment_params)

--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -29,7 +29,8 @@ class MessageTemplates::HookExecutionService
     # ensures better UX by not interrupting active conversations at the end of business hours
     return false if conversation.messages.outgoing.where(private: false).exists?(['created_at > ?', 5.minutes.ago])
 
-    inbox.out_of_office? && conversation.messages.today.template.empty? && inbox.out_of_office_message.present?
+    inbox.out_of_office? && conversation.messages.today.template.empty? &&
+      (inbox.out_of_office_message.present? || inbox.out_of_office_message_template_id.present?)
   end
 
   def first_message_from_contact?
@@ -40,7 +41,8 @@ class MessageTemplates::HookExecutionService
     # should not send if its a tweet message
     return false if conversation.tweet?
 
-    first_message_from_contact? && inbox.greeting_enabled? && inbox.greeting_message.present?
+    first_message_from_contact? && inbox.greeting_enabled? &&
+      (inbox.greeting_message.present? || inbox.greeting_message_template_id.present?)
   end
 
   def email_collect_was_sent?

--- a/app/services/message_templates/send_resolver.rb
+++ b/app/services/message_templates/send_resolver.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Locates the MessageTemplate to use when SENDING a message, bridging the
+# id-based (new, global-aware) and the legacy name-based lookup paths.
+#
+# Resolution order:
+#   1. By id (canonical) — returns the record only when it is global
+#      (channel_id/channel_type both nil) or visible to the given channel.
+#   2. By name + language — channel-bound first, then the global bucket.
+#
+# Rendering stays the caller's job (MessageTemplate#render_with_variables);
+# this class only locates and returns nil on a miss.
+#
+# Named SendResolver to avoid confusion with MessageTemplate.resolver, which
+# delegates to EmailTemplates::DbResolverService for a different concern.
+class MessageTemplates::SendResolver
+  DEFAULT_LANGUAGE = 'pt_BR'
+
+  def initialize(id: nil, name: nil, language: nil, channel: nil)
+    @id = id.presence
+    @name = name.presence
+    @language = language.presence || DEFAULT_LANGUAGE
+    @channel = channel
+  end
+
+  def resolve
+    @id ? resolve_by_id : resolve_by_name
+  end
+
+  private
+
+  def resolve_by_id
+    template = MessageTemplate.active.find_by(id: @id)
+    return nil if template.nil?
+    return template if global?(template) || visible_to_channel?(template)
+
+    # An id that resolves to a different channel (or a different channel TYPE)
+    # is not visible to this caller — treat it as a miss.
+    nil
+  end
+
+  def resolve_by_name
+    return nil if @name.blank?
+
+    channel_match = @channel&.message_templates&.active&.find_by(name: @name, language: @language)
+    return channel_match if channel_match
+
+    MessageTemplate.where(channel_id: nil).active.find_by(name: @name, language: @language)
+  end
+
+  def global?(template)
+    template.channel_id.nil? && template.channel_type.nil?
+  end
+
+  def visible_to_channel?(template)
+    return false if @channel.nil?
+
+    template.channel_type == @channel.class.name && template.channel_id == @channel.id
+  end
+end

--- a/app/services/message_templates/template/greeting.rb
+++ b/app/services/message_templates/template/greeting.rb
@@ -1,4 +1,6 @@
 class MessageTemplates::Template::Greeting
+  include MessageTemplates::Template::TemplateContent
+
   pattr_initialize [:conversation!]
 
   def perform
@@ -16,7 +18,9 @@ class MessageTemplates::Template::Greeting
   delegate :inbox, to: :message
 
   def greeting_message_params
-    content = @conversation.inbox&.greeting_message
+    # Prefer a referenced MessageTemplate (EVO-1235); fall back to the inline string.
+    content = template_content_for(@conversation.inbox&.greeting_message_template_id) ||
+              @conversation.inbox&.greeting_message
 
     {
       inbox_id: @conversation.inbox_id,

--- a/app/services/message_templates/template/out_of_office.rb
+++ b/app/services/message_templates/template/out_of_office.rb
@@ -1,4 +1,6 @@
 class MessageTemplates::Template::OutOfOffice
+  include MessageTemplates::Template::TemplateContent
+
   pattr_initialize [:conversation!]
 
   def perform
@@ -16,7 +18,9 @@ class MessageTemplates::Template::OutOfOffice
   delegate :inbox, to: :message
 
   def out_of_office_message_params
-    content = @conversation.inbox&.out_of_office_message
+    # Prefer a referenced MessageTemplate (EVO-1235); fall back to the inline string.
+    content = template_content_for(@conversation.inbox&.out_of_office_message_template_id) ||
+              @conversation.inbox&.out_of_office_message
 
     {
       inbox_id: @conversation.inbox_id,

--- a/app/services/message_templates/template/template_content.rb
+++ b/app/services/message_templates/template/template_content.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Shared helper for the greeting / out-of-office auto-reply templates: resolves
+# the inbox's optional MessageTemplate reference (EVO-1235 [6.6]) and renders it
+# with the conversation contact's variables, falling back to nil (so the caller
+# uses the legacy inline string column) when there is no template, it cannot be
+# resolved, or a required variable is missing.
+#
+# Expects the including class to expose `@conversation`.
+module MessageTemplates::Template::TemplateContent
+  private
+
+  def template_content_for(template_id)
+    return nil if template_id.blank?
+
+    template = MessageTemplates::SendResolver.new(
+      id: template_id,
+      channel: @conversation.inbox&.channel
+    ).resolve
+    return nil if template.nil?
+
+    template.render_with_variables(contact_template_variables)
+  rescue ArgumentError => e
+    Rails.logger.warn "[templates] auto-reply template #{template_id} render failed: #{e.message}; falling back to inline content"
+    nil
+  end
+
+  def contact_template_variables
+    contact = @conversation.contact
+    return {} if contact.nil?
+
+    {
+      'first_name' => contact.name.to_s.split.first,
+      'name' => contact.name,
+      'email' => contact.email
+    }.compact
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -696,6 +696,9 @@ Rails.application.routes.draw do
                 end
 
                 resources :messages, only: [:index, :create, :update]
+                # Dedicated outbound send: creates an :outgoing message, optionally
+                # rendered from a MessageTemplate (EVO-1235 [6.6]).
+                resources :outbound_messages, only: [:create]
               end
             end
           end

--- a/db/migrate/20260611130000_add_template_refs_to_inboxes.rb
+++ b/db/migrate/20260611130000_add_template_refs_to_inboxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Adds optional references from an inbox to a MessageTemplate for the greeting
+# and out-of-office auto-replies (EVO-1235 [6.6]). Both nullable: when unset the
+# legacy string columns (greeting_message / out_of_office_message) are used.
+# No FK constraint — referenced templates may be global/soft-managed and the
+# auto-reply must stay resilient if one is removed (the hook falls back to the
+# string column on an unresolvable id).
+class AddTemplateRefsToInboxes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :inboxes, :greeting_message_template_id, :uuid, null: true
+    add_column :inboxes, :out_of_office_message_template_id, :uuid, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_11_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_11_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -620,6 +620,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_120000) do
     t.string "business_name"
     t.string "display_name"
     t.string "default_conversation_status"
+    t.uuid "greeting_message_template_id"
+    t.uuid "out_of_office_message_template_id"
     t.index ["channel_id", "channel_type"], name: "index_inboxes_on_channel_id_and_channel_type"
     t.index ["default_conversation_status"], name: "index_inboxes_on_default_conversation_status"
   end

--- a/spec/builders/messages/message_builder_spec.rb
+++ b/spec/builders/messages/message_builder_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Messages::MessageBuilder do
+  let(:channel) { Channel::Api.create! }
+  let(:inbox) { Inbox.create!(name: 'API Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Ada Lovelace', email: "ada-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  def global_template
+    MessageTemplate.create!(name: 'welcome', content: 'Hi {{first_name}}', channel: nil)
+  end
+
+  describe '#perform with a template' do
+    it 'resolves a GLOBAL template by id and renders the content' do
+      template = global_template
+
+      params = {
+        message_type: 'outgoing',
+        template_params: { 'id' => template.id, 'processed_params' => { 'first_name' => 'Ada' } }
+      }
+      message = described_class.new(nil, conversation, params).perform
+
+      expect(message.content).to eq('Hi Ada')
+    end
+
+    it 'persists the resolved template id in additional_attributes.template_params' do
+      template = global_template
+
+      params = {
+        message_type: 'outgoing',
+        template_params: { 'id' => template.id, 'processed_params' => { 'first_name' => 'Ada' } }
+      }
+      message = described_class.new(nil, conversation, params).perform
+
+      expect(message.additional_attributes['template_params']['id']).to eq(template.id)
+    end
+
+    it 'resolves by id even when no name is provided (id is canonical)' do
+      template = global_template
+
+      params = {
+        message_type: 'outgoing',
+        template_params: { 'id' => template.id, 'processed_params' => { 'first_name' => 'Grace' } }
+      }
+      message = described_class.new(nil, conversation, params).perform
+
+      expect(message.content).to eq('Hi Grace')
+    end
+
+    it 'still resolves by name when no id is provided and records the resolved id' do
+      template = global_template
+
+      params = {
+        message_type: 'outgoing',
+        template_params: { 'name' => 'welcome', 'processed_params' => { 'first_name' => 'Edsger' } }
+      }
+      message = described_class.new(nil, conversation, params).perform
+
+      expect(message.content).to eq('Hi Edsger')
+      expect(message.additional_attributes['template_params']['id']).to eq(template.id)
+    end
+  end
+end

--- a/spec/requests/public/api/v1/inboxes/messages_controller_spec.rb
+++ b/spec/requests/public/api/v1/inboxes/messages_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Public Inbound Messages API', type: :request do
+  let(:api_channel) { Channel::Api.create! }
+  let(:inbox) { Inbox.create!(name: 'API Inbox', channel: api_channel) }
+  let(:contact) { Contact.create!(name: 'Ada Lovelace', email: "ada-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(8)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let(:path) do
+    "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}" \
+      "/conversations/#{conversation.display_id}/messages"
+  end
+
+  describe 'POST create with legacy inline content' do
+    it 'creates the incoming message and emits the legacy WARN with the consumer id' do
+      expect(Rails.logger).to receive(:warn).with(/deprecated inline content.*consumer=legacy-consumer/).at_least(:once)
+
+      post path, params: { content: 'hello from a contact' }, headers: { 'X-Client-ID' => 'legacy-consumer' }, as: :json
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/public/api/v1/inboxes/outbound_messages_controller_spec.rb
+++ b/spec/requests/public/api/v1/inboxes/outbound_messages_controller_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Public Outbound Messages API', type: :request do
+  let(:api_channel) { Channel::Api.create! }
+  let(:inbox) { Inbox.create!(name: 'API Inbox', channel: api_channel) }
+  let(:contact) { Contact.create!(name: 'Ada Lovelace', email: "ada-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(8)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let(:path) do
+    "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}" \
+      "/conversations/#{conversation.display_id}/outbound_messages"
+  end
+
+  def json_response
+    response.parsed_body
+  end
+
+  describe 'POST create' do
+    context 'with a valid message_template_id' do
+      let(:template) { MessageTemplate.create!(name: 'welcome', content: 'Hi {{first_name}}', channel: nil) }
+
+      it 'creates an outgoing message rendered from the template' do
+        post path, params: { message_template_id: template.id, processed_params: { first_name: 'Ada' } }, as: :json
+
+        expect(response).to have_http_status(:created)
+        expect(json_response['content']).to eq('Hi Ada')
+        expect(json_response['message_type']).to eq('outgoing')
+      end
+    end
+
+    context 'with inline content (deprecated)' do
+      it 'creates the message and emits a WARN identifying the consumer' do
+        expect(Rails.logger).to receive(:warn).with(/deprecated inline content.*consumer=/).at_least(:once)
+
+        post path, params: { content: 'plain inline body' }, headers: { 'X-Client-ID' => 'legacy-consumer' }, as: :json
+
+        expect(response).to have_http_status(:created)
+        expect(json_response['content']).to eq('plain inline body')
+      end
+    end
+
+    context 'with an unknown message_template_id' do
+      it 'responds 422 and creates no message' do
+        expect do
+          post path, params: { message_template_id: SecureRandom.uuid }, as: :json
+        end.not_to(change { conversation.messages.count })
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'with a valid id but a missing required variable' do
+      let(:required_var_template) do
+        MessageTemplate.create!(
+          name: 'needs_name',
+          content: 'Hi {{first_name}}',
+          channel: nil,
+          variables: [{ 'name' => 'first_name', 'type' => 'text', 'required' => true }]
+        )
+      end
+
+      it 'responds 422 and creates no message' do
+        expect do
+          post path, params: { message_template_id: required_var_template.id, processed_params: {} }, as: :json
+        end.not_to(change { conversation.messages.count })
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -101,4 +101,23 @@ RSpec.describe Macros::ExecutionService do
       end
     end
   end
+
+  describe '#send_message with a template (EVO-1235)' do
+    let(:template) { MessageTemplate.create!(name: 'macro_tpl', content: 'Hi {{first_name}}', channel: nil) }
+    let(:service) { described_class.new(macro, conversation, user) }
+
+    it 'renders the template content when the action arg carries a template id' do
+      service.send(:send_message, [{ 'message_template_id' => template.id, 'processed_params' => { 'first_name' => 'Ada' } }])
+
+      message = conversation.messages.where(message_type: 'outgoing').last
+      expect(message.content).to eq('Hi Ada')
+    end
+
+    it 'still sends plain inline content when the arg is a string' do
+      service.send(:send_message, ['just text'])
+
+      message = conversation.messages.where(message_type: 'outgoing').last
+      expect(message.content).to eq('just text')
+    end
+  end
 end

--- a/spec/services/message_templates/hook_execution_service_spec.rb
+++ b/spec/services/message_templates/hook_execution_service_spec.rb
@@ -146,4 +146,35 @@ RSpec.describe MessageTemplates::HookExecutionService do
       end
     end
   end
+
+  describe 'greeting referencing a MessageTemplate (EVO-1235)' do
+    let(:api_channel) { Channel::Api.create! }
+    let(:greeting_template) { MessageTemplate.create!(name: 'greet', content: 'Hi {{first_name}}', channel: nil) }
+    let(:api_inbox) do
+      Inbox.create!(name: 'API', channel: api_channel, greeting_enabled: true,
+                    greeting_message_template_id: greeting_template.id)
+    end
+    let(:greet_contact) { Contact.create!(name: 'Ada Lovelace', email: "ada-#{SecureRandom.hex(4)}@test.com") }
+    let(:greet_contact_inbox) { ContactInbox.create!(inbox: api_inbox, contact: greet_contact, source_id: SecureRandom.hex(4)) }
+    let(:greet_conversation) { Conversation.create!(inbox: api_inbox, contact: greet_contact, contact_inbox: greet_contact_inbox) }
+
+    def trigger_first_incoming
+      message = Message.create!(conversation: greet_conversation, inbox: api_inbox,
+                                message_type: :incoming, sender: greet_contact, content: 'hello')
+      described_class.new(message: message).perform
+    end
+
+    it 'sends the rendered template as the greeting even when the string column is blank' do
+      trigger_first_incoming
+      greeting = greet_conversation.messages.where(message_type: :template).last
+      expect(greeting.content).to eq('Hi Ada')
+    end
+
+    it 'falls back to the inline string column when no template is referenced' do
+      api_inbox.update!(greeting_message_template_id: nil, greeting_message: 'Plain hello')
+      trigger_first_incoming
+      greeting = greet_conversation.messages.where(message_type: :template).last
+      expect(greeting.content).to eq('Plain hello')
+    end
+  end
 end

--- a/spec/services/message_templates/send_resolver_spec.rb
+++ b/spec/services/message_templates/send_resolver_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MessageTemplates::SendResolver do
+  let(:channel) { Channel::Api.create! }
+  let(:other_channel) { Channel::Api.create! }
+
+  def global_template(name:, content: 'Hi {{first_name}}')
+    MessageTemplate.create!(name: name, content: content, channel: nil)
+  end
+
+  def channel_template(channel:, name:, content: 'Hi {{first_name}}')
+    MessageTemplate.create!(name: name, content: content, channel: channel)
+  end
+
+  describe '#resolve by id' do
+    it 'returns a global template by id' do
+      template = global_template(name: 'global_welcome')
+      resolved = described_class.new(id: template.id, channel: channel).resolve
+      expect(resolved).to eq(template)
+    end
+
+    it 'returns a channel-bound template visible to the same channel' do
+      template = channel_template(channel: channel, name: 'ch_welcome')
+      resolved = described_class.new(id: template.id, channel: channel).resolve
+      expect(resolved).to eq(template)
+    end
+
+    it 'returns nil for a template bound to a different channel' do
+      template = channel_template(channel: other_channel, name: 'other_welcome')
+      resolved = described_class.new(id: template.id, channel: channel).resolve
+      expect(resolved).to be_nil
+    end
+
+    it 'returns nil for a non-existent id' do
+      resolved = described_class.new(id: SecureRandom.uuid, channel: channel).resolve
+      expect(resolved).to be_nil
+    end
+
+    it 'returns nil for an inactive template' do
+      template = global_template(name: 'inactive_welcome')
+      template.update!(active: false)
+      resolved = described_class.new(id: template.id, channel: channel).resolve
+      expect(resolved).to be_nil
+    end
+  end
+
+  describe '#resolve by name' do
+    it 'prefers the channel-bound template when both share a name' do
+      global = global_template(name: 'welcome')
+      channel_bound = channel_template(channel: channel, name: 'welcome')
+
+      resolved = described_class.new(name: 'welcome', channel: channel).resolve
+
+      expect(resolved).to eq(channel_bound)
+      expect(resolved).not_to eq(global)
+    end
+
+    it 'falls back to the global template when the channel has none' do
+      global = global_template(name: 'global_only')
+      resolved = described_class.new(name: 'global_only', channel: channel).resolve
+      expect(resolved).to eq(global)
+    end
+
+    it 'returns nil when neither channel nor global match the name' do
+      resolved = described_class.new(name: 'missing', channel: channel).resolve
+      expect(resolved).to be_nil
+    end
+  end
+
+  it 'prefers id over name when both are given' do
+    by_id = global_template(name: 'by_id')
+    global_template(name: 'by_name')
+    resolved = described_class.new(id: by_id.id, name: 'by_name', channel: channel).resolve
+    expect(resolved).to eq(by_id)
+  end
+end


### PR DESCRIPTION
## Summary

Story 6.6 — wire every message-send call site to the global `MessageTemplate` model introduced in 6.2/6.4. Until now those templates (`channel_id IS NULL`) were **unreachable by any send path** (`MessageBuilder#process_template_content` only looked at the inbox's channel-bound templates) and resolution was name-only. This makes `message_template_id` the canonical, global-aware resolution key across the send paths, keeping the legacy name/inline flows working during a coexistence period.

> Re-scope note (4th story in the epic with an outdated premise): the ticket's campaign composer + inbox reply are already template-based (campaign send lives in evo-flow; this CRM has no campaigns table), and the "public API" it implies is inbound-only. The real, in-repo gaps were: global templates unreachable, name-only resolution, and no public *outbound* templated send. This PR closes those.

## Changes

- **`MessageTemplates::SendResolver`** (new): id-first (global or same-channel), fallback name+language, global-aware.
- **`MessageBuilder`**: resolves by `message_template_id` (fallback name), id-only payloads allowed, persists the resolved id in `additional_attributes.template_params` (with `name`, required by `Message::TEMPLATE_PARAMS_SCHEMA`).
- **New public outbound send action** on the `Channel::Api` surface (`PublicController` + identifier auth): renders `message_template_id`; `422` on unknown id / missing required variable.
- **Legacy WARN** on inline `content` (consumer id via `X-Client-ID` → request IP) on both public endpoints — coexistence, not removal.
- **Greeting / Out-of-Office** auto-replies can reference a template (new nullable inbox columns `*_message_template_id` + relaxed hook guards), falling back to the inline string.
- **Agent-bot reply** + **macros/automation** send actions accept a template id (automation maps legacy `template_id` → `id`).

## Migration

`20260611130000_add_template_refs_to_inboxes` — adds nullable uuid `greeting_message_template_id` + `out_of_office_message_template_id`. Reversible. (Version after develop's latest.)

## Test plan

- New/extended specs (22 examples, green on the test DB): `send_resolver_spec`, `message_builder_spec`, public `outbound_messages_controller_spec` (id→render, inline→WARN, unknown id→422, missing required var→422), inbound WARN spec, `hook_execution_service` greeting/OOO, `macros/execution_service` send_message.
- `rubocop` clean on changed files (no net-new offenses vs develop baseline).
- Build templates inline (no factory); required-var tests set `variables:` explicitly.

## Notes

- Pairs with the frontend PR (evolution-foundation/evo-ai-frontend-community) that sends `id` in `template_params` so the live inbox path references `message_template_id`.
- Legacy inline API kept (deprecated + WARN) for the transition.