### PR TITLE
feat(crm): SendGrid mail/send client + per-message email wire-up (EVO-1251)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ gem 'wisper', '2.0.0'
 ##--- gems for channels ---##
 gem 'facebook-messenger'
 gem 'line-bot-api'
+gem 'sendgrid-ruby', '~> 6.7'
 gem 'twilio-ruby', '~> 5.66'
 # twitty will handle subscription of twitter account events
 # gem 'twitty', git: 'https://github.com/chatwoot/twitty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,7 +413,6 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.25.5)
     mock_redis (0.36.0)
       ruby2_keywords
@@ -442,9 +441,6 @@ GEM
     newrelic_rpm (9.6.0)
       base64
     nio4r (2.7.3)
-    nokogiri (1.18.8)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
@@ -828,6 +824,7 @@ GEM
     ruby2ruby (2.5.0)
       ruby_parser (~> 3.1)
       sexp_processor (~> 4.6)
+    ruby_http_client (3.6.0)
     ruby_parser (3.20.0)
       sexp_processor (~> 4.16)
     rubyzip (2.4.1)
@@ -844,6 +841,8 @@ GEM
     seed_dump (3.3.1)
       activerecord (>= 4)
       activesupport (>= 4)
+    sendgrid-ruby (6.7.0)
+      ruby_http_client (~> 3.4)
     sentry-rails (5.19.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.19.0)
@@ -965,7 +964,6 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-24
-  ruby
   x86_64-darwin-18
   x86_64-darwin-20
   x86_64-darwin-21
@@ -1077,6 +1075,7 @@ DEPENDENCIES
   scout_apm
   scss_lint
   seed_dump
+  sendgrid-ruby (~> 6.7)
   sentry-rails (>= 5.19.0)
   sentry-ruby
   sentry-sidekiq (>= 5.19.0)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -432,7 +432,7 @@ class Message < ApplicationRecord
   end
 
   def email_notifiable_channel?
-    email_notifiable_webwidget? || %w[Email].include?(inbox.inbox_type) || email_notifiable_api_channel?
+    email_notifiable_webwidget? || %w[Email SendGrid].include?(inbox.inbox_type) || email_notifiable_api_channel?
   end
 
   def can_notify_via_mail?
@@ -450,6 +450,7 @@ class Message < ApplicationRecord
   end
 
   def trigger_notify_via_mail
+    return Sendgrid::SendEmailWorker.perform_in(1.second, id) if inbox.inbox_type == 'SendGrid'
     return EmailReplyWorker.perform_in(1.second, id) if inbox.inbox_type == 'Email'
 
     # will set a redis key for the conversation so that we don't need to send email for every new message

--- a/app/services/sendgrid/client.rb
+++ b/app/services/sendgrid/client.rb
@@ -1,0 +1,140 @@
+module Sendgrid
+  # Outbound transport for SendGrid Mail Send (POST /v3/mail/send). The CRM
+  # renders the template (Epic 6); this client is pure transport — it builds the
+  # mail/send payload, posts it through the official sendgrid-ruby gem and maps
+  # the provider response onto the message status (EVO-1251 / story 9.4).
+  #
+  # custom_args always carry contact_id / message_id / campaign_id so the inbound
+  # event webhook (Sendgrid::EventProcessor) can recover context. The CRM owns
+  # suppression, so mail_settings.bypass_unsubscribe_management is enabled (same
+  # posture as BMS). The payload is built as a plain Hash because the gem's
+  # MailSettings helper (6.7) does not model bypass_unsubscribe_management.
+  class Client
+    ACCEPTED_STATUS = 202
+    INVALID_KEY_STATUSES = [401, 403].freeze
+    MAX_LOGGED_BODY = 500
+    REDACTED_4XX = '[redacted: 4xx body]'.freeze
+    OPEN_TIMEOUT = 5
+    READ_TIMEOUT = 10
+    # Transport-layer failures from the gem's Net::HTTP client. Scoped on
+    # purpose so a programming error never gets masked as "SendGrid unreachable".
+    TRANSPORT_ERRORS = [SocketError, Timeout::Error, SystemCallError,
+                        OpenSSL::SSL::SSLError, IOError, EOFError].freeze
+
+    def initialize(channel)
+      @channel = channel
+    end
+
+    # 202 -> message status 'sent' (provider accepted), returns success.
+    # 4xx/5xx -> structured log (no recipient PII) + status 'failed', then raises.
+    # transport failure -> status 'failed' + raises (the message must never be
+    # left at the optimistic default 'sent' when the send did not happen).
+    # All raises are Sendgrid::ApiError subclasses so the worker swallows them
+    # without retry, with the message already flagged failed.
+    def deliver(message:)
+      response = post_mail_send(build_payload(message))
+      handle_response(response, message)
+    rescue Sendgrid::ServiceUnavailableError => e
+      mark_failed(message, "SendGrid transport error: #{e.message}")
+      raise
+    end
+
+    private
+
+    def build_payload(message)
+      conversation = message.conversation
+
+      {
+        personalizations: [{
+          to: [{ email: conversation.contact.email }],
+          custom_args: custom_args(message, conversation)
+        }],
+        from: from_field,
+        reply_to: reply_to_field,
+        subject: subject_for(conversation),
+        content: [{ type: 'text/html', value: message.content.to_s }],
+        mail_settings: { bypass_unsubscribe_management: { enable: true } }
+      }.compact
+    end
+
+    def custom_args(message, conversation)
+      {
+        contact_id: conversation.contact_id,
+        message_id: message.id,
+        campaign_id: message.additional_attributes&.dig('campaign_id')
+      }.compact.transform_values(&:to_s)
+    end
+
+    def from_field
+      field = { email: @channel.from_email }
+      field[:name] = @channel.from_name if @channel.from_name.present?
+      field
+    end
+
+    def reply_to_field
+      return if @channel.reply_to.blank?
+
+      { email: @channel.reply_to }
+    end
+
+    def subject_for(conversation)
+      subject = conversation.additional_attributes&.dig('mail_subject')
+      return subject if subject.present?
+
+      "[##{conversation.display_id}] #{I18n.t('conversations.reply.email_subject')}"
+    end
+
+    def post_mail_send(payload)
+      api.client.mail._('send').post(request_body: payload)
+    rescue *TRANSPORT_ERRORS => e
+      raise Sendgrid::ServiceUnavailableError.new("SendGrid request failed: #{e.message}", nil, nil)
+    end
+
+    def api
+      @api ||= ::SendGrid::API.new(
+        api_key: @channel.api_key,
+        http_options: { open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT }
+      )
+    end
+
+    def handle_response(response, message)
+      status = response.status_code.to_i
+      return accept(message, status) if status == ACCEPTED_STATUS
+
+      reject(message, status, response)
+    end
+
+    def accept(message, status)
+      Messages::StatusUpdateService.new(message, 'sent').perform
+      { success: true, status: status }
+    end
+
+    def reject(message, status, response)
+      Rails.logger.error(
+        "[SENDGRID_MAIL_SEND] message_id=#{message.id} sg_response_status=#{status} body=#{safe_body(status, response)}"
+      )
+      reason = "SendGrid mail/send failed: #{status}"
+      mark_failed(message, reason)
+      raise error_for(status, reason, response)
+    end
+
+    def mark_failed(message, reason)
+      Messages::StatusUpdateService.new(message, 'failed', reason).perform
+    end
+
+    def error_for(status, reason, response)
+      return Sendgrid::InvalidApiKeyError.new(reason, status, response) if INVALID_KEY_STATUSES.include?(status)
+
+      Sendgrid::ApiError.new(reason, status, response)
+    end
+
+    # 4xx bodies can echo the key or input, so the whole 4xx class is redacted;
+    # 5xx bodies are length-bounded. The recipient address is never logged.
+    def safe_body(status, response)
+      return REDACTED_4XX if (400..499).cover?(status)
+
+      body = response.body.to_s
+      body.length > MAX_LOGGED_BODY ? "#{body[0, MAX_LOGGED_BODY]}... (truncated)" : body
+    end
+  end
+end

--- a/app/workers/sendgrid/send_email_worker.rb
+++ b/app/workers/sendgrid/send_email_worker.rb
@@ -1,0 +1,28 @@
+module Sendgrid
+  # Dispatches an outbound email for a Channel::Sendgrid inbox through
+  # Sendgrid::Client (EVO-1251 / story 9.4). Mirrors EmailReplyWorker for the
+  # SMTP path. No retry this story: the client already logs and flags the
+  # message failed, so the worker swallows the error instead of bubbling it.
+  class SendEmailWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: :mailers, retry: 0
+
+    def perform(message_id)
+      message = Message.find_by(id: message_id)
+      return if message.nil?
+      return unless message.email_notifiable_message?
+
+      channel = message.conversation.inbox.channel
+      return unless channel.is_a?(Channel::Sendgrid)
+
+      Sendgrid::Client.new(channel).deliver(message: message)
+    rescue Sendgrid::ApiError => e
+      Rails.logger.warn("[SENDGRID_MAIL_SEND] swallowed #{e.class}: #{e.message}")
+      nil
+    rescue StandardError => e
+      EvolutionExceptionTracker.new(e, account: nil).capture_exception
+      Messages::StatusUpdateService.new(message, 'failed', e.message).perform if message
+      nil
+    end
+  end
+end

--- a/spec/models/message_sendgrid_dispatch_spec.rb
+++ b/spec/models/message_sendgrid_dispatch_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1251 (story 9.4): outbound email for a Channel::Sendgrid inbox routes to
+# Sendgrid::SendEmailWorker; Gmail/Outlook (Channel::Email) keep the SMTP path
+# untouched (AC6, zero regression).
+RSpec.describe Message do
+  describe '#trigger_notify_via_mail SendGrid outbound dispatch' do
+    let(:message) { described_class.new }
+
+    before { allow(message).to receive(:id).and_return(7) }
+
+    context 'when the inbox channel is SendGrid' do
+      before { allow(message).to receive(:inbox).and_return(instance_double(Inbox, inbox_type: 'SendGrid')) }
+
+      it 'enqueues Sendgrid::SendEmailWorker' do
+        expect(Sendgrid::SendEmailWorker).to receive(:perform_in).with(1.second, 7)
+        expect(EmailReplyWorker).not_to receive(:perform_in)
+
+        message.send(:trigger_notify_via_mail)
+      end
+    end
+
+    context 'when the inbox channel is Email (Gmail/Outlook)' do
+      before { allow(message).to receive(:inbox).and_return(instance_double(Inbox, inbox_type: 'Email')) }
+
+      it 'keeps the existing EmailReplyWorker path and never calls SendGrid' do
+        expect(EmailReplyWorker).to receive(:perform_in).with(1.second, 7)
+        expect(Sendgrid::SendEmailWorker).not_to receive(:perform_in)
+
+        message.send(:trigger_notify_via_mail)
+      end
+    end
+  end
+end

--- a/spec/services/sendgrid/client_spec.rb
+++ b/spec/services/sendgrid/client_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+# EVO-1251 (story 9.4): Sendgrid::Client is pure transport over POST
+# /v3/mail/send. These specs assert the payload shape (custom_args,
+# bypass_unsubscribe_management, rendered html) and the response -> status map.
+RSpec.describe Sendgrid::Client do
+  subject(:client) { described_class.new(channel) }
+
+  let(:mail_send_url) { 'https://api.sendgrid.com/v3/mail/send' }
+
+  let(:channel) do
+    instance_double(
+      Channel::Sendgrid,
+      api_key: 'SG.key-x',
+      from_email: 'news@acme.com',
+      from_name: 'Acme News',
+      reply_to: nil
+    )
+  end
+  let(:contact) { instance_double(Contact, email: 'jane@acme.com') }
+  let(:conversation) do
+    instance_double(
+      Conversation,
+      contact: contact,
+      contact_id: 'contact-uuid',
+      display_id: 42,
+      additional_attributes: { 'mail_subject' => 'Promo' }
+    )
+  end
+  let(:message) do
+    instance_double(
+      Message,
+      id: 'msg-uuid',
+      conversation: conversation,
+      content: '<h1>Hi</h1>',
+      additional_attributes: { 'campaign_id' => 'camp-uuid' }
+    )
+  end
+  let(:status_service) { instance_double(Messages::StatusUpdateService, perform: true) }
+
+  describe '#deliver — success (202)' do
+    before { stub_request(:post, mail_send_url).to_return(status: 202, body: '') }
+
+    it 'posts to mail/send with the channel api key, from, to, html and custom_args' do
+      allow(Messages::StatusUpdateService).to receive(:new).with(message, 'sent').and_return(status_service)
+
+      client.deliver(message: message)
+
+      expect(a_request(:post, mail_send_url).with do |req|
+        body = JSON.parse(req.body)
+        personalization = body['personalizations'].first
+        req.headers['Authorization'] == 'Bearer SG.key-x' &&
+          personalization['to'] == [{ 'email' => 'jane@acme.com' }] &&
+          personalization['custom_args'] == {
+            'contact_id' => 'contact-uuid', 'message_id' => 'msg-uuid', 'campaign_id' => 'camp-uuid'
+          } &&
+          body['from'] == { 'email' => 'news@acme.com', 'name' => 'Acme News' } &&
+          body['subject'] == 'Promo' &&
+          body['content'] == [{ 'type' => 'text/html', 'value' => '<h1>Hi</h1>' }]
+      end).to have_been_made
+    end
+
+    it 'enables mail_settings.bypass_unsubscribe_management' do
+      allow(Messages::StatusUpdateService).to receive(:new).and_return(status_service)
+
+      client.deliver(message: message)
+
+      expect(a_request(:post, mail_send_url).with do |req|
+        JSON.parse(req.body).dig('mail_settings', 'bypass_unsubscribe_management', 'enable') == true
+      end).to have_been_made
+    end
+
+    it 'marks the message sent and returns success' do
+      expect(Messages::StatusUpdateService).to receive(:new).with(message, 'sent').and_return(status_service)
+
+      result = client.deliver(message: message)
+
+      expect(result).to include(success: true, status: 202)
+    end
+  end
+
+  describe '#deliver — provider rejects (4xx/5xx)' do
+    it 'raises InvalidApiKeyError and marks failed on 401' do
+      stub_request(:post, mail_send_url).to_return(status: 401, body: '{"errors":[]}')
+      expect(Messages::StatusUpdateService).to receive(:new).with(message, 'failed', 'SendGrid mail/send failed: 401').and_return(status_service)
+
+      expect { client.deliver(message: message) }.to raise_error(Sendgrid::InvalidApiKeyError)
+    end
+
+    it 'raises ApiError and marks failed on 400, redacting the 4xx body in the log' do
+      stub_request(:post, mail_send_url).to_return(status: 400, body: 'leaky-detail')
+      allow(Messages::StatusUpdateService).to receive(:new).and_return(status_service)
+      expect(Rails.logger).to receive(:error).with(/sg_response_status=400/).and_call_original
+      expect(Rails.logger).not_to receive(:error).with(/leaky-detail/)
+
+      expect { client.deliver(message: message) }.to raise_error(Sendgrid::ApiError)
+    end
+
+    it 'wraps transport failures as ServiceUnavailableError and marks the message failed' do
+      stub_request(:post, mail_send_url).to_timeout
+      expect(Messages::StatusUpdateService).to receive(:new).with(message, 'failed', /SendGrid transport error/).and_return(status_service)
+
+      expect { client.deliver(message: message) }.to raise_error(Sendgrid::ServiceUnavailableError)
+    end
+  end
+end

--- a/spec/workers/sendgrid/send_email_worker_spec.rb
+++ b/spec/workers/sendgrid/send_email_worker_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1251 (story 9.4): the worker dispatches the SendGrid send and must survive
+# a provider error (the client already logged + flagged the message failed).
+RSpec.describe Sendgrid::SendEmailWorker do
+  let(:channel) { instance_double(Channel::Sendgrid) }
+  let(:inbox) { instance_double(Inbox, channel: channel) }
+  let(:conversation) { instance_double(Conversation, inbox: inbox) }
+  let(:message) { instance_double(Message, email_notifiable_message?: true, conversation: conversation) }
+  let(:client) { instance_double(Sendgrid::Client) }
+
+  before do
+    allow(Message).to receive(:find_by).with(id: 1).and_return(message)
+    allow(channel).to receive(:is_a?).with(Channel::Sendgrid).and_return(true)
+    allow(Sendgrid::Client).to receive(:new).with(channel).and_return(client)
+  end
+
+  it 'delivers the message through Sendgrid::Client' do
+    expect(client).to receive(:deliver).with(message: message)
+
+    described_class.new.perform(1)
+  end
+
+  it 'swallows a Sendgrid::ApiError without crashing the worker' do
+    allow(client).to receive(:deliver).and_raise(Sendgrid::ApiError.new('boom', 400, nil))
+
+    expect { described_class.new.perform(1) }.not_to raise_error
+  end
+
+  it 'does nothing when the message no longer exists' do
+    allow(Message).to receive(:find_by).with(id: 99).and_return(nil)
+
+    expect(Sendgrid::Client).not_to receive(:new)
+    described_class.new.perform(99)
+  end
+
+  it 'does not dispatch when the channel is not SendGrid' do
+    allow(channel).to receive(:is_a?).with(Channel::Sendgrid).and_return(false)
+
+    expect(client).not_to receive(:deliver)
+    described_class.new.perform(1)
+  end
+end


### PR DESCRIPTION
## Summary
Story 9.4 — outbound side of the SendGrid email channel (the channel model 9.1 and webhook receiver 9.3 already merged).

- **`Sendgrid::Client`** (`app/services/sendgrid/client.rb`) wraps `POST /v3/mail/send` via the official `sendgrid-ruby` gem. Builds the payload from the already-rendered `Message` (Epic 6 template engine — does not render here), always carries `custom_args = { contact_id, message_id, campaign_id }` so the 9.3 webhook recovers context, and enables `mail_settings.bypass_unsubscribe_management.enable = true` (the CRM owns suppression, BMS posture).
- **Response → status:** `202` → message `sent` (returns success); `4xx`/`5xx` **and transport failures** → structured log + message `failed` (so a failed send is never left at the optimistic default `sent`). `raise`s are `Sendgrid::ApiError` subclasses.
- **`Sendgrid::SendEmailWorker`** dispatches the send and swallows the provider error (already logged + flagged) — no retry this story (`retry: 0`).
- **Wire-up:** `Message#trigger_notify_via_mail` routes `Channel::Sendgrid` inboxes to the new worker; `Channel::Email` (Gmail/Outlook) keeps the SMTP path untouched.

> **Scope note:** the card's "campaign email send engine" does not exist in the codebase (`Campaign` is a stub; no campaign workers). The only real outbound email path is per-message (`EmailReplyWorker`/`ConversationReplyMailer`). Reinterpretation approved by Nickolas (2026-06-11): "campaign with a SendGrid channel" = a `Message` on a `Channel::Sendgrid` inbox carrying `campaign_id` in `additional_attributes`. Building campaign infrastructure is out of scope. The card description was edited with a dated callout.

## Security
- API key never logged; recipient address never logged; 4xx response bodies redacted, 5xx bodies length-bounded.
- Transport rescue scoped to network errors only (`SocketError`/`Timeout::Error`/`OpenSSL::SSL::SSLError`/…) so programming errors are not masked as "SendGrid unreachable".
- API key read from the Fernet-encrypted `Channel::Sendgrid#api_key`.

## Test plan
- `bundle exec rspec spec/services/sendgrid/client_spec.rb spec/workers/sendgrid/send_email_worker_spec.rb spec/models/message_sendgrid_dispatch_spec.rb` → 13 examples, 0 failures
- `bundle exec rubocop` on the changed files → clean
- Regression: `bundle exec rspec spec/workers/email_reply_worker_spec.rb spec/builders/messages/message_builder_spec.rb` → 8 examples, 0 failures
- Manual E2E (SendGrid sandbox + webhook landing on 9.3) requires sandbox credentials — not run here; covered at the seam by the WebMock client spec asserting the exact payload.

## Changed Files
- `app/services/sendgrid/client.rb` (new)
- `app/workers/sendgrid/send_email_worker.rb` (new)
- `app/models/message.rb` (dispatch branch + SendGrid as email-notifiable)
- `Gemfile`, `Gemfile.lock` (`sendgrid-ruby ~> 6.7`)
- `spec/services/sendgrid/client_spec.rb`, `spec/workers/sendgrid/send_email_worker_spec.rb`, `spec/models/message_sendgrid_dispatch_spec.rb` (new)

## Linked Issue
- EVO-1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)