### PR TITLE
feat(message-templates): dedicated CRUD endpoint + inbox cutover (EVO-1716)

### DIFF
--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -28,11 +28,10 @@ module Api
           disconnect_channel_provider: 'inboxes.update',
           sync_whatsapp_subscription: 'inboxes.update',
           avatar: 'inboxes.update',
-          message_templates: 'inboxes.message_templates',
+          # Template CRUD moved to MessageTemplatesController (EVO-1716); only the
+          # per-channel Meta sync remains here, keeping its inbox permission.
           sync_message_templates: 'inboxes.message_templates',
           sync_template_with_whatsapp_cloud: 'inboxes.message_templates',
-          update_message_template: 'inboxes.update_message_template',
-          delete_message_template: 'inboxes.delete_message_template',
           facebook_posts: 'inboxes.read'
         })
 
@@ -347,139 +346,6 @@ module Api
           )
         end
 
-        # Generic message templates (for all channel types)
-        def message_templates
-          # Global (channel-less) mode is gated by the require_permissions
-          # before_action; the inbox is irrelevant so skip the inbox policy.
-          authorize @inbox, :message_templates? unless global_template_request?
-
-          case request.method
-          when 'GET'
-            # List templates
-            begin
-              @templates =
-                if global_template_request?
-                  # Only channel-less (global) templates, and only active ones
-                  # to mirror the per-channel listing semantics.
-                  MessageTemplate.where(channel_id: nil).active
-                else
-                  @inbox.channel&.message_templates&.active || MessageTemplate.none
-                end
-
-              @templates = @templates.by_category(params[:category]) if params[:category].present?
-              @templates = @templates.by_type(params[:template_type]) if params[:template_type].present?
-              @templates = @templates.search_by_name(params[:search]) if params[:search].present?
-
-              @templates = case params[:sort_by]
-                         when 'name'
-                           @templates.order(:name)
-                         else
-                           @templates.recently_created
-                         end
-
-              if params[:page]&.to_i == -1 || params[:per_page]&.to_i == -1
-                # Return all templates without pagination
-                success_response(
-                  data: @templates.map(&:serialized),
-                  meta: {
-                    total: @templates.count,
-                    page: 1,
-                    per_page: @templates.count,
-                    total_pages: 1
-                  },
-                  message: 'Inbox templates retrieved successfully'
-                )
-                return
-              end
-
-              apply_pagination
-
-              paginated_response(
-                data: @templates.map(&:serialized),
-                collection: @templates,
-                message: 'Inbox templates retrieved successfully'
-              )
-            rescue StandardError => e
-              Rails.logger.error "Message templates list error: #{e.message}"
-              error_response(
-                ApiErrorCodes::INTERNAL_ERROR,
-                e.message,
-                status: :unprocessable_entity
-              )
-            end
-          when 'POST'
-            # Create template
-            begin
-              template_params = extract_message_template_params
-              Rails.logger.info "Creating template with params: #{template_params.inspect}"
-
-              # For providers that publish templates to an external service
-              # (WhatsApp Cloud, Notificame, Evolution Go …), submit the
-              # template upstream and rely on the provider's sync flow to
-              # persist the record locally with the real approval status
-              # (PENDING/APPROVED/REJECTED). For channels without upstream
-              # template approval (Api, Email, etc.), fall back to the
-              # local-only path so behaviour is unchanged.
-              template =
-                if global_template_request?
-                  # Global template: not tied to any channel. A self-reported
-                  # `provider == whatsapp_cloud` is rejected by the model, since
-                  # a WhatsApp Cloud template must be bound to its channel.
-                  MessageTemplate.create!(
-                    template_params.to_h.merge(
-                      channel: nil,
-                      intended_provider: params.dig(:message_template, :provider)
-                    )
-                  )
-                elsif @inbox.channel.respond_to?(:create_template)
-                  @inbox.channel.create_template(template_params.to_h.stringify_keys)
-                else
-                  @inbox.channel.create_message_template(template_params)
-                end
-
-              # Reload channel to clear any cached associations
-              @inbox.channel.reload unless global_template_request?
-
-              success_response(
-                data: template.serialized,
-                message: 'Message template created successfully',
-                status: :created
-              )
-            rescue ActiveRecord::RecordInvalid => e
-              Rails.logger.error "Template validation error: #{e.message}"
-              error_response(
-                ApiErrorCodes::VALIDATION_ERROR,
-                e.message,
-                details: format_validation_errors(e.record.errors),
-                status: :unprocessable_entity
-              )
-            rescue ActiveRecord::RecordNotUnique => e
-              # Partial unique index race for global template names.
-              Rails.logger.error "Template uniqueness conflict: #{e.message}"
-              error_response(
-                ApiErrorCodes::VALIDATION_ERROR,
-                'A template with this name already exists',
-                status: :unprocessable_entity
-              )
-            rescue StandardError => e
-              Rails.logger.error "Message template creation error: #{e.message}"
-              Rails.logger.error "Error backtrace: #{e.backtrace.first(10).join("\n")}"
-              error_response(
-                ApiErrorCodes::INTERNAL_ERROR,
-                'Failed to create message template',
-                details: e.message,
-                status: :unprocessable_entity
-              )
-            end
-          else
-            error_response(
-              ApiErrorCodes::METHOD_NOT_ALLOWED,
-              'Method not allowed',
-              status: :method_not_allowed
-            )
-          end
-        end
-
         def sync_message_templates
           Rails.logger.info '=== SYNC MESSAGE TEMPLATES START ==='
           authorize @inbox, :message_templates?
@@ -545,161 +411,6 @@ module Api
           )
         rescue ActiveRecord::RecordNotFound
           error_response(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Message template not found', status: :not_found)
-        end
-
-        def update_message_template
-          Rails.logger.info '=== UPDATE MESSAGE TEMPLATE START ==='
-          Rails.logger.info "Params: #{params.inspect}"
-          Rails.logger.info "Template ID: #{params[:template_id]}"
-
-          authorize @inbox, :update_message_template? unless global_template_request?
-          Rails.logger.info 'Authorization passed'
-
-          Rails.logger.info 'Channel type validation passed'
-
-          begin
-            template_id = params[:template_id]
-            Rails.logger.info "Template ID extracted: #{template_id}"
-
-            return render_template_id_required_error if template_id.blank?
-
-            template_params = extract_message_template_params
-            Rails.logger.info "Template params extracted: #{template_params.inspect}"
-            Rails.logger.info "Template params class: #{template_params.class}"
-            Rails.logger.info "Template params keys: #{template_params.keys}"
-            Rails.logger.info "Calling update_message_template with ID: #{template_id}"
-
-            updated_template =
-              if global_template_request?
-                # Global template: update the channel-less record directly.
-                # Scoping to channel_id: nil prevents reaching channel-bound
-                # templates through the global endpoint.
-                template = MessageTemplate.where(channel_id: nil).find(template_id)
-                template.intended_provider = params.dig(:message_template, :provider)
-                template.update!(template_params)
-                template
-              else
-                @inbox.channel.update_message_template(template_id, template_params)
-              end
-            Rails.logger.info "Template updated successfully"
-            Rails.logger.info "Updated template ID: #{updated_template.id}"
-            Rails.logger.info "Updated template attributes: #{updated_template.attributes.inspect}"
-
-            # Reload channel to clear any cached associations
-            @inbox.channel.reload unless global_template_request?
-
-            success_response(
-              data: { template: updated_template.serialized },
-              message: 'Template updated successfully'
-            )
-          rescue ActiveRecord::RecordNotFound
-            Rails.logger.error "Template not found: #{template_id}"
-            error_response(
-              ApiErrorCodes::RESOURCE_NOT_FOUND,
-              'Template not found',
-              status: :not_found
-            )
-          rescue ActiveRecord::RecordInvalid => e
-            Rails.logger.error "Template validation error: #{e.message}"
-            error_response(
-              ApiErrorCodes::VALIDATION_ERROR,
-              e.message,
-              details: format_validation_errors(e.record.errors),
-              status: :unprocessable_entity
-            )
-          rescue ActiveRecord::RecordNotUnique => e
-            # Partial unique index race for global template names.
-            Rails.logger.error "Template uniqueness conflict: #{e.message}"
-            error_response(
-              ApiErrorCodes::VALIDATION_ERROR,
-              'A template with this name already exists',
-              status: :unprocessable_entity
-            )
-          rescue StandardError => e
-            Rails.logger.error "Error in update_message_template: #{e.message}"
-            Rails.logger.error "Error backtrace: #{e.backtrace.join("\n")}"
-
-            error_response(
-              ApiErrorCodes::INTERNAL_ERROR,
-              'Failed to update message template',
-              details: e.message,
-              status: :unprocessable_entity
-            )
-          ensure
-            Rails.logger.info '=== UPDATE MESSAGE TEMPLATE END ==='
-          end
-        end
-
-        def delete_message_template
-          Rails.logger.info '=== DELETE MESSAGE TEMPLATE START ==='
-          Rails.logger.info "Params: #{params.inspect}"
-          Rails.logger.info "Template ID or Name: #{params[:template_id] || params[:template_name]}"
-
-          authorize @inbox, :delete_message_template? unless global_template_request?
-          Rails.logger.info 'Authorization passed'
-
-          Rails.logger.info 'Channel type validation passed'
-
-          begin
-            template_id = params[:template_id] || params[:id]
-            template_name = params[:template_name]
-
-            Rails.logger.info "Template ID: #{template_id}, Name: #{template_name}"
-
-            if template_id.present?
-              # Delete by ID (new way)
-              if global_template_request?
-                # Scope to channel_id: nil so the global endpoint cannot delete
-                # channel-bound templates.
-                MessageTemplate.where(channel_id: nil).find(template_id).destroy!
-              else
-                @inbox.channel.delete_message_template(template_id)
-              end
-              Rails.logger.info "Template deleted successfully by ID: #{template_id}"
-            elsif template_name.present?
-              # Delete by name (legacy support)
-              template = @inbox.channel.message_templates.active.find_by(name: template_name)
-              return render_template_not_found_error if template.blank?
-
-              @inbox.channel.delete_message_template(template.id)
-              Rails.logger.info "Template deleted successfully by name: #{template_name}"
-            else
-              return error_response(
-                ApiErrorCodes::MISSING_REQUIRED_FIELD,
-                'Template ID ou nome é obrigatório',
-                status: :bad_request
-              )
-            end
-
-            # Reload channel to clear any cached associations
-            @inbox.channel.reload unless global_template_request?
-
-            success_response(
-              data: nil,
-              message: 'Template deleted successfully'
-            )
-          rescue ActiveRecord::RecordNotFound
-            Rails.logger.error "Template not found"
-            render_template_not_found_error
-          rescue ActiveRecord::RecordNotDestroyed => e
-            Rails.logger.error "Template could not be destroyed: #{e.message}"
-            error_response(
-              ApiErrorCodes::VALIDATION_ERROR,
-              'Template could not be deleted',
-              status: :unprocessable_entity
-            )
-          rescue StandardError => e
-            Rails.logger.error "Error in delete_message_template: #{e.message}"
-            Rails.logger.error "Error backtrace: #{e.backtrace.join("\n")}"
-            error_response(
-              ApiErrorCodes::INTERNAL_ERROR,
-              'Failed to delete message template',
-              details: e.message,
-              status: :unprocessable_entity
-            )
-          ensure
-            Rails.logger.info '=== DELETE MESSAGE TEMPLATE END ==='
-          end
         end
 
         def destroy
@@ -1074,29 +785,12 @@ module Api
           )
         end
 
-        def render_template_id_required_error
-          Rails.logger.error 'Template ID is required'
-          error_response(
-            ApiErrorCodes::MISSING_REQUIRED_FIELD,
-            'Template ID is required',
-            status: :unprocessable_entity
-          )
-        end
-
         def render_template_name_required_error
           Rails.logger.error 'Template name is blank'
           error_response(
             ApiErrorCodes::MISSING_REQUIRED_FIELD,
             'Template name is required',
             status: :unprocessable_entity
-          )
-        end
-
-        def render_template_not_found_error
-          error_response(
-            ApiErrorCodes::RESOURCE_NOT_FOUND,
-            'Template not found',
-            status: :not_found
           )
         end
 
@@ -1115,58 +809,6 @@ module Api
               }
             ]
           )
-        end
-
-        # Global (channel-less) template mode toggle: `?global=true`.
-        def global_template_request?
-          ActiveModel::Type::Boolean.new.cast(params[:global])
-        end
-
-        def extract_message_template_params
-          params.require(:message_template).permit(
-            :name,
-            :content,
-            :language,
-            :category,
-            :template_type,
-            :media_url,
-            :media_type,
-            :active,
-            components: [
-              :type,
-              :format,
-              :text,
-              :url,
-              {
-                buttons: [:type, :text, :url, :phone_number]
-              }
-            ],
-            variables: [:name, :label, :type, :required, :default_value, :source, :example, :position, :component],
-            settings: {},
-            metadata: {}
-          )
-        end
-
-        def find_template_by_name(template_name)
-          @inbox.channel.message_templates&.find { |t| t['name'] == template_name }
-        end
-
-        def determine_update_error_message(error_message)
-          case error_message
-          when /Template cannot be edited.*status/i
-            'Template cannot be edited in its current status. Only APPROVED, REJECTED, or PAUSED templates can be edited.'
-          when /Content already exists in this language/i
-            'Cannot update template: A template with this content already exists in this language. ' \
-            'Consider creating a new template with a different name.'
-          when /No valid fields to update/i
-            'No valid fields to update. You can only update category (for non-approved templates) and components.'
-          when /Template not found/i
-            'Template not found with the provided ID.'
-          when /Cannot change category of approved template/i
-            'Cannot change category of approved templates. You can only modify components.'
-          else
-            "Failed to update template: #{error_message}"
-          end
         end
 
       end

--- a/app/controllers/api/v1/message_templates_controller.rb
+++ b/app/controllers/api/v1/message_templates_controller.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Dedicated, account-scoped CRUD for message templates. (EVO-1716)
+    #
+    # Replaces the inbox-nested member actions + `?global=true` toggle that used
+    # to live in InboxesController. Serves BOTH:
+    #   * global templates (channel-less) — the default when no inbox is given;
+    #   * channel-bound templates — when `inbox_id` is present, the operation is
+    #     delegated to that inbox's channel, preserving the WhatsApp Cloud
+    #     writeback (create_template → Meta) exactly as before.
+    #
+    # Template sync with Meta stays inbox-scoped on InboxesController
+    # (sync_message_templates / sync_template_with_whatsapp_cloud) — by nature
+    # per-channel — and is intentionally NOT moved here.
+    #
+    # Templates are an instance-wide catalog (no account_id; this CRM runs against
+    # a single runtime account). Authorization is by the `message_templates.*`
+    # RBAC resource (via require_permissions) plus MessageTemplatePolicy.
+    class MessageTemplatesController < Api::V1::BaseController
+      include MessageTemplateParams
+
+      require_permissions({
+                            index: 'message_templates.read',
+                            show: 'message_templates.read',
+                            create: 'message_templates.create',
+                            update: 'message_templates.update',
+                            destroy: 'message_templates.delete'
+                          })
+
+      # GET /api/v1/message_templates
+      # Filters: inbox_id (resolve inbox→channel), channel_id, or neither (global).
+      # Plus category / template_type / search / sort_by / page / per_page.
+      def index
+        authorize MessageTemplate, :index?, policy_class: MessageTemplatePolicy
+
+        @templates = filtered_templates
+
+        return render_unpaginated if unpaginated?
+
+        apply_pagination
+
+        paginated_response(
+          data: @templates.map(&:serialized),
+          collection: @templates,
+          message: 'Message templates retrieved successfully'
+        )
+      rescue ActiveRecord::RecordNotFound
+        render_inbox_not_found
+      rescue StandardError => e
+        Rails.logger.error "Message templates list error: #{e.message}"
+        error_response(ApiErrorCodes::INTERNAL_ERROR, e.message, status: :unprocessable_entity)
+      end
+
+      # GET /api/v1/message_templates/:id
+      def show
+        template = MessageTemplate.find(params[:id])
+        authorize template, :show?, policy_class: MessageTemplatePolicy
+
+        success_response(data: template.serialized, message: 'Message template retrieved successfully')
+      rescue ActiveRecord::RecordNotFound
+        error_response(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Template not found', status: :not_found)
+      end
+
+      # POST /api/v1/message_templates
+      def create
+        authorize MessageTemplate, :create?, policy_class: MessageTemplatePolicy
+
+        template = build_template(extract_message_template_params)
+        success_response(data: template.serialized, message: 'Message template created successfully', status: :created)
+      rescue ActiveRecord::RecordNotFound
+        render_inbox_not_found
+      rescue ActiveRecord::RecordInvalid => e
+        error_response(ApiErrorCodes::VALIDATION_ERROR, e.message,
+                       details: format_validation_errors(e.record.errors), status: :unprocessable_entity)
+      rescue ActiveRecord::RecordNotUnique => e
+        render_name_conflict(e)
+      rescue StandardError => e
+        Rails.logger.error "Message template creation error: #{e.message}"
+        error_response(ApiErrorCodes::INTERNAL_ERROR, 'Failed to create message template',
+                       details: e.message, status: :unprocessable_entity)
+      end
+
+      # PUT/PATCH /api/v1/message_templates/:id
+      def update
+        template = persist_update(extract_message_template_params)
+        success_response(data: { template: template.serialized }, message: 'Template updated successfully')
+      rescue ActiveRecord::RecordNotFound
+        error_response(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Template not found', status: :not_found)
+      rescue ActiveRecord::RecordInvalid => e
+        error_response(ApiErrorCodes::VALIDATION_ERROR, e.message,
+                       details: format_validation_errors(e.record.errors), status: :unprocessable_entity)
+      rescue ActiveRecord::RecordNotUnique => e
+        render_name_conflict(e)
+      rescue StandardError => e
+        Rails.logger.error "Error in update message template: #{e.message}"
+        error_response(ApiErrorCodes::INTERNAL_ERROR, 'Failed to update message template',
+                       details: e.message, status: :unprocessable_entity)
+      end
+
+      # DELETE /api/v1/message_templates/:id
+      def destroy
+        if channel_bound?
+          channel = resolve_channel
+          authorize_template(:destroy?)
+          channel.delete_message_template(params[:id])
+        else
+          template = global_scope.find(params[:id])
+          authorize template, :destroy?, policy_class: MessageTemplatePolicy
+          template.destroy!
+        end
+
+        success_response(data: nil, message: 'Template deleted successfully')
+      rescue ActiveRecord::RecordNotFound
+        error_response(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Template not found', status: :not_found)
+      rescue ActiveRecord::RecordNotDestroyed
+        error_response(ApiErrorCodes::VALIDATION_ERROR, 'Template could not be deleted', status: :unprocessable_entity)
+      rescue StandardError => e
+        Rails.logger.error "Error in delete message template: #{e.message}"
+        error_response(ApiErrorCodes::INTERNAL_ERROR, 'Failed to delete message template',
+                       details: e.message, status: :unprocessable_entity)
+      end
+
+      private
+
+      def unpaginated?
+        params[:page]&.to_i == -1 || params[:per_page]&.to_i == -1
+      end
+
+      def render_unpaginated
+        success_response(
+          data: @templates.map(&:serialized),
+          meta: { total: @templates.count, page: 1, per_page: @templates.count, total_pages: 1 },
+          message: 'Message templates retrieved successfully'
+        )
+      end
+
+      # Create dispatch: channel-bound (delegate to the channel, preserving the
+      # provider's upstream writeback) vs global (channel-less local record).
+      def build_template(template_params)
+        return create_global_template(template_params) unless channel_bound?
+
+        channel = resolve_channel
+        if channel.respond_to?(:create_template)
+          channel.create_template(template_params.to_h.stringify_keys)
+        else
+          channel.create_message_template(template_params)
+        end
+      end
+
+      def create_global_template(template_params)
+        # A self-reported provider == whatsapp_cloud is rejected by the model,
+        # since a WhatsApp Cloud template must be bound to its channel.
+        MessageTemplate.create!(
+          template_params.to_h.merge(channel: nil, intended_provider: params.dig(:message_template, :provider))
+        )
+      end
+
+      # Update dispatch mirrors create: channel-bound delegates to the channel;
+      # global scopes to channel_id: nil so it cannot reach channel-bound rows.
+      def persist_update(template_params)
+        if channel_bound?
+          channel = resolve_channel
+          authorize_template(:update?)
+          channel.update_message_template(params[:id], template_params)
+        else
+          template = global_scope.find(params[:id])
+          authorize template, :update?, policy_class: MessageTemplatePolicy
+          template.intended_provider = params.dig(:message_template, :provider)
+          template.update!(template_params)
+          template
+        end
+      end
+
+      def filtered_templates
+        scope = base_scope.active
+        scope = scope.by_category(params[:category]) if params[:category].present?
+        scope = scope.by_type(params[:template_type]) if params[:template_type].present?
+        scope = scope.search_by_name(params[:search]) if params[:search].present?
+        params[:sort_by] == 'name' ? scope.order(:name) : scope.recently_created
+      end
+
+      def base_scope
+        if params[:inbox_id].present?
+          channel = Inbox.find(params[:inbox_id]).channel
+          channel ? channel.message_templates : MessageTemplate.none
+        elsif params[:channel_id].present?
+          MessageTemplate.where(channel_id: params[:channel_id])
+        else
+          global_scope
+        end
+      end
+
+      def global_scope
+        MessageTemplate.where(channel_id: nil)
+      end
+
+      # Channel-bound when an inbox (or explicit channel) is supplied; otherwise
+      # the operation targets the global (channel-less) catalog.
+      def channel_bound?
+        params[:inbox_id].present? || params[:channel_id].present?
+      end
+
+      def resolve_channel
+        return Inbox.find(params[:inbox_id]).channel if params[:inbox_id].present?
+
+        # channel_id alone: resolve via the polymorphic column of existing rows.
+        MessageTemplate.find_by!(channel_id: params[:channel_id]).channel
+      end
+
+      def authorize_template(action)
+        authorize MessageTemplate.find(params[:id]), action, policy_class: MessageTemplatePolicy
+      end
+
+      def render_name_conflict(error)
+        # Partial unique index race for global template names.
+        Rails.logger.error "Template uniqueness conflict: #{error.message}"
+        error_response(ApiErrorCodes::VALIDATION_ERROR, 'A template with this name already exists',
+                       status: :unprocessable_entity)
+      end
+
+      def render_inbox_not_found
+        error_response(ApiErrorCodes::RESOURCE_NOT_FOUND, 'Inbox not found', status: :not_found)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/message_template_params.rb
+++ b/app/controllers/concerns/message_template_params.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Strong params for message template create/update, shared between the dedicated
+# Api::V1::MessageTemplatesController (global + channel-bound CRUD) and any other
+# consumer. Extracted from InboxesController during the EVO-1716 cutover so the
+# permitted shape lives in one place. (EVO-1716)
+module MessageTemplateParams
+  extend ActiveSupport::Concern
+
+  private
+
+  def extract_message_template_params # rubocop:disable Metrics/MethodLength
+    params.require(:message_template).permit(
+      :name,
+      :content,
+      :language,
+      :category,
+      :template_type,
+      :media_url,
+      :media_type,
+      :active,
+      components: [
+        :type,
+        :format,
+        :text,
+        :url,
+        {
+          buttons: [:type, :text, :url, :phone_number]
+        }
+      ],
+      variables: [:name, :label, :type, :required, :default_value, :source, :example, :position, :component],
+      settings: {},
+      metadata: {}
+    )
+  end
+end

--- a/app/policies/message_template_policy.rb
+++ b/app/policies/message_template_policy.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Authorization for the dedicated, account-scoped message templates endpoint
+# (Api::V1::MessageTemplatesController). Templates are an instance-wide catalog
+# (no account_id column; global names are unique via a partial index), so access
+# is gated purely by role/permission — there is no per-record account scoping.
+#
+# The `require_permissions` before_action is the primary 403 gate; this policy is
+# defense-in-depth and mirrors InboxPolicy's template predicates. Before EVO-1716
+# the global template path skipped the Pundit policy entirely (it relied only on
+# `inboxes.message_templates`); the dedicated resource closes that gap. (EVO-1716)
+class MessageTemplatePolicy < ApplicationPolicy
+  class Scope
+    attr_reader :user_context, :user, :scope, :account
+
+    def initialize(user_context, scope)
+      @user_context = user_context
+      @user = user_context[:user]
+      @account = user_context[:account]
+      @service_authenticated = user_context[:service_authenticated]
+      @scope = scope
+    end
+
+    def resolve
+      return scope if @service_authenticated == true
+      return scope if @user&.administrator? || @user&.has_permission?('message_templates.read')
+
+      scope.none
+    end
+  end
+
+  def index?
+    permitted?('message_templates.read')
+  end
+
+  def show?
+    permitted?('message_templates.read')
+  end
+
+  def create?
+    permitted?('message_templates.create')
+  end
+
+  def update?
+    permitted?('message_templates.update')
+  end
+
+  def destroy?
+    permitted?('message_templates.delete')
+  end
+
+  private
+
+  def permitted?(permission)
+    return true if service_authenticated?
+
+    @user&.administrator? || @user&.has_permission?(permission)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,11 +94,9 @@ Rails.application.routes.draw do
         post :disconnect_channel_provider, on: :member
         post :sync_whatsapp_subscription, on: :member
         delete :avatar, on: :member
-        get :message_templates, on: :member
-        post :message_templates, on: :member
+        # Template CRUD moved to the dedicated flat /api/v1/message_templates
+        # endpoint (EVO-1716). Only the per-channel Meta sync stays inbox-scoped.
         post 'message_templates/sync', action: :sync_message_templates, on: :member
-        put 'message_templates/:template_id', action: :update_message_template, on: :member
-        delete 'message_templates/:template_id', action: :delete_message_template, on: :member
         post 'message_templates/:template_id/sync_with_whatsapp_cloud',
              action: :sync_template_with_whatsapp_cloud, on: :member
       end
@@ -158,6 +156,10 @@ Rails.application.routes.draw do
       end
 
       resources :canned_responses, only: [:index, :show, :create, :update, :destroy], controller: 'canned_responses'
+
+      # Dedicated, account-scoped message templates CRUD (global + channel-bound).
+      # Channel-bound ops pass inbox_id; Meta sync stays on the inbox routes. (EVO-1716)
+      resources :message_templates, only: [:index, :show, :create, :update, :destroy], controller: 'message_templates'
 
       resources :facebook_comment_moderations, only: [:index, :show], controller: 'facebook_comment_moderations' do
         member do

--- a/spec/requests/api/v1/message_templates_service_token_spec.rb
+++ b/spec/requests/api/v1/message_templates_service_token_spec.rb
@@ -2,11 +2,12 @@
 
 require 'rails_helper'
 
-# EVO-1255: evo-flow journey nodes list an inbox's templates server-side with
-# the service token. The per-inbox path runs InboxPolicy#message_templates?
-# (unlike ?global=true, which skips authorize), so the policy must honor
-# service authentication instead of dereferencing a nil user.
-RSpec.describe 'Api::V1::Inboxes message templates (service token, per-inbox)', type: :request do
+# EVO-1255 / EVO-1716: evo-flow journey nodes list a channel's templates
+# server-side with the service token. After the EVO-1716 cutover this is served
+# by the flat endpoint with an `inbox_id` filter (the inbox-nested GET route was
+# removed). The MessageTemplatePolicy must honor service authentication instead
+# of dereferencing a nil user.
+RSpec.describe 'Api::V1::MessageTemplates (service token)', type: :request do
   let(:service_token) { 'spec-service-token' }
   let(:headers) { { 'X-Service-Token' => service_token } }
   let(:channel) { Channel::Api.create!(hmac_mandatory: false) }
@@ -19,14 +20,14 @@ RSpec.describe 'Api::V1::Inboxes message templates (service token, per-inbox)', 
     Current.reset
   end
 
-  it 'lists the inbox templates with a valid service token' do
+  it 'lists a channel templates by inbox_id with a valid service token' do
     template = MessageTemplate.create!(
       name: "ch-#{SecureRandom.hex(4)}",
       content: 'Olá {{first_name}}',
       channel: channel
     )
 
-    get "/api/v1/inboxes/#{inbox.id}/message_templates?active=true&per_page=-1",
+    get "/api/v1/message_templates?inbox_id=#{inbox.id}&active=true&per_page=-1",
         headers: headers, as: :json
 
     expect(response).to have_http_status(:ok)
@@ -35,7 +36,7 @@ RSpec.describe 'Api::V1::Inboxes message templates (service token, per-inbox)', 
   end
 
   it 'rejects the call without a service token or user' do
-    get "/api/v1/inboxes/#{inbox.id}/message_templates", as: :json
+    get '/api/v1/message_templates', as: :json
 
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/api/v1/message_templates_spec.rb
+++ b/spec/requests/api/v1/message_templates_spec.rb
@@ -2,9 +2,10 @@
 
 require 'rails_helper'
 
-# EVO-1231 [6.2]: global (channel-less) message-template CRUD exposed via the
-# existing per-inbox endpoints with the `?global=true` toggle.
-RSpec.describe 'Api::V1::Inboxes message templates (global mode)', type: :request do
+# EVO-1716: dedicated, account-scoped message-template CRUD at the flat
+# /api/v1/message_templates endpoint. Global (channel-less) when no inbox is
+# given; channel-bound when `inbox_id` is supplied. Meta sync stays inbox-scoped.
+RSpec.describe 'Api::V1::MessageTemplates', type: :request do
   let(:service_token) { 'spec-service-token' }
   let(:headers) { { 'X-Service-Token' => service_token } }
   let(:channel) { Channel::Api.create!(hmac_mandatory: false) }
@@ -21,9 +22,15 @@ RSpec.describe 'Api::V1::Inboxes message templates (global mode)', type: :reques
     JSON.parse(response.body)
   end
 
-  describe 'POST /api/v1/inboxes/:id/message_templates?global=true' do
+  def whatsapp_channel(provider = 'evolution')
+    ch = Channel::Whatsapp.new(provider: provider, phone_number: "+1555#{SecureRandom.hex(3)}")
+    ch.save!(validate: false)
+    ch
+  end
+
+  describe 'POST /api/v1/message_templates (global)' do
     it 'creates a channel-less template (AC1)' do
-      post "/api/v1/inboxes/#{inbox.id}/message_templates?global=true",
+      post '/api/v1/message_templates',
            params: { message_template: { name: "g-#{SecureRandom.hex(4)}", content: 'Hello' } },
            headers: headers, as: :json
 
@@ -33,128 +40,180 @@ RSpec.describe 'Api::V1::Inboxes message templates (global mode)', type: :reques
       expect(created.channel_type).to be_nil
     end
 
-    it 'rejects a WhatsApp Cloud template without a channel (AC5)' do
-      post "/api/v1/inboxes/#{inbox.id}/message_templates?global=true",
-           params: { message_template: { name: "wac-#{SecureRandom.hex(4)}", content: 'Hello', provider: 'whatsapp_cloud' } },
+    it 'rejects a WhatsApp Cloud template without a channel (AC1)' do
+      post '/api/v1/message_templates',
+           params: { message_template: { name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', provider: 'whatsapp_cloud' } },
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 on a duplicate global name (AC5)' do
+      name = "dup-#{SecureRandom.hex(4)}"
+      MessageTemplate.create!(name: name, content: 'first')
+
+      post '/api/v1/message_templates',
+           params: { message_template: { name: name, content: 'second' } },
            headers: headers, as: :json
 
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 
-  describe 'GET /api/v1/inboxes/:id/message_templates?global=true (AC2)' do
+  describe 'GET /api/v1/message_templates (global, AC1)' do
     it 'lists global templates' do
       template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Hi')
 
-      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", headers: headers, as: :json
+      get '/api/v1/message_templates', headers: headers, as: :json
 
       expect(response).to have_http_status(:ok)
       expect(json_response['data'].map { |t| t['name'] }).to include(template.name)
     end
-  end
 
-  describe 'PUT /api/v1/inboxes/:id/message_templates/:template_id?global=true (AC3)' do
-    it 'updates a global template' do
-      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Old')
-
-      put "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}?global=true",
-          params: { message_template: { content: 'New' } },
-          headers: headers, as: :json
-
-      expect(response).to have_http_status(:ok)
-      expect(template.reload.content).to eq('New')
-    end
-  end
-
-  describe 'DELETE /api/v1/inboxes/:id/message_templates/:template_id?global=true (AC4)' do
-    it 'deletes a global template' do
-      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Bye')
-
-      delete "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}?global=true",
-             headers: headers, as: :json
-
-      expect(response).to have_http_status(:ok)
-      expect(MessageTemplate.exists?(template.id)).to be(false)
-    end
-  end
-
-  describe 'global scoping (excludes channel-bound and inactive templates)' do
-    def whatsapp_channel
-      ch = Channel::Whatsapp.new(provider: 'evolution', phone_number: "+1555#{SecureRandom.hex(3)}")
-      ch.save!(validate: false)
-      ch
-    end
-
-    it 'GET does not leak channel-bound templates' do
+    it 'does not leak channel-bound templates' do
       global = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'global')
       bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: whatsapp_channel)
 
-      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", headers: headers, as: :json
+      get '/api/v1/message_templates', headers: headers, as: :json
 
       names = json_response['data'].map { |t| t['name'] }
       expect(names).to include(global.name)
       expect(names).not_to include(bound.name)
     end
 
-    it 'GET does not return inactive global templates' do
+    it 'does not return inactive global templates' do
       inactive = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'hidden', active: false)
 
-      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", headers: headers, as: :json
+      get '/api/v1/message_templates', headers: headers, as: :json
 
       expect(json_response['data'].map { |t| t['name'] }).not_to include(inactive.name)
     end
+  end
 
-    it 'PUT cannot reach a channel-bound template' do
+  describe 'GET /api/v1/message_templates/:id (AC1)' do
+    it 'returns a single template' do
+      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Hi')
+
+      get "/api/v1/message_templates/#{template.id}", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data']['id']).to eq(template.id)
+    end
+
+    it 'returns 404 for an unknown id' do
+      get "/api/v1/message_templates/#{SecureRandom.uuid}", headers: headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'PUT /api/v1/message_templates/:id (global, AC1)' do
+    it 'updates a global template' do
+      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Old')
+
+      put "/api/v1/message_templates/#{template.id}",
+          params: { message_template: { content: 'New' } },
+          headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(template.reload.content).to eq('New')
+    end
+
+    it 'cannot reach a channel-bound template' do
       bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: whatsapp_channel)
 
-      put "/api/v1/inboxes/#{inbox.id}/message_templates/#{bound.id}?global=true",
+      put "/api/v1/message_templates/#{bound.id}",
           params: { message_template: { content: 'hacked' } },
           headers: headers, as: :json
 
       expect(response).to have_http_status(:not_found)
       expect(bound.reload.content).to eq('bound')
     end
+  end
 
-    it 'DELETE cannot reach a channel-bound template' do
+  describe 'DELETE /api/v1/message_templates/:id (global, AC1)' do
+    it 'deletes a global template' do
+      template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Bye')
+
+      delete "/api/v1/message_templates/#{template.id}", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(MessageTemplate.exists?(template.id)).to be(false)
+    end
+
+    it 'cannot reach a channel-bound template' do
       bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: whatsapp_channel)
 
-      delete "/api/v1/inboxes/#{inbox.id}/message_templates/#{bound.id}?global=true",
-             headers: headers, as: :json
+      delete "/api/v1/message_templates/#{bound.id}", headers: headers, as: :json
 
       expect(response).to have_http_status(:not_found)
       expect(MessageTemplate.exists?(bound.id)).to be(true)
     end
   end
 
-  describe 'permission enforcement (AC6)' do
+  describe 'channel-bound CRUD via inbox_id (AC2 / AC3)' do
+    it 'creates a template bound to the inbox channel' do
+      post '/api/v1/message_templates',
+           params: { inbox_id: inbox.id, message_template: { name: "b-#{SecureRandom.hex(4)}", content: 'bound' } },
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:created)
+      created = MessageTemplate.find(json_response['data']['id'])
+      expect(created.channel_id).to eq(channel.id)
+    end
+
+    it 'lists only that channel templates when filtered by inbox_id' do
+      global = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'global')
+      bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: channel)
+
+      get "/api/v1/message_templates?inbox_id=#{inbox.id}", headers: headers, as: :json
+
+      names = json_response['data'].map { |t| t['name'] }
+      expect(names).to include(bound.name)
+      expect(names).not_to include(global.name)
+    end
+
+    it 'lists the same set when filtered by channel_id' do
+      bound = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'bound', channel: channel)
+
+      get "/api/v1/message_templates?channel_id=#{channel.id}", headers: headers, as: :json
+
+      expect(json_response['data'].map { |t| t['name'] }).to include(bound.name)
+    end
+  end
+
+  describe 'authorization (AC4)' do
     let(:forbidden_user) { User.create!(name: 'No Perm', email: "noperm-#{SecureRandom.hex(4)}@example.com") }
 
     before do
-      # Authenticate as a user (not a service token) so the require_permissions
-      # gate evaluates the remote permission, which we deny.
-      allow_any_instance_of(Api::V1::InboxesController)
+      allow_any_instance_of(Api::V1::MessageTemplatesController)
         .to receive(:authenticate_request!) { Current.user = forbidden_user }
       allow_any_instance_of(EvoAuthService).to receive(:check_user_permission).and_return(false)
     end
 
-    it 'returns 403 when the user lacks inboxes.message_templates' do
-      get "/api/v1/inboxes/#{inbox.id}/message_templates?global=true", as: :json
+    it 'returns 403 when the user lacks message_templates.read' do
+      get '/api/v1/message_templates', as: :json
 
       expect(response).to have_http_status(:forbidden)
     end
   end
 
-  # EVO-1232 [6.3]: push a single template up to Meta (WhatsApp Cloud) for
-  # approval via POST .../message_templates/:template_id/sync_with_whatsapp_cloud.
-  describe 'POST /api/v1/inboxes/:id/message_templates/:template_id/sync_with_whatsapp_cloud' do
-    def whatsapp_cloud_channel
-      ch = Channel::Whatsapp.new(provider: 'whatsapp_cloud', phone_number: "+1555#{SecureRandom.hex(3)}")
-      ch.save!(validate: false)
-      ch
-    end
+  describe 'cutover: legacy inbox-nested CRUD routes are gone (AC7)' do
+    it 'no longer routes the old global GET/POST (404)' do
+      get "/api/v1/inboxes/#{inbox.id}/message_templates", headers: headers, as: :json
+      expect(response).to have_http_status(:not_found)
 
-    it 'enqueues the sync job and returns 202 for a WhatsApp Cloud template (AC4)' do
-      template = MessageTemplate.create!(name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', channel: whatsapp_cloud_channel)
+      post "/api/v1/inboxes/#{inbox.id}/message_templates",
+           params: { message_template: { name: 'x', content: 'y' } }, headers: headers, as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # EVO-1232 [6.3] — STAYS inbox-scoped (NOT moved by EVO-1716). Regression guard. (AC6)
+  describe 'POST /api/v1/inboxes/:id/message_templates/:template_id/sync_with_whatsapp_cloud' do
+    it 'enqueues the sync job and returns 202 for a WhatsApp Cloud template' do
+      template = MessageTemplate.create!(name: "wac-#{SecureRandom.hex(4)}", content: 'Hi',
+                                         channel: whatsapp_channel('whatsapp_cloud'))
 
       expect(SyncMessageTemplateWithWhatsappCloudJob).to receive(:perform_later).with(an_instance_of(MessageTemplate))
 
@@ -165,7 +224,7 @@ RSpec.describe 'Api::V1::Inboxes message templates (global mode)', type: :reques
       expect(json_response['data']['template']['id']).to eq(template.id)
     end
 
-    it 'returns 422 and does not enqueue for a channel-less template (AC5)' do
+    it 'returns 422 and does not enqueue for a channel-less template' do
       template = MessageTemplate.create!(name: "g-#{SecureRandom.hex(4)}", content: 'Hi')
 
       expect(SyncMessageTemplateWithWhatsappCloudJob).not_to receive(:perform_later)
@@ -176,28 +235,9 @@ RSpec.describe 'Api::V1::Inboxes message templates (global mode)', type: :reques
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
-    it 'returns 422 for a template bound to a non-WhatsApp-Cloud channel (AC5)' do
-      bound = Channel::Whatsapp.new(provider: 'baileys', phone_number: "+1555#{SecureRandom.hex(3)}")
-      bound.save!(validate: false)
-      template = MessageTemplate.create!(name: "b-#{SecureRandom.hex(4)}", content: 'Hi', channel: bound)
-
-      expect(SyncMessageTemplateWithWhatsappCloudJob).not_to receive(:perform_later)
-
-      post "/api/v1/inboxes/#{inbox.id}/message_templates/#{template.id}/sync_with_whatsapp_cloud",
-           headers: headers, as: :json
-
-      expect(response).to have_http_status(:unprocessable_entity)
-    end
-
-    it 'returns 404 for an unknown template id' do
-      post "/api/v1/inboxes/#{inbox.id}/message_templates/#{SecureRandom.uuid}/sync_with_whatsapp_cloud",
-           headers: headers, as: :json
-
-      expect(response).to have_http_status(:not_found)
-    end
-
     it 'returns 403 without the inboxes.message_templates permission' do
-      template = MessageTemplate.create!(name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', channel: whatsapp_cloud_channel)
+      template = MessageTemplate.create!(name: "wac-#{SecureRandom.hex(4)}", content: 'Hi',
+                                         channel: whatsapp_channel('whatsapp_cloud'))
       forbidden_user = User.create!(name: 'No Perm', email: "noperm-#{SecureRandom.hex(4)}@example.com")
       allow_any_instance_of(Api::V1::InboxesController)
         .to receive(:authenticate_request!) { Current.user = forbidden_user }


### PR DESCRIPTION
## Summary

EVO-1716 closes the loop opened at the start of the Templates epic: a dedicated, account-scoped endpoint for the template save flow, instead of the inbox-nested member actions + `?global=true` toggle bolted onto `InboxesController`.

- **New `Api::V1::MessageTemplatesController`** at flat `/api/v1/message_templates`, serving both:
  - **global** (channel-less) templates — the default when no inbox is given;
  - **channel-bound** templates — when `inbox_id` (or `channel_id`) is present, the op delegates to the channel, preserving the WhatsApp Cloud writeback (`create_template` → Meta) **exactly as before**.
- **New `MessageTemplatePolicy`** + **`MessageTemplateParams`** concern (the permitted shape was extracted verbatim from `InboxesController`, now single-sourced).
- **Routes**: flat `resources :message_templates`; removed the 4 inbox CRUD member routes. **Meta sync stays inbox-scoped** (`sync` / `sync_with_whatsapp_cloud` kept — per-channel by nature).
- **`InboxesController`**: −360 lines (CRUD methods + orphaned helpers + 3 stale `require_permissions` entries).

Templates are an **instance-wide catalog** (no `account_id`; this CRM runs against a single runtime account), so there is no per-record account scoping to add.

## Test plan

- `spec/requests/api/v1/message_templates_spec.rb` — global + channel-bound CRUD, global-vs-bound isolation, duplicate-name 422, authorization 403, legacy-route cutover 404. **22 examples, all green.**
- `spec/requests/api/v1/message_templates_service_token_spec.rb` — evo-flow service-token journey via `inbox_id` filter.
- Inbox controller sync regression specs: 3/3 green. Rubocop clean on touched production files.

## Notas

- **Deploy ordering**: the auth-service RBAC PR (`message_templates` resource) **must ship before** this backend, otherwise non-admin users lose template CRUD access.
- Companion PRs: auth-service (RBAC resource) and frontend (repoint to flat endpoint).

## Summary by Sourcery

Introduce a dedicated, account-scoped message templates API and cut over from inbox-nested CRUD while preserving per-channel Meta sync.

New Features:
- Add Api::V1::MessageTemplatesController providing global and channel-bound CRUD via a flat /api/v1/message_templates endpoint.
- Introduce MessageTemplatePolicy and MessageTemplateParams concern to centralize authorization and strong parameters for templates.

Enhancements:
- Remove message template CRUD logic from InboxesController and simplify inbox routes to only keep per-channel Meta sync actions.
- Update service-token and request specs to cover the new message templates endpoint, including authorization, scoping, and legacy route cutover behavior.

Tests:
- Expand and adjust request specs for message templates to cover global and channel-bound CRUD, isolation rules, authorization, and WhatsApp Cloud sync regression.
- Update service token request specs to validate access to channel templates through the new endpoint.