### PR TITLE
fix(message-templates): WABA-wide template status lookup + channel_id error key (EVO-1717)

### DIFF
--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -89,7 +89,9 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
   #   { event: 'APPROVED'|'REJECTED'|'PENDING'|'PAUSED'|'FLAGGED',
   #     message_template_id: <int>, message_template_name: <str>,
   #     message_template_language: <str>, reason: <str|null> }
-  def handle_message_template_status_update(channel, params)
+  # _channel is the WABA's `.first` channel resolved upstream; it is intentionally
+  # NOT used to scope the template lookup (see find_template_for_waba). (EVO-1717)
+  def handle_message_template_status_update(_channel, params)
     # Defensive: ensure indifferent access even if the queue adapter handed us a
     # string-keyed hash. (adversarial review F4)
     params = params.with_indifferent_access
@@ -101,7 +103,8 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     reason = value[:reason]
     return if external_id.blank? || new_status.blank?
 
-    template = channel.message_templates.find_by("metadata ->> 'external_id' = ?", external_id)
+    # params is already with_indifferent_access here, so digging the WABA id is safe.
+    template = find_template_for_waba(params.dig(:entry, 0, :id), external_id)
     if template.nil?
       Rails.logger.warn "[WHATSAPP] template_status_update: no template for external_id #{external_id}"
       return
@@ -120,6 +123,34 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
     Rails.logger.info "[WHATSAPP] template #{template.id} status → #{new_status}"
   rescue StandardError => e
     Rails.logger.error "[WHATSAPP] message_template_status_update failed: #{e.message}"
+  end
+
+  # Meta template ids (metadata['external_id']) are unique per-WABA, but a single
+  # WABA can host multiple whatsapp_cloud channels. find_channel_by_waba_id only
+  # returns the `.first` of those, so scoping the template lookup to that one
+  # channel silently drops status updates for templates living on a sibling
+  # channel. Resolve the template across every channel of the WABA instead.
+  # (EVO-1717 / EVO-1232 follow-up)
+  #
+  # Note: unlike find_channel_by_waba_id we intentionally omit joins(:inbox) — a
+  # template can legitimately be owned by a channel without an inbox, and only the
+  # template (not the inbox) is needed here.
+  def find_template_for_waba(waba_id, external_id)
+    return nil if waba_id.blank?
+
+    channel_ids = Channel::Whatsapp
+                  .where(provider: 'whatsapp_cloud')
+                  .where(
+                    "provider_config ->> 'waba_id' = :id OR provider_config ->> 'business_account_id' = :id",
+                    id: waba_id.to_s
+                  )
+                  .select(:id)
+
+    # Channel::Whatsapp is a plain ActiveRecord model (not STI), so the
+    # polymorphic channel_type stored on templates is the literal class name.
+    MessageTemplate
+      .where(channel_type: 'Channel::Whatsapp', channel_id: channel_ids)
+      .find_by("metadata ->> 'external_id' = ?", external_id)
   end
 
   def handle_account_update(channel, params)

--- a/app/models/message_template.rb
+++ b/app/models/message_template.rb
@@ -232,10 +232,12 @@ class MessageTemplate < ApplicationRecord
   def channel_required_for_whatsapp_cloud
     return unless intended_provider == 'whatsapp_cloud' || whatsapp_cloud_channel?(channel)
 
+    # Error key is :channel_id (not :channel) so the JSON payload / frontend bind
+    # the validation to the channel_id form field, matching the 6.3 AC. (EVO-1717)
     if channel.blank?
-      errors.add(:channel, 'is required for WhatsApp Cloud templates')
+      errors.add(:channel_id, 'is required for WhatsApp Cloud templates')
     elsif !whatsapp_cloud_channel?(channel)
-      errors.add(:channel, 'must reference a WhatsApp Cloud channel')
+      errors.add(:channel_id, 'must reference a WhatsApp Cloud channel')
     end
   end
 

--- a/spec/jobs/sync_message_template_with_whatsapp_cloud_job_spec.rb
+++ b/spec/jobs/sync_message_template_with_whatsapp_cloud_job_spec.rb
@@ -42,16 +42,33 @@ RSpec.describe SyncMessageTemplateWithWhatsappCloudJob, type: :job do
     described_class.new.perform(template)
   end
 
-  it 'lands a pending status + external id on the same record (via the re-sync writeback)' do
-    allow(channel).to receive(:create_template) do
-      template.settings = { 'status' => 'PENDING' }
-      template.metadata = { 'external_id' => '777' }
+  # Production's writeback lands via TemplateSync#sync_template_to_database ->
+  # find_or_initialize_by(channel:, name:, language:), i.e. on the DB record matched
+  # by (channel, name, language) — NOT on the in-memory instance the job holds. So
+  # we persist the template, have the stub write back through that SAME lookup (same
+  # name/language so it resolves to the existing row, not a second one — review F8),
+  # and assert on reload. (review F4 — the old mock mutated the in-memory instance
+  # and gave false confidence.) Note: the external_id value is injected by the stub,
+  # mirroring that the real sync copies metadata['external_id'] from Meta's payload;
+  # this guards "writeback hit the right record", not Meta-id propagation itself (F11).
+  it 'lands a pending status + external id on the persisted record (via the find_or_initialize_by writeback)' do
+    persisted = MessageTemplate.create!(
+      name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', category: 'UTILITY',
+      language: 'pt_BR', channel: channel, components: [{ 'type' => 'BODY', 'text' => 'Hi' }]
+    )
+
+    allow(channel).to receive(:create_template) do |payload|
+      record = MessageTemplate.find_or_initialize_by(
+        channel: channel, name: payload['name'], language: payload['language']
+      )
+      record.update!(settings: { 'status' => 'PENDING' }, metadata: { 'external_id' => '777' })
     end
 
-    described_class.new.perform(template)
+    described_class.new.perform(persisted)
 
-    expect(template.approval_status).to eq('pending')
-    expect(template.external_template_id).to eq('777')
+    persisted.reload
+    expect(persisted.approval_status).to eq('pending')
+    expect(persisted.external_template_id).to eq('777')
   end
 
   it 'skips and does not call create_template when the channel is not WhatsApp Cloud' do

--- a/spec/jobs/webhooks/whatsapp_events_job_spec.rb
+++ b/spec/jobs/webhooks/whatsapp_events_job_spec.rb
@@ -83,4 +83,67 @@ RSpec.describe Webhooks::WhatsappEventsJob, type: :job do
 
     expect(template.reload.settings['status']).to eq('PENDING')
   end
+
+  # EVO-1717 [Follow-up 6.8]: a WABA can host multiple whatsapp_cloud channels, but
+  # Meta's template id (metadata['external_id']) is unique per-WABA. The status
+  # update must resolve the template across ALL channels of the WABA, not just the
+  # `.first` one that find_channel_by_waba_id returns.
+  describe 'multi-channel WABA' do
+    let(:sibling_channel) do
+      ch = Channel::Whatsapp.new(
+        provider: 'whatsapp_cloud',
+        phone_number: "+1555#{SecureRandom.hex(3)}",
+        provider_config: { 'waba_id' => waba_id }
+      )
+      ch.save!(validate: false)
+      ch
+    end
+
+    let!(:sibling_template) do
+      MessageTemplate.create!(
+        name: "wac-#{SecureRandom.hex(4)}", content: 'Hi', channel: sibling_channel,
+        metadata: { 'external_id' => '99999' }, settings: { 'status' => 'PENDING' }
+      )
+    end
+
+    before { Inbox.create!(channel: sibling_channel, name: "Inbox #{SecureRandom.hex(3)}") }
+
+    # Deterministic regression guard: exercises the lookup directly so it does not
+    # depend on which channel find_channel_by_waba_id.first happens to return.
+    it 'resolves a template living on a sibling channel of the same WABA' do
+      found = described_class.new.send(:find_template_for_waba, waba_id, '99999')
+      expect(found).to eq(sibling_template)
+    end
+
+    it 'does not match an external id from a different WABA' do
+      found = described_class.new.send(:find_template_for_waba, "other-#{SecureRandom.hex(4)}", '99999')
+      expect(found).to be_nil
+    end
+
+    it 'returns nil for a blank WABA id' do
+      expect(described_class.new.send(:find_template_for_waba, '', '99999')).to be_nil
+    end
+
+    it 'updates the sibling-channel template status end-to-end' do
+      described_class.new.perform(payload(event: 'APPROVED', message_template_id: '99999'))
+
+      expect(sibling_template.reload.settings['status']).to eq('APPROVED')
+      expect(sibling_template.approval_status).to eq('approved')
+    end
+
+    # The webhook write goes through update_columns, so it must land even on a
+    # record that would fail model validation (e.g. blank content). (EVO-1717 AC4)
+    it 'writes the status via update_columns even when the record is model-invalid' do
+      invalid_template = MessageTemplate.new(
+        name: "wac-#{SecureRandom.hex(4)}", content: '', channel: sibling_channel,
+        metadata: { 'external_id' => '77777' }, settings: { 'status' => 'PENDING' }
+      )
+      invalid_template.save!(validate: false)
+      expect(invalid_template).not_to be_valid
+
+      described_class.new.perform(payload(event: 'APPROVED', message_template_id: '77777'))
+
+      expect(invalid_template.reload.settings['status']).to eq('APPROVED')
+    end
+  end
 end

--- a/spec/models/message_template_spec.rb
+++ b/spec/models/message_template_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe MessageTemplate, type: :model do
       )
 
       expect(template).not_to be_valid
-      expect(template.errors[:channel]).to include('is required for WhatsApp Cloud templates')
+      expect(template.errors[:channel_id]).to include('is required for WhatsApp Cloud templates')
     end
 
     it 'is valid as a WhatsApp Cloud template when a channel is present' do
@@ -125,7 +125,7 @@ RSpec.describe MessageTemplate, type: :model do
       )
 
       expect(template).not_to be_valid
-      expect(template.errors[:channel]).to include('must reference a WhatsApp Cloud channel')
+      expect(template.errors[:channel_id]).to include('must reference a WhatsApp Cloud channel')
     end
 
     it 'is invalid when the channel is not a WhatsApp channel at all' do
@@ -135,7 +135,7 @@ RSpec.describe MessageTemplate, type: :model do
       )
 
       expect(template).not_to be_valid
-      expect(template.errors[:channel]).to include('must reference a WhatsApp Cloud channel')
+      expect(template.errors[:channel_id]).to include('must reference a WhatsApp Cloud channel')
     end
 
     it 'treats a template bound to a WhatsApp Cloud channel as WhatsApp Cloud even without intended_provider' do


### PR DESCRIPTION
## Summary

Non-blocking follow-up to the EVO-1232 [6.3] review (PR #132, already merged). Addresses the findings verified against the merged code:

- **🟡 [Medium] WABA multi-channel status webhook no-op.** `handle_message_template_status_update` resolved the template via the single `.first` channel returned by `find_channel_by_waba_id`. Meta's template id (`metadata['external_id']`) is **per-WABA**, but a WABA can host multiple `whatsapp_cloud` channels — so a template living on a sibling channel had its `APPROVED`/`REJECTED` status silently dropped. New private `find_template_for_waba(waba_id, external_id)` resolves the template across **every** channel of the WABA. The `update_columns` write and `rescue` envelope are unchanged. (1-phone-per-WABA deploys — the common community case — were unaffected.)
- **🔵 [Low] Validation error key.** The WhatsApp Cloud channel validations moved from `:channel` to `:channel_id`, so the JSON error key / frontend field binding matches the 6.3 AC. Server-side blast radius verified empty (only the model + its spec read the key; `InboxesController` uses an independent string).
- **🔵 [Low] Inbox-scoped route note.** Already delivered by EVO-1716 (flat `/api/v1/message_templates`, `routes.rb:162`) — verified, no code change.

## Test plan

- `spec/jobs/webhooks/whatsapp_events_job_spec.rb` — new `multi-channel WABA` group: a deterministic regression guard exercising `find_template_for_waba` directly (independent of which channel is `.first`), a cross-WABA negative, a blank-WABA-id guard, an end-to-end `perform`, and an `update_columns`-skips-validation case on a model-invalid record.
- `spec/models/message_template_spec.rb` — the three error assertions flipped to `errors[:channel_id]`.
- `spec/jobs/sync_message_template_with_whatsapp_cloud_job_spec.rb` — the writeback example reworked to mirror prod's `find_or_initialize_by(channel:, name:, language:)` persistence (persist + reload) instead of mutating the in-memory instance, which gave false confidence.
- **38 examples, 0 failures.** RuboCop clean on touched production files.

## Notas

- **Merge ordering:** touches `whatsapp_events_job.rb` — coordinate with **7.4a** (disjoint `case` branches, merge-conflict risk only, no logic interaction).
- The `:channel` → `:channel_id` rename changes the error key any client could read; frontend handling is tracked under 6.4.
- Scope intentionally narrow: `find_channel_by_waba_id` still returns `.first` for *channel* resolution (other handlers act on a single channel by design) — only the *template* lookup is broadened.