### PR TITLE
fix(conversations): avoid NoMethodError on nil user in PermissionFilterService

### DIFF
--- a/app/services/conversations/permission_filter_service.rb
+++ b/app/services/conversations/permission_filter_service.rb
@@ -7,7 +7,10 @@ class Conversations::PermissionFilterService
   end
 
   def perform
-    return conversations if user_role == 'administrator'
+    # Service-token (internal) calls have no Current.user. Treat them as
+    # fully trusted/internal and skip inbox-based filtering, since the
+    # caller already scopes the query (e.g. by contact_id).
+    return conversations if user.nil? || user_role == 'administrator'
 
     accessible_conversations
   end


### PR DESCRIPTION
## Summary
- `Conversations::PermissionFilterService#user_role` calls `user.role`, but service-token (internal) requests never set `Current.user`, so it raises `NoMethodError: undefined method 'role' for nil`.
- This makes `GET /api/v1/contacts/:contact_id/conversations` always return a 500 for service-token callers (e.g. evo-ai-processor), breaking features that rely on resolving a contact's conversation_id (such as `transfer_to_human`).
- Treat a `nil` user as fully trusted/internal and skip inbox-based filtering, since the caller already scopes the query (e.g. by `contact_id`).

## Test plan
- [ ] `GET /api/v1/contacts/:contact_id/conversations` with a service-token request returns 200 with the contact's conversations instead of 500
- [ ] Authenticated user requests still go through `accessible_conversations` (inbox-based filtering) unchanged

## Summary by Sourcery

Bug Fixes:
- Prevent NoMethodError in conversation permission filtering when requests are made without an authenticated user by treating nil users as trusted and skipping inbox-based filtering.