### PR TITLE
fix(contacts): render conversations list for GET /contacts/:id/conversations

### DIFF
--- a/app/controllers/api/v1/contacts/conversations_controller.rb
+++ b/app/controllers/api/v1/contacts/conversations_controller.rb
@@ -13,5 +13,7 @@ class Api::V1::Contacts::ConversationsController < Api::V1::Contacts::BaseContro
     ).perform
 
     @conversations = conversations.order(last_activity_at: :desc).limit(20)
+
+    success_response(data: ConversationSerializer.serialize_collection(@conversations, include_labels: true))
   end
 end


### PR DESCRIPTION
## Summary
- `Api::V1::Contacts::ConversationsController#index` set `@conversations` but had no corresponding view, so Rails returned `204 No Content` for every request to `GET /api/v1/contacts/:contact_id/conversations`.
- Now renders the serialized conversation collection via `success_response`, matching the standard API response format used elsewhere.

## Why
The AI agent processor's "Teste seu agente" feature loads a contact's conversation context from this endpoint to populate `evoai_crm_data.conversation_id`, which tools like `transfer_to_human` rely on. With the endpoint returning empty, that context was never available.

## Test plan
- [x] Verified via `curl` against production that the endpoint returned `HTTP 204` before the fix
- [ ] After deploy, verify `GET /api/v1/contacts/:id/conversations` returns `{ "success": true, "data": [...] }` with conversation entries

## Summary by Sourcery

Bug Fixes:
- Fix GET /api/v1/contacts/:contact_id/conversations returning 204 No Content by rendering the serialized conversations collection.