### PR TITLE
fix(labels): renderizar JSON no GET/POST de labels (corrige 204 que apagava tags)

### DIFF
--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -4,10 +4,12 @@ module LabelConcern
   def create
     model.update_labels(resolve_label_titles(permitted_params[:labels]))
     @labels = model.label_list
+    render json: { payload: @labels }
   end
 
   def index
     @labels = model.label_list
+    render json: { payload: @labels }
   end
 
   private


### PR DESCRIPTION
## Resumo
- Cherry-pick do commit `fe17f72` (já presente em `develop`) para `main` como hotfix.
- `LabelConcern#index` e `#create` setavam `@labels` mas não renderizavam resposta, e não há view jbuilder — o Rails respondia **204 No Content** com corpo vazio.
- Qualquer consumidor que lê labels atuais via `GET /conversations/:id/labels` (ex.: a tool `manage_conversation_labels` do AI Processor) recebia 204 vazio, concluía "0 labels" e, como o `POST` faz `update_labels` (replace, não append), um "add" do agente **apagava todas as labels existentes da conversa** — incluindo `atendimento_ia`, que mantém a IA elegível para responder. Sem ela, o postback seguinte falha (422) e a resposta é descartada.

## Mudança
`render json: { payload: @labels }` em `index` e `create` (formato `payload` já é o esperado pelos consumidores existentes).

## Descoberto via
Teste end-to-end do agente "Inter Rural - Atendimento" com `allow_manage_labels=true`: um `remove` de label reportou sucesso (`"None of the requested labels were present; nothing to update"`) mas a label permaneceu no banco — comportamento consistente com `current_labels` sempre vindo `[]` por causa do 204.

## Test plan
- [ ] Aplicar em ambiente de teste e repetir: `GET /conversations/:id/labels` deve retornar `{"payload": [...]}` com as labels reais (não 204).
- [ ] `add` de uma label em conversa que já tem outras labels deve preservar as existentes.
- [ ] `remove` de uma label existente deve realmente removê-la (`labels` resultante sem o item removido).

## Summary by Sourcery

Return labels as JSON payload from label create and index actions to prevent 204 responses that cleared conversation tags.

Bug Fixes:
- Fix label create endpoint to respond with the current labels in a JSON payload instead of an empty 204 response.
- Fix label index endpoint to return the existing labels in a JSON payload so consumers can correctly preserve and update conversation labels.