### PR TITLE
fix(api): define missing ApiErrorCodes constants used by error_response

### DIFF
--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -43,7 +43,8 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
       if conversation.nil?
         error_response(
           ApiErrorCodes::CONVERSATION_NOT_FOUND,
-          'Conversation not found'
+          'Conversation not found',
+          status: :not_found
         )
         return
       end
@@ -64,7 +65,8 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
       if contact.nil?
         error_response(
           ApiErrorCodes::CONTACT_NOT_FOUND,
-          'Contact not found'
+          'Contact not found',
+          status: :not_found
         )
         return
       end

--- a/app/models/concerns/api_error_codes.rb
+++ b/app/models/concerns/api_error_codes.rb
@@ -50,13 +50,28 @@ module ApiErrorCodes
   # ============================================================================
   # 404 Not Found - Resource not found errors (specific resources)
   # ============================================================================
-  
+
   RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND'
+  CONTACT_NOT_FOUND = 'CONTACT_NOT_FOUND'
+  CONVERSATION_NOT_FOUND = 'CONVERSATION_NOT_FOUND'
+  TEAM_NOT_FOUND = 'TEAM_NOT_FOUND'
+  LABEL_NOT_FOUND = 'LABEL_NOT_FOUND'
+  AUTOMATION_RULE_NOT_FOUND = 'AUTOMATION_RULE_NOT_FOUND'
+  MACRO_NOT_FOUND = 'MACRO_NOT_FOUND'
+  CUSTOM_FILTER_NOT_FOUND = 'CUSTOM_FILTER_NOT_FOUND'
+  NOTIFICATION_NOT_FOUND = 'NOTIFICATION_NOT_FOUND'
+  CUSTOM_ATTRIBUTE_NOT_FOUND = 'CUSTOM_ATTRIBUTE_NOT_FOUND'
+
+  # ============================================================================
+  # 405 Method Not Allowed
+  # ============================================================================
+
+  METHOD_NOT_ALLOWED = 'METHOD_NOT_ALLOWED'
 
   # ============================================================================
   # 409 Conflict - Resource already exists or state conflicts
   # ============================================================================
-  
+
   RESOURCE_ALREADY_EXISTS = 'RESOURCE_ALREADY_EXISTS'
   DUPLICATE_EMAIL = 'DUPLICATE_EMAIL'
   DUPLICATE_PHONE = 'DUPLICATE_PHONE'
@@ -64,14 +79,16 @@ module ApiErrorCodes
   CONFLICT = 'CONFLICT'
   RESOURCE_IN_USE = 'RESOURCE_IN_USE'
   CANNOT_DELETE_ACTIVE_RESOURCE = 'CANNOT_DELETE_ACTIVE_RESOURCE'
+  CANNOT_DELETE_RESOURCE = 'CANNOT_DELETE_RESOURCE'
 
   # ============================================================================
   # 422 Unprocessable Entity - Business logic violations
   # ============================================================================
-  
+
   BUSINESS_RULE_VIOLATION = 'BUSINESS_RULE_VIOLATION'
   INVALID_STATE_TRANSITION = 'INVALID_STATE_TRANSITION'
   OPERATION_NOT_ALLOWED = 'OPERATION_NOT_ALLOWED'
+  OPERATION_FAILED = 'OPERATION_FAILED'
   LIMIT_EXCEEDED = 'LIMIT_EXCEEDED'
   QUOTA_EXCEEDED = 'QUOTA_EXCEEDED'
   INVALID_OPERATION = 'INVALID_OPERATION'


### PR DESCRIPTION
## Summary
- 12 error codes referenced as `ApiErrorCodes::XXX` across 11+ controllers (`pipeline_items`, `contacts`, `pipelines`, `labels`, `teams`, `macros`, `automation_rules`, `custom_filters`, `notifications`, `custom_attribute_definitions`, `dashboard_apps`, `webhooks`, `agent_bots`, `inboxes`, `pipeline_tasks`, integration hooks) were used but never defined as constants in `ApiErrorCodes`.
- Evaluating `ApiErrorCodes::XXX` for an undefined constant raises `NameError` *before* `error_response` even runs, turning what should be a clean 404/405/409/422 into an HTTP 500 `INTERNAL_ERROR`.
- Found while testing the AI agent's `pipeline_manipulation` tool: `add_to_pipeline` (POST `/pipelines/:id/pipeline_items`) crashed with `NameError - uninitialized constant ApiErrorCodes::CONVERSATION_NOT_FOUND` whenever the lookup conversation wasn't found.
- Added the 12 missing constants (`CONTACT_NOT_FOUND`, `CONVERSATION_NOT_FOUND`, `TEAM_NOT_FOUND`, `LABEL_NOT_FOUND`, `AUTOMATION_RULE_NOT_FOUND`, `MACRO_NOT_FOUND`, `CUSTOM_FILTER_NOT_FOUND`, `NOTIFICATION_NOT_FOUND`, `CUSTOM_ATTRIBUTE_NOT_FOUND`, `METHOD_NOT_ALLOWED`, `CANNOT_DELETE_RESOURCE`, `OPERATION_FAILED`) to `app/models/concerns/api_error_codes.rb`.
- Added `status: :not_found` to the two `pipeline_items_controller.rb` "not found" responses (conversation/contact), matching the pattern used by every other `*_NOT_FOUND` response in the codebase.

## Test plan
- [x] `ruby -c` syntax check on both changed files
- [ ] Verify `POST /api/v1/pipelines/:id/pipeline_items` with a non-existent `item_id` now returns `404 CONVERSATION_NOT_FOUND` / `404 CONTACT_NOT_FOUND` instead of `500 INTERNAL_ERROR`
- [ ] Verify `PATCH /api/v1/pipelines/:id/pipeline_items/:id/move_to_stage` failure path (`OPERATION_FAILED`) returns `422` instead of `500`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Define missing API error codes and ensure pipeline item not-found errors return 404 instead of 500.

Bug Fixes:
- Add missing ApiErrorCodes constants referenced across controllers to prevent NameError and HTTP 500 responses.
- Update pipeline_items_controller not-found responses for conversations and contacts to use 404 status via error_response.