### PR TITLE
feat(products): bulk import endpoint (EVO-1555 S1)

### DIFF
--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -1,11 +1,12 @@
 class Api::V1::ProductsController < Api::V1::BaseController
   require_permissions({
-    index:   'products.read',
-    show:    'products.read',
-    create:  'products.create',
-    update:  'products.update',
-    destroy: 'products.delete'
-  })
+                        index: 'products.read',
+                        show: 'products.read',
+                        create: 'products.create',
+                        update: 'products.update',
+                        destroy: 'products.delete',
+                        bulk: 'products.create'
+                      })
 
   before_action :fetch_product, only: %i[show update destroy]
 
@@ -57,6 +58,25 @@ class Api::V1::ProductsController < Api::V1::BaseController
     end
   end
 
+  def bulk
+    items = extract_bulk_items
+    return if items.nil?
+
+    created = Products::BulkImporter.new(items).call
+    success_response(
+      data: ProductSerializer.serialize_collection(created.map(&:reload)),
+      message: "#{created.size} products created successfully",
+      status: :created
+    )
+  rescue Products::BulkImporter::BulkImportError => e
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Bulk import failed; no products were created',
+      details: e.errors_payload,
+      status: :unprocessable_entity
+    )
+  end
+
   def destroy
     if @product.destroy
       success_response(
@@ -86,6 +106,29 @@ class Api::V1::ProductsController < Api::V1::BaseController
     )
   end
 
+  def extract_bulk_items
+    raw_items = params[:products]
+    items = raw_items.is_a?(Array) || raw_items.is_a?(ActionController::Parameters) ? Array(raw_items) : []
+    return reject_bulk(ApiErrorCodes::VALIDATION_ERROR, 'products array is required and must not be empty') if items.empty?
+    return reject_bulk_limit(items.size) if items.size > Products::BulkImporter::MAX_ITEMS
+
+    items
+  end
+
+  def reject_bulk(code, message, details: nil)
+    error_response(code, message, details: details, status: :unprocessable_entity)
+    nil
+  end
+
+  def reject_bulk_limit(received)
+    max = Products::BulkImporter::MAX_ITEMS
+    reject_bulk(
+      ApiErrorCodes::LIMIT_EXCEEDED,
+      "Bulk import exceeds maximum of #{max} items per request",
+      details: { max: max, received: received }
+    )
+  end
+
   def filtered_products
     scope = Product.all
     scope = scope.by_kind(params[:kind])
@@ -108,7 +151,7 @@ class Api::V1::ProductsController < Api::V1::BaseController
         variants_attributes: [
           :id, :_destroy, :name, :sku,
           :price_override, :stock_quantity, :position,
-          attributes_data: {}
+          { attributes_data: {} }
         ]
       )
   end

--- a/app/services/products/bulk_importer.rb
+++ b/app/services/products/bulk_importer.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Bulk-imports products in a single ACID transaction (EVO-1555 S1).
+#
+# Public entry point: `Products::BulkImporter.new(items).call`.
+# Raises Products::BulkImporter::BulkImportError carrying a positional
+# errors payload when any item fails — the whole batch is rolled back.
+module Products
+  class BulkImporter
+    MAX_ITEMS = 500
+    SCALAR_ATTRS = %i[
+      name slug kind description sku
+      default_price currency purchase_url
+      status stock_quantity
+    ].freeze
+
+    class BulkImportError < StandardError
+      attr_reader :errors_payload
+
+      def initialize(errors_payload)
+        @errors_payload = errors_payload
+        super('Bulk import failed')
+      end
+    end
+
+    def initialize(items)
+      @items = items
+    end
+
+    def call
+      pre_errors = pre_validate_items
+      raise BulkImportError, pre_errors if pre_errors.any?
+
+      created = []
+
+      ActiveRecord::Base.transaction do
+        errors_acc = []
+        @items.each_with_index { |raw_item, index| import_one(raw_item, index, created, errors_acc) }
+        raise BulkImportError, errors_acc if errors_acc.any?
+      end
+
+      created
+    end
+
+    private
+
+    # First pass: collects all type errors AND intra-batch SKU conflicts together,
+    # so the client gets the full picture in a single 422 instead of finding the
+    # next error only after fixing the previous one.
+    def pre_validate_items
+      errors = []
+      seen_skus = {}
+
+      @items.each_with_index do |raw_item, index|
+        unless hash_like?(raw_item)
+          errors << { index: index, sku: nil, errors: { base: ['item must be a JSON object'] } }
+          next
+        end
+
+        sku = raw_item[:sku]
+        next if sku.blank?
+
+        if seen_skus.key?(sku)
+          errors << { index: index, sku: sku, errors: { sku: ['duplicated within batch'] } }
+        else
+          seen_skus[sku] = index
+        end
+      end
+
+      errors
+    end
+
+    def import_one(raw_item, index, created, errors_acc)
+      scalar_attrs, labels = item_params(raw_item)
+      product = Product.new(scalar_attrs)
+
+      unless product.save
+        errors_acc << { index: index, sku: scalar_attrs[:sku], errors: product.errors.as_json }
+        return
+      end
+
+      product.update_labels(labels) if labels.present?
+      created << product
+    end
+
+    def item_params(raw_item)
+      params_obj = raw_item.is_a?(ActionController::Parameters) ? raw_item : ActionController::Parameters.new(raw_item.to_h)
+      permitted = params_obj.permit(*SCALAR_ATTRS, metadata: {}).to_h.symbolize_keys
+
+      # Normalise blank SKU to nil so the partial unique index (WHERE sku IS NOT NULL)
+      # treats "no SKU" rows as truly absent — otherwise two items with sku: "" raise
+      # PG::UniqueViolation outside the AR validation layer.
+      permitted[:sku] = nil if permitted[:sku].blank?
+
+      labels_raw = params_obj[:labels]
+      labels = labels_raw.present? ? Array(labels_raw).map(&:to_s) : nil
+
+      [permitted, labels]
+    end
+
+    def hash_like?(item)
+      item.is_a?(Hash) || item.is_a?(ActionController::Parameters)
+    end
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,3 +1,5 @@
+require 'digest'
+
 class Rack::Attack
   ### Configure Cache ###
 
@@ -197,6 +199,25 @@ class Rack::Attack
   throttle('/api/v2/reports', limit: ENV.fetch('RATE_LIMIT_REPORTS_API_ACCOUNT_LEVEL', '1000').to_i, period: 1.minute) do |req|
     match_data = %r{/api/v2/reports}.match(req.path)
     req.ip if match_data.present?
+  end
+
+  ## Prevent abuse of products bulk import (EVO-1555 S1)
+  ## Each request can ingest up to 500 products; default 10 reqs/min/key = 5000 products/min/key.
+  ## Endpoint authenticates via Authorization: Bearer; discriminator hashes the token (digest, not raw)
+  ## so the Redis key never holds credentials. Falls back to api_access_token then IP.
+  throttle('api/v1/products/bulk', limit: ENV.fetch('RATE_LIMIT_PRODUCTS_BULK', '10').to_i, period: 1.minute) do |req|
+    if req.path_without_extentions == '/api/v1/products/bulk' && req.post?
+      authorization = req.get_header('HTTP_AUTHORIZATION')
+      api_token     = req.get_header('HTTP_API_ACCESS_TOKEN') || req.get_header('api_access_token')
+
+      if authorization.present?
+        "bearer:#{Digest::SHA256.hexdigest(authorization)}"
+      elsif api_token.present?
+        "api_token:#{Digest::SHA256.hexdigest(api_token)}"
+      else
+        "ip:#{req.ip}"
+      end
+    end
   end
 
   ## ----------------------------------------------- ##

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,10 @@ Rails.application.routes.draw do
 
       # Product Catalog (EVO-1109)
       resources :products, only: [:index, :create, :show, :update, :destroy], controller: 'products' do
+        # Bulk import endpoint (EVO-1555 S1)
+        collection do
+          post :bulk
+        end
         resources :variants, controller: 'products/variants', only: [:index, :create, :update, :destroy]
       end
 

--- a/spec/requests/api/v1/products_bulk_spec.rb
+++ b/spec/requests/api/v1/products_bulk_spec.rb
@@ -1,0 +1,393 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe 'Api::V1::ProductsController#bulk', type: :request do
+  let(:base_url) { 'http://auth.test' }
+  let(:validate_url) { "#{base_url}/api/v1/auth/validate" }
+  let(:token) { 'test-bearer-token' }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+  let!(:user) { User.create!(name: 'Bulk Test User', email: "products-bulk-#{SecureRandom.hex(4)}@example.com") }
+
+  let(:permission_check_url) { "#{base_url}/api/v1/users/#{user.id}/check_permission" }
+
+  around do |example|
+    original_base_url = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+    ENV['EVO_AUTH_SERVICE_URL'] = base_url
+    Rails.cache.clear
+    Current.reset
+    example.run
+    Rails.cache.clear
+    Current.reset
+    ENV['EVO_AUTH_SERVICE_URL'] = original_base_url
+  end
+
+  def stub_auth_ok
+    stub_request(:post, validate_url)
+      .with(headers: { 'Authorization' => "Bearer #{token}" })
+      .to_return(
+        status: 200,
+        body: { success: true, data: { user: { id: user.id, email: user.email } } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def stub_permission(granted:)
+    stub_request(:post, permission_check_url)
+      .to_return(
+        status: 200,
+        body: { success: true, data: { has_permission: granted } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def valid_item(idx)
+    {
+      name: "Product #{idx}",
+      kind: 'physical',
+      sku: "BULK-#{idx}-#{SecureRandom.hex(3)}"
+    }
+  end
+
+  context 'when payload is valid' do
+    before do
+      stub_auth_ok
+      stub_permission(granted: true)
+      Current.user = user
+    end
+
+    it 'AC1 — creates 1 product successfully (201)' do
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: [valid_item(1)] },
+             headers: headers,
+             as: :json
+      end.to change(Product, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      parsed = response.parsed_body
+      expect(parsed['success']).to be(true)
+      expect(parsed['data'].size).to eq(1)
+      expect(parsed['message']).to match(/1 products created/)
+    end
+
+    it 'AC2 — creates 500 products in a single transaction' do
+      items = (1..500).map { |i| valid_item(i) }
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.to change(Product, :count).by(500)
+
+      expect(response).to have_http_status(:created)
+      parsed = response.parsed_body
+      expect(parsed['data'].size).to eq(500)
+    end
+
+    it 'AC8 — allows multiple items without SKU (partial unique index) and normalises blank SKU to nil' do
+      # M3 hardening: two items with sku: "" would otherwise hit PG::UniqueViolation
+      # because the partial index covers non-NULL "" — importer normalises blank → nil.
+      items = [
+        { name: 'No SKU 1', kind: 'physical' },
+        { name: 'No SKU 2', kind: 'physical', sku: '' },
+        { name: 'No SKU 3', kind: 'physical', sku: '' },
+        { name: 'No SKU 4', kind: 'physical', sku: nil }
+      ]
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.to change(Product, :count).by(4)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'M2 — non-Hash array element yields structured 422 (not a 500)' do
+      items = ['not-a-hash', { name: 'OK', kind: 'physical' }]
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      details = response.parsed_body['error']['details']
+      offender = details.find { |d| d['index'] == 0 }
+      expect(offender['errors']['base']).to include('item must be a JSON object')
+    end
+
+    it 'M5 — pre-validation reports type errors AND intra-batch SKU dupes in the same response' do
+      items = [
+        'junk',                                  # type error at index 0
+        { name: 'A', kind: 'physical', sku: 'X' }, # ok
+        { name: 'B', kind: 'physical', sku: 'X' }  # dup at index 2
+      ]
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      details = response.parsed_body['error']['details']
+
+      type_err = details.find { |d| d['index'] == 0 }
+      expect(type_err['errors']['base']).to include('item must be a JSON object')
+
+      dup_err = details.find { |d| d['index'] == 2 }
+      expect(dup_err['errors']['sku']).to include('duplicated within batch')
+    end
+
+    it 'AC9 — applies labels via update_labels (atomic in same transaction)' do
+      items = [{ name: 'Labelled', kind: 'physical', labels: %w[promo novo] }]
+
+      post '/api/v1/products/bulk',
+           params: { products: items },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:created)
+      created = Product.order(created_at: :desc).first
+      expect(created.label_list.sort).to eq(%w[novo promo])
+    end
+  end
+
+  context 'with size violations' do
+    before do
+      stub_auth_ok
+      stub_permission(granted: true)
+      Current.user = user
+    end
+
+    it 'AC3 — returns 422 VALIDATION_ERROR when products array is empty' do
+      post '/api/v1/products/bulk',
+           params: { products: [] },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      parsed = response.parsed_body
+      expect(parsed['success']).to be(false)
+      expect(parsed['error']['code']).to eq('VALIDATION_ERROR')
+      expect(parsed['error']['message']).to match(/required/i)
+    end
+
+    it 'AC3b — returns 422 VALIDATION_ERROR when products key is missing' do
+      post '/api/v1/products/bulk',
+           params: {},
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']['code']).to eq('VALIDATION_ERROR')
+    end
+
+    it 'AC4 — returns 422 LIMIT_EXCEEDED when payload > 500 items' do
+      items = (1..501).map { |i| valid_item(i) }
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      parsed = response.parsed_body
+      expect(parsed['error']['code']).to eq('LIMIT_EXCEEDED')
+      expect(parsed['error']['message']).to match(/500/)
+      expect(parsed['error']['details']['max']).to eq(500)
+      expect(parsed['error']['details']['received']).to eq(501)
+    end
+  end
+
+  context 'when validation fails (rollback)' do
+    before do
+      stub_auth_ok
+      stub_permission(granted: true)
+      Current.user = user
+    end
+
+    it 'AC5 — invalid item in the middle aborts the whole batch' do
+      items = [
+        valid_item(1),
+        valid_item(2),
+        { kind: 'physical', sku: 'NO-NAME' }, # name blank → invalid
+        valid_item(4),
+        valid_item(5)
+      ]
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      parsed = response.parsed_body
+      expect(parsed['error']['code']).to eq('VALIDATION_ERROR')
+      details = parsed['error']['details']
+      expect(details).to be_an(Array)
+      offender = details.find { |d| d['index'] == 2 }
+      expect(offender).to be_present
+      expect(offender['sku']).to eq('NO-NAME')
+      expect(offender['errors']).to have_key('name')
+    end
+
+    it 'AC6 — SKU conflict vs existing DB row aborts batch' do
+      Product.create!(name: 'Existing', kind: 'physical', sku: 'EXISTS-001')
+      items = [
+        valid_item(1),
+        { name: 'Conflict', kind: 'physical', sku: 'EXISTS-001' }
+      ]
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      offender = response.parsed_body['error']['details'].find { |d| d['sku'] == 'EXISTS-001' }
+      expect(offender).to be_present
+      expect(offender['errors']['sku'].join(' ')).to match(/taken/i)
+    end
+
+    it 'AC7 — duplicated SKU within the batch is reported at the 2nd occurrence' do
+      items = [
+        { name: 'A', kind: 'physical', sku: 'DUP-001' },
+        { name: 'B', kind: 'physical' },
+        { name: 'C', kind: 'physical' },
+        { name: 'D', kind: 'physical', sku: 'DUP-001' }
+      ]
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      details = response.parsed_body['error']['details']
+      offender = details.find { |d| d['index'] == 3 }
+      expect(offender).to be_present
+      expect(offender['sku']).to eq('DUP-001')
+      expect(offender['errors']['sku']).to include('duplicated within batch')
+    end
+
+    it 'AC13 — atomicity: no taggings leak when batch aborts mid-loop' do
+      taggings_before = ActsAsTaggableOn::Tagging.count
+      items = [
+        { name: 'With labels', kind: 'physical', labels: %w[tag-a tag-b] },
+        { kind: 'physical' } # name blank → triggers rollback after first label was attempted
+      ]
+
+      expect do
+        post '/api/v1/products/bulk',
+             params: { products: items },
+             headers: headers,
+             as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(ActsAsTaggableOn::Tagging.count).to eq(taggings_before)
+    end
+  end
+
+  context 'when authn/authz checks run' do
+    it 'AC10 — returns 403 when user lacks products.create' do
+      stub_auth_ok
+      stub_permission(granted: false)
+      Current.user = user
+
+      post '/api/v1/products/bulk',
+           params: { products: [valid_item(1)] },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'AC11 — returns 401 when no auth header is provided' do
+      post '/api/v1/products/bulk',
+           params: { products: [valid_item(1)] },
+           as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'with rate-limit (Rack::Attack)' do
+    before do
+      stub_auth_ok
+      stub_permission(granted: true)
+      Current.user = user
+      Rack::Attack.enabled = true
+      Rack::Attack.reset!
+    end
+
+    after do
+      Rack::Attack.enabled = false
+      Rack::Attack.reset!
+    end
+
+    it 'AC12 — registers the api/v1/products/bulk throttle with sane defaults' do
+      throttle = Rack::Attack.throttles['api/v1/products/bulk']
+      expect(throttle).to be_present
+      expect(throttle.limit).to eq(10)
+      expect(throttle.period).to eq(60)
+    end
+
+    # We drive Rack::Attack directly via Rack::MockRequest because Rails request
+    # specs construct a middleware stack that bypasses Rack::Attack throttles even
+    # when Rack::Attack.enabled is toggled at runtime (verified by tracing the throttle
+    # block — it is never invoked under rspec request flow). The MockRequest path
+    # exercises the *same* throttle declaration end-to-end (discriminator + counter)
+    # and proves the 11th hit returns 429 in production-equivalent code paths.
+    #
+    # We swap the cache store to MemoryStore here because the production store
+    # ($velma + redis-namespace) is incompatible with Rack::Attack::Cache#increment
+    # under direct invocation — that's a known wiring quirk and unrelated to the
+    # throttle declaration itself.
+    context 'when driven via Rack::MockRequest' do
+      let(:downstream_app) { ->(_env) { [200, {}, ['ok']] } }
+      let(:mock_session) { Rack::MockRequest.new(Rack::Attack.new(downstream_app)) }
+
+      around do |example|
+        original_store = Rack::Attack.cache.store
+        Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+        example.run
+        Rack::Attack.cache.store = original_store
+      end
+
+      it 'AC12b — the 11th POST /api/v1/products/bulk returns 429' do
+        headers_env = { 'HTTP_API_ACCESS_TOKEN' => 'rl-mock-evo1555' }
+
+        10.times { mock_session.post('/api/v1/products/bulk', headers_env) }
+        last = mock_session.post('/api/v1/products/bulk', headers_env)
+
+        expect(last.status).to eq(429)
+      end
+
+      it 'AC12c — non-bulk POST /api/v1/products is not throttled (route specificity)' do
+        headers_env = { 'HTTP_API_ACCESS_TOKEN' => 'rl-mock-evo1555' }
+
+        12.times { mock_session.post('/api/v1/products', headers_env) }
+
+        expect(mock_session.post('/api/v1/products', headers_env).status).to eq(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/products/bulk` accepting up to 500 products in a single ACID transaction (S1 da EVO-1555). Reaproveita 100% da modelagem entregue na EVO-1109 — apenas adiciona o pipeline de ingestão em lote.

- Endpoint novo no `Api::V1::ProductsController` (`require_permissions(bulk: 'products.create')`)
- Service object `Products::BulkImporter` encapsula a transação, dedup intra-batch de SKU, normalização e tratamento de erros
- Rate-limit dedicado no Rack::Attack: 10 req/min/key, discriminator = SHA256(Authorization Bearer) → SHA256(api_access_token) → IP (credenciais nunca caem em chave de Redis)
- Resposta 422 estruturada com array de erros indexados por posição quando algo falha — sempre rollback total

## v1 entrega só `fail` na política de conflito de SKU

A AC original do card Linear cita `skip / overwrite / fail` como política configurável. **Esta story (S1) entrega apenas `fail` (rollback total em qualquer conflito de SKU vs DB ou intra-batch).** `skip` e `overwrite` são out-of-scope por decisão do tech-spec — fast-follow se virar demanda real. CSV UI (S2) e webhook ERP (S3) também ficam para stories filhas.

## Hardening rounds 1+2 (revisão antes do PR)

- **H1:** Gemfile.lock revertido (poluído por bundle install em container Linux durante test run)
- **M1:** discriminator do throttle agora hasheia o token em vez de usar header literal
- **M2:** elemento não-Hash no array vira 422 estruturado, não 500
- **M3:** `sku: ''` normalizado pra `nil` antes do save (evita `PG::UniqueViolation` no índice parcial)
- **M5:** pre-validação unifica type-check + dedup SKU numa única passada — cliente recebe todos os erros estruturais juntos

## Validation

- `evo-ai-crm-community: docker exec evo-crm-community-evo-crm-1 sh -lc "cd /app && DATABASE_NAME=evo_community_test POSTGRES_DATABASE=evo_community_test bundle exec rspec spec/requests/api/v1/products_bulk_spec.rb"` → **18/18 verde em 8.81s** (cobre AC1–AC13 + M2/M5)
- `evo-ai-crm-community: bundle exec rubocop app/controllers/api/v1/products_controller.rb app/services/products/bulk_importer.rb config/initializers/rack_attack.rb config/routes.rb spec/requests/api/v1/products_bulk_spec.rb` → limpo no diff (2 offenses pré-existentes em `rack_attack.rb:187,200` fora do escopo)

### Smoke manual (a fazer pré-merge)

Endpoint requer container rodando + auth-service. Comandos sugeridos:
- `curl POST /api/v1/products/bulk` com 1 item válido → 201
- `curl POST /api/v1/products/bulk` com 501 itens → 422 `LIMIT_EXCEEDED`
- `curl POST /api/v1/products/bulk` 11x em <1min → 11ª deve voltar 429 (Rack::Attack)

## Changed Files

- `app/controllers/api/v1/products_controller.rb`
- `app/services/products/bulk_importer.rb` (NEW)
- `config/routes.rb`
- `config/initializers/rack_attack.rb`
- `spec/requests/api/v1/products_bulk_spec.rb` (NEW — primeiro spec de Products no repo)

## Linked Issue

- EVO-1555 (S1)

cc @Davidson

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a bulk products import API endpoint that creates multiple products in a single transactional operation with structured validation errors and rate limiting.

New Features:
- Introduce POST /api/v1/products/bulk endpoint to create up to 500 products per request under products.create permissions.
- Add Products::BulkImporter service to handle transactional batch creation, validation, and label assignment for products.

Enhancements:
- Add request-level validations for bulk import payload shape, item count limits, and intra-batch SKU conflicts with unified error reporting.
- Normalize blank SKUs to nil during bulk import to align with partial unique index semantics.
- Configure a dedicated Rack::Attack throttle for the bulk products import endpoint keyed by hashed credentials or IP for abuse protection.

Tests:
- Add request specs for the bulk products import endpoint covering success, validation failures, limits, and rate limiting behavior.