### PR TITLE
fix(templates): preserve same-named legacy migrations + harden run (EVO-1718)

### DIFF
--- a/app/jobs/migrate_legacy_templates_to_message_template_job.rb
+++ b/app/jobs/migrate_legacy_templates_to_message_template_job.rb
@@ -35,13 +35,14 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
   }.freeze
   DEFAULT_SOURCE_LABEL = 'other_legacy_template'
 
-  # Skip reasons. The four below are the documented taxonomy; specs/ACs assert on
-  # these exact keys. `:invalid` (built copy failed validation, e.g. a stray
+  # Skip reasons. The three below are the documented taxonomy; specs/ACs assert
+  # on these exact keys. `:invalid` (built copy failed validation, e.g. a stray
   # media_type) and `:error` (unexpected exception) are diagnostic buckets.
+  # NOTE: there is deliberately no :duplicate_name reason — same-named legacy
+  # rows are preserved (the later one is name-suffixed), never skipped (EVO-1718).
   REASON_WHATSAPP_CLOUD = :whatsapp_cloud
   REASON_INVALID_CONTENT = :invalid_content
   REASON_ALREADY_MIGRATED = :already_migrated
-  REASON_DUPLICATE_NAME = :duplicate_name
 
   def perform(dry_run: false)
     summary = { migrated: Hash.new(0), skipped: Hash.new(0), dry_run: dry_run }
@@ -51,8 +52,7 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
       dry_run: dry_run,
       summary: summary,
       seen_keys: Set.new,    # external_legacy_id keys produced this run
-      all_names: Set.new,    # every global name produced this run (downcased)
-      legacy_names: Set.new  # global names produced by THIS migration this run (downcased)
+      all_names: Set.new     # every global name produced this run (downcased)
     }
 
     MessageTemplate.where.not(channel_id: nil).find_in_batches(batch_size: BATCH_SIZE) do |batch|
@@ -60,7 +60,7 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
         migrate_one(source, ctx)
       rescue StandardError => e
         Rails.logger.error(
-          "[migrate_legacy_templates] source_id=#{source.id} error=#{e.class}: #{e.message}"
+          "[migrate_legacy_templates] source_id=#{source.id} error=#{e.class}: #{error_detail(e)}"
         )
         summary[:skipped][:error] += 1
       end
@@ -89,9 +89,9 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
       return skip(ctx, REASON_ALREADY_MIGRATED, source, 'already migrated')
     end
 
-    # 4. Resolve the global name (dedupe vs other legacy rows, suffix vs admin globals).
+    # 4. Resolve the global name. Collisions (with an admin global OR another
+    #    legacy row) are suffixed, never skipped — every legacy row gets a global.
     target_name = resolve_name(source, ctx)
-    return skip(ctx, REASON_DUPLICATE_NAME, source, 'another legacy row already owns this name') if target_name == :duplicate
 
     attrs = build_attrs(source, key, target_name)
 
@@ -120,27 +120,29 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
     channel.provider == 'whatsapp_cloud'
   end
 
-  # Returns the global name to use, or :duplicate when another legacy migration
-  # row already owns this base name (one global per legacy name is enough).
+  # Returns the global name to use for this source. Every legacy row gets a
+  # global: a free name is used as-is; a taken one (owned by an admin global OR
+  # by another legacy row migrated this run/earlier) is suffixed so both rows
+  # survive (EVO-1718 preserve-both).
   def resolve_name(source, ctx)
     base = source.name
-    base_key = base.downcase
-
-    # Owned by a legacy migration already (this run OR committed) -> duplicate.
-    return :duplicate if ctx[:legacy_names].include?(base_key) || legacy_global_exists?(base)
 
     # Free among all globals -> use as-is.
     return base unless global_name_taken?(base, ctx)
 
-    # Collides with a genuine pre-existing (admin-created) global -> suffix.
+    # Taken -> prefer the human-friendly "(legacy)" suffix.
     suffixed = "#{base} (legacy)"
     return suffixed unless global_name_taken?(suffixed, ctx)
 
-    "#{base} (legacy #{source.id})"
+    # "(legacy)" is also taken -> fall back to the id-qualified form. We do not
+    # re-check it against the name set: source.id is unique per row, so this
+    # matches the original final-fallback behavior (no guard against a
+    # hand-crafted admin global of the same literal text, just as before).
+    id_suffixed_name(source)
   end
 
-  def legacy_global_exists?(name)
-    MessageTemplate.where(channel_id: nil, name: name).where.not(external_legacy_id: nil).exists?
+  def id_suffixed_name(source)
+    "#{source.name} (legacy #{source.id})"
   end
 
   def global_name_taken?(name, ctx)
@@ -165,22 +167,29 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
       # only survives for vars whose names actually appear in content.
       variables: deep_dup(source.variables),
       media_url: source.media_url,
-      media_type: source.media_type.presence, # '' -> nil so inclusion+allow_nil passes (F6)
+      media_type: normalized_media_type(source.media_type),
       settings: deep_dup(source.settings),
       metadata: deep_dup(source.metadata)
     }
   end
 
-  # The Dec-2025 migration only ever wrote text/media/interactive (all valid enum
-  # keys). Guard defensively anyway: an out-of-enum value raises ArgumentError at
-  # assignment, so fall back to the model default (set_defaults => 'text').
+  # Defensive enum normalization. In Rails 7.1 the enum reader already
+  # deserializes any out-of-enum stored value to nil (EnumType#deserialize ->
+  # mapping.key(...) misses) and assignment coerces via value.presence without
+  # raising — so these guards fix no observed bug. They exist for symmetry and to
+  # keep build_attrs honest if a non-enum value ever reaches us: an unknown key
+  # (or '') becomes nil, which the model treats as "unset" — set_defaults supplies
+  # the template_type default and media_type stays nil (passes inclusion allow_nil).
   def normalized_template_type(value)
     MessageTemplate.template_types.key?(value) ? value : nil
   end
 
+  def normalized_media_type(value)
+    MessageTemplate.media_types.key?(value) ? value : nil
+  end
+
   def record_success(ctx, source, name, key)
     ctx[:all_names] << name.downcase
-    ctx[:legacy_names] << name.downcase
     ctx[:seen_keys] << key
     ctx[:summary][:migrated][source_label(source)] += 1
   end
@@ -193,6 +202,17 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
     ctx[:summary][:skipped][reason] += 1
     increment_skipped_metric(reason) unless ctx[:dry_run]
     nil
+  end
+
+  # Prefer a record's validation messages (RecordInvalid et al.) over the bare
+  # exception message, but never regress to an empty string when a record carries
+  # no messages — fall back to the exception message in that case (F10).
+  def error_detail(error)
+    if error.respond_to?(:record) && error.record
+      error.record.errors.full_messages.join('; ').presence || error.message
+    else
+      error.message
+    end
   end
 
   def legacy_key(source)

--- a/lib/tasks/templates.rake
+++ b/lib/tasks/templates.rake
@@ -17,6 +17,14 @@ namespace :templates do
     summary = MigrateLegacyTemplatesToMessageTemplateJob.perform_now(dry_run: dry_run)
     puts "[templates:migrate_legacy] dry_run=#{dry_run} #{summary.except(:dry_run).inspect}"
     puts '[templates:migrate_legacy] DRY RUN — no rows were written. Re-run without DRY_RUN to apply.' if dry_run
+
+    # The job only buckets a row under :error when an UNEXPECTED exception is
+    # rescued (expected skips use their own reasons). Surface that as a non-zero
+    # exit AFTER printing the summary, so operators/CI never read a partially
+    # failed run as success. Applies to dry-run too: a dry-run that errors is
+    # predicting a broken real run. (skipped is a Hash.new(0) — always Integer.)
+    errors = summary[:skipped][:error]
+    abort("[templates:migrate_legacy] FAILED: #{errors} row(s) errored — see log above") if errors.positive?
   end
 
   desc 'Rollback: delete every global template created by the legacy migration'

--- a/spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb
+++ b/spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe MigrateLegacyTemplatesToMessageTemplateJob, type: :job do
       expect(@summary[:skipped]).to be_empty
     end
 
-    it 'predicts the SAME count a real run produces for same-named sources (F1 regression)' do
+    it 'predicts the SAME count a real run produces for same-named sources (EVO-1718 preserve-both)' do
       c2 = whatsapp_channel(provider: 'baileys')
       coupled_template(channel: baileys, name: 'Shared', content: 'A')
       coupled_template(channel: c2, name: 'Shared', content: 'B')
 
       summary = described_class.new.perform(dry_run: true)
 
-      # One global would be created; the second same-named row is a duplicate —
-      # exactly what a real run yields. Dry run must not double-count.
+      # Both rows are preserved (the 2nd gets a suffixed name), so a real run
+      # would create TWO globals — dry run must predict the same and skip nothing.
       migrated_total = summary[:migrated].values.sum
-      expect(migrated_total).to eq(1)
-      expect(summary[:skipped][:duplicate_name]).to eq(1)
+      expect(migrated_total).to eq(2)
+      expect(summary[:skipped]).to be_empty
       expect(globals.count).to eq(0)
     end
   end
@@ -122,15 +122,19 @@ RSpec.describe MigrateLegacyTemplatesToMessageTemplateJob, type: :job do
       expect(globals.find_by(name: 'Offer').external_legacy_id).to be_nil # admin row intact
     end
 
-    it 'creates exactly one global when two legacy rows share a name' do
+    it 'preserves both legacy rows when two share a name (2nd suffixed)' do
       c2 = whatsapp_channel(provider: 'baileys')
       coupled_template(channel: baileys, name: 'Dup', content: 'A')
       coupled_template(channel: c2, name: 'Dup', content: 'B')
 
       summary = described_class.new.perform
 
-      expect(globals.where(name: 'Dup').count).to eq(1)
-      expect(summary[:skipped][:duplicate_name]).to eq(1)
+      # find_in_batches orders by id, so the earlier row keeps the bare name and
+      # the later one is suffixed — both survive, nothing is skipped.
+      migrated_names = globals.where.not(external_legacy_id: nil).pluck(:name)
+      expect(migrated_names).to contain_exactly('Dup', 'Dup (legacy)')
+      expect(summary[:migrated].values.sum).to eq(2)
+      expect(summary[:skipped]).to be_empty
     end
   end
 
@@ -146,6 +150,81 @@ RSpec.describe MigrateLegacyTemplatesToMessageTemplateJob, type: :job do
       expect(MessageTemplate.exists?(admin.id)).to be(true)
       expect(MessageTemplate.exists?(source.id)).to be(true)
       expect(globals.where.not(external_legacy_id: nil).count).to eq(0)
+    end
+  end
+
+  # EVO-1718 follow-up: the AC labels above (AC1–AC7) are EVO-1234's. The blocks
+  # below cover the EVO-1718 review findings directly; they are named by finding
+  # rather than reusing the AСn labels to avoid collision.
+
+  # F2: defensive enum symmetry. NOTE — in Rails 7.1 the media_type reader already
+  # nils any out-of-enum stored value, so this guard fixes no observed bug; we
+  # unit-test the guard directly (a DB round-trip would be a tautology).
+  describe 'media_type normalization (EVO-1718 F2)' do
+    it 'maps unknown/blank/nil media_type to nil and passes valid keys through' do
+      job = described_class.new
+      expect(job.send(:normalized_media_type, 'sticker')).to be_nil
+      expect(job.send(:normalized_media_type, '')).to be_nil
+      expect(job.send(:normalized_media_type, nil)).to be_nil
+      expect(job.send(:normalized_media_type, 'image')).to eq('image')
+    end
+  end
+
+  # F11: channel_type drives the source label. We exercise the private mapper with
+  # a stub rather than building a real Telegram-coupled template — wiring a
+  # mismatched polymorphic channel_type/channel_id would pass for the wrong reason.
+  describe 'source label by channel_type (EVO-1718 F11)' do
+    it 'maps known channel types to their label and falls back to the default' do
+      job = described_class.new
+      expect(job.send(:source_label, instance_double(MessageTemplate, channel_type: 'Channel::Telegram')))
+        .to eq('telegram_legacy_template')
+      expect(job.send(:source_label, instance_double(MessageTemplate, channel_type: 'Channel::Instagram')))
+        .to eq('instagram_legacy_template')
+      expect(job.send(:source_label, instance_double(MessageTemplate, channel_type: 'Channel::Unknown')))
+        .to eq('other_legacy_template')
+    end
+  end
+
+  # F5: the copy's before_save re-derives variables from {{tokens}} in content.
+  # The Dec-2025 rows were written by raw SQL, so they can carry synthetic
+  # component vars (var_1...) absent from content. update_columns reproduces that
+  # callback-bypassing shape (the model would otherwise prune them on save).
+  describe 'synthetic variable pruning on the copy (EVO-1718 F5)' do
+    it 'drops component-derived vars absent from content, keeping real tokens' do
+      source = coupled_template(channel: baileys, name: 'Vars', content: 'Hi {{name}}')
+      # rubocop:disable Rails/SkipsModelValidations -- intentional: mimic the raw
+      # Dec-2025 SQL write that bypasses the model's variable-pruning callback.
+      source.update_columns(variables: [
+                              { 'name' => 'name', 'type' => 'text', 'required' => false },
+                              { 'name' => 'var_1', 'type' => 'text', 'required' => false }
+                            ])
+      # rubocop:enable Rails/SkipsModelValidations
+
+      described_class.new.perform
+
+      copy = MessageTemplate.find_by(external_legacy_id: "message_template:#{source.id}")
+      var_names = copy.variables.map { |v| v['name'] }
+      expect(var_names).to include('name')
+      expect(var_names).not_to include('var_1')
+    end
+  end
+
+  # F3/F10: an unexpected create! failure is rescued, logged with the record's
+  # validation messages (not an empty string), and bucketed under :error.
+  describe 'unexpected create failure diagnostics (EVO-1718)' do
+    it 'logs the record full_messages and buckets the row under :error' do
+      coupled_template(channel: baileys, name: 'Boom', content: 'hi')
+
+      invalid = MessageTemplate.new
+      invalid.errors.add(:content, "can't be blank")
+      allow(MessageTemplate).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(invalid))
+      allow(Rails.logger).to receive(:error).and_call_original
+
+      summary = described_class.new.perform
+
+      expect(Rails.logger).to have_received(:error).with(/Content can't be blank/)
+      expect(summary[:skipped][:error]).to eq(1)
+      expect(globals.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
## Summary

Non-blocking follow-up to the review of the EVO-1234 [6.5] legacy → `MessageTemplate` migration job (`MigrateLegacyTemplatesToMessageTemplateJob`). The feature was already correct (dry-run + rollback + idempotent); this addresses the review findings:

- **🟡 [Medium] Duplicate name → data loss.** When two channel-coupled rows shared a name (different channels), only the first became a global; the second was skipped `:duplicate_name` **forever**, so its content never reached the global menu. `resolve_name` now **preserves both**: a legacy-vs-legacy collision is suffixed (`"<name> (legacy)"`, then `"<name> (legacy <id>)"`), never skipped. The dead `:duplicate` sentinel, `REASON_DUPLICATE_NAME`, the `legacy_names` dedup set and `legacy_global_exists?` are removed (the latter is subsumed by `global_name_taken?`). The two-tier admin-collision suffix is unchanged.
- **🟡 [Medium] `media_type` had no enum guard.** Added `normalized_media_type` mirroring `normalized_template_type`, wired into `build_attrs` (replacing `source.media_type.presence`). **Note:** in Rails 7.1 the enum reader already deserializes an out-of-enum stored value to `nil` and assignment does not raise — so this is **defensive symmetry, not a behavior fix** (the prior "raises ArgumentError on assignment" comment was wrong and is corrected). The rescue now logs `record.errors.full_messages.presence || e.message`, never an empty string.
- **🟡 [Medium] Rake exited 0 even when every row failed.** `templates:migrate_legacy` now `abort`s (non-zero exit) when `summary[:skipped][:error] > 0`, **after** printing the summary. Gates on `:error` (unexpected exceptions) only, not `:invalid` (a predictable dry-run validation skip); applies to dry-run too. `rollback_legacy_migration` is unchanged.

No DB migration, no destructive change — originals and admin globals are never touched.

## Test plan

`spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb` — **13 examples, 0 failures** (run locally; crm-community does not run RSpec in CI):

- The two same-name cases reworked to **preserve-both** (dry-run predicts 2 migrations; a real run creates `Dup` + `Dup (legacy)`, nothing skipped).
- `normalized_media_type` unit-tested directly (`'sticker'`/`''`/`nil` → nil, `'image'` passes) — a DB round-trip would be a tautology given the Rails 7.1 reader.
- `source_label` tested via `instance_double(MessageTemplate, channel_type:)` (a mismatched polymorphic fixture would pass for the wrong reason).
- Rescue diagnostics: a `RecordInvalid` is logged with `full_messages` and bucketed under `:error`.
- Synthetic-variable pruning (`var_1` injected via `update_columns` to mimic the raw Dec-2025 SQL write) is dropped on the copy.
- Existing EVO-1234 ACs (idempotency, rollback scope, WhatsApp Cloud, blank content) remain green.

Rake gate verified out-of-spec (rake tasks aren't loaded there): forced `skipped[:error]=2` → prints summary then `FAILED: …` and **exit 1**; clean run and dry-run → **exit 0**. RuboCop: no new offenses on touched files.

## Notas

- **Behavior change:** `skipped[:duplicate_name]` disappears for legacy-vs-legacy collisions (now suffixed). Any dashboard keying on that bucket will see it drop to 0 — expected.
- **Bare-name "winner" is arbitrary** (UUID/PK order) but now cosmetic only — both contents survive. Left non-deterministic by design.
- The `channel_id` error-key rename mentioned in the EVO-1717 review is **EVO-1717 #2**, not this ticket; its client-facing benefit unblocks via 6.4 / EVO-1233 (already merged).