### PR TITLE
fix(templates): harden legacy-migration job per Sourcery review (EVO-1719)

### DIFF
--- a/app/jobs/migrate_legacy_templates_to_message_template_job.rb
+++ b/app/jobs/migrate_legacy_templates_to_message_template_job.rb
@@ -36,13 +36,17 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
   DEFAULT_SOURCE_LABEL = 'other_legacy_template'
 
   # Skip reasons. The three below are the documented taxonomy; specs/ACs assert
-  # on these exact keys. `:invalid` (built copy failed validation, e.g. a stray
-  # media_type) and `:error` (unexpected exception) are diagnostic buckets.
+  # on these exact keys. REASON_VALIDATION_FAILED (built copy failed validation,
+  # e.g. a stray media_type) and REASON_ERROR (unexpected exception) are the
+  # lower-tier diagnostic buckets — kept distinct from the taxonomy above.
   # NOTE: there is deliberately no :duplicate_name reason — same-named legacy
   # rows are preserved (the later one is name-suffixed), never skipped (EVO-1718).
   REASON_WHATSAPP_CLOUD = :whatsapp_cloud
   REASON_INVALID_CONTENT = :invalid_content
   REASON_ALREADY_MIGRATED = :already_migrated
+  # Diagnostic buckets (named distinctly from REASON_INVALID_CONTENT on purpose).
+  REASON_VALIDATION_FAILED = :invalid
+  REASON_ERROR = :error
 
   def perform(dry_run: false)
     summary = { migrated: Hash.new(0), skipped: Hash.new(0), dry_run: dry_run }
@@ -55,14 +59,14 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
       all_names: Set.new     # every global name produced this run (downcased)
     }
 
-    MessageTemplate.where.not(channel_id: nil).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+    MessageTemplate.where.not(channel_id: nil).includes(:channel).find_in_batches(batch_size: BATCH_SIZE) do |batch|
       batch.each do |source|
         migrate_one(source, ctx)
       rescue StandardError => e
         Rails.logger.error(
           "[migrate_legacy_templates] source_id=#{source.id} error=#{e.class}: #{error_detail(e)}"
         )
-        summary[:skipped][:error] += 1
+        summary[:skipped][REASON_ERROR] += 1
       end
     end
 
@@ -98,7 +102,7 @@ class MigrateLegacyTemplatesToMessageTemplateJob < ApplicationJob
     if ctx[:dry_run]
       candidate = MessageTemplate.new(attrs)
       unless candidate.valid?
-        return skip(ctx, :invalid, source, candidate.errors.full_messages.join('; '))
+        return skip(ctx, REASON_VALIDATION_FAILED, source, candidate.errors.full_messages.join('; '))
       end
     else
       MessageTemplate.create!(attrs)

--- a/lib/tasks/templates.rake
+++ b/lib/tasks/templates.rake
@@ -23,15 +23,18 @@ namespace :templates do
     # exit AFTER printing the summary, so operators/CI never read a partially
     # failed run as success. Applies to dry-run too: a dry-run that errors is
     # predicting a broken real run. (skipped is a Hash.new(0) — always Integer.)
-    errors = summary[:skipped][:error]
+    errors = summary[:skipped][MigrateLegacyTemplatesToMessageTemplateJob::REASON_ERROR]
     abort("[templates:migrate_legacy] FAILED: #{errors} row(s) errored — see log above") if errors.positive?
   end
 
   desc 'Rollback: delete every global template created by the legacy migration'
   task rollback_legacy_migration: :environment do
-    # Only rows carrying a provenance key are deleted; channel-bound originals
-    # and admin-created globals (external_legacy_id IS NULL) are never touched.
-    scope = MessageTemplate.where.not(external_legacy_id: nil)
+    # Only rows whose provenance key was minted by THIS migration are deleted
+    # (external_legacy_id LIKE 'message_template:%'); channel-bound originals,
+    # admin-created globals (external_legacy_id IS NULL), and any rows tagged by
+    # a future unrelated integration are never touched.
+    prefix = MigrateLegacyTemplatesToMessageTemplateJob::LEGACY_KEY_PREFIX
+    scope = MessageTemplate.where('external_legacy_id LIKE ?', "#{prefix}:%")
     count = scope.count
     scope.delete_all
     puts "[templates:rollback_legacy_migration] deleted #{count} migrated global templates"

--- a/spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb
+++ b/spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb
@@ -139,17 +139,24 @@ RSpec.describe MigrateLegacyTemplatesToMessageTemplateJob, type: :job do
   end
 
   describe 'rollback scope (AC7)' do
-    it 'deletes only migrated globals, leaving originals and admin globals' do
+    it 'deletes only this migration\'s globals, leaving originals, admin globals, and foreign-provenance rows' do
       admin = MessageTemplate.create!(channel: nil, name: 'Kept', content: 'admin')
       source = coupled_template(channel: baileys, name: 'Migrated')
+      # A global tagged by a hypothetical OTHER integration. The old unscoped
+      # rollback (where.not(external_legacy_id: nil)) would have wrongly deleted
+      # this; the prefix-scoped delete must spare it. Without this row the test
+      # is vacuous — it would pass against the old scope too.
+      foreign = MessageTemplate.create!(channel: nil, name: 'Foreign', content: 'x',
+                                        external_legacy_id: 'other_integration:1')
       described_class.new.perform
 
-      # Mirrors lib/tasks/templates.rake rollback_legacy_migration.
-      MessageTemplate.where.not(external_legacy_id: nil).delete_all
+      # Mirrors lib/tasks/templates.rake rollback_legacy_migration (prefix-scoped).
+      MessageTemplate.where('external_legacy_id LIKE ?', "#{described_class::LEGACY_KEY_PREFIX}:%").delete_all
 
       expect(MessageTemplate.exists?(admin.id)).to be(true)
       expect(MessageTemplate.exists?(source.id)).to be(true)
-      expect(globals.where.not(external_legacy_id: nil).count).to eq(0)
+      expect(MessageTemplate.exists?(foreign.id)).to be(true)
+      expect(globals.where('external_legacy_id LIKE ?', "#{described_class::LEGACY_KEY_PREFIX}:%").count).to eq(0)
     end
   end
 
@@ -223,7 +230,7 @@ RSpec.describe MigrateLegacyTemplatesToMessageTemplateJob, type: :job do
       summary = described_class.new.perform
 
       expect(Rails.logger).to have_received(:error).with(/Content can't be blank/)
-      expect(summary[:skipped][:error]).to eq(1)
+      expect(summary[:skipped][described_class::REASON_ERROR]).to eq(1)
       expect(globals.count).to eq(0)
     end
   end


### PR DESCRIPTION
## Summary

Non-blocking follow-up (6.10) to the **Sourcery review** of the EVO-1234 [6.5] legacy → `MessageTemplate` migration job. Four points raised; three applied, one intentionally declined.

- **🟡 [Medium] N+1 on the batch loop.** `MessageTemplate.where.not(channel_id: nil).find_in_batches` had no preload, so `keep_channel_bound?` issued a per-row `source.channel` query for every WhatsApp row. Added `.includes(:channel)`. (`channel` is a polymorphic `belongs_to`; `includes` keeps it a preload and preserves `find_in_batches`' default `ORDER BY id`.)
- **🟡 [Medium] Over-broad rollback DELETE.** `rollback_legacy_migration` deleted `where.not(external_legacy_id: nil)`. The column is exclusive to this migration today, but a future integration reusing it would be wiped. Scoped to this migration's provenance prefix: `external_legacy_id LIKE 'message_template:%'`, reusing `MigrateLegacyTemplatesToMessageTemplateJob::LEGACY_KEY_PREFIX`. The rollback spec mirrors the filter **and** now seeds a foreign-provenance row (`other_integration:1`) that must survive — without it the test was vacuous (passed against the old scope too).
- **🟢 [Low] Raw skip-reason symbols.** `:invalid` and `:error` escaped the `REASON_*` convention. Promoted to `REASON_VALIDATION_FAILED` / `REASON_ERROR` (used in the job, the rake `:error` gate, and the spec). Named **`REASON_VALIDATION_FAILED`, not `REASON_INVALID`**, to avoid a near-synonym collision with the existing `REASON_INVALID_CONTENT`. Symbol values are unchanged, and the comment's deliberate "documented taxonomy vs. diagnostic buckets" two-tier distinction is preserved.
- **⚪ [Declined] `require 'set'`.** Not added. Under Ruby 3.4 `Set` is autoloaded and `require 'set'` trips `Lint/RedundantRequireStatement` (verified: 1 offense, autocorrectable) — adding it would *introduce* a lint offense. This matches Sourcery's own "não procede / inócuo" verdict on this point.

No migration, no schema change, no behavior change.

## Test plan

- `POSTGRES_PORT=5433 ... bundle exec rspec spec/jobs/migrate_legacy_templates_to_message_template_job_spec.rb` → **13 examples, 0 failures**.
- **Non-vacuity check (rollback):** temporarily reverting the spec's delete to the old `where.not(external_legacy_id: nil)` makes the example FAIL on the foreign-provenance assertion — confirming the test now distinguishes the new scope.
- **RuboCop:** 9 offenses on the branch == 9 on the `develop` baseline → **zero new offenses**; `Lint/RedundantRequireStatement` = 0.

## Notes

- Builds on EVO-1234 (#136) and EVO-1718 (#148), both merged to `develop`.
- The `require 'set'` decision is the only one of the 4 points not coded; rationale above is the resolution for the Sourcery thread.

## Summary by Sourcery

Harden the legacy-to-MessageTemplate migration job and rollback task based on Sourcery review feedback, tightening rollback scoping, naming skip reasons, and reducing query overhead.

Bug Fixes:
- Restrict the rollback migration to delete only templates created by this migration using the legacy key prefix, ensuring admin and foreign-provenance templates are preserved.

Enhancements:
- Add eager loading of channels when batching message templates to avoid N+1 queries during migration.
- Introduce named constants for validation-failure and error skip reasons and update the job, rake task, and specs to consistently use them.
- Strengthen the rollback spec to assert that foreign-provenance templates survive and that only this migration's templates are removed.