### PR TITLE
fix(templates): silence inbound WARN + guard blank auto-replies (EVO-1720)

### DIFF
--- a/app/controllers/public/api/v1/inboxes/messages_controller.rb
+++ b/app/controllers/public/api/v1/inboxes/messages_controller.rb
@@ -1,6 +1,4 @@
 class Public::Api::V1::Inboxes::MessagesController < Public::Api::V1::InboxesController
-  include TemplateConsumerLogging
-
   before_action :set_message, only: [:update]
 
   def index
@@ -8,9 +6,6 @@ class Public::Api::V1::Inboxes::MessagesController < Public::Api::V1::InboxesCon
   end
 
   def create
-    # Coexistence (EVO-1235): flag external consumers still pushing inline body
-    # so they can be migrated to the templated send action.
-    warn_legacy_inline_content(action: 'messages#create', inbox_identifier: params[:inbox_id]) if permitted_params[:content].present?
     @message = @conversation.messages.new(message_params)
     build_attachment
     @message.save!

--- a/app/services/message_templates/template/greeting.rb
+++ b/app/services/message_templates/template/greeting.rb
@@ -4,8 +4,17 @@ class MessageTemplates::Template::Greeting
   pattr_initialize [:conversation!]
 
   def perform
+    content = greeting_content
+    # Skip silently when neither the template nor the inline fallback yields
+    # content, so a blank auto-reply is never delivered (EVO-1720 [6.11]).
+    return if content.blank?
+
     ActiveRecord::Base.transaction do
-      conversation.messages.create!(greeting_message_params)
+      conversation.messages.create!(
+        inbox_id: @conversation.inbox_id,
+        message_type: :template,
+        content: content
+      )
     end
   rescue StandardError => e
     EvolutionExceptionTracker.new(e, account: nil).capture_exception
@@ -17,15 +26,10 @@ class MessageTemplates::Template::Greeting
   delegate :contact, to: :conversation
   delegate :inbox, to: :message
 
-  def greeting_message_params
-    # Prefer a referenced MessageTemplate (EVO-1235); fall back to the inline string.
-    content = template_content_for(@conversation.inbox&.greeting_message_template_id) ||
-              @conversation.inbox&.greeting_message
-
-    {
-      inbox_id: @conversation.inbox_id,
-      message_type: :template,
-      content: content
-    }
+  # Prefer a referenced MessageTemplate (EVO-1235); fall back to the inline
+  # string. Resolved once so the blank guard adds no extra SendResolver lookup.
+  def greeting_content
+    template_content_for(@conversation.inbox&.greeting_message_template_id) ||
+      @conversation.inbox&.greeting_message
   end
 end

--- a/app/services/message_templates/template/out_of_office.rb
+++ b/app/services/message_templates/template/out_of_office.rb
@@ -4,8 +4,17 @@ class MessageTemplates::Template::OutOfOffice
   pattr_initialize [:conversation!]
 
   def perform
+    content = out_of_office_content
+    # Skip silently when neither the template nor the inline fallback yields
+    # content, so a blank auto-reply is never delivered (EVO-1720 [6.11]).
+    return if content.blank?
+
     ActiveRecord::Base.transaction do
-      conversation.messages.create!(out_of_office_message_params)
+      conversation.messages.create!(
+        inbox_id: @conversation.inbox_id,
+        message_type: :template,
+        content: content
+      )
     end
   rescue StandardError => e
     EvolutionExceptionTracker.new(e, account: nil).capture_exception
@@ -17,15 +26,10 @@ class MessageTemplates::Template::OutOfOffice
   delegate :contact, to: :conversation
   delegate :inbox, to: :message
 
-  def out_of_office_message_params
-    # Prefer a referenced MessageTemplate (EVO-1235); fall back to the inline string.
-    content = template_content_for(@conversation.inbox&.out_of_office_message_template_id) ||
-              @conversation.inbox&.out_of_office_message
-
-    {
-      inbox_id: @conversation.inbox_id,
-      message_type: :template,
-      content: content
-    }
+  # Prefer a referenced MessageTemplate (EVO-1235); fall back to the inline
+  # string. Resolved once so the blank guard adds no extra SendResolver lookup.
+  def out_of_office_content
+    template_content_for(@conversation.inbox&.out_of_office_message_template_id) ||
+      @conversation.inbox&.out_of_office_message
   end
 end

--- a/spec/requests/public/api/v1/inboxes/messages_controller_spec.rb
+++ b/spec/requests/public/api/v1/inboxes/messages_controller_spec.rb
@@ -14,13 +14,23 @@ RSpec.describe 'Public Inbound Messages API', type: :request do
       "/conversations/#{conversation.display_id}/messages"
   end
 
-  describe 'POST create with legacy inline content' do
-    it 'creates the incoming message and emits the legacy WARN with the consumer id' do
-      expect(Rails.logger).to receive(:warn).with(/deprecated inline content.*consumer=legacy-consumer/).at_least(:once)
+  describe 'POST create with inline content' do
+    # Inbound messages always carry content and have no template alternative, so
+    # the deprecated-inline-content WARN must NOT fire here — it would spam the
+    # signal meant to identify legacy OUTBOUND consumers (EVO-1720 [6.11]).
+    it 'creates the incoming message without the legacy deprecated-content WARN' do
+      allow(Rails.logger).to receive(:warn)
 
-      post path, params: { content: 'hello from a contact' }, headers: { 'X-Client-ID' => 'legacy-consumer' }, as: :json
+      expect do
+        post path, params: { content: 'hello from a contact' },
+                   headers: { 'X-Client-ID' => 'legacy-consumer' }, as: :json
+      end.to change(conversation.messages, :count).by(1)
 
       expect(response).to have_http_status(:success)
+      created = conversation.messages.last
+      expect(created.message_type).to eq('incoming')
+      expect(created.content).to eq('hello from a contact')
+      expect(Rails.logger).not_to have_received(:warn).with(/deprecated inline content/)
     end
   end
 end

--- a/spec/services/message_templates/template/greeting_spec.rb
+++ b/spec/services/message_templates/template/greeting_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MessageTemplates::Template::Greeting do
+  # Plain ActiveRecord setup (this repo has no model factories beyond roles;
+  # mirrors spec/requests/.../messages_controller_spec.rb).
+  let(:api_channel) { Channel::Api.create! }
+  let(:inbox) { Inbox.create!(name: 'API Inbox', channel: api_channel) }
+  let(:contact) { Contact.create!(name: 'Ada Lovelace', email: "ada-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(8)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:service) { described_class.new(conversation: conversation) }
+
+  # A global template with a required variable the auto-reply never supplies
+  # (the auto-reply only passes first_name/name/email), so rendering raises.
+  # NOTE: the token MUST appear in `content` or extract_variables_from_content
+  # strips the explicit variable on save (see EVO-1720 spec, F1).
+  let(:raising_template) do
+    MessageTemplate.create!(
+      name: "greeting-required-#{SecureRandom.hex(4)}",
+      content: 'Hi {{order_id}}',
+      variables: [{ 'name' => 'order_id', 'required' => true }],
+      channel: nil
+    )
+  end
+
+  it 'builds a template whose render actually raises (guards against a vacuous test)' do
+    expect { raising_template.render_with_variables('first_name' => 'Ada') }
+      .to raise_error(ArgumentError)
+  end
+
+  describe '#perform' do
+    context 'when the template render fails AND the inline fallback is blank (AC3)' do
+      before do
+        inbox.update!(
+          greeting_enabled: true,
+          greeting_message: '',
+          greeting_message_template_id: raising_template.id
+        )
+      end
+
+      it 'creates no message (no blank greeting is delivered)' do
+        expect { service.perform }.not_to change(conversation.messages, :count)
+      end
+    end
+
+    context 'when the template render fails but the inline fallback is present (AC4a)' do
+      before do
+        inbox.update!(
+          greeting_enabled: true,
+          greeting_message: 'Welcome!',
+          greeting_message_template_id: raising_template.id
+        )
+      end
+
+      it 'falls back to the inline content and creates one template message' do
+        expect { service.perform }.to change(conversation.messages, :count).by(1)
+
+        message = conversation.messages.last
+        expect(message.message_type).to eq('template')
+        expect(message.content_type).to eq('text')
+        expect(message.content).to eq('Welcome!')
+      end
+    end
+
+    context 'when there is no template id but inline content is present (AC4b)' do
+      before do
+        inbox.update!(
+          greeting_enabled: true,
+          greeting_message: 'Hello there',
+          greeting_message_template_id: nil
+        )
+      end
+
+      it 'creates one template message from the inline content' do
+        expect { service.perform }.to change(conversation.messages, :count).by(1)
+        expect(conversation.messages.last.content).to eq('Hello there')
+      end
+    end
+
+    context 'when a blank greeting was previously skipped (AC6 — no false "already greeted")' do
+      before do
+        inbox.update!(
+          greeting_enabled: true,
+          greeting_message: '',
+          greeting_message_template_id: raising_template.id
+        )
+      end
+
+      it 'leaves zero template messages so a later valid greeting can still fire' do
+        service.perform
+        # The blank skip created nothing — the messages.template count that
+        # HookExecutionService#first_message_from_contact? checks stays at zero.
+        expect(conversation.messages.template.count).to eq(0)
+
+        inbox.update!(greeting_message: 'Welcome!')
+        expect { described_class.new(conversation: conversation).perform }
+          .to change(conversation.messages.template, :count).by(1)
+      end
+    end
+  end
+end

--- a/spec/services/message_templates/template/out_of_office_spec.rb
+++ b/spec/services/message_templates/template/out_of_office_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MessageTemplates::Template::OutOfOffice do
+  # Plain ActiveRecord setup (this repo has no model factories beyond roles;
+  # mirrors spec/requests/.../messages_controller_spec.rb).
+  let(:api_channel) { Channel::Api.create! }
+  let(:inbox) { Inbox.create!(name: 'API Inbox', channel: api_channel) }
+  let(:contact) { Contact.create!(name: 'Ada Lovelace', email: "ada-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(8)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:service) { described_class.new(conversation: conversation) }
+
+  # Global template with a required variable the auto-reply never supplies, so
+  # rendering raises and TemplateContent falls back to the inline column. The
+  # token must appear in content or the explicit var is stripped on save (F1).
+  let(:raising_template) do
+    MessageTemplate.create!(
+      name: "ooo-required-#{SecureRandom.hex(4)}",
+      content: 'Away, ref {{order_id}}',
+      variables: [{ 'name' => 'order_id', 'required' => true }],
+      channel: nil
+    )
+  end
+
+  it 'builds a template whose render actually raises (guards against a vacuous test)' do
+    expect { raising_template.render_with_variables('first_name' => 'Ada') }
+      .to raise_error(ArgumentError)
+  end
+
+  describe '#perform' do
+    context 'when the template render fails AND the inline fallback is blank (AC5)' do
+      before do
+        inbox.update!(
+          out_of_office_message: '',
+          out_of_office_message_template_id: raising_template.id
+        )
+      end
+
+      it 'creates no message (no blank out-of-office is delivered)' do
+        expect { service.perform }.not_to change(conversation.messages, :count)
+      end
+    end
+
+    context 'when the template render fails but the inline fallback is present' do
+      before do
+        inbox.update!(
+          out_of_office_message: 'We are away',
+          out_of_office_message_template_id: raising_template.id
+        )
+      end
+
+      it 'falls back to the inline content and creates one template message' do
+        expect { service.perform }.to change(conversation.messages, :count).by(1)
+
+        message = conversation.messages.last
+        expect(message.message_type).to eq('template')
+        expect(message.content_type).to eq('text')
+        expect(message.content).to eq('We are away')
+      end
+    end
+
+    context 'when there is no template id but inline content is present' do
+      before do
+        inbox.update!(
+          out_of_office_message: 'Out of office',
+          out_of_office_message_template_id: nil
+        )
+      end
+
+      it 'creates one template message from the inline content' do
+        expect { service.perform }.to change(conversation.messages, :count).by(1)
+        expect(conversation.messages.last.content).to eq('Out of office')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Non-blocking follow-up (6.11) to the **EVO-1235 [6.6]** wire-call-sites review. Three findings raised; two fixed, one documented.

- **🟡 [Medium] False-positive "deprecated inline content" WARN on INBOUND.** `Public::Api::V1::Inboxes::MessagesController#create` included `TemplateConsumerLogging` and fired `warn_legacy_inline_content` whenever `content` was present. But an **inbound** message (from the contact) always carries `content` and has **no template alternative** — there is nothing to migrate. The WARN fired on every inbound message, spamming the very signal meant to identify legacy **outbound** consumers. Removed the `include` + the call (and its coexistence comment). The `outbound_messages_controller` (the legitimate WARN site) and the `TemplateConsumerLogging` concern are untouched; `permitted_params`/`message_params` are preserved.

- **🟢 [Low] Blank auto-reply edge.** Greeting/Out-of-Office fire when `*_message_template_id` is present. If the referenced template has a `required: true` variable outside `{first_name, name, email}`, `render_with_variables` raises `ArgumentError`; `TemplateContent#template_content_for` rescues it and falls back to the inline column. `Message` has **no `content` presence validation**, so a blank inline column produced a blank `:template` message. `perform` now resolves the content **once** (via a `*_content` helper, so the guard adds no extra `SendResolver` lookup) and `return if content.blank?` — skip silently. Skipping the blank `:template` message keeps `HookExecutionService#first_message_from_contact?` accurate, so a later valid greeting can still fire.

- **🟢 [Low / Documented] Dormant `message_template_id` accept-paths** in agent-bot/macro/automation are intentionally untouched — no producer feeds the id yet (expected until a UI does).

No migration, no schema change.

## Test plan

- `POSTGRES_PORT=5433 ... bundle exec rspec spec/services/message_templates/template/greeting_spec.rb spec/services/message_templates/template/out_of_office_spec.rb spec/requests/public/api/v1/inboxes/messages_controller_spec.rb spec/requests/public/api/v1/inboxes/outbound_messages_controller_spec.rb` → **14 examples, 0 failures**.
- **Inbound spec inverted:** the existing example asserted the WARN *fired*; it now asserts the incoming message persists (`incoming`, with the posted content) **and** the deprecated WARN is **not** emitted (`allow → have_received` so unrelated warns don't interfere).
- **New service specs** build a global `MessageTemplate` with a surviving `required` variable (`{{order_id}}` in content + explicit `required: true`, since `extract_variables_from_content` strips vars absent from content) and **assert `render_with_variables` actually raises before relying on the guard** (no vacuous test). Cover: blank-skip, render-raise→inline fallback, and no-template→inline. Created fallback message is `message_type: :template`, `content_type: 'text'`.
- **RuboCop:** clean on all 6 touched files.

## Notes

- Builds on EVO-1235 [6.6] (the reviewed work). No dependency on the dormant-paths finding (#2).
- This repo has no model factories beyond `roles.rb` and does not include FactoryBot syntax (`csat_survey_spec` using `create(:inbox)` is itself non-running) — the new specs use plain `ActiveRecord.create!`, mirroring the request specs.

## Summary by Sourcery

Silence deprecated inline-content warnings for inbound messages and prevent sending blank auto-reply template messages for greeting and out-of-office flows.

Bug Fixes:
- Stop emitting deprecated inline-content WARN logs for inbound inbox messages that always carry content and have no template alternative.
- Avoid creating blank greeting auto-reply messages when both the referenced template and inline fallback yield empty content.
- Avoid creating blank out-of-office auto-reply messages when both the referenced template and inline fallback yield empty content.

Tests:
- Update inbound messages controller request spec to assert message creation without deprecated inline-content warnings.
- Add service specs for greeting and out-of-office template services covering blank-skipped replies, template render failures falling back to inline content, and no-template inline scenarios.