### PR TITLE
feat(inboxes): allow a global template as greeting/out-of-office message (EVO-1760)

### DIFF
--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -697,8 +697,10 @@ module Api
         end
 
         def inbox_attributes
-          [:name, :avatar, :display_name, :greeting_enabled, :greeting_message, :enable_email_collect, :csat_survey_enabled,
-           :enable_auto_assignment, :working_hours_enabled, :out_of_office_message, :timezone, :allow_messages_after_resolved,
+          [:name, :avatar, :display_name, :greeting_enabled, :greeting_message, :greeting_message_template_id,
+           :enable_email_collect, :csat_survey_enabled,
+           :enable_auto_assignment, :working_hours_enabled, :out_of_office_message, :out_of_office_message_template_id,
+           :timezone, :allow_messages_after_resolved,
            :lock_to_single_conversation, :sender_name_type, :business_name, :default_conversation_status,
            { csat_config: [:display_type, :message, { survey_rules: [:operator, { values: [] }, { triggers: [:type, :operator, { values: [] }, { stage_ids: [] }, :pattern, :field, :days, :time, :minutes] }] }] }]
         end

--- a/app/serializers/inbox_serializer.rb
+++ b/app/serializers/inbox_serializer.rb
@@ -25,8 +25,9 @@ module InboxSerializer
     # It will be conditionally added later only for administrators
     result = inbox.as_json(
       only: [:id, :channel_id, :name, :display_name, :channel_type, :greeting_enabled,
-             :greeting_message, :enable_email_collect, :csat_survey_enabled,
+             :greeting_message, :greeting_message_template_id, :enable_email_collect, :csat_survey_enabled,
              :enable_auto_assignment, :working_hours_enabled, :out_of_office_message,
+             :out_of_office_message_template_id,
              :timezone, :allow_messages_after_resolved, :auto_assignment_config,
              :business_name, :portal_id,
              :sender_name_type, :additional_attributes, :csat_config,

--- a/app/views/api/v1/models/_inbox.json.jbuilder
+++ b/app/views/api/v1/models/_inbox.json.jbuilder
@@ -6,6 +6,7 @@ json.display_name resource.display_name
 json.channel_type resource.channel_type
 json.greeting_enabled resource.greeting_enabled
 json.greeting_message resource.greeting_message
+json.greeting_message_template_id resource.greeting_message_template_id
 json.working_hours_enabled resource.working_hours_enabled
 json.enable_email_collect resource.enable_email_collect
 json.csat_survey_enabled resource.csat_survey_enabled
@@ -13,6 +14,7 @@ json.csat_config resource.csat_config
 json.enable_auto_assignment resource.enable_auto_assignment
 json.auto_assignment_config resource.auto_assignment_config
 json.out_of_office_message resource.out_of_office_message
+json.out_of_office_message_template_id resource.out_of_office_message_template_id
 json.working_hours resource.weekly_schedule
 json.timezone resource.timezone
 json.callback_webhook_url resource.callback_webhook_url

--- a/spec/requests/api/v1/inboxes_template_refs_spec.rb
+++ b/spec/requests/api/v1/inboxes_template_refs_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1760: the inbox greeting / out-of-office message can reference a global
+# MessageTemplate (greeting_message_template_id / out_of_office_message_template_id).
+# These columns exist since EVO-1235; this spec covers the FE-facing contract:
+# they must be permitted on update and echoed back by the serializer.
+RSpec.describe 'PATCH /api/v1/inboxes/:id template refs', type: :request do
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+
+  let(:channel) { Channel::Api.create! }
+  let(:inbox) { Inbox.create!(channel: channel, name: 'API Inbox') }
+  let(:template_id) { '11111111-1111-4111-8111-111111111111' }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  it 'permits, persists and serializes greeting/out-of-office template ids' do
+    patch "/api/v1/inboxes/#{inbox.id}",
+          params: {
+            greeting_enabled: true,
+            greeting_message_template_id: template_id,
+            working_hours_enabled: true,
+            out_of_office_message_template_id: template_id
+          },
+          headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(inbox.reload.greeting_message_template_id).to eq(template_id)
+    expect(inbox.out_of_office_message_template_id).to eq(template_id)
+    expect(json_response['data']['greeting_message_template_id']).to eq(template_id)
+    expect(json_response['data']['out_of_office_message_template_id']).to eq(template_id)
+  end
+
+  it 'clears the refs when the FE sends the "null" sentinel' do
+    inbox.update!(greeting_message_template_id: template_id, out_of_office_message_template_id: template_id)
+
+    patch "/api/v1/inboxes/#{inbox.id}",
+          params: { greeting_message_template_id: 'null', out_of_office_message_template_id: 'null' },
+          headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(inbox.reload.greeting_message_template_id).to be_nil
+    expect(inbox.out_of_office_message_template_id).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

The inbox `greeting_message_template_id` / `out_of_office_message_template_id` columns (added in EVO-1235, read by the greeting / out-of-office send services) had no way in or out: inbox update did not permit them and neither `InboxSerializer` nor the inbox jbuilder returned them. So a global template could never be attached to an inbox greeting / OOO from the API.

- Permit both ids on inbox update (`inbox_attributes`).
- Expose both in `InboxSerializer` and `app/views/api/v1/models/_inbox.json.jbuilder`.

Pairs with the frontend PR that adds the picker.

## Test plan

- `spec/requests/api/v1/inboxes_template_refs_spec.rb` — **2 examples, 0 failures**: update persists + serializes both ids; the FE `"null"` sentinel clears them.
- Columns already exist (EVO-1235 migration) — no migration here.

## Linked issue
- EVO-1760

## Summary by Sourcery

Allow inbox greeting and out-of-office global templates to be set and exposed via the API.

New Features:
- Support configuring greeting and out-of-office message template IDs on inbox update and expose them in inbox API responses.

Tests:
- Add request specs covering persistence, serialization, and clearing of inbox greeting and out-of-office template IDs via the API.