### PR TITLE
fix(pipelines): idempotent heal for stage_movements pipeline_item_id drift (EVO-1845)

### DIFF
--- a/db/migrate/20260619150000_heal_stage_movements_pipeline_item_fk.rb
+++ b/db/migrate/20260619150000_heal_stage_movements_pipeline_item_fk.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Heals installations where the stage_movements column/FK rename from
+# 20251119170940 (pipeline_conversations -> pipeline_items) was recorded as
+# applied but never took effect on stage_movements, leaving the old column
+# `pipeline_conversation_id` (FK to the orphaned pipeline_conversations table).
+# The app expects `pipeline_item_id`, so any StageMovement write fails with
+# "unknown attribute 'pipeline_item_id'".
+#
+# Idempotent / heal-forward: a no-op on schemas that are already correct.
+class HealStageMovementsPipelineItemFk < ActiveRecord::Migration[7.1]
+  def up
+    return unless column_exists?(:stage_movements, :pipeline_conversation_id)
+
+    if foreign_key_exists?(:stage_movements, column: :pipeline_conversation_id)
+      remove_foreign_key :stage_movements, column: :pipeline_conversation_id
+    end
+
+    rename_column :stage_movements, :pipeline_conversation_id, :pipeline_item_id
+
+    if index_name_exists?(:stage_movements, 'index_stage_movements_on_pipeline_conversation_id')
+      rename_index :stage_movements,
+                   'index_stage_movements_on_pipeline_conversation_id',
+                   'index_stage_movements_on_pipeline_item_id'
+    end
+
+    add_foreign_key :stage_movements, :pipeline_items, column: :pipeline_item_id unless foreign_key_exists?(:stage_movements, :pipeline_items)
+  end
+
+  def down
+    # Heal-forward only.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_19_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"


### PR DESCRIPTION
## Summary

Heals installations where the `stage_movements` column/FK rename from `20251119170940_rename_pipeline_conversations_to_pipeline_items` was recorded as applied (`schema_migrations` bumped, `needs_migration? = CLEAN`) but never took effect on `stage_movements`. On such DBs the table still has `pipeline_conversation_id` (FK to the orphaned `pipeline_conversations` table) while the app/`schema.rb` expect `pipeline_item_id`, so any `StageMovement` write — e.g. moving an item into a pipeline stage — fails with `unknown attribute 'pipeline_item_id' for StageMovement`.

The migration is **idempotent / heal-forward**: guarded by `column_exists?(:stage_movements, :pipeline_conversation_id)`, so it is a **no-op on correct schemas** (fresh installs via `migrate`/`schema:load` are unaffected). When the drift is present it: removes the stale FK → `rename_column` → `rename_index` → adds the FK to `pipeline_items`.

This is **not** a code or B14 bug — code, prior migrations and `schema.rb` are correct. The drift was surfaced on a dev DB during EVO-1771 (B14) validation, but lives in the **pipeline** module.

### Changes
- `db/migrate/20260619150000_heal_stage_movements_pipeline_item_fk.rb` (new) — the heal migration.
- `db/schema.rb` — version bump `2026_06_12_000000` → `2026_06_19_150000` only. Every migration must ship with its schema version bump or the **"Verify EvoExtensionPoints contract"** check fails with `ActiveRecord::PendingMigrationError`. The heal is a no-op on a correct schema, so the version line is the **only** schema change.

### Addresses review (PR was reproved on CI blocker B1)
The previous revision omitted the `schema.rb` bump → the contract check failed listing this migration as pending. Fixed here. Branch was also **rebased onto current `develop`** — `develop` has since added `stage_inactivity_executions` and bumped to `2026_06_12_000000`, so the earlier "two pending migrations" situation is resolved upstream and this PR's schema diff is now just the single version line. No factory/RSpec coverage (crm-community does not run RSpec in CI); validated manually — see test plan.

## Test plan

- On a clean schema (`schema:load` develop → `migrate`): `20260619150000` runs and is a **no-op** after the `column_exists?` guard; the resulting `schema.rb` differs from develop only by the version line — no table/index/FK churn, no cross-service pollution.
- On a drifted dev DB (`evo_community`): `db:migrate` renamed the column to `pipeline_item_id`, repointed the FK to `pipeline_items`, and `StageMovement` writes work again.
- Re-running the heal migration is a no-op (guard short-circuits) — idempotency confirmed.

## Notes

- Separate branch/PR by design — not bundled with the B14 work where it was discovered.
- Follow-ups (tracked on EVO-1845, non-blocking): investigate how a community DB reaches this drift (setup/seed) and whether other installs are affected; consider a schema-consistency check at setup; optionally drop the orphaned `pipeline_conversations` table on drifted DBs (empty in dev).
- Per review: `down` is a deliberate heal-forward no-op (could be `raise ActiveRecord::IrreversibleMigration` to make `db:rollback` explicit — left as no-op for now).
