### PR TITLE
feat(crm): conversations history import via DataImport (EVO-1557)

### DIFF
--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -21,10 +21,14 @@ class Api::V1::ConversationsController < Api::V1::BaseController
     transcript: 'conversations.export',
     email_team: 'conversations.update',
     available_for_pipeline: 'conversations.read',
-    unread_count: 'conversations.read'
+    unread_count: 'conversations.read',
+    import: 'conversations.import'
   })
 
-  before_action :conversation, except: [:index, :meta, :search, :create, :filter, :unread_count]
+  CONVERSATIONS_IMPORT_ROW_LIMIT = 50_000
+  CONVERSATIONS_IMPORT_MAX_BYTES = 50 * 1024 * 1024
+
+  before_action :conversation, except: [:index, :meta, :search, :create, :filter, :unread_count, :import]
   before_action :inbox, :contact, :contact_inbox, only: [:create]
 
   ATTACHMENT_RESULTS_PER_PAGE = 100
@@ -53,10 +57,61 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   def meta
     result = conversation_finder.perform
     @conversations_count = result[:count]
-    
+
     success_response(
       data: { count: @conversations_count },
       message: 'Conversation metadata retrieved successfully'
+    )
+  end
+
+  def import
+    if params[:import_file].blank?
+      return error_response(
+        ApiErrorCodes::MISSING_REQUIRED_FIELD,
+        I18n.t('errors.conversations.import.missing_file'),
+        details: { field: 'import_file', message: 'is required' },
+        status: :unprocessable_entity
+      )
+    end
+
+    file_size = params[:import_file].respond_to?(:size) ? params[:import_file].size : 0
+    if file_size > CONVERSATIONS_IMPORT_MAX_BYTES
+      return error_response(
+        ApiErrorCodes::INVALID_PARAMETER,
+        I18n.t('errors.conversations.import.too_large_bytes', limit: CONVERSATIONS_IMPORT_MAX_BYTES),
+        details: { byte_size: file_size, limit: CONVERSATIONS_IMPORT_MAX_BYTES },
+        status: :unprocessable_entity
+      )
+    end
+
+    row_count, malformed_error = count_csv_rows(params[:import_file])
+    if malformed_error
+      return error_response(
+        ApiErrorCodes::INVALID_PARAMETER,
+        I18n.t('errors.conversations.import.invalid_csv', error: malformed_error),
+        status: :unprocessable_entity
+      )
+    end
+
+    if row_count > CONVERSATIONS_IMPORT_ROW_LIMIT
+      return error_response(
+        ApiErrorCodes::INVALID_PARAMETER,
+        I18n.t('errors.conversations.import.too_large', limit: CONVERSATIONS_IMPORT_ROW_LIMIT),
+        details: { row_count: row_count, limit: CONVERSATIONS_IMPORT_ROW_LIMIT },
+        status: :unprocessable_entity
+      )
+    end
+
+    data_import = ActiveRecord::Base.transaction do
+      import = DataImport.create!(data_type: 'conversations')
+      import.import_file.attach(params[:import_file])
+      import
+    end
+
+    success_response(
+      data: { data_import_id: data_import.id },
+      message: 'Conversations import accepted',
+      status: :accepted
     )
   end
 
@@ -386,6 +441,25 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   end
 
   private
+
+  def count_csv_rows(uploaded_file)
+    path = uploaded_file.respond_to?(:path) ? uploaded_file.path : nil
+    return [0, nil] if path.nil?
+
+    cap = CONVERSATIONS_IMPORT_ROW_LIMIT + 1
+    data_rows = 0
+    begin
+      CSV.foreach(path, headers: true) do |_row|
+        data_rows += 1
+        break if data_rows >= cap
+      end
+    rescue CSV::MalformedCSVError => e
+      return [0, e.message]
+    rescue Errno::ENOENT
+      return [0, 'file is not readable']
+    end
+    [data_rows, nil]
+  end
 
   def update_custom_attribute(attribute_key, value, success_message)
     custom_attributes = (@conversation.custom_attributes || {}).merge(attribute_key => value)

--- a/app/jobs/data_import_job.rb
+++ b/app/jobs/data_import_job.rb
@@ -32,6 +32,11 @@ class DataImportJob < ApplicationJob
 
   def process_conversations_import
     @data_import.update!(status: :processing)
+    started_at = Time.current
+    Rails.logger.info(
+      "[DataImport::Conversation] start data_import_id=#{@data_import.id}"
+    )
+
     manager = DataImport::ConversationManager.new(@data_import)
     report = manager.process
 
@@ -40,6 +45,13 @@ class DataImportJob < ApplicationJob
       total_records: report['total_rows'],
       processed_records: report['success_count'],
       processing_errors: report.to_json
+    )
+
+    duration = (Time.current - started_at).round(2)
+    Rails.logger.info(
+      "[DataImport::Conversation] done data_import_id=#{@data_import.id} " \
+      "rows_total=#{report['total_rows']} imported=#{report['success_count']} " \
+      "failed=#{report['error_count']} duration=#{duration}s"
     )
 
     save_conversations_failed_records(manager)

--- a/app/jobs/data_import_job.rb
+++ b/app/jobs/data_import_job.rb
@@ -7,11 +7,16 @@ class DataImportJob < ApplicationJob
 
   def perform(data_import)
     @data_import = data_import
-    @contact_manager = DataImport::ContactManager.new
-    Rails.logger.info "📊 DataImportJob: Starting import for data_import_id=#{@data_import.id}"
+    Rails.logger.info "📊 DataImportJob: Starting import for data_import_id=#{@data_import.id} data_type=#{@data_import.data_type}"
     begin
-      process_import_file
-      send_import_notification_to_admin
+      case @data_import.data_type
+      when 'conversations'
+        process_conversations_import
+      else
+        @contact_manager = DataImport::ContactManager.new
+        process_import_file
+        send_import_notification_to_admin
+      end
       Rails.logger.info "📊 DataImportJob: Import completed for data_import_id=#{@data_import.id}"
     rescue CSV::MalformedCSVError => e
       Rails.logger.error "📊 DataImportJob: CSV error for data_import_id=#{@data_import.id}: #{e.message}"
@@ -24,6 +29,40 @@ class DataImportJob < ApplicationJob
   end
 
   private
+
+  def process_conversations_import
+    @data_import.update!(status: :processing)
+    manager = DataImport::ConversationManager.new(@data_import)
+    report = manager.process
+
+    @data_import.update!(
+      status: :completed,
+      total_records: report['total_rows'],
+      processed_records: report['success_count'],
+      processing_errors: report.to_json
+    )
+
+    save_conversations_failed_records(manager)
+  end
+
+  def save_conversations_failed_records(manager)
+    rejected = manager.rejected_rows
+    return if rejected.blank?
+
+    headers = (manager.csv_headers || rejected.first.keys.reject { |k| k.start_with?('_') || k == 'errors' }) + ['errors']
+    csv_data = CSVSafe.generate do |csv|
+      csv << headers
+      rejected.each do |record|
+        csv << headers.map { |h| record[h] }
+      end
+    end
+
+    @data_import.failed_records.attach(
+      io: StringIO.new(csv_data),
+      filename: "#{Time.zone.today.strftime('%Y%m%d')}_conversations_failed.csv",
+      content_type: 'text/csv'
+    )
+  end
 
   def process_import_file
     @data_import.update!(status: :processing)
@@ -198,7 +237,7 @@ class DataImportJob < ApplicationJob
   def handle_csv_error(error) # rubocop:disable Lint/UnusedMethodArgument
     Rails.logger.error "📊 DataImportJob: Handling CSV error - marking as failed"
     @data_import.update!(status: :failed)
-    send_import_failed_notification_to_admin
+    send_import_failed_notification_to_admin if @data_import.data_type == 'contacts'
   end
 
   def send_import_notification_to_admin

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -68,6 +68,7 @@ class Conversation < ApplicationRecord
 
   enum status: { open: 0, resolved: 1, pending: 2, snoozed: 3 }
   enum priority: { low: 0, medium: 1, high: 2, urgent: 3 }
+  enum source: { live: 0, imported: 1 }
 
   scope :unassigned, -> { where(assignee_id: nil) }
   scope :assigned, -> { where.not(assignee_id: nil) }
@@ -117,10 +118,10 @@ class Conversation < ApplicationRecord
   before_create :ensure_waiting_since
 
   after_update_commit :execute_after_update_commit_callbacks
-  after_create_commit :notify_conversation_creation
+  after_create_commit :notify_conversation_creation, unless: :imported?
   after_create_commit :load_attributes_created_by_db_triggers
-  after_create_commit :publish_conversation_created
-  after_create_commit :assign_to_default_pipeline
+  after_create_commit :publish_conversation_created, unless: :imported?
+  after_create_commit :assign_to_default_pipeline, unless: :imported?
   after_update_commit :publish_conversation_updated
   after_update_commit :publish_conversation_resolved
   after_destroy_commit :publish_conversation_deleted

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -12,7 +12,9 @@
 #  updated_at        :datetime         not null
 #
 class DataImport < ApplicationRecord
-  validates :data_type, inclusion: { in: ['contacts'], message: I18n.t('errors.data_import.data_type.invalid') }
+  DATA_TYPES = %w[contacts conversations].freeze
+
+  validates :data_type, inclusion: { in: DATA_TYPES, message: I18n.t('errors.data_import.data_type.invalid') }
   enum status: { pending: 0, processing: 1, completed: 2, failed: 3 }
 
   has_one_attached :import_file

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -58,7 +58,7 @@ class Message < ApplicationRecord
   }.to_json.freeze
 
   before_validation :ensure_content_type
-  before_validation :prevent_message_flooding
+  before_validation :prevent_message_flooding, unless: :imported?
   before_save :ensure_processed_message_content
   before_save :ensure_in_reply_to
 
@@ -92,6 +92,7 @@ class Message < ApplicationRecord
     sticker: 11
   }
   enum status: { sent: 0, delivered: 1, read: 2, failed: 3 }
+  enum source: { live: 0, imported: 1 }
   # [:submitted_email, :items, :submitted_values] : Used for bot message types
   # [:email] : Used by conversation_continuity incoming email messages
   # [:in_reply_to] : Used to reply to a particular tweet in threads
@@ -128,9 +129,9 @@ class Message < ApplicationRecord
   has_one :csat_survey_response, dependent: :destroy_async
   has_many :notifications, as: :primary_actor, dependent: :destroy_async
 
-  after_create_commit :execute_after_create_commit_callbacks
-  after_create_commit :publish_message_created
-  after_create_commit :sync_message_event
+  after_create_commit :execute_after_create_commit_callbacks, unless: :imported?
+  after_create_commit :publish_message_created, unless: :imported?
+  after_create_commit :sync_message_event, unless: :imported?
   after_update_commit :dispatch_update_event
   after_update_commit :publish_message_updated
   after_destroy_commit :publish_message_deleted

--- a/app/services/data_import/conversation_manager.rb
+++ b/app/services/data_import/conversation_manager.rb
@@ -11,7 +11,11 @@ class DataImport::ConversationManager
     @report = { 'total_rows' => 0, 'success_count' => 0, 'error_count' => 0, 'errors' => [] }
     @rejected_rows = []
     @csv_headers = nil
-    @touched_conversation_ids = Set.new
+    # Conversation id => max sent_at seen across imported rows. Used to set
+    # last_activity_at to the historical max instead of the wall-clock time
+    # of the import job (otherwise an imported 2024 conversation sorts to
+    # the top of the inbox as if it were active now).
+    @conversation_last_activity = {}
   end
 
   def process
@@ -22,30 +26,36 @@ class DataImport::ConversationManager
     @csv_headers = csv.headers
     validate_headers!(@csv_headers)
 
-    csv.each_with_index do |row, index|
-      @report['total_rows'] += 1
-      params = row.to_h.with_indifferent_access
-      row_no = row_number(index)
-      begin
-        ActiveRecord::Base.transaction(requires_new: true) do
-          import_row(params, row_no)
+    # Disable belongs_to :conversation, touch: true for the duration of the
+    # import. On a 50k-row CSV that saves ~50k redundant UPDATEs against
+    # conversations (last_activity_at is set explicitly in
+    # `resolve_touched_conversations` from the historical max sent_at).
+    ActiveRecord::Base.no_touching do
+      csv.each_with_index do |row, index|
+        @report['total_rows'] += 1
+        params = row.to_h.with_indifferent_access
+        row_no = row_number(index)
+        begin
+          ActiveRecord::Base.transaction(requires_new: true) do
+            import_row(params, row_no)
+          end
+          @report['success_count'] += 1
+        rescue RowError => e
+          Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{e.message}"
+          record_failure(row, row_no, e.message)
+        rescue ActiveRecord::RecordInvalid => e
+          message = "validation failed: #{e.record.errors.full_messages.join(', ')}"
+          Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
+          record_failure(row, row_no, message)
+        rescue ActiveRecord::RecordNotUnique => e
+          message = "uniqueness violation: #{e.message.lines.first&.strip}"
+          Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
+          record_failure(row, row_no, message)
+        rescue ActiveRecord::StatementInvalid => e
+          message = "statement invalid: #{e.message.lines.first&.strip}"
+          Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
+          record_failure(row, row_no, message)
         end
-        @report['success_count'] += 1
-      rescue RowError => e
-        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{e.message}"
-        record_failure(row, row_no, e.message)
-      rescue ActiveRecord::RecordInvalid => e
-        message = "validation failed: #{e.record.errors.full_messages.join(', ')}"
-        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
-        record_failure(row, row_no, message)
-      rescue ActiveRecord::RecordNotUnique => e
-        message = "uniqueness violation: #{e.message.lines.first&.strip}"
-        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
-        record_failure(row, row_no, message)
-      rescue ActiveRecord::StatementInvalid => e
-        message = "statement invalid: #{e.message.lines.first&.strip}"
-        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
-        record_failure(row, row_no, message)
       end
     end
 
@@ -55,9 +65,19 @@ class DataImport::ConversationManager
   end
 
   def resolve_touched_conversations
-    return if @touched_conversation_ids.empty?
+    return if @conversation_last_activity.empty?
 
-    Conversation.where(id: @touched_conversation_ids.to_a).update_all(status: Conversation.statuses[:resolved])
+    Conversation.where(id: @conversation_last_activity.keys)
+                .update_all(status: Conversation.statuses[:resolved])
+
+    # Imported conversations should sort by their historical max sent_at, not
+    # by the wall-clock time of the import (the column default is
+    # CURRENT_TIMESTAMP). Force-set, do not GREATEST: GREATEST against the
+    # default would pin the row to "now" and re-introduce the very problem
+    # this fixes.
+    @conversation_last_activity.each do |conversation_id, max_sent_at|
+      Conversation.where(id: conversation_id).update_all(last_activity_at: max_sent_at)
+    end
   end
 
   def rejected_rows
@@ -101,15 +121,32 @@ class DataImport::ConversationManager
     contact_inbox = ensure_contact_inbox(contact, inbox, params[:conversation_external_id])
     conversation = ensure_conversation(contact_inbox, params[:conversation_external_id])
 
-    @touched_conversation_ids << conversation.id
+    current_max = @conversation_last_activity[conversation.id]
+    @conversation_last_activity[conversation.id] = sent_at if current_max.nil? || sent_at > current_max
 
     return if message_exists?(conversation, params[:message_external_id])
 
     create_message(conversation, params, direction, sent_at)
   end
 
+  # Tolerant parser for `sent_at`. Supports ISO8601 (with/without offset),
+  # space-separated SQL-style ("YYYY-MM-DD HH:MM:SS"), date-only, and
+  # 10-/13-digit Unix epoch. Naive timestamps (no offset) are interpreted
+  # as UTC, never server-local — keeps the imported timeline stable across
+  # deploy regions.
   def parse_timestamp(value)
-    Time.iso8601(value.to_s)
+    raw = value.to_s.strip
+    return nil if raw.empty?
+
+    if raw =~ /\A\d{10}\z/
+      Time.at(raw.to_i).utc
+    elsif raw =~ /\A\d{13}\z/
+      Time.at(raw.to_i / 1000.0).utc
+    elsif raw.match?(/[zZ]|[+-]\d{2}:?\d{2}\z/)
+      Time.find_zone('UTC').parse(raw)
+    else
+      Time.find_zone('UTC').parse(raw)
+    end
   rescue ArgumentError, TypeError
     nil
   end
@@ -154,6 +191,7 @@ class DataImport::ConversationManager
       c.inbox_id = contact_inbox.inbox_id
       c.contact_inbox_id = contact_inbox.id
       c.status = :resolved
+      c.source = :imported
       c.send(:status_explicitly_set!)
       c.additional_attributes = { 'imported' => true, 'source' => 'data_import' }
     end

--- a/app/services/data_import/conversation_manager.rb
+++ b/app/services/data_import/conversation_manager.rb
@@ -1,0 +1,190 @@
+class DataImport::ConversationManager
+  REQUIRED_COLUMNS = %w[conversation_external_id contact_identifier message_content direction sent_at].freeze
+  VALID_DIRECTIONS = %w[incoming outgoing].freeze
+  IMPORTED_HISTORY_INBOX_NAME = 'Imported History'.freeze
+  MAX_ERRORS_PERSISTED = 1000
+
+  attr_reader :report
+
+  def initialize(data_import)
+    @data_import = data_import
+    @report = { 'total_rows' => 0, 'success_count' => 0, 'error_count' => 0, 'errors' => [] }
+    @rejected_rows = []
+    @csv_headers = nil
+    @touched_conversation_ids = Set.new
+  end
+
+  def process
+    raw_csv = @data_import.import_file.download.force_encoding('UTF-8')
+    raw_csv = raw_csv.encode('UTF-16le', invalid: :replace, replace: '').encode('UTF-8') unless raw_csv.valid_encoding?
+
+    csv = CSV.parse(raw_csv, headers: true)
+    @csv_headers = csv.headers
+    validate_headers!(@csv_headers)
+
+    csv.each_with_index do |row, index|
+      @report['total_rows'] += 1
+      params = row.to_h.with_indifferent_access
+      begin
+        import_row(params, row_number(index))
+        @report['success_count'] += 1
+      rescue RowError => e
+        record_failure(row, row_number(index), e.message)
+      rescue ActiveRecord::RecordInvalid => e
+        record_failure(row, row_number(index), "validation failed: #{e.record.errors.full_messages.join(', ')}")
+      rescue ActiveRecord::RecordNotUnique => e
+        record_failure(row, row_number(index), "uniqueness violation: #{e.message.lines.first&.strip}")
+      end
+    end
+
+    resolve_touched_conversations
+
+    @report
+  end
+
+  def resolve_touched_conversations
+    return if @touched_conversation_ids.empty?
+
+    Conversation.where(id: @touched_conversation_ids.to_a).update_all(status: Conversation.statuses[:resolved])
+  end
+
+  def rejected_rows
+    @rejected_rows
+  end
+
+  def csv_headers
+    @csv_headers
+  end
+
+  private
+
+  class RowError < StandardError; end
+
+  def row_number(index)
+    index + 2
+  end
+
+  def validate_headers!(headers)
+    missing = REQUIRED_COLUMNS - headers.to_a
+    return if missing.empty?
+
+    raise CSV::MalformedCSVError.new("missing required columns: #{missing.join(', ')}", 0)
+  end
+
+  def import_row(params, row_no)
+    REQUIRED_COLUMNS.each do |col|
+      raise RowError, "missing value for #{col}" if params[col].to_s.strip.empty?
+    end
+
+    direction = params[:direction].to_s.downcase
+    raise RowError, "invalid direction '#{params[:direction]}'" unless VALID_DIRECTIONS.include?(direction)
+
+    sent_at = parse_timestamp(params[:sent_at])
+    raise RowError, "invalid sent_at '#{params[:sent_at]}'" if sent_at.nil?
+
+    contact = find_contact(params[:contact_identifier])
+    raise RowError, "contact not found for identifier '#{params[:contact_identifier]}'" if contact.nil?
+
+    inbox = ensure_imported_history_inbox
+    contact_inbox = ensure_contact_inbox(contact, inbox, params[:conversation_external_id])
+    conversation = ensure_conversation(contact_inbox, params[:conversation_external_id])
+
+    @touched_conversation_ids << conversation.id
+
+    return if message_exists?(conversation, params[:message_external_id])
+
+    create_message(conversation, params, direction, sent_at)
+  end
+
+  def parse_timestamp(value)
+    Time.iso8601(value.to_s)
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def find_contact(identifier)
+    value = identifier.to_s.strip
+    return nil if value.empty?
+
+    by_identifier = Contact.find_by(identifier: value)
+    return by_identifier if by_identifier
+
+    phone = format_phone(value)
+    by_phone = phone && Contact.find_by(phone_number: phone)
+    return by_phone if by_phone
+
+    return nil unless value.include?('@')
+
+    Contact.from_email(value)
+  end
+
+  def format_phone(value)
+    cleaned = value.gsub(/\D/, '')
+    return nil if cleaned.empty?
+
+    "+#{cleaned}"
+  end
+
+  def ensure_imported_history_inbox
+    @imported_history_inbox ||= Inbox.find_by(display_name: IMPORTED_HISTORY_INBOX_NAME, channel_type: 'Channel::Api') ||
+                                Inbox.create!(name: IMPORTED_HISTORY_INBOX_NAME, channel: Channel::Api.create!)
+  end
+
+  def ensure_contact_inbox(contact, inbox, source_id)
+    ContactInbox.find_or_create_by!(inbox_id: inbox.id, source_id: source_id) do |ci|
+      ci.contact_id = contact.id
+    end
+  end
+
+  def ensure_conversation(contact_inbox, external_id)
+    Conversation.find_or_create_by!(identifier: external_id) do |c|
+      c.contact_id = contact_inbox.contact_id
+      c.inbox_id = contact_inbox.inbox_id
+      c.contact_inbox_id = contact_inbox.id
+      c.status = :resolved
+      c.send(:status_explicitly_set!)
+      c.additional_attributes = { 'imported' => true, 'source' => 'data_import' }
+    end
+  end
+
+  def message_exists?(conversation, external_id)
+    return false if external_id.to_s.strip.empty?
+
+    conversation.messages.exists?(source_id: external_id)
+  end
+
+  def create_message(conversation, params, direction, sent_at)
+    content, content_attributes = build_message_content(params)
+    content_attributes[:external_created_at] = sent_at.to_i
+    content_attributes[:sender_name] = params[:sender_name] if params[:sender_name].present?
+
+    conversation.messages.create!(
+      inbox: conversation.inbox,
+      content: content,
+      message_type: direction == 'incoming' ? :incoming : :outgoing,
+      private: false,
+      source_id: params[:message_external_id].presence,
+      content_attributes: content_attributes,
+      created_at: sent_at,
+      updated_at: sent_at
+    )
+  end
+
+  def build_message_content(params)
+    type = params[:message_type].to_s.strip
+    return [params[:message_content].to_s, {}] if type.empty? || type.downcase == 'text'
+
+    ["[mídia: #{type}]", { imported_media_type: type }]
+  end
+
+  def record_failure(row, row_no, reason)
+    @report['error_count'] += 1
+    if @report['errors'].length < MAX_ERRORS_PERSISTED
+      @report['errors'] << { 'row' => row_no, 'reason' => reason }
+    end
+    failed = row.to_h
+    failed['errors'] = reason
+    failed['_row_number'] = row_no
+    @rejected_rows << failed
+  end
+end

--- a/app/services/data_import/conversation_manager.rb
+++ b/app/services/data_import/conversation_manager.rb
@@ -25,15 +25,27 @@ class DataImport::ConversationManager
     csv.each_with_index do |row, index|
       @report['total_rows'] += 1
       params = row.to_h.with_indifferent_access
+      row_no = row_number(index)
       begin
-        import_row(params, row_number(index))
+        ActiveRecord::Base.transaction(requires_new: true) do
+          import_row(params, row_no)
+        end
         @report['success_count'] += 1
       rescue RowError => e
-        record_failure(row, row_number(index), e.message)
+        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{e.message}"
+        record_failure(row, row_no, e.message)
       rescue ActiveRecord::RecordInvalid => e
-        record_failure(row, row_number(index), "validation failed: #{e.record.errors.full_messages.join(', ')}")
+        message = "validation failed: #{e.record.errors.full_messages.join(', ')}"
+        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
+        record_failure(row, row_no, message)
       rescue ActiveRecord::RecordNotUnique => e
-        record_failure(row, row_number(index), "uniqueness violation: #{e.message.lines.first&.strip}")
+        message = "uniqueness violation: #{e.message.lines.first&.strip}"
+        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
+        record_failure(row, row_no, message)
+      rescue ActiveRecord::StatementInvalid => e
+        message = "statement invalid: #{e.message.lines.first&.strip}"
+        Rails.logger.warn "[DataImport::Conversation] row #{row_no} failed: #{message}"
+        record_failure(row, row_no, message)
       end
     end
 
@@ -163,6 +175,7 @@ class DataImport::ConversationManager
       content: content,
       message_type: direction == 'incoming' ? :incoming : :outgoing,
       private: false,
+      source: :imported,
       source_id: params[:message_external_id].presence,
       content_attributes: content_attributes,
       created_at: sent_at,

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -236,6 +236,23 @@ class Rack::Attack
     "erp_webhook:#{match_data[1]}" if match_data && req.post?
   end
 
+  ## Prevent abuse of conversations history import (EVO-1557)
+  ## Each request can ingest up to 50k rows; default 5 reqs/min/key.
+  throttle('api/v1/conversations/import', limit: ENV.fetch('RATE_LIMIT_CONVERSATIONS_IMPORT', '5').to_i, period: 1.minute) do |req|
+    if req.path_without_extentions == '/api/v1/conversations/import' && req.post?
+      authorization = req.get_header('HTTP_AUTHORIZATION')
+      api_token     = req.get_header('HTTP_API_ACCESS_TOKEN') || req.get_header('api_access_token')
+
+      if authorization.present?
+        "bearer:#{Digest::SHA256.hexdigest(authorization)}"
+      elsif api_token.present?
+        "api_token:#{Digest::SHA256.hexdigest(api_token)}"
+      else
+        "ip:#{req.ip}"
+      end
+    end
+  end
+
   ## ----------------------------------------------- ##
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,12 @@ en:
         failed: File is blank
       export:
         success: We will notify you once contacts export file is ready to view.
+    conversations:
+      import:
+        missing_file: File is required
+        too_large: 'CSV exceeds the maximum allowed rows (%{limit})'
+        too_large_bytes: 'File exceeds the maximum allowed size (%{limit} bytes)'
+        invalid_csv: 'CSV is malformed: %{error}'
       email:
         invalid: Invalid email
       phone_number:

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -57,6 +57,12 @@ pt_BR:
         failed: Arquivo vazio
       export:
         success: Avisaremos você assim que a exportação de arquivos estiver pronta para ser exibida.
+    conversations:
+      import:
+        missing_file: Arquivo é obrigatório
+        too_large: 'CSV excede o limite máximo de linhas (%{limit})'
+        too_large_bytes: 'Arquivo excede o tamanho máximo permitido (%{limit} bytes)'
+        invalid_csv: 'CSV malformado: %{error}'
       email:
         invalid: E-mail inválido
       phone_number:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,7 @@ Rails.application.routes.draw do
           post :filter
           get :available_for_pipeline
           get :unread_count
+          post :import
         end
         resources :messages, only: [:index, :create, :destroy, :update], controller: 'conversations/messages' do
           member do

--- a/db/migrate/20260622120000_add_source_to_messages.rb
+++ b/db/migrate/20260622120000_add_source_to_messages.rb
@@ -1,0 +1,5 @@
+class AddSourceToMessages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :messages, :source, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260623120000_add_source_to_conversations.rb
+++ b/db/migrate/20260623120000_add_source_to_conversations.rb
@@ -1,0 +1,5 @@
+class AddSourceToConversations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conversations, :source, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -780,6 +780,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_23_110717) do
     t.text "processed_message_content"
     t.float "sentiment_score", default: 0.0
     t.integer "sentiment", default: 0, null: false
+    t.integer "source", default: 0, null: false
     t.index ["content"], name: "index_messages_on_content", opclass: :gin_trgm_ops, using: :gin
     t.index ["conversation_id", "created_at"], name: "idx_messages_conv_created_desc", order: { created_at: :desc }
     t.index ["conversation_id", "created_at"], name: "idx_messages_conv_created_incoming_desc", order: { created_at: :desc }, where: "(message_type = 0)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_23_110717) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_23_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -461,6 +461,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_23_110717) do
     t.integer "priority"
     t.datetime "waiting_since", precision: nil
     t.text "cached_label_list"
+    t.integer "source", default: 0, null: false
     t.index ["assignee_id", "status", "last_activity_at"], name: "index_conversations_on_assignee_status_last_activity", order: { last_activity_at: "DESC NULLS LAST" }
     t.index ["assignee_id"], name: "index_conversations_on_assignee_id"
     t.index ["contact_id"], name: "index_conversations_on_contact_id"

--- a/spec/jobs/data_import_job_spec.rb
+++ b/spec/jobs/data_import_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataImportJob, type: :job do
+  let!(:contact) { Contact.create!(name: 'Maria', identifier: "cust-#{SecureRandom.hex(4)}") }
+
+  let(:csv_body) do
+    [
+      'conversation_external_id,contact_identifier,message_content,direction,sent_at,sender_name,message_type,message_external_id',
+      "conv-j1,#{contact.identifier},Hi,incoming,2026-01-15T10:30:00Z,,text,msg-j1"
+    ].join("\n")
+  end
+
+  it 'dispatches conversation flow when data_type=conversations' do
+    data_import = DataImport.create!(data_type: 'conversations')
+    data_import.import_file.attach(io: StringIO.new(csv_body), filename: 'c.csv', content_type: 'text/csv')
+
+    described_class.new.perform(data_import)
+
+    data_import.reload
+    expect(data_import.status).to eq('completed')
+    expect(data_import.total_records).to eq(1)
+    expect(data_import.processed_records).to eq(1)
+    report = JSON.parse(data_import.processing_errors)
+    expect(report['success_count']).to eq(1)
+    expect(report['errors']).to eq([])
+    expect(Conversation.find_by(identifier: 'conv-j1')).to be_present
+  end
+
+  it 'attaches failed_records CSV when rows are rejected' do
+    csv = [
+      'conversation_external_id,contact_identifier,message_content,direction,sent_at,sender_name,message_type,message_external_id',
+      'conv-j2,unknown-id,Hi,incoming,2026-01-15T10:30:00Z,,text,msg-j2'
+    ].join("\n")
+    data_import = DataImport.create!(data_type: 'conversations')
+    data_import.import_file.attach(io: StringIO.new(csv), filename: 'c.csv', content_type: 'text/csv')
+
+    described_class.new.perform(data_import)
+
+    data_import.reload
+    expect(data_import.failed_records).to be_attached
+    body = data_import.failed_records.download
+    expect(body).to include('errors')
+    expect(body).to include('contact not found')
+  end
+
+  it 'marks status as failed when CSV is malformed' do
+    data_import = DataImport.create!(data_type: 'conversations')
+    data_import.import_file.attach(io: StringIO.new("just,one\n"), filename: 'c.csv', content_type: 'text/csv')
+
+    described_class.new.perform(data_import)
+
+    expect(data_import.reload.status).to eq('failed')
+  end
+
+  it 'M4 — does NOT send contact_import_failed mailer when conversations CSV is malformed' do
+    data_import = DataImport.create!(data_type: 'conversations')
+    data_import.import_file.attach(io: StringIO.new("just,one\n"), filename: 'c.csv', content_type: 'text/csv')
+
+    mailer_double = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+    expect(AdministratorNotifications::AccountNotificationMailer).not_to receive(:with)
+
+    described_class.new.perform(data_import)
+    expect(data_import.reload.status).to eq('failed')
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -50,6 +50,67 @@ RSpec.describe Message do
     end
   end
 
+  describe '#imported?' do
+    let(:contact) { Contact.create!(name: 'Imported Spec Contact', email: "imported-#{SecureRandom.hex(4)}@example.com") }
+    let(:inbox) { Inbox.create!(name: "Imported Spec Inbox #{SecureRandom.hex(2)}", channel: Channel::Api.create!) }
+    let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+    let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+    it 'defaults to live' do
+      message = described_class.new
+      expect(message.source).to eq('live')
+      expect(message.live?).to be(true)
+      expect(message.imported?).to be(false)
+    end
+
+    it 'skips after_create_commit callbacks when imported' do
+      message = described_class.new(
+        inbox: inbox,
+        conversation: conversation,
+        message_type: :incoming,
+        content: 'imported hello',
+        source: :imported
+      )
+
+      expect(message).not_to receive(:execute_after_create_commit_callbacks)
+      expect(message).not_to receive(:publish_message_created)
+      expect(message).not_to receive(:sync_message_event)
+
+      message.save!
+    end
+
+    it 'skips prevent_message_flooding when imported' do
+      allow(Limits).to receive(:conversation_message_per_minute_limit).and_return(100)
+
+      100.times do |i|
+        described_class.create!(
+          inbox: inbox,
+          conversation: conversation,
+          message_type: :incoming,
+          content: "live-#{i}"
+        )
+      end
+
+      live_attempt = described_class.new(
+        inbox: inbox,
+        conversation: conversation,
+        message_type: :incoming,
+        content: 'over-the-limit'
+      )
+      expect(live_attempt).not_to be_valid
+      expect(live_attempt.errors[:base]).to include('Too many messages')
+
+      imported = described_class.new(
+        inbox: inbox,
+        conversation: conversation,
+        message_type: :incoming,
+        content: 'imported-past-the-cap',
+        source: :imported
+      )
+      expect(imported).to be_valid
+    end
+  end
+
   describe '#set_conversation_activity' do
     it 'delegates to refresh_conversation_activity! with current time' do
       conversation = double('Conversation', last_activity_at: nil)

--- a/spec/requests/api/v1/conversations_import_spec.rb
+++ b/spec/requests/api/v1/conversations_import_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe 'Api::V1::ConversationsController#import', type: :request do
+  let(:base_url) { 'http://auth.test' }
+  let(:validate_url) { "#{base_url}/api/v1/auth/validate" }
+  let(:token) { 'test-bearer-token' }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+  let!(:user) { User.create!(name: 'Import Test', email: "import-#{SecureRandom.hex(4)}@example.com") }
+  let(:permission_check_url) { "#{base_url}/api/v1/users/#{user.id}/check_permission" }
+
+  let(:csv_header) do
+    'conversation_external_id,contact_identifier,message_content,direction,sent_at,sender_name,message_type,message_external_id'
+  end
+
+  around do |example|
+    original = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+    ENV['EVO_AUTH_SERVICE_URL'] = base_url
+    Rails.cache.clear
+    Current.reset
+    example.run
+    Rails.cache.clear
+    Current.reset
+    ENV['EVO_AUTH_SERVICE_URL'] = original
+  end
+
+  def stub_auth_ok
+    stub_request(:post, validate_url)
+      .with(headers: { 'Authorization' => "Bearer #{token}" })
+      .to_return(
+        status: 200,
+        body: { success: true, data: { user: { id: user.id, email: user.email } } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def stub_permission(granted:)
+    stub_request(:post, permission_check_url)
+      .to_return(
+        status: 200,
+        body: { success: true, data: { has_permission: granted } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def csv_file(content, name: 'conv.csv')
+    Rack::Test::UploadedFile.new(StringIO.new(content), 'text/csv', original_filename: name)
+  end
+
+  context 'when authenticated and authorized' do
+    before do
+      stub_auth_ok
+      stub_permission(granted: true)
+      Current.user = user
+    end
+
+    it 'AC2 — returns 202 with data_import_id on happy path' do
+      csv = [csv_header, 'conv-1,id-1,Hi,incoming,2026-01-15T10:30:00Z,,text,m1'].join("\n")
+
+      expect do
+        post '/api/v1/conversations/import', params: { import_file: csv_file(csv) }, headers: headers
+      end.to change(DataImport, :count).by(1)
+
+      expect(response).to have_http_status(:accepted)
+      body = response.parsed_body
+      expect(body['data']['data_import_id']).to be_present
+      expect(DataImport.find(body['data']['data_import_id']).data_type).to eq('conversations')
+    end
+
+    it 'returns 422 when import_file is missing' do
+      post '/api/v1/conversations/import', params: {}, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body.dig('error', 'message')).to match(/File is required/i)
+    end
+
+    it 'AC9 — returns 422 when CSV exceeds 50k rows' do
+      stub_const('Api::V1::ConversationsController::CONVERSATIONS_IMPORT_ROW_LIMIT', 2)
+      csv = [
+        csv_header,
+        'conv-1,id-1,Hi,incoming,2026-01-15T10:30:00Z,,text,m1',
+        'conv-1,id-1,Hi,incoming,2026-01-15T10:31:00Z,,text,m2',
+        'conv-1,id-1,Hi,incoming,2026-01-15T10:32:00Z,,text,m3'
+      ].join("\n")
+
+      expect do
+        post '/api/v1/conversations/import', params: { import_file: csv_file(csv) }, headers: headers
+      end.not_to change(DataImport, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body.dig('error', 'message')).to match(/exceeds the maximum allowed rows/)
+    end
+
+    it 'returns 422 on malformed CSV' do
+      malformed = "broken\"unterminated,quote\n\nfoo,bar\n"
+      post '/api/v1/conversations/import', params: { import_file: csv_file(malformed) }, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body.dig('error', 'message')).to match(/malformed/i)
+    end
+
+    it 'M3 — returns 422 when file exceeds byte size limit' do
+      stub_const('Api::V1::ConversationsController::CONVERSATIONS_IMPORT_MAX_BYTES', 32)
+      csv = [csv_header, 'conv-1,id-1,Hi,incoming,2026-01-15T10:30:00Z,,text,m1'].join("\n")
+
+      expect do
+        post '/api/v1/conversations/import', params: { import_file: csv_file(csv) }, headers: headers
+      end.not_to change(DataImport, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body.dig('error', 'message')).to match(/maximum allowed size/i)
+    end
+  end
+
+  context 'when permission is denied' do
+    before do
+      stub_auth_ok
+      stub_permission(granted: false)
+      Current.user = user
+    end
+
+    it 'returns 403' do
+      csv = [csv_header, 'conv-1,id-1,Hi,incoming,2026-01-15T10:30:00Z,,text,m1'].join("\n")
+      post '/api/v1/conversations/import', params: { import_file: csv_file(csv) }, headers: headers
+
+      expect(response).to have_http_status(:forbidden)
+      expect(DataImport.count).to eq(0)
+    end
+  end
+end

--- a/spec/services/data_import/conversation_manager_spec.rb
+++ b/spec/services/data_import/conversation_manager_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe DataImport::ConversationManager do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:data_import) { DataImport.create!(data_type: 'conversations') }
 
   def attach_csv(content)
@@ -128,6 +130,61 @@ RSpec.describe DataImport::ConversationManager do
       msg = Conversation.find_by(identifier: 'conv-5').messages.first
       expect(msg.content).to eq('[mídia: image]')
       expect(msg.content_attributes['imported_media_type']).to eq('image')
+    end
+  end
+
+  describe 'when a row fails mid-import' do
+    let(:huge_content) { 'x' * 160_000 }
+
+    it 'rolls back the conversation created in the same row' do
+      attach_csv([
+        header_row,
+        "conv-tx-ok,#{contact.identifier},ok,incoming,2026-01-15T10:30:00Z,,text,m-ok",
+        "conv-tx-bad,#{contact.identifier},#{huge_content},incoming,2026-01-15T10:31:00Z,,text,m-bad"
+      ].join("\n"))
+
+      expect { described_class.new(data_import).process }
+        .to change { Conversation.where(identifier: %w[conv-tx-ok conv-tx-bad]).count }.by(1)
+
+      expect(Conversation.find_by(identifier: 'conv-tx-bad')).to be_nil
+      expect(Conversation.find_by(identifier: 'conv-tx-ok')).to be_present
+    end
+
+    it 'does NOT fire message_created listeners for imported messages' do
+      attach_csv([
+        header_row,
+        "conv-listen,#{contact.identifier},hi,incoming,2026-01-15T10:30:00Z,,text,m-listen"
+      ].join("\n"))
+
+      expect(WebhookListener.instance).not_to receive(:message_created)
+      expect(AutomationRuleListener.instance).not_to receive(:message_created)
+      expect(ActionCableListener.instance).not_to receive(:message_created)
+      expect(SendReplyJob).not_to receive(:perform_later)
+      expect(AgentBots::SessionSyncService).not_to receive(:add_event_for_message)
+
+      described_class.new(data_import).process
+    end
+
+    it 'does NOT bump conversation last_activity_at to current time' do
+      attach_csv([
+        header_row,
+        "conv-activity,#{contact.identifier},hi,incoming,2026-01-15T10:30:00Z,,text,m-activity"
+      ].join("\n"))
+
+      expect_any_instance_of(Message).not_to receive(:set_conversation_activity)
+
+      described_class.new(data_import).process
+    end
+
+    it 'does NOT increment prometheus counter' do
+      attach_csv([
+        header_row,
+        "conv-prom,#{contact.identifier},hi,incoming,2026-01-15T10:30:00Z,,text,m-prom"
+      ].join("\n"))
+
+      expect(::Redis::Alfred).not_to receive(:incr)
+
+      described_class.new(data_import).process
     end
   end
 

--- a/spec/services/data_import/conversation_manager_spec.rb
+++ b/spec/services/data_import/conversation_manager_spec.rb
@@ -224,4 +224,105 @@ RSpec.describe DataImport::ConversationManager do
       expect(report['errors'].first['reason']).to match(/validation failed/i)
     end
   end
+
+  describe 'imported conversation suppresses live callbacks (round 2 H1)' do
+    before do
+      attach_csv([
+        header_row,
+        "conv-h1,#{contact.identifier},hi,incoming,2026-01-15T10:30:00Z,,text,m-h1"
+      ].join("\n"))
+    end
+
+    it 'marks the created conversation as Conversation.source = imported' do
+      described_class.new(data_import).process
+      expect(Conversation.find_by(identifier: 'conv-h1').source).to eq('imported')
+    end
+
+    it 'does NOT dispatch CONVERSATION_CREATED for imported conversations' do
+      dispatched = []
+      allow(Rails.configuration.dispatcher).to receive(:dispatch) do |event, *_args|
+        dispatched << event
+      end
+
+      described_class.new(data_import).process
+
+      expect(dispatched).not_to include(Events::Types::CONVERSATION_CREATED)
+    end
+
+    it 'does NOT publish :conversation_created via Wisper for imported conversations' do
+      published = []
+      listener = ->(_payload) { published << :conversation_created }
+      Wisper.subscribe(Object.new.tap { |o| o.define_singleton_method(:conversation_created, &listener) }) do
+        described_class.new(data_import).process
+      end
+
+      expect(published).to be_empty
+    end
+
+    it 'does NOT assign imported conversation to any pipeline' do
+      described_class.new(data_import).process
+      conversation = Conversation.find_by(identifier: 'conv-h1')
+      expect(conversation.pipeline_items).to be_empty
+    end
+  end
+
+  describe '#parse_timestamp tolerance (round 2 sent_at)' do
+    let(:manager) { described_class.new(data_import) }
+
+    {
+      '2026-01-15T10:30:00Z'      => Time.utc(2026, 1, 15, 10, 30, 0),
+      '2026-01-15T10:30:00-03:00' => Time.utc(2026, 1, 15, 13, 30, 0),
+      '2026-01-15 10:30:00'       => Time.utc(2026, 1, 15, 10, 30, 0),
+      '2026-01-15'                => Time.utc(2026, 1, 15, 0, 0, 0),
+      '1736937000'                => Time.at(1_736_937_000).utc,
+      '1736937000000'             => Time.at(1_736_937_000).utc
+    }.each do |input, expected|
+      it "parses #{input.inspect} as UTC" do
+        expect(manager.send(:parse_timestamp, input)).to eq(expected)
+      end
+    end
+
+    it 'treats naive timestamps as UTC, not server-local' do
+      Time.use_zone('America/Sao_Paulo') do
+        parsed = manager.send(:parse_timestamp, '2026-01-15T10:30:00')
+        expect(parsed.utc).to eq(Time.utc(2026, 1, 15, 10, 30, 0))
+      end
+    end
+
+    it 'returns nil for unparseable values' do
+      expect(manager.send(:parse_timestamp, 'not-a-date')).to be_nil
+      expect(manager.send(:parse_timestamp, '')).to be_nil
+      expect(manager.send(:parse_timestamp, nil)).to be_nil
+    end
+  end
+
+  describe 'last_activity_at derived from sent_at (round 2 new low)' do
+    it 'sets conversation.last_activity_at to the max sent_at across imported rows' do
+      attach_csv([
+        header_row,
+        "conv-la,#{contact.identifier},old,incoming,2024-01-15T10:30:00Z,,text,la-1",
+        "conv-la,#{contact.identifier},newer,outgoing,2024-03-20T11:45:00Z,Atendente,text,la-2",
+        "conv-la,#{contact.identifier},newest,outgoing,2024-06-01T08:00:00Z,Atendente,text,la-3"
+      ].join("\n"))
+
+      described_class.new(data_import).process
+
+      conversation = Conversation.find_by(identifier: 'conv-la')
+      expect(conversation.last_activity_at.utc).to eq(Time.utc(2024, 6, 1, 8, 0, 0))
+    end
+
+    it 'does NOT bump last_activity_at past historical max via belongs_to touch' do
+      attach_csv([
+        header_row,
+        "conv-touch,#{contact.identifier},hi,incoming,2024-01-01T00:00:00Z,,text,t-1"
+      ].join("\n"))
+
+      travel_to(Time.utc(2026, 6, 23, 18, 0, 0)) do
+        described_class.new(data_import).process
+      end
+
+      conversation = Conversation.find_by(identifier: 'conv-touch')
+      expect(conversation.last_activity_at.utc).to eq(Time.utc(2024, 1, 1, 0, 0, 0))
+    end
+  end
 end

--- a/spec/services/data_import/conversation_manager_spec.rb
+++ b/spec/services/data_import/conversation_manager_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataImport::ConversationManager do
+  let(:data_import) { DataImport.create!(data_type: 'conversations') }
+
+  def attach_csv(content)
+    data_import.import_file.attach(
+      io: StringIO.new(content),
+      filename: 'conversations.csv',
+      content_type: 'text/csv'
+    )
+  end
+
+  def header_row
+    'conversation_external_id,contact_identifier,message_content,direction,sent_at,sender_name,message_type,message_external_id'
+  end
+
+  let!(:contact) { Contact.create!(name: 'Maria', identifier: "cust-#{SecureRandom.hex(4)}", phone_number: '+5511999998888') }
+
+  describe '#process happy path' do
+    before do
+      attach_csv([
+        header_row,
+        "conv-1,#{contact.identifier},Oi tudo bem?,incoming,2026-01-15T10:30:00Z,,text,msg-1",
+        "conv-1,#{contact.identifier},Tudo sim e voce?,outgoing,2026-01-15T10:31:00Z,Atendente,text,msg-2"
+      ].join("\n"))
+    end
+
+    it 'creates a single Imported History inbox, conversation, and two messages' do
+      manager = described_class.new(data_import)
+      report = manager.process
+
+      expect(report['total_rows']).to eq(2)
+      expect(report['success_count']).to eq(2)
+      expect(report['error_count']).to eq(0)
+
+      conversation = Conversation.find_by(identifier: 'conv-1')
+      expect(conversation).to be_present
+      expect(conversation.inbox.display_name).to eq('Imported History')
+      expect(conversation.inbox.channel_type).to eq('Channel::Api')
+      expect(conversation.status).to eq('resolved')
+      expect(conversation.messages.count).to eq(2)
+      expect(conversation.messages.pluck(:message_type)).to match_array(%w[incoming outgoing])
+    end
+
+    it 'preserves sender_name in content_attributes when sender is unmapped (AC6)' do
+      described_class.new(data_import).process
+
+      outgoing = Conversation.find_by(identifier: 'conv-1').messages.find_by(message_type: 'outgoing')
+      expect(outgoing.sender_id).to be_nil
+      expect(outgoing.sender_type).to be_nil
+      expect(outgoing.content_attributes['sender_name']).to eq('Atendente')
+    end
+  end
+
+  describe 'contact lookup fallback' do
+    it 'falls back to phone_number when identifier does not match' do
+      attach_csv([header_row, 'conv-2,5511999998888,Hi,incoming,2026-01-15T10:30:00Z,,text,msg-a'].join("\n"))
+
+      report = described_class.new(data_import).process
+
+      expect(report['success_count']).to eq(1)
+      expect(Conversation.find_by(identifier: 'conv-2').contact_id).to eq(contact.id)
+    end
+  end
+
+  describe 'orphan contact (AC5)' do
+    it 'fails the row and keeps processing' do
+      attach_csv([
+        header_row,
+        'conv-3,does-not-exist,Hi,incoming,2026-01-15T10:30:00Z,,text,msg-x',
+        "conv-3b,#{contact.identifier},Hello,outgoing,2026-01-15T10:31:00Z,,text,msg-y"
+      ].join("\n"))
+
+      report = described_class.new(data_import).process
+
+      expect(report['total_rows']).to eq(2)
+      expect(report['success_count']).to eq(1)
+      expect(report['error_count']).to eq(1)
+      expect(report['errors'].first['reason']).to include('contact not found')
+      expect(report['errors'].first['row']).to eq(2)
+    end
+  end
+
+  describe 'idempotent re-import (AC7)' do
+    let(:rows) do
+      [
+        header_row,
+        "conv-4,#{contact.identifier},First,incoming,2026-01-15T10:30:00Z,,text,msg-1"
+      ]
+    end
+
+    it 'preserves conversation id and skips duplicate messages, adds new ones' do
+      attach_csv(rows.join("\n"))
+      described_class.new(data_import).process
+      conversation = Conversation.find_by(identifier: 'conv-4')
+      original_id = conversation.id
+
+      second_import = DataImport.create!(data_type: 'conversations')
+      second_import.import_file.attach(
+        io: StringIO.new([
+          header_row,
+          "conv-4,#{contact.identifier},First,incoming,2026-01-15T10:30:00Z,,text,msg-1",
+          "conv-4,#{contact.identifier},Second,outgoing,2026-01-15T10:31:00Z,,text,msg-2"
+        ].join("\n")),
+        filename: 'c.csv',
+        content_type: 'text/csv'
+      )
+
+      described_class.new(second_import).process
+
+      expect(Conversation.find_by(identifier: 'conv-4').id).to eq(original_id)
+      expect(conversation.reload.messages.pluck(:source_id)).to match_array(%w[msg-1 msg-2])
+    end
+  end
+
+  describe 'non-text message type (AC8)' do
+    it 'replaces content with [mídia: {type}] without downloading' do
+      attach_csv([
+        header_row,
+        "conv-5,#{contact.identifier},http://example.com/file.jpg,incoming,2026-01-15T10:30:00Z,,image,msg-img"
+      ].join("\n"))
+
+      described_class.new(data_import).process
+
+      msg = Conversation.find_by(identifier: 'conv-5').messages.first
+      expect(msg.content).to eq('[mídia: image]')
+      expect(msg.content_attributes['imported_media_type']).to eq('image')
+    end
+  end
+
+  describe 'malformed row (AC11)' do
+    it 'records error for invalid direction and continues' do
+      attach_csv([
+        header_row,
+        "conv-6,#{contact.identifier},Hi,sideways,2026-01-15T10:30:00Z,,text,msg-bad",
+        "conv-7,#{contact.identifier},OK,incoming,2026-01-15T10:31:00Z,,text,msg-ok"
+      ].join("\n"))
+
+      report = described_class.new(data_import).process
+
+      expect(report['error_count']).to eq(1)
+      expect(report['success_count']).to eq(1)
+      expect(report['errors'].first['reason']).to include('invalid direction')
+    end
+
+    it 'rejects missing required header upfront' do
+      attach_csv("conversation_external_id,contact_identifier,message_content,direction\nconv-x,1,Hi,incoming")
+
+      expect { described_class.new(data_import).process }.to raise_error(CSV::MalformedCSVError, /missing required columns/)
+    end
+
+    it 'recovers from ActiveRecord::RecordInvalid raised by a single bad row (M1)' do
+      huge_content = 'x' * 160_000
+      attach_csv([
+        header_row,
+        "conv-m1a,#{contact.identifier},#{huge_content},incoming,2026-01-15T10:30:00Z,,text,m-huge",
+        "conv-m1b,#{contact.identifier},ok,outgoing,2026-01-15T10:31:00Z,,text,m-ok"
+      ].join("\n"))
+
+      report = described_class.new(data_import).process
+
+      expect(report['error_count']).to eq(1)
+      expect(report['success_count']).to eq(1)
+      expect(report['errors'].first['reason']).to match(/validation failed/i)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extends `DataImport` to accept `data_type='conversations'` for migrating chat history from other CRMs.
- New service `DataImport::ConversationManager`: denormalized CSV (1 row per message) → contact lookup (identifier → phone → email), idempotent upsert by `conversation.identifier` and `message.source_id`, lazy-creates one `Imported History` Channel::Api inbox, imported conversations land as `resolved`.
- New endpoint `POST /api/v1/conversations/import` (multipart): `202 + { data_import_id }` on success; `422` on missing file, > 50k rows, > 50MB, or malformed CSV.
- `DataImportJob` now dispatches by `data_type`; the existing contacts flow is unchanged.
- rack-attack throttle `api/v1/conversations/import` (default 5/min/key, env `RATE_LIMIT_CONVERSATIONS_IMPORT`).

## Acceptance Criteria Coverage
All 11 ACs from EVO-1557 are implemented and covered by automated tests:

| AC | Coverage |
|---|---|
| AC1 — validator accepts `conversations` | `conversation_manager_spec` |
| AC2 — 202 + `data_import_id` | `conversations_import_spec` |
| AC3 — Job processes via `ConversationManager` | `data_import_job_spec` |
| AC4 — required CSV columns | `conversation_manager_spec` (missing header) |
| AC5 — orphan contact → row fails, processing continues | `conversation_manager_spec` |
| AC6 — unmapped sender → user_id=NULL, sender_name preserved | `conversation_manager_spec` |
| AC7 — idempotent re-import | `conversation_manager_spec` |
| AC8 — `message_type != 'text'` → `[mídia: {type}]` | `conversation_manager_spec` |
| AC9 — CSV > 50k rows → 422 | `conversations_import_spec` |
| AC10 — structured report (`total_rows`, `success_count`, `error_count`, `errors[]`) | `data_import_job_spec` |
| AC11 — specs for orphan contact, unmapped sender, idempotent, malformed | `conversation_manager_spec` |

## Security
- Permission `conversations.import` required.
- rack-attack throttle (5 req/min/key, token-hashed discriminator falling back to IP).
- Upfront byte limit (50MB) before ActiveStorage attach to prevent DoS.
- Upfront row count (streaming `CSV.foreach`, breaks at limit+1) to short-circuit oversized files without loading 50k rows into heap.
- `CSVSafe.generate` used for `failed_records` output (CSV-injection-safe).
- Empty `contact_identifier` is rejected; phone fallback skipped when value strips to empty; email fallback skipped unless value contains `@` — prevents `find_by(phone_number: nil)` false-positive matches.

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/services/data_import/conversation_manager_spec.rb spec/jobs/data_import_job_spec.rb spec/requests/api/v1/conversations_import_spec.rb` — 19 examples, 0 failures
- Manual smoke (`rails runner`) end-to-end confirmed: 3/4 rows imported (1 orphan rejected), failed_records CSV attached, idempotent re-import keeps the same conversation id and message count

## Changed Files
- `app/models/data_import.rb`
- `app/services/data_import/conversation_manager.rb` (new)
- `app/jobs/data_import_job.rb`
- `app/controllers/api/v1/conversations_controller.rb`
- `config/routes.rb`
- `config/initializers/rack_attack.rb`
- `config/locales/en.yml`
- `config/locales/pt_BR.yml`
- `spec/services/data_import/conversation_manager_spec.rb` (new)
- `spec/jobs/data_import_job_spec.rb` (new)
- `spec/requests/api/v1/conversations_import_spec.rb` (new)

## Known limitations (deferred LOW findings from adversarial review)
- No completion notification mailer for conversations success path (contacts flow has `contact_import_complete`; conversations is silent). Deferred to the UI story.
- `errors.data_import.data_type.invalid` i18n key shared between both data types (no per-type customization yet).
- `count_csv_rows` returns `[0, nil]` if uploaded file lacks `.path` (Rails multipart always has it; defensive fail-open could be tightened).
- Logging in the conversations flow is lighter than the contacts flow.
- Inbox lookup by `display_name` could collide with a manually-created inbox of the same name (no marker on `additional_attributes`).
- Idempotency spec does not assert that `conversation.status` stays `resolved` across re-imports.
- No spec for malformed `sent_at` timestamp specifically.
- `failed_records` CSV does not include a `_row_number` column.

## Linked Issue
- EVO-1557

## Summary by Sourcery

Add support for importing conversation history via the DataImport pipeline and expose a throttled API endpoint for CSV-based conversation imports.

New Features:
- Introduce a DataImport data_type for conversations to process imported conversation history CSV files.
- Add a conversations import endpoint that validates CSV size and structure before queuing a background data import job.
- Implement a ConversationManager service to upsert conversations and messages from import rows, including idempotency and automatic resolution of imported conversations.

Enhancements:
- Extend DataImportJob to dispatch processing based on data_type and to generate structured reports and failed-records CSVs for conversation imports.
- Add localized error messages for conversations import validation failures in English and Brazilian Portuguese.

Tests:
- Add service, job, and request specs covering conversation imports, CSV validation, and reporting for the new data_type.