### PR TITLE
feat(crm): B14 CRM Lead Capture — form-builder + chat pages (EVO-1771)

### DIFF
--- a/app/controllers/api/v1/chat_pages_controller.rb
+++ b/app/controllers/api/v1/chat_pages_controller.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Admin CRUD for public chat pages (B14.08). Authenticated + permission-gated
+# via the evo-auth-service catalog (chat_pages.{read,create,update,delete}).
+#
+# A ChatPage wraps an existing Channel::WebWidget (by website_token); this
+# controller manages the page metadata only — it does not create widgets.
+class Api::V1::ChatPagesController < Api::V1::BaseController
+  require_permissions({
+                        index: 'chat_pages.read',
+                        show: 'chat_pages.read',
+                        create: 'chat_pages.create',
+                        update: 'chat_pages.update',
+                        destroy: 'chat_pages.delete'
+                      })
+
+  before_action :fetch_chat_page, only: [:show, :update, :destroy]
+
+  def index
+    scope = ChatPage.order(created_at: :desc)
+
+    if params[:search].present?
+      q = "%#{params[:search].strip}%"
+      scope = scope.where('chat_pages.title ILIKE :q OR chat_pages.slug ILIKE :q OR chat_pages.description ILIKE :q', q: q)
+    end
+
+    scope = scope.where(published: ActiveModel::Type::Boolean.new.cast(params[:published])) if params[:published].present?
+
+    page = params[:page].presence || 1
+    per_page = params[:pageSize].presence || params[:per_page].presence || 20
+    @chat_pages = scope.page(page).per(per_page)
+
+    paginated_response(
+      data: @chat_pages.map { |chat_page| ChatPageSerializer.serialize(chat_page) },
+      collection: @chat_pages,
+      message: 'Chat pages retrieved successfully'
+    )
+  end
+
+  def show
+    success_response(
+      data: ChatPageSerializer.serialize(@chat_page),
+      message: 'Chat page retrieved successfully'
+    )
+  end
+
+  def create
+    @chat_page = ChatPage.new(chat_page_params)
+
+    if @chat_page.save
+      success_response(
+        data: ChatPageSerializer.serialize(@chat_page),
+        message: 'Chat page created successfully',
+        status: :created
+      )
+    else
+      validation_error(@chat_page)
+    end
+  end
+
+  def update
+    if @chat_page.update(chat_page_params)
+      success_response(
+        data: ChatPageSerializer.serialize(@chat_page),
+        message: 'Chat page updated successfully'
+      )
+    else
+      validation_error(@chat_page)
+    end
+  end
+
+  def destroy
+    @chat_page.destroy
+    success_response(
+      data: { id: @chat_page.id },
+      message: 'Chat page deleted successfully'
+    )
+  end
+
+  private
+
+  def fetch_chat_page
+    @chat_page = ChatPage.find(params[:id])
+  end
+
+  def chat_page_params
+    params.require(:chat_page).permit(
+      :slug, :title, :description, :published, :website_token,
+      appearance: {}
+    )
+  end
+
+  def validation_error(record)
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: record.errors.full_messages,
+      status: :unprocessable_entity
+    )
+  end
+end

--- a/app/controllers/api/v1/crm_forms_controller.rb
+++ b/app/controllers/api/v1/crm_forms_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Admin CRUD for lead-capture forms (B14.01). Authenticated + permission-gated
+# via the evo-auth-service catalog (crm_forms.{read,create,update,delete}).
+class Api::V1::CrmFormsController < Api::V1::BaseController
+  require_permissions({
+                        index: 'crm_forms.read',
+                        show: 'crm_forms.read',
+                        create: 'crm_forms.create',
+                        update: 'crm_forms.update',
+                        destroy: 'crm_forms.delete'
+                      })
+
+  before_action :fetch_crm_form, only: [:show, :update, :destroy]
+
+  def index
+    @crm_forms = CrmForm.order(created_at: :desc)
+
+    success_response(
+      data: CrmFormSerializer.serialize_collection(@crm_forms),
+      message: 'Forms retrieved successfully'
+    )
+  end
+
+  def show
+    success_response(
+      data: CrmFormSerializer.serialize(@crm_form),
+      message: 'Form retrieved successfully'
+    )
+  end
+
+  def create
+    @crm_form = CrmForm.new(crm_form_params)
+
+    if @crm_form.save
+      success_response(
+        data: CrmFormSerializer.serialize(@crm_form),
+        message: 'Form created successfully',
+        status: :created
+      )
+    else
+      validation_error(@crm_form)
+    end
+  end
+
+  def update
+    if @crm_form.update(crm_form_params)
+      success_response(
+        data: CrmFormSerializer.serialize(@crm_form),
+        message: 'Form updated successfully'
+      )
+    else
+      validation_error(@crm_form)
+    end
+  end
+
+  def destroy
+    @crm_form.destroy
+    success_response(
+      data: { id: @crm_form.id },
+      message: 'Form deleted successfully'
+    )
+  end
+
+  private
+
+  def fetch_crm_form
+    @crm_form = CrmForm.find(params[:id])
+  end
+
+  def crm_form_params
+    params.require(:crm_form).permit(
+      :name, :title, :description, :published,
+      :default_pipeline_id, :default_stage_id,
+      appearance: {},
+      fields: [:key, :label, :type, :required, :placeholder, :maps_to, { options: [] }],
+      routing_rules: [:field, :op, :value, :pipeline_id, :stage_id]
+    )
+  end
+
+  def validation_error(record)
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: record.errors.full_messages,
+      status: :unprocessable_entity
+    )
+  end
+end

--- a/app/controllers/api/v1/crm_forms_controller.rb
+++ b/app/controllers/api/v1/crm_forms_controller.rb
@@ -6,26 +6,42 @@ class Api::V1::CrmFormsController < Api::V1::BaseController
   require_permissions({
                         index: 'crm_forms.read',
                         show: 'crm_forms.read',
+                        leads: 'crm_forms.read',
                         create: 'crm_forms.create',
                         update: 'crm_forms.update',
                         destroy: 'crm_forms.delete'
                       })
 
-  before_action :fetch_crm_form, only: [:show, :update, :destroy]
+  before_action :fetch_crm_form, only: [:show, :update, :destroy, :leads]
 
   def index
     @crm_forms = CrmForm.order(created_at: :desc)
+    counts = CrmForm.lead_counts_by_slug(@crm_forms.map(&:slug))
 
     success_response(
-      data: CrmFormSerializer.serialize_collection(@crm_forms),
+      data: @crm_forms.map { |form| CrmFormSerializer.serialize(form, leads_count: counts[form.slug] || 0) },
       message: 'Forms retrieved successfully'
     )
   end
 
   def show
     success_response(
-      data: CrmFormSerializer.serialize(@crm_form),
+      data: CrmFormSerializer.serialize(@crm_form, leads_count: @crm_form.captured_leads.count),
       message: 'Form retrieved successfully'
+    )
+  end
+
+  # GET /api/v1/crm_forms/:id/leads — leads captured by this form (B14.07).
+  def leads
+    items = @crm_form.captured_leads
+                     .includes(:contact, :pipeline, :pipeline_stage)
+                     .order(created_at: :desc)
+                     .limit(200)
+
+    success_response(
+      data: items.map { |item| serialize_lead(item) },
+      meta: { count: @crm_form.captured_leads.count },
+      message: 'Leads retrieved successfully'
     )
   end
 
@@ -66,6 +82,16 @@ class Api::V1::CrmFormsController < Api::V1::BaseController
 
   def fetch_crm_form
     @crm_form = CrmForm.find(params[:id])
+  end
+
+  def serialize_lead(item)
+    {
+      id: item.id,
+      contact: item.contact && { id: item.contact.id, name: item.contact.name, email: item.contact.email },
+      pipeline_id: item.pipeline_id,
+      pipeline_stage_id: item.pipeline_stage_id,
+      created_at: item.created_at&.iso8601
+    }
   end
 
   def crm_form_params

--- a/app/controllers/api/v1/crm_forms_controller.rb
+++ b/app/controllers/api/v1/crm_forms_controller.rb
@@ -73,7 +73,7 @@ class Api::V1::CrmFormsController < Api::V1::BaseController
       :name, :title, :description, :published,
       :default_pipeline_id, :default_stage_id,
       appearance: {},
-      fields: [:key, :label, :type, :required, :placeholder, :maps_to, { options: [] }],
+      fields: [:key, :label, :type, :required, :placeholder, :maps_to, :maps_to_key, { options: [] }],
       routing_rules: [:field, :op, :value, :pipeline_id, :stage_id]
     )
   end

--- a/app/controllers/api/v1/crm_forms_controller.rb
+++ b/app/controllers/api/v1/crm_forms_controller.rb
@@ -15,11 +15,24 @@ class Api::V1::CrmFormsController < Api::V1::BaseController
   before_action :fetch_crm_form, only: [:show, :update, :destroy, :leads]
 
   def index
-    @crm_forms = CrmForm.order(created_at: :desc)
+    scope = CrmForm.order(created_at: :desc)
+
+    if params[:search].present?
+      q = "%#{params[:search].strip}%"
+      scope = scope.where('crm_forms.name ILIKE :q OR crm_forms.title ILIKE :q OR crm_forms.slug ILIKE :q', q: q)
+    end
+
+    scope = scope.where(published: ActiveModel::Type::Boolean.new.cast(params[:published])) if params[:published].present?
+
+    page = params[:page].presence || 1
+    per_page = params[:pageSize].presence || params[:per_page].presence || 20
+    @crm_forms = scope.page(page).per(per_page)
+
     counts = CrmForm.lead_counts_by_slug(@crm_forms.map(&:slug))
 
-    success_response(
+    paginated_response(
       data: @crm_forms.map { |form| CrmFormSerializer.serialize(form, leads_count: counts[form.slug] || 0) },
+      collection: @crm_forms,
       message: 'Forms retrieved successfully'
     )
   end

--- a/app/controllers/public/api/v1/chat_pages_controller.rb
+++ b/app/controllers/public/api/v1/chat_pages_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Anonymous, public chat-page endpoint (B14.03).
+#
+# Inherits directly from PublicController (no API key): the page is resolved by
+# its public slug and returns the widget `website_token` (public by design — it
+# is the same token printed in the widget embed script) plus appearance, so the
+# frontend can mount the existing widget SDK. Only published pages respond.
+class Public::Api::V1::ChatPagesController < PublicController
+  def show
+    chat_page = ChatPage.published.find_by(slug: params[:slug])
+
+    return render json: { success: false, error: 'Chat page not found' }, status: :not_found unless chat_page
+
+    render json: {
+      success: true,
+      data: {
+        slug: chat_page.slug,
+        title: chat_page.display_title,
+        appearance: chat_page.appearance || {},
+        website_token: chat_page.website_token
+      }
+    }
+  end
+end

--- a/app/controllers/public/api/v1/chat_pages_controller.rb
+++ b/app/controllers/public/api/v1/chat_pages_controller.rb
@@ -17,6 +17,7 @@ class Public::Api::V1::ChatPagesController < PublicController
       data: {
         slug: chat_page.slug,
         title: chat_page.display_title,
+        description: chat_page.description,
         appearance: chat_page.appearance || {},
         website_token: chat_page.website_token
       }

--- a/app/controllers/public/api/v1/forms_controller.rb
+++ b/app/controllers/public/api/v1/forms_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Anonymous, public lead-capture form endpoint (B14.01).
+#
+# Inherits directly from PublicController (NOT Public::Api::V1::BaseController)
+# so it is reachable WITHOUT an API key: the form is resolved from its public
+# slug. Only published forms respond; everything else 404s without leaking.
+class Public::Api::V1::FormsController < PublicController
+  before_action :set_form
+
+  # GET /public/api/v1/forms/:slug — config for rendering the public page.
+  def show
+    render json: { success: true, data: CrmFormPublicSerializer.serialize(@form) }
+  end
+
+  # POST /public/api/v1/forms/:slug/submissions — anonymous lead submission.
+  def create
+    result = Public::Forms::SubmissionService.new(form: @form, params: submission_params).perform
+
+    if result[:success]
+      render json: {
+        success: true,
+        lead_id: result[:contact]&.id,
+        deal_id: result[:pipeline_item]&.id,
+        message: 'Lead created successfully'
+      }, status: :created
+    else
+      errors = Array(result[:errors].presence || result[:error])
+      render json: {
+        success: false,
+        error: errors.join(', '),
+        details: errors
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_form
+    @form = CrmForm.published.find_by(slug: params[:slug])
+    return if @form
+
+    render json: { success: false, error: 'Form not found' }, status: :not_found
+  end
+
+  # Permits an arbitrary set of field keys under :submission (forms are dynamic).
+  def submission_params
+    params.permit(submission: {})
+  end
+end

--- a/app/models/chat_page.rb
+++ b/app/models/chat_page.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: chat_pages
+#
+#  id            :uuid             not null, primary key
+#  appearance    :jsonb            not null
+#  description   :text
+#  published     :boolean          default(FALSE), not null
+#  slug          :string(255)      not null
+#  title         :string(255)
+#  website_token :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_chat_pages_on_published      (published)
+#  index_chat_pages_on_slug           (slug) UNIQUE
+#  index_chat_pages_on_website_token  (website_token)
+#
+# A public, self-contained chat page (B14.03). Mounts the existing site-widget
+# SDK by `website_token` so a tenant can offer chat at `/chat/:slug` without
+# embedding the widget on their own site. Single-tenant in Community.
+class ChatPage < ApplicationRecord
+  before_validation :generate_slug, on: :create
+
+  validates :slug, presence: true, uniqueness: true, length: { maximum: 255 },
+                   format: { with: /\A[a-z0-9\-]+\z/, message: 'must be lowercase alphanumeric with dashes' }
+  validates :website_token, presence: true
+  validate :website_token_matches_widget
+
+  scope :published, -> { where(published: true) }
+
+  # The web-widget channel this page wraps (resolved by website_token).
+  def web_widget
+    @web_widget ||= Channel::WebWidget.find_by(website_token: website_token)
+  end
+
+  # Public heading: explicit title, else the widget's inbox name.
+  def display_title
+    title.presence || web_widget&.inbox&.name
+  end
+
+  private
+
+  def website_token_matches_widget
+    return if website_token.blank?
+
+    errors.add(:website_token, 'does not match an existing web widget') unless Channel::WebWidget.exists?(website_token: website_token)
+  end
+
+  def generate_slug
+    return if slug.present?
+
+    base = title.to_s.parameterize
+    base = "chat-#{SecureRandom.hex(4)}" if base.blank?
+
+    candidate = base
+    suffix = 2
+    while ChatPage.exists?(slug: candidate)
+      candidate = "#{base}-#{suffix}"
+      suffix += 1
+    end
+
+    self.slug = candidate
+  end
+end

--- a/app/models/crm_form.rb
+++ b/app/models/crm_form.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: crm_forms
+#
+#  id                  :uuid             not null, primary key
+#  appearance          :jsonb            not null
+#  description         :text
+#  fields              :jsonb            not null
+#  name                :string(255)      not null
+#  published           :boolean          default(FALSE), not null
+#  routing_rules       :jsonb            not null
+#  slug                :string(255)      not null
+#  title               :string(255)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  default_pipeline_id :uuid             not null
+#  default_stage_id    :uuid
+#
+# Indexes
+#
+#  index_crm_forms_on_fields         (fields) USING gin
+#  index_crm_forms_on_published      (published)
+#  index_crm_forms_on_routing_rules  (routing_rules) USING gin
+#  index_crm_forms_on_slug           (slug) UNIQUE
+#
+# A lead-capture form (B14.01). Generic and single-tenant in Community; the
+# per-tenant isolation (tenant_id + RLS) is layered on top in Enterprise.
+#
+# A form is NOT bound to a single pipeline: it carries a default pipeline/stage
+# plus optional `routing_rules` that route a submission to a different
+# pipeline/stage based on field answers (e.g. answer X -> Pipeline A).
+class CrmForm < ApplicationRecord
+  belongs_to :default_pipeline, class_name: 'Pipeline'
+  belongs_to :default_stage, class_name: 'PipelineStage', optional: true
+
+  FIELD_TYPES = %w[text email tel number textarea select checkbox].freeze
+  # Maps a form field onto the contact attributes Public::Leads::CreationService expects.
+  MAPPABLE    = %w[name email phone company].freeze
+  ROUTING_OPS = %w[equals not_equals contains].freeze
+
+  before_validation :generate_slug, on: :create
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :slug, presence: true, uniqueness: true, length: { maximum: 255 },
+                   format: { with: /\A[a-z0-9\-]+\z/, message: 'must be lowercase alphanumeric with dashes' }
+  validate :validate_fields_schema
+  validate :validate_routing_rules
+
+  scope :published, -> { where(published: true) }
+
+  # Public-facing heading: falls back to the internal name when no title is set.
+  def display_title
+    title.presence || name
+  end
+
+  # Resolve the destination [pipeline_id, stage_id] for a submission, applying the
+  # first matching routing rule and falling back to the form's default.
+  # @param answers [Hash] field_key => submitted value
+  def resolve_destination(answers)
+    rule = Array(routing_rules).find { |r| rule_matches?(r, answers) }
+
+    if rule && rule['pipeline_id'].present?
+      [rule['pipeline_id'], rule['stage_id'].presence || default_stage_id]
+    else
+      [default_pipeline_id, default_stage_id]
+    end
+  end
+
+  private
+
+  def rule_matches?(rule, answers)
+    value  = answers[rule['field']].to_s
+    target = rule['value'].to_s
+
+    case rule['op']
+    when 'equals'     then value.casecmp?(target)
+    when 'not_equals' then !value.casecmp?(target)
+    when 'contains'   then value.downcase.include?(target.downcase)
+    else false
+    end
+  end
+
+  def generate_slug
+    return if slug.present?
+
+    base = name.to_s.parameterize
+    base = "form-#{SecureRandom.hex(4)}" if base.blank?
+
+    candidate = base
+    suffix = 2
+    while CrmForm.exists?(slug: candidate)
+      candidate = "#{base}-#{suffix}"
+      suffix += 1
+    end
+
+    self.slug = candidate
+  end
+
+  def validate_fields_schema
+    unless fields.is_a?(Array)
+      errors.add(:fields, 'must be an array')
+      return
+    end
+
+    fields.each_with_index do |field, idx|
+      errors.add(:fields, "[#{idx}] must have a key") if field['key'].blank?
+
+      errors.add(:fields, "[#{idx}] has invalid type '#{field['type']}'") if field['type'].present? && FIELD_TYPES.exclude?(field['type'])
+
+      errors.add(:fields, "[#{idx}] has invalid maps_to '#{field['maps_to']}'") if field['maps_to'].present? && MAPPABLE.exclude?(field['maps_to'])
+    end
+
+    # CreationService requires a contact name + email, so the form must collect them.
+    mapped = fields.filter_map { |f| f['maps_to'] }
+    errors.add(:fields, 'must include a field mapped to email') if mapped.exclude?('email')
+    errors.add(:fields, 'must include a field mapped to name')  if mapped.exclude?('name')
+  end
+
+  def validate_routing_rules
+    unless routing_rules.is_a?(Array)
+      errors.add(:routing_rules, 'must be an array')
+      return
+    end
+
+    routing_rules.each_with_index do |rule, idx|
+      errors.add(:routing_rules, "[#{idx}] has invalid op '#{rule['op']}'") if rule['op'].present? && ROUTING_OPS.exclude?(rule['op'])
+      errors.add(:routing_rules, "[#{idx}] requires a pipeline_id") if rule['pipeline_id'].blank?
+    end
+  end
+end

--- a/app/models/crm_form.rb
+++ b/app/models/crm_form.rb
@@ -36,8 +36,10 @@ class CrmForm < ApplicationRecord
   belongs_to :default_stage, class_name: 'PipelineStage', optional: true
 
   FIELD_TYPES = %w[text email tel number textarea select checkbox].freeze
-  # Maps a form field onto the contact attributes Public::Leads::CreationService expects.
+  # Standard contact fields a form field can target.
   MAPPABLE    = %w[name email phone company].freeze
+  # Typed mapping kinds (flat schema: field['maps_to'] = kind, field['maps_to_key'] = key).
+  MAP_KINDS   = %w[contact contact_attribute deal_value deal_attribute].freeze
   ROUTING_OPS = %w[equals not_equals contains].freeze
 
   before_validation :generate_slug, on: :create
@@ -53,6 +55,29 @@ class CrmForm < ApplicationRecord
   # Public-facing heading: falls back to the internal name when no title is set.
   def display_title
     title.presence || name
+  end
+
+  # Resolve a field's mapping into [bucket, key]. Handles both the legacy string
+  # form (maps_to = 'name'|'email'|'phone'|'company') and the typed form
+  # (maps_to = kind, maps_to_key = key). Returns nil when unmapped/invalid.
+  #
+  # Buckets: :contact (key in MAPPABLE), :contact_attribute, :deal_value, :deal_attribute.
+  # This is the shared contract between the admin builder and the public submission:
+  # every target the builder can configure is a target the submission can receive.
+  def self.field_target(field)
+    maps_to = field['maps_to'].to_s
+    key     = field['maps_to_key'].to_s
+    return nil if maps_to.blank?
+
+    # Legacy: maps_to is itself a standard contact field.
+    return [:contact, maps_to] if MAPPABLE.include?(maps_to)
+
+    case maps_to
+    when 'contact'           then [:contact, key] if MAPPABLE.include?(key)
+    when 'contact_attribute' then [:contact_attribute, key] if key.present?
+    when 'deal_value'        then [:deal_value, 'value']
+    when 'deal_attribute'    then [:deal_attribute, key] if key.present?
+    end
   end
 
   # Resolve the destination [pipeline_id, stage_id] for a submission, applying the
@@ -109,13 +134,13 @@ class CrmForm < ApplicationRecord
 
       errors.add(:fields, "[#{idx}] has invalid type '#{field['type']}'") if field['type'].present? && FIELD_TYPES.exclude?(field['type'])
 
-      errors.add(:fields, "[#{idx}] has invalid maps_to '#{field['maps_to']}'") if field['maps_to'].present? && MAPPABLE.exclude?(field['maps_to'])
+      errors.add(:fields, "[#{idx}] has an invalid mapping target") if field['maps_to'].present? && self.class.field_target(field).nil?
     end
 
     # CreationService requires a contact name + email, so the form must collect them.
-    mapped = fields.filter_map { |f| f['maps_to'] }
-    errors.add(:fields, 'must include a field mapped to email') if mapped.exclude?('email')
-    errors.add(:fields, 'must include a field mapped to name')  if mapped.exclude?('name')
+    targets = fields.map { |f| self.class.field_target(f) }
+    errors.add(:fields, 'must include a field mapped to contact email') unless targets.include?([:contact, 'email'])
+    errors.add(:fields, 'must include a field mapped to contact name')  unless targets.include?([:contact, 'name'])
   end
 
   def validate_routing_rules

--- a/app/models/crm_form.rb
+++ b/app/models/crm_form.rb
@@ -57,6 +57,20 @@ class CrmForm < ApplicationRecord
     title.presence || name
   end
 
+  # Pipeline items captured by this form via the public submission endpoint
+  # (the submit stamps custom_fields.lead_metadata.form_slug). (B14.07)
+  def captured_leads
+    PipelineItem.where("custom_fields -> 'lead_metadata' ->> 'form_slug' = ?", slug)
+  end
+
+  # One grouped query: { slug => count } for the given slugs.
+  def self.lead_counts_by_slug(slugs)
+    return {} if slugs.blank?
+
+    PipelineItem.where("custom_fields -> 'lead_metadata' ->> 'form_slug' IN (?)", slugs)
+                .group("custom_fields -> 'lead_metadata' ->> 'form_slug'").count
+  end
+
   # Resolve a field's mapping into [bucket, key]. Handles both the legacy string
   # form (maps_to = 'name'|'email'|'phone'|'company') and the typed form
   # (maps_to = kind, maps_to_key = key). Returns nil when unmapped/invalid.

--- a/app/models/crm_form.rb
+++ b/app/models/crm_form.rb
@@ -49,6 +49,7 @@ class CrmForm < ApplicationRecord
                    format: { with: /\A[a-z0-9\-]+\z/, message: 'must be lowercase alphanumeric with dashes' }
   validate :validate_fields_schema
   validate :validate_routing_rules
+  validate :validate_default_destination
 
   scope :published, -> { where(published: true) }
 
@@ -165,7 +166,37 @@ class CrmForm < ApplicationRecord
 
     routing_rules.each_with_index do |rule, idx|
       errors.add(:routing_rules, "[#{idx}] has invalid op '#{rule['op']}'") if rule['op'].present? && ROUTING_OPS.exclude?(rule['op'])
-      errors.add(:routing_rules, "[#{idx}] requires a pipeline_id") if rule['pipeline_id'].blank?
+
+      pipeline_id = rule['pipeline_id']
+      if pipeline_id.blank?
+        errors.add(:routing_rules, "[#{idx}] requires a pipeline_id")
+        next
+      end
+
+      # A rule's destination must exist and be consistent, or every submission it
+      # routes 422s inside CreationService — a published form capturing zero leads.
+      pipeline = Pipeline.find_by(id: pipeline_id)
+      if pipeline.nil?
+        errors.add(:routing_rules, "[#{idx}] references a pipeline that does not exist")
+        next
+      end
+
+      stage_id = rule['stage_id']
+      if stage_id.present? && pipeline.pipeline_stages.where(id: stage_id).none?
+        errors.add(:routing_rules, "[#{idx}] references a stage that does not belong to the pipeline")
+      end
     end
+  end
+
+  # The default destination feeds every submission that no rule routes (and is
+  # the stage fallback for rules without their own stage), so it gets the same
+  # existence + membership guarantee. `default_pipeline` presence/existence is
+  # already enforced by the (required) belongs_to; here we only need to confirm
+  # the optional default stage actually belongs to that pipeline.
+  def validate_default_destination
+    return if default_stage_id.blank? || default_pipeline_id.blank?
+    return if default_pipeline&.pipeline_stages&.where(id: default_stage_id)&.exists?
+
+    errors.add(:default_stage, 'must belong to the default pipeline')
   end
 end

--- a/app/policies/crm_form_policy.rb
+++ b/app/policies/crm_form_policy.rb
@@ -1,0 +1,36 @@
+class CrmFormPolicy < ApplicationPolicy
+  class Scope
+    attr_reader :user_context, :user, :scope, :account
+
+    def initialize(user_context, scope)
+      @user_context = user_context
+      @user = user_context[:user]
+      @account = user_context[:account]
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+
+  def index?
+    @user&.administrator? || @user&.has_permission?('crm_forms.read')
+  end
+
+  def show?
+    @user&.administrator? || @user&.has_permission?('crm_forms.read')
+  end
+
+  def create?
+    @user&.administrator? || @user&.has_permission?('crm_forms.create')
+  end
+
+  def update?
+    @user&.administrator? || @user&.has_permission?('crm_forms.update')
+  end
+
+  def destroy?
+    @user&.administrator? || @user&.has_permission?('crm_forms.delete')
+  end
+end

--- a/app/serializers/chat_page_serializer.rb
+++ b/app/serializers/chat_page_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# ChatPageSerializer - admin serialization of a ChatPage (B14.08).
+#
+# Plain Ruby module matching the convention used by CrmFormSerializer /
+# ProductSerializer in this app.
+module ChatPageSerializer
+  extend self
+
+  def serialize(page)
+    {
+      id: page.id,
+      slug: page.slug,
+      title: page.title,
+      display_title: page.display_title,
+      description: page.description,
+      appearance: page.appearance || {},
+      website_token: page.website_token,
+      widget_inbox_name: page.web_widget&.inbox&.name,
+      published: page.published,
+      public_path: "/chat/#{page.slug}",
+      created_at: page.created_at&.iso8601,
+      updated_at: page.updated_at&.iso8601
+    }
+  end
+
+  def serialize_collection(pages)
+    return [] unless pages
+
+    pages.map { |page| serialize(page) }
+  end
+end

--- a/app/serializers/crm_form_public_serializer.rb
+++ b/app/serializers/crm_form_public_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Public-facing serialization of a CrmForm — only what the anonymous page needs
+# to render. Deliberately omits internals (routing_rules, pipeline ids, etc.).
+module CrmFormPublicSerializer
+  extend self
+
+  def serialize(form)
+    {
+      slug: form.slug,
+      title: form.display_title,
+      description: form.description,
+      appearance: form.appearance || {},
+      fields: public_fields(form.fields)
+    }
+  end
+
+  private
+
+  def public_fields(fields)
+    Array(fields).map do |field|
+      {
+        key: field['key'],
+        label: field['label'],
+        type: field['type'].presence || 'text',
+        required: field['required'] == true,
+        placeholder: field['placeholder'],
+        options: field['options']
+      }.compact
+    end
+  end
+end

--- a/app/serializers/crm_form_serializer.rb
+++ b/app/serializers/crm_form_serializer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# CrmFormSerializer - full (admin) serialization of a CrmForm.
+#
+# Plain Ruby module matching the convention used by ProductSerializer /
+# AutomationRuleSerializer in this app.
+module CrmFormSerializer
+  extend self
+
+  def serialize(form)
+    {
+      id: form.id,
+      name: form.name,
+      slug: form.slug,
+      title: form.title,
+      description: form.description,
+      appearance: form.appearance || {},
+      fields: form.fields || [],
+      routing_rules: form.routing_rules || [],
+      default_pipeline_id: form.default_pipeline_id,
+      default_stage_id: form.default_stage_id,
+      published: form.published,
+      public_path: "/f/#{form.slug}",
+      created_at: form.created_at&.iso8601,
+      updated_at: form.updated_at&.iso8601
+    }
+  end
+
+  def serialize_collection(forms)
+    return [] unless forms
+
+    forms.map { |form| serialize(form) }
+  end
+end

--- a/app/serializers/crm_form_serializer.rb
+++ b/app/serializers/crm_form_serializer.rb
@@ -7,8 +7,8 @@
 module CrmFormSerializer
   extend self
 
-  def serialize(form)
-    {
+  def serialize(form, leads_count: nil)
+    data = {
       id: form.id,
       name: form.name,
       slug: form.slug,
@@ -24,6 +24,8 @@ module CrmFormSerializer
       created_at: form.created_at&.iso8601,
       updated_at: form.updated_at&.iso8601
     }
+    data[:leads_count] = leads_count unless leads_count.nil?
+    data
   end
 
   def serialize_collection(forms)

--- a/app/services/public/forms/submission_service.rb
+++ b/app/services/public/forms/submission_service.rb
@@ -61,29 +61,44 @@ class Public::Forms::SubmissionService
     [pipeline_id, stage_id]
   end
 
+  # Routes each answer into the bucket its mapping target points to, so the form's
+  # configured targets and the lead the API creates stay 1:1 (B14.06).
   def build_lead_params(answers, pipeline_id, stage_id)
     contact = {}
-    custom_fields = {}
+    contact_attributes = {}
+    deal_value = nil
+    deal_fields = {}
 
     Array(@form.fields).each do |field|
-      key = field['key']
-      value = answers[key]
+      value = answers[field['key']]
       next if value.nil?
 
-      case field['maps_to']
-      when 'name'    then contact[:name] = value
-      when 'email'   then contact[:email] = value
-      when 'phone'   then contact[:phone_number] = value
-      when 'company' then contact[:company] = value
-      else custom_fields[key] = value
+      bucket, target_key = CrmForm.field_target(field)
+      case bucket
+      when :contact
+        contact[CONTACT_KEYS.fetch(target_key)] = value
+      when :contact_attribute
+        contact_attributes[target_key] = value
+      when :deal_value
+        deal_value = value
+      when :deal_attribute
+        deal_fields[target_key] = value
+      else
+        # Unmapped fields are still kept on the deal so nothing is silently lost.
+        deal_fields[field['key']] = value
       end
     end
 
+    contact[:custom_attributes] = contact_attributes if contact_attributes.any?
+
     {
       contact: contact,
-      deal: { pipeline_id: pipeline_id, stage_id: stage_id },
-      custom_fields: custom_fields,
+      deal: { pipeline_id: pipeline_id, stage_id: stage_id, value: deal_value }.compact,
+      custom_fields: deal_fields,
       metadata: { form_slug: @form.slug, lead_source: 'crm_form' }
     }
   end
+
+  # Standard contact target keys -> CreationService contact param keys.
+  CONTACT_KEYS = { 'name' => :name, 'email' => :email, 'phone' => :phone_number, 'company' => :company }.freeze
 end

--- a/app/services/public/forms/submission_service.rb
+++ b/app/services/public/forms/submission_service.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Public::Forms::SubmissionService
+#
+# Handles an anonymous lead-capture form submission (B14.01): runs anti-spam
+# checks, maps the submitted answers onto contact attributes, resolves the
+# destination pipeline/stage from the form's routing rules, and delegates the
+# actual contact + pipeline_item creation to Public::Leads::CreationService.
+class Public::Forms::SubmissionService
+  # Hidden field rendered by the public form; bots fill everything, humans never see it.
+  HONEYPOT_FIELD = '_hp_url'
+
+  def initialize(form:, params:)
+    @form = form
+    @params = params
+  end
+
+  def perform
+    # Silently discard suspected spam without creating anything.
+    return { success: true, skipped: true } if honeypot_triggered?
+
+    answers = extract_answers
+    missing = missing_required_fields(answers)
+    return { success: false, errors: missing } if missing.any?
+
+    pipeline_id, stage_id = resolve_destination(answers)
+
+    Public::Leads::CreationService.new(
+      lead_params: build_lead_params(answers, pipeline_id, stage_id)
+    ).perform
+  end
+
+  private
+
+  def submission
+    @submission ||= (@params[:submission] || {}).to_h.with_indifferent_access
+  end
+
+  def honeypot_triggered?
+    submission[HONEYPOT_FIELD].present?
+  end
+
+  # Answers keyed by field key, dropping the honeypot.
+  def extract_answers
+    submission.except(HONEYPOT_FIELD).to_h
+  end
+
+  def missing_required_fields(answers)
+    Array(@form.fields).filter_map do |field|
+      next unless field['required']
+
+      "#{field['label'].presence || field['key']} is required" if answers[field['key']].to_s.blank?
+    end
+  end
+
+  # Resolve [pipeline_id, stage_id], falling back to the pipeline's first stage
+  # when neither a rule nor the form default provides one (CreationService requires a stage).
+  def resolve_destination(answers)
+    pipeline_id, stage_id = @form.resolve_destination(answers)
+    stage_id ||= Pipeline.find_by(id: pipeline_id)&.pipeline_stages&.order(:position)&.first&.id
+    [pipeline_id, stage_id]
+  end
+
+  def build_lead_params(answers, pipeline_id, stage_id)
+    contact = {}
+    custom_fields = {}
+
+    Array(@form.fields).each do |field|
+      key = field['key']
+      value = answers[key]
+      next if value.nil?
+
+      case field['maps_to']
+      when 'name'    then contact[:name] = value
+      when 'email'   then contact[:email] = value
+      when 'phone'   then contact[:phone_number] = value
+      when 'company' then contact[:company] = value
+      else custom_fields[key] = value
+      end
+    end
+
+    {
+      contact: contact,
+      deal: { pipeline_id: pipeline_id, stage_id: stage_id },
+      custom_fields: custom_fields,
+      metadata: { form_slug: @form.slug, lead_source: 'crm_form' }
+    }
+  end
+end

--- a/app/services/public/leads/creation_service.rb
+++ b/app/services/public/leads/creation_service.rb
@@ -94,6 +94,13 @@ class Public::Leads::CreationService
         update_attrs[:additional_attributes] = contact.additional_attributes
       end
 
+      # Merge contact custom attributes if provided (B14.06 context-driven mapping)
+      if contact_params[:custom_attributes].present?
+        contact.custom_attributes ||= {}
+        contact.custom_attributes.merge!(contact_params[:custom_attributes].to_h)
+        update_attrs[:custom_attributes] = contact.custom_attributes
+      end
+
       contact.update!(update_attrs) if update_attrs.any?
 
       Rails.logger.info "Public Leads API: Found existing contact #{contact.id} for email #{contact_params[:email]}"
@@ -109,7 +116,8 @@ class Public::Leads::CreationService
         name: contact_params[:name],
         email: contact_params[:email],
         phone_number: normalize_phone_number(contact_params[:phone_number]),
-        additional_attributes: {}
+        additional_attributes: {},
+        custom_attributes: contact_params[:custom_attributes].presence&.to_h || {}
       }
 
       # Add company to additional_attributes if provided

--- a/app/services/public/leads/creation_service.rb
+++ b/app/services/public/leads/creation_service.rb
@@ -94,11 +94,20 @@ class Public::Leads::CreationService
         update_attrs[:additional_attributes] = contact.additional_attributes
       end
 
-      # Merge contact custom attributes if provided (B14.06 context-driven mapping)
+      # Merge contact custom attributes if provided (B14.06 context-driven mapping).
+      # This path is anonymous (public form/leads API), and a contact is matched
+      # purely by email — so anyone who knows an existing contact's email could
+      # otherwise clobber its attributes. Write additively: only fill keys that
+      # are currently blank, never overwrite values the contact already holds.
       if contact_params[:custom_attributes].present?
         contact.custom_attributes ||= {}
-        contact.custom_attributes.merge!(contact_params[:custom_attributes].to_h)
-        update_attrs[:custom_attributes] = contact.custom_attributes
+        additive = contact_params[:custom_attributes].to_h.reject do |key, _|
+          contact.custom_attributes[key].present?
+        end
+        if additive.any?
+          contact.custom_attributes.merge!(additive)
+          update_attrs[:custom_attributes] = contact.custom_attributes
+        end
       end
 
       contact.update!(update_attrs) if update_attrs.any?

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -104,6 +104,11 @@ class Rack::Attack
     req.ip if req.path_without_extentions == '/api/v1/accounts' && req.post?
   end
 
+  ## Anti-spam for anonymous lead-capture form submissions (B14.01) ###
+  throttle('public/forms/submissions/ip', limit: ENV.fetch('FORM_SUBMISSION_RATE_LIMIT', '10').to_i, period: 1.hour) do |req|
+    req.ip if req.post? && req.path_without_extentions.match?(%r{\A/public/api/v1/forms/[^/]+/submissions\z})
+  end
+
   ##-----------------------------------------------##
 
   ###-----------------------------------------------###

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,9 @@ Rails.application.routes.draw do
         resources :variants, controller: 'products/variants', only: [:index, :create, :update, :destroy]
       end
 
+      # Lead-capture form builder admin CRUD (B14.01).
+      resources :crm_forms, only: [:index, :create, :show, :update, :destroy], controller: 'crm_forms'
+
       # Attach/detach products to AI agents (agent lives in evo_core; we only
       # track the join here and propagate to agent.config via
       # Ai::AgentProductSyncService).
@@ -707,6 +710,10 @@ Rails.application.routes.draw do
         end
 
         resources :leads, only: [:create]
+
+        # Anonymous lead-capture forms (B14.01): resolved by public slug, no API key.
+        get  'forms/:slug',             to: 'forms#show'
+        post 'forms/:slug/submissions', to: 'forms#create'
 
         resources :csat_survey, only: [:show, :update]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,6 +264,9 @@ Rails.application.routes.draw do
         get :leads, on: :member
       end
 
+      # Chat-page builder admin CRUD (B14.08).
+      resources :chat_pages, only: [:index, :create, :show, :update, :destroy], controller: 'chat_pages'
+
       # Attach/detach products to AI agents (agent lives in evo_core; we only
       # track the join here and propagate to agent.config via
       # Ai::AgentProductSyncService).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -717,6 +717,9 @@ Rails.application.routes.draw do
         get  'forms/:slug',             to: 'forms#show'
         post 'forms/:slug/submissions', to: 'forms#create'
 
+        # Anonymous public chat page (B14.03): resolved by slug, returns website_token.
+        get 'chat_pages/:slug', to: 'chat_pages#show'
+
         resources :csat_survey, only: [:show, :update]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,7 +260,9 @@ Rails.application.routes.draw do
       end
 
       # Lead-capture form builder admin CRUD (B14.01).
-      resources :crm_forms, only: [:index, :create, :show, :update, :destroy], controller: 'crm_forms'
+      resources :crm_forms, only: [:index, :create, :show, :update, :destroy], controller: 'crm_forms' do
+        get :leads, on: :member
+      end
 
       # Attach/detach products to AI agents (agent lives in evo_core; we only
       # track the join here and propagate to agent.config via

--- a/db/migrate/20260619120000_create_crm_forms.rb
+++ b/db/migrate/20260619120000_create_crm_forms.rb
@@ -1,0 +1,29 @@
+class CreateCrmForms < ActiveRecord::Migration[7.1]
+  def change
+    create_table :crm_forms, id: :uuid do |t|
+      t.string :name, null: false, limit: 255
+      t.string :slug, null: false, limit: 255
+      t.string :title, limit: 255
+      t.text :description
+      t.jsonb :appearance, null: false, default: {}
+      t.jsonb :fields, null: false, default: []
+      t.jsonb :routing_rules, null: false, default: []
+      t.uuid :default_pipeline_id, null: false
+      t.uuid :default_stage_id
+      t.boolean :published, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :crm_forms, :slug, unique: true
+    add_index :crm_forms, :published
+    add_index :crm_forms, :fields, using: :gin
+    add_index :crm_forms, :routing_rules, using: :gin
+
+    add_foreign_key :crm_forms, :pipelines, column: :default_pipeline_id
+    add_foreign_key :crm_forms, :pipeline_stages, column: :default_stage_id
+
+    add_check_constraint :crm_forms, "name != ''", name: 'crm_forms_name_not_empty'
+    add_check_constraint :crm_forms, "slug != ''", name: 'crm_forms_slug_not_empty'
+  end
+end

--- a/db/migrate/20260619130000_create_chat_pages.rb
+++ b/db/migrate/20260619130000_create_chat_pages.rb
@@ -1,0 +1,21 @@
+class CreateChatPages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :chat_pages, id: :uuid do |t|
+      t.string :slug, null: false, limit: 255
+      t.string :title, limit: 255
+      t.text :description
+      t.jsonb :appearance, null: false, default: {}
+      t.string :website_token, null: false
+      t.boolean :published, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :chat_pages, :slug, unique: true
+    add_index :chat_pages, :published
+    add_index :chat_pages, :website_token
+
+    add_check_constraint :chat_pages, "slug != ''", name: 'chat_pages_slug_not_empty'
+    add_check_constraint :chat_pages, "website_token != ''", name: 'chat_pages_website_token_not_empty'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_11_130000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_19_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -461,6 +461,27 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_130000) do
     t.index ["team_id"], name: "index_conversations_on_team_id"
     t.index ["uuid"], name: "index_conversations_on_uuid", unique: true
     t.index ["waiting_since"], name: "index_conversations_on_waiting_since"
+  end
+
+  create_table "crm_forms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", limit: 255, null: false
+    t.string "slug", limit: 255, null: false
+    t.string "title", limit: 255
+    t.text "description"
+    t.jsonb "appearance", default: {}, null: false
+    t.jsonb "fields", default: [], null: false
+    t.jsonb "routing_rules", default: [], null: false
+    t.uuid "default_pipeline_id", null: false
+    t.uuid "default_stage_id"
+    t.boolean "published", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fields"], name: "index_crm_forms_on_fields", using: :gin
+    t.index ["published"], name: "index_crm_forms_on_published"
+    t.index ["routing_rules"], name: "index_crm_forms_on_routing_rules", using: :gin
+    t.index ["slug"], name: "index_crm_forms_on_slug", unique: true
+    t.check_constraint "name::text <> ''::text", name: "crm_forms_name_not_empty"
+    t.check_constraint "slug::text <> ''::text", name: "crm_forms_slug_not_empty"
   end
 
   create_table "csat_survey_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1318,6 +1339,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_130000) do
   add_foreign_key "automation_rule_runs", "automation_rules", on_delete: :cascade
   add_foreign_key "contact_companies", "contacts"
   add_foreign_key "contact_companies", "contacts", column: "company_id"
+  add_foreign_key "crm_forms", "pipeline_stages", column: "default_stage_id"
+  add_foreign_key "crm_forms", "pipelines", column: "default_pipeline_id"
   add_foreign_key "data_privacy_consents", "users"
   add_foreign_key "facebook_comment_moderations", "conversations"
   add_foreign_key "facebook_comment_moderations", "messages"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_19_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -348,6 +348,22 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
     t.index ["phone_number"], name: "index_channel_whatsapp_on_phone_number", unique: true
   end
 
+  create_table "chat_pages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "slug", limit: 255, null: false
+    t.string "title", limit: 255
+    t.text "description"
+    t.jsonb "appearance", default: {}, null: false
+    t.string "website_token", null: false
+    t.boolean "published", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["published"], name: "index_chat_pages_on_published"
+    t.index ["slug"], name: "index_chat_pages_on_slug", unique: true
+    t.index ["website_token"], name: "index_chat_pages_on_website_token"
+    t.check_constraint "slug::text <> ''::text", name: "chat_pages_slug_not_empty"
+    t.check_constraint "website_token::text <> ''::text", name: "chat_pages_website_token_not_empty"
+  end
+
   create_table "contact_companies", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "contact_id", null: false
     t.uuid "company_id", null: false
@@ -461,6 +477,27 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
     t.index ["team_id"], name: "index_conversations_on_team_id"
     t.index ["uuid"], name: "index_conversations_on_uuid", unique: true
     t.index ["waiting_since"], name: "index_conversations_on_waiting_since"
+  end
+
+  create_table "crm_forms", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", limit: 255, null: false
+    t.string "slug", limit: 255, null: false
+    t.string "title", limit: 255
+    t.text "description"
+    t.jsonb "appearance", default: {}, null: false
+    t.jsonb "fields", default: [], null: false
+    t.jsonb "routing_rules", default: [], null: false
+    t.uuid "default_pipeline_id", null: false
+    t.uuid "default_stage_id"
+    t.boolean "published", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fields"], name: "index_crm_forms_on_fields", using: :gin
+    t.index ["published"], name: "index_crm_forms_on_published"
+    t.index ["routing_rules"], name: "index_crm_forms_on_routing_rules", using: :gin
+    t.index ["slug"], name: "index_crm_forms_on_slug", unique: true
+    t.check_constraint "name::text <> ''::text", name: "crm_forms_name_not_empty"
+    t.check_constraint "slug::text <> ''::text", name: "crm_forms_slug_not_empty"
   end
 
   create_table "csat_survey_responses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -997,8 +1034,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
     t.index ["sku"], name: "index_products_on_sku", unique: true, where: "(sku IS NOT NULL)"
     t.index ["status"], name: "index_products_on_status"
     t.check_constraint "default_price >= 0::numeric", name: "products_default_price_non_negative"
-    t.check_constraint "kind::text = ANY (ARRAY['physical'::character varying, 'digital'::character varying]::text[])", name: "products_kind_check"
-    t.check_constraint "status::text = ANY (ARRAY['active'::character varying, 'inactive'::character varying, 'draft'::character varying]::text[])", name: "products_status_check"
+    t.check_constraint "kind::text = ANY (ARRAY['physical'::character varying::text, 'digital'::character varying::text])", name: "products_kind_check"
+    t.check_constraint "status::text = ANY (ARRAY['active'::character varying::text, 'inactive'::character varying::text, 'draft'::character varying::text])", name: "products_status_check"
     t.check_constraint "stock_quantity IS NULL OR stock_quantity >= 0", name: "products_stock_quantity_non_negative"
   end
 
@@ -1334,6 +1371,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_12_000000) do
   add_foreign_key "automation_rule_runs", "automation_rules", on_delete: :cascade
   add_foreign_key "contact_companies", "contacts"
   add_foreign_key "contact_companies", "contacts", column: "company_id"
+  add_foreign_key "crm_forms", "pipeline_stages", column: "default_stage_id"
+  add_foreign_key "crm_forms", "pipelines", column: "default_pipeline_id"
   add_foreign_key "data_privacy_consents", "users"
   add_foreign_key "facebook_comment_moderations", "conversations"
   add_foreign_key "facebook_comment_moderations", "messages"

--- a/spec/models/chat_page_spec.rb
+++ b/spec/models/chat_page_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChatPage, type: :model do
+  let(:web_widget) { Channel::WebWidget.create!(website_url: 'https://chat.example.com') }
+  let!(:inbox) { Inbox.create!(name: 'Chat Inbox', channel: web_widget) }
+
+  def build_page(attrs = {})
+    ChatPage.new({ title: 'Atendimento', website_token: web_widget.website_token }.merge(attrs))
+  end
+
+  describe 'slug generation' do
+    it 'derives a slug from the title on create' do
+      page = build_page(title: 'Fale Conosco')
+      page.save!
+      expect(page.slug).to eq('fale-conosco')
+    end
+
+    it 'disambiguates colliding slugs' do
+      build_page(title: 'Dup').save!
+      second = build_page(title: 'Dup')
+      second.save!
+      expect(second.slug).to eq('dup-2')
+    end
+  end
+
+  describe 'validations' do
+    it 'requires a website_token that matches an existing web widget' do
+      page = build_page(website_token: 'nonexistent-token')
+      expect(page).not_to be_valid
+      expect(page.errors[:website_token].join).to include('does not match')
+    end
+  end
+
+  describe '#display_title' do
+    it 'falls back to the widget inbox name when no title' do
+      page = build_page(title: nil)
+      page.save!
+      expect(page.display_title).to eq(inbox.name)
+    end
+  end
+end

--- a/spec/models/crm_form_spec.rb
+++ b/spec/models/crm_form_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CrmForm, type: :model do
+  let(:user) { User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", name: 'Owner') }
+  let(:pipeline) { Pipeline.create!(name: "Sales #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user) }
+  let!(:stage) { pipeline.pipeline_stages.create!(name: 'New', position: 1) }
+
+  let(:valid_fields) do
+    [
+      { 'key' => 'full_name', 'label' => 'Name', 'type' => 'text', 'required' => true, 'maps_to' => 'name' },
+      { 'key' => 'email', 'label' => 'Email', 'type' => 'email', 'required' => true, 'maps_to' => 'email' }
+    ]
+  end
+
+  def build_form(attrs = {})
+    CrmForm.new({
+      name: 'Contact Us',
+      default_pipeline: pipeline,
+      default_stage: stage,
+      fields: valid_fields
+    }.merge(attrs))
+  end
+
+  describe 'slug generation' do
+    it 'derives a slug from the name on create' do
+      form = build_form(name: 'My Lead Form')
+      form.save!
+      expect(form.slug).to eq('my-lead-form')
+    end
+
+    it 'disambiguates colliding slugs' do
+      build_form(name: 'Dup').save!
+      second = build_form(name: 'Dup')
+      second.save!
+      expect(second.slug).to eq('dup-2')
+    end
+
+    it 'keeps an explicitly provided slug' do
+      form = build_form(slug: 'custom-slug')
+      form.save!
+      expect(form.slug).to eq('custom-slug')
+    end
+  end
+
+  describe 'validations' do
+    it 'requires a field mapped to email and name' do
+      form = build_form(fields: [{ 'key' => 'email', 'maps_to' => 'email' }])
+      expect(form).not_to be_valid
+      expect(form.errors[:fields].join).to include('mapped to name')
+    end
+
+    it 'rejects invalid field types and maps_to' do
+      form = build_form(fields: valid_fields + [{ 'key' => 'x', 'type' => 'bogus', 'maps_to' => 'nope' }])
+      expect(form).not_to be_valid
+      expect(form.errors[:fields].join).to include('invalid type', 'invalid maps_to')
+    end
+
+    it 'rejects routing rules without a pipeline_id' do
+      form = build_form(routing_rules: [{ 'field' => 'plan', 'op' => 'equals', 'value' => 'pro' }])
+      expect(form).not_to be_valid
+      expect(form.errors[:routing_rules].join).to include('requires a pipeline_id')
+    end
+  end
+
+  describe '#resolve_destination' do
+    let(:other_pipeline) { Pipeline.create!(name: "Support #{SecureRandom.hex(4)}", pipeline_type: 'support', created_by: user) }
+    let!(:other_stage) { other_pipeline.pipeline_stages.create!(name: 'Triage', position: 1) }
+
+    it 'routes by a matching rule' do
+      form = build_form(routing_rules: [
+        { 'field' => 'plan', 'op' => 'equals', 'value' => 'pro', 'pipeline_id' => other_pipeline.id, 'stage_id' => other_stage.id }
+      ])
+      form.save!
+      expect(form.resolve_destination('plan' => 'pro')).to eq([other_pipeline.id, other_stage.id])
+    end
+
+    it 'falls back to the default pipeline/stage when no rule matches' do
+      form = build_form(routing_rules: [
+        { 'field' => 'plan', 'op' => 'equals', 'value' => 'pro', 'pipeline_id' => other_pipeline.id, 'stage_id' => other_stage.id }
+      ])
+      form.save!
+      expect(form.resolve_destination('plan' => 'free')).to eq([pipeline.id, stage.id])
+    end
+  end
+end

--- a/spec/models/crm_form_spec.rb
+++ b/spec/models/crm_form_spec.rb
@@ -48,19 +48,45 @@ RSpec.describe CrmForm, type: :model do
     it 'requires a field mapped to email and name' do
       form = build_form(fields: [{ 'key' => 'email', 'maps_to' => 'email' }])
       expect(form).not_to be_valid
-      expect(form.errors[:fields].join).to include('mapped to name')
+      expect(form.errors[:fields].join).to include('mapped to contact name')
     end
 
-    it 'rejects invalid field types and maps_to' do
+    it 'rejects invalid field types and mapping targets' do
       form = build_form(fields: valid_fields + [{ 'key' => 'x', 'type' => 'bogus', 'maps_to' => 'nope' }])
       expect(form).not_to be_valid
-      expect(form.errors[:fields].join).to include('invalid type', 'invalid maps_to')
+      expect(form.errors[:fields].join).to include('invalid type', 'invalid mapping target')
+    end
+
+    it 'accepts typed mapping targets (kind + key)' do
+      form = build_form(fields: valid_fields + [
+        { 'key' => 'city', 'maps_to' => 'contact_attribute', 'maps_to_key' => 'city' },
+        { 'key' => 'budget', 'maps_to' => 'deal_value' }
+      ])
+      expect(form).to be_valid
     end
 
     it 'rejects routing rules without a pipeline_id' do
       form = build_form(routing_rules: [{ 'field' => 'plan', 'op' => 'equals', 'value' => 'pro' }])
       expect(form).not_to be_valid
       expect(form.errors[:routing_rules].join).to include('requires a pipeline_id')
+    end
+  end
+
+  describe '.field_target' do
+    it 'resolves the legacy string form' do
+      expect(CrmForm.field_target('maps_to' => 'email')).to eq([:contact, 'email'])
+    end
+
+    it 'resolves typed contact_attribute / deal_value / deal_attribute' do
+      expect(CrmForm.field_target('maps_to' => 'contact_attribute', 'maps_to_key' => 'city')).to eq([:contact_attribute, 'city'])
+      expect(CrmForm.field_target('maps_to' => 'deal_value')).to eq([:deal_value, 'value'])
+      expect(CrmForm.field_target('maps_to' => 'deal_attribute', 'maps_to_key' => 'source')).to eq([:deal_attribute, 'source'])
+    end
+
+    it 'returns nil for blank or invalid targets' do
+      expect(CrmForm.field_target('maps_to' => '')).to be_nil
+      expect(CrmForm.field_target('maps_to' => 'nope')).to be_nil
+      expect(CrmForm.field_target('maps_to' => 'contact_attribute')).to be_nil
     end
   end
 

--- a/spec/models/crm_form_spec.rb
+++ b/spec/models/crm_form_spec.rb
@@ -70,6 +70,39 @@ RSpec.describe CrmForm, type: :model do
       expect(form).not_to be_valid
       expect(form.errors[:routing_rules].join).to include('requires a pipeline_id')
     end
+
+    it 'rejects a routing rule pointing at a pipeline that does not exist' do
+      form = build_form(routing_rules: [
+        { 'field' => 'plan', 'op' => 'equals', 'value' => 'pro', 'pipeline_id' => SecureRandom.uuid }
+      ])
+      expect(form).not_to be_valid
+      expect(form.errors[:routing_rules].join).to include('pipeline that does not exist')
+    end
+
+    it 'rejects a routing rule whose stage does not belong to its pipeline' do
+      foreign = Pipeline.create!(name: "Other #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user)
+      foreign_stage = foreign.pipeline_stages.create!(name: 'Elsewhere', position: 1)
+      form = build_form(routing_rules: [
+        { 'field' => 'plan', 'op' => 'equals', 'value' => 'pro', 'pipeline_id' => pipeline.id, 'stage_id' => foreign_stage.id }
+      ])
+      expect(form).not_to be_valid
+      expect(form.errors[:routing_rules].join).to include('stage that does not belong to the pipeline')
+    end
+
+    it 'accepts a routing rule with a consistent pipeline/stage' do
+      form = build_form(routing_rules: [
+        { 'field' => 'plan', 'op' => 'equals', 'value' => 'pro', 'pipeline_id' => pipeline.id, 'stage_id' => stage.id }
+      ])
+      expect(form).to be_valid
+    end
+
+    it 'rejects a default stage that does not belong to the default pipeline' do
+      foreign = Pipeline.create!(name: "Other #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user)
+      foreign_stage = foreign.pipeline_stages.create!(name: 'Elsewhere', position: 1)
+      form = build_form(default_stage: foreign_stage)
+      expect(form).not_to be_valid
+      expect(form.errors[:default_stage].join).to include('must belong to the default pipeline')
+    end
   end
 
   describe '.field_target' do

--- a/spec/models/crm_form_spec.rb
+++ b/spec/models/crm_form_spec.rb
@@ -110,4 +110,28 @@ RSpec.describe CrmForm, type: :model do
       expect(form.resolve_destination('plan' => 'free')).to eq([pipeline.id, stage.id])
     end
   end
+
+  describe 'captured leads (B14.07)' do
+    let(:form) { build_form.tap(&:save!) }
+
+    def lead_item(slug)
+      contact = Contact.create!(name: 'Lead', email: "lead-#{SecureRandom.hex(4)}@example.com")
+      pipeline.pipeline_items.create!(
+        contact: contact, pipeline_stage: stage, entered_at: Time.current,
+        custom_fields: { 'lead_metadata' => { 'form_slug' => slug } }
+      )
+    end
+
+    it 'finds only pipeline_items stamped with its form_slug' do
+      mine = lead_item(form.slug)
+      lead_item('another-form')
+      pipeline.pipeline_items.create!(
+        contact: Contact.create!(name: 'X', email: "x-#{SecureRandom.hex(4)}@example.com"),
+        pipeline_stage: stage, entered_at: Time.current, custom_fields: {}
+      )
+
+      expect(form.captured_leads).to contain_exactly(mine)
+      expect(CrmForm.lead_counts_by_slug([form.slug])[form.slug]).to eq(1)
+    end
+  end
 end

--- a/spec/requests/public/api/v1/chat_pages_controller_spec.rb
+++ b/spec/requests/public/api/v1/chat_pages_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Public Chat Pages API', type: :request do
+  let(:web_widget) { Channel::WebWidget.create!(website_url: 'https://chat.example.com') }
+  let!(:inbox) { Inbox.create!(name: 'Chat Inbox', channel: web_widget) }
+
+  let(:chat_page) do
+    ChatPage.create!(
+      title: 'Atendimento',
+      website_token: web_widget.website_token,
+      published: true,
+      appearance: { 'primary_color' => '#1E40AF' }
+    )
+  end
+
+  describe 'GET /public/api/v1/chat_pages/:slug' do
+    it 'returns the published page config with the widget website_token' do
+      get "/public/api/v1/chat_pages/#{chat_page.slug}"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body['data']['website_token']).to eq(web_widget.website_token)
+      expect(body['data']['title']).to eq('Atendimento')
+      expect(body['data']['appearance']['primary_color']).to eq('#1E40AF')
+    end
+
+    it '404s for a draft page without leaking it' do
+      chat_page.update!(published: false)
+      get "/public/api/v1/chat_pages/#{chat_page.slug}"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it '404s for an unknown slug' do
+      get '/public/api/v1/chat_pages/does-not-exist'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/public/api/v1/forms_controller_spec.rb
+++ b/spec/requests/public/api/v1/forms_controller_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Public CRM Forms API', type: :request do
+  let(:user) { User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", name: 'Owner') }
+  let(:pipeline) { Pipeline.create!(name: "Sales #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user) }
+  let!(:stage) { pipeline.pipeline_stages.create!(name: 'New', position: 1) }
+
+  let(:fields) do
+    [
+      { 'key' => 'full_name', 'label' => 'Name', 'type' => 'text', 'required' => true, 'maps_to' => 'name' },
+      { 'key' => 'email', 'label' => 'Email', 'type' => 'email', 'required' => true, 'maps_to' => 'email' },
+      { 'key' => 'plan', 'label' => 'Plan', 'type' => 'select', 'required' => false }
+    ]
+  end
+
+  let(:form) do
+    CrmForm.create!(
+      name: 'Contact Us',
+      title: 'Talk to us',
+      default_pipeline: pipeline,
+      default_stage: stage,
+      published: true,
+      fields: fields
+    )
+  end
+
+  describe 'GET /public/api/v1/forms/:slug' do
+    it 'returns the public form config for a published form' do
+      get "/public/api/v1/forms/#{form.slug}"
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body['data']['title']).to eq('Talk to us')
+      expect(body['data']['fields'].map { |f| f['key'] }).to contain_exactly('full_name', 'email', 'plan')
+      # Internals must not leak.
+      expect(body['data']).not_to have_key('routing_rules')
+      expect(body['data']).not_to have_key('default_pipeline_id')
+    end
+
+    it '404s for a draft form without leaking it' do
+      form.update!(published: false)
+      get "/public/api/v1/forms/#{form.slug}"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it '404s for an unknown slug' do
+      get '/public/api/v1/forms/does-not-exist'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /public/api/v1/forms/:slug/submissions' do
+    let(:path) { "/public/api/v1/forms/#{form.slug}/submissions" }
+
+    it 'creates a contact and a pipeline_item in the form destination' do
+      expect do
+        post path, params: { submission: { full_name: 'Ada Lovelace', email: "ada-#{SecureRandom.hex(4)}@example.com" } }, as: :json
+      end.to change(Contact, :count).by(1).and change(PipelineItem, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      item = PipelineItem.last
+      expect(item.pipeline_id).to eq(pipeline.id)
+      expect(item.pipeline_stage_id).to eq(stage.id)
+    end
+
+    it 'routes to a different pipeline when a rule matches' do
+      other_pipeline = Pipeline.create!(name: "Support #{SecureRandom.hex(4)}", pipeline_type: 'support', created_by: user)
+      other_stage = other_pipeline.pipeline_stages.create!(name: 'Triage', position: 1)
+      form.update!(routing_rules: [
+        { 'field' => 'plan', 'op' => 'equals', 'value' => 'pro', 'pipeline_id' => other_pipeline.id, 'stage_id' => other_stage.id }
+      ])
+
+      post path, params: { submission: { full_name: 'Pro Lead', email: "pro-#{SecureRandom.hex(4)}@example.com", plan: 'pro' } }, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(PipelineItem.last.pipeline_id).to eq(other_pipeline.id)
+    end
+
+    it 'silently discards a submission that trips the honeypot' do
+      expect do
+        post path, params: { submission: { full_name: 'Bot', email: "bot-#{SecureRandom.hex(4)}@example.com", _hp_url: 'http://spam' } }, as: :json
+      end.to change(Contact, :count).by(0).and change(PipelineItem, :count).by(0)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'returns 422 when a required field is missing' do
+      expect do
+        post path, params: { submission: { full_name: 'No Email' } }, as: :json
+      end.to change(Contact, :count).by(0)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)['success']).to be(false)
+    end
+  end
+end

--- a/spec/requests/public/api/v1/forms_controller_spec.rb
+++ b/spec/requests/public/api/v1/forms_controller_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe 'Public CRM Forms API', type: :request do
       expect(item.pipeline_stage_id).to eq(stage.id)
     end
 
+    it 'routes typed targets into contact custom attributes and the deal' do
+      form.update!(fields: fields + [
+        { 'key' => 'city', 'label' => 'Cidade', 'type' => 'text', 'maps_to' => 'contact_attribute', 'maps_to_key' => 'city' },
+        { 'key' => 'budget', 'label' => 'Orçamento', 'type' => 'number', 'maps_to' => 'deal_value' },
+        { 'key' => 'source', 'label' => 'Origem', 'type' => 'text', 'maps_to' => 'deal_attribute', 'maps_to_key' => 'source' }
+      ])
+
+      post path, params: { submission: {
+        full_name: 'Mapped Lead', email: "map-#{SecureRandom.hex(4)}@example.com",
+        city: 'Porto Alegre', budget: '5000', source: 'instagram'
+      } }, as: :json
+
+      expect(response).to have_http_status(:created)
+      contact = Contact.last
+      item = PipelineItem.last
+      expect(contact.custom_attributes['city']).to eq('Porto Alegre')
+      expect(item.custom_fields['value']).to eq('5000')
+      expect(item.custom_fields['source']).to eq('instagram')
+    end
+
     it 'routes to a different pipeline when a rule matches' do
       other_pipeline = Pipeline.create!(name: "Support #{SecureRandom.hex(4)}", pipeline_type: 'support', created_by: user)
       other_stage = other_pipeline.pipeline_stages.create!(name: 'Triage', position: 1)

--- a/spec/services/public/leads/creation_service_spec.rb
+++ b/spec/services/public/leads/creation_service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Public::Leads::CreationService do
+  let(:user) { User.create!(email: "owner-#{SecureRandom.hex(4)}@example.com", name: 'Owner') }
+  let(:pipeline) { Pipeline.create!(name: "Sales #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user) }
+  let!(:stage) { pipeline.pipeline_stages.create!(name: 'New', position: 1) }
+
+  def perform(contact:, custom_attributes: nil)
+    contact = contact.merge(custom_attributes: custom_attributes) if custom_attributes
+    described_class.new(lead_params: {
+      contact: contact,
+      deal: { pipeline_id: pipeline.id, stage_id: stage.id }
+    }).perform
+  end
+
+  describe 'anonymous custom_attributes write' do
+    let(:email) { "lead-#{SecureRandom.hex(4)}@example.com" }
+
+    it 'sets custom attributes when creating a new contact' do
+      result = perform(contact: { name: 'Ada', email: email }, custom_attributes: { 'city' => 'Porto Alegre' })
+
+      expect(result[:success]).to be(true)
+      expect(result[:contact].custom_attributes['city']).to eq('Porto Alegre')
+    end
+
+    it 'does not overwrite an existing contact\'s custom attributes, only fills blank keys' do
+      existing = Contact.create!(
+        name: 'Ada', email: email,
+        custom_attributes: { 'city' => 'São Paulo', 'plan' => 'gold' }
+      )
+
+      result = perform(
+        contact: { name: 'Ada', email: email },
+        custom_attributes: { 'city' => 'Hacked', 'plan' => '', 'segment' => 'enterprise' }
+      )
+
+      expect(result[:success]).to be(true)
+      existing.reload
+      # Pre-existing values are preserved against the anonymous submitter…
+      expect(existing.custom_attributes['city']).to eq('São Paulo')
+      expect(existing.custom_attributes['plan']).to eq('gold')
+      # …while genuinely new keys are still captured.
+      expect(existing.custom_attributes['segment']).to eq('enterprise')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Backend do **B14 — CRM Lead Capture**, consolidado sob a tarefa pai **EVO-1771** (épico guarda-chuva; os sub-cards 1772/1841/1843/1844 + chat 1774 já estão Done e seus commits seguem com seus refs — "os commits falam por si").

Duas features genéricas/single-tenant (Community), reusando `Public::Leads::CreationService` + `Channel::WebWidget`:

### Form-builder → pipeline (crm_forms)
- Tabela `crm_forms` + model (slug, validações, `resolve_destination`, `routing_rules`).
- Endpoint público **anônimo** `POST /public/api/v1/forms/:slug/submissions` (honeypot + rate-limit) → contato + pipeline_item no pipeline/estágio (default + regras de roteamento modulares).
- Admin CRUD `Api::V1::CrmFormsController` (busca + filtro published + paginação Kaminari) + serializer.
- Mapeamento tipado `maps_to`/`maps_to_key` (contact/contact_attribute/deal_value/deal_attribute) + endpoint de leads capturados por form.

### Chat page (chat_pages)
- Tabela `chat_pages` + model (embute um `Channel::WebWidget` existente por `website_token`; não cria widget).
- Endpoint público anônimo `GET /public/api/v1/chat_pages/:slug` (devolve token + appearance + description).
- Admin CRUD `Api::V1::ChatPagesController` + serializer.

`db/schema.rb` regenerado (versão → `2026_06_19_130000` + tabelas `crm_forms`/`chat_pages`), via `schema:load` develop + `migrate` num DB limpo — diff vs develop = exatamente as 2 tabelas + versão.

## Test plan

- Specs de model/request do crm_form e chat_page (verde no `evolution_test`).
- E2E ao vivo: submit de form demo (`plano=pro` → roteia pro pipeline da rule), chat page demo resolve token → widget; endpoints anônimos 201/200, drafts 404.
- `rails routes` carrega (crm_forms + chat_pages registrados); merge com develop sem perdas.

## Notas
- Sem migration nova além de crm_forms/chat_pages. RBAC (`crm_forms.*`, `chat_pages.*`) está no PR do evo-auth-service (precisa de seed no release).
- Camada Enterprise (tenant_id/RLS) fica como seam, fora deste PR (Community single-tenant).
