### PR TITLE
feat(crm): update_custom_attribute automation action (EVO-1751)

### DIFF
--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -47,7 +47,8 @@ class AutomationRule < ApplicationRecord
   def actions_attributes
     %w[send_message send_canned_response send_template add_label remove_label send_email_to_team assign_team assign_agent
        send_webhook_event mute_conversation send_attachment change_status resolve_conversation snooze_conversation
-       change_priority send_email_transcript assign_to_pipeline update_pipeline_stage create_pipeline_task].freeze
+       change_priority send_email_transcript assign_to_pipeline update_pipeline_stage create_pipeline_task
+       update_custom_attribute].freeze
   end
 
   def file_base_data

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -42,6 +42,7 @@ class AutomationRules::ContactActionService
     action_params = action[:action_params]
 
     return record_skip(action_name) unless CONTACT_NATIVE_ACTIONS.include?(action_name)
+    return record_skip(action_name) if action_name == 'update_custom_attribute' && !contact_scoped_attribute?(action_params)
 
     dispatch_native_action(action_name, action_params)
     @recorder&.add_step("Action: #{action_name}", level: 'success', data: { params: action_params })
@@ -60,6 +61,14 @@ class AutomationRules::ContactActionService
         reason: 'requires a conversation; contact trigger has no conversation in scope'
       }
     )
+  end
+
+  # update_custom_attribute is contact-native ONLY for contact_attribute targets;
+  # conversation/pipeline_item attributes need a conversation, so on a contact
+  # trigger they would be a silent no-op — record them as skipped instead.
+  def contact_scoped_attribute?(action_params)
+    raw = Array(action_params).first
+    raw.is_a?(Hash) && raw.with_indifferent_access[:custom_attribute_model].to_s == 'contact_attribute'
   end
 
   # The action_name is constrained to CONTACT_NATIVE_ACTIONS before we get here,

--- a/app/services/automation_rules/contact_action_service.rb
+++ b/app/services/automation_rules/contact_action_service.rb
@@ -18,7 +18,7 @@ class AutomationRules::ContactActionService
   include AutomationRules::ConversationActionHandlers
 
   # Actions that operate on the contact itself and need no conversation.
-  CONTACT_NATIVE_ACTIONS = %w[send_webhook_event add_label remove_label].freeze
+  CONTACT_NATIVE_ACTIONS = %w[send_webhook_event add_label remove_label update_custom_attribute].freeze
 
   def initialize(rule, contact, recorder: nil)
     @rule = rule
@@ -69,6 +69,7 @@ class AutomationRules::ContactActionService
     when 'send_webhook_event' then send_webhook_event(action_params)
     when 'add_label' then add_label(action_params)
     when 'remove_label' then remove_label(action_params)
+    when 'update_custom_attribute' then update_custom_attribute(action_params)
     end
   end
 

--- a/app/services/automation_rules/conversation_action_handlers.rb
+++ b/app/services/automation_rules/conversation_action_handlers.rb
@@ -140,9 +140,22 @@ module AutomationRules
       key = param[:custom_attribute_key].to_s
       model = param[:custom_attribute_model].to_s
       return if key.blank? || model.blank?
-      return unless CustomAttributeDefinition.exists?(attribute_key: key, attribute_model: model)
 
-      apply_custom_attribute(model, key, param[:custom_attribute_value])
+      definition = CustomAttributeDefinition.find_by(attribute_key: key, attribute_model: model)
+      return unless definition
+
+      value = cast_custom_attribute_value(definition, param[:custom_attribute_value])
+      apply_custom_attribute(model, key, value)
+    end
+
+    # The wire value is a string; checkbox attributes must be stored as a real
+    # boolean so the canonical read path (Boolean(raw)) matches — "false" stored
+    # as a string would otherwise read back as truthy. Other display types stay
+    # verbatim (cast at read/query time, as the rest of the custom-attribute code).
+    def cast_custom_attribute_value(definition, value)
+      return value unless definition.attribute_display_type == 'checkbox'
+
+      ActiveModel::Type::Boolean.new.cast(value)
     end
 
     def apply_custom_attribute(model, key, value)

--- a/app/services/automation_rules/conversation_action_handlers.rb
+++ b/app/services/automation_rules/conversation_action_handlers.rb
@@ -123,6 +123,62 @@ module AutomationRules
       end
     end
 
+    # --- Custom attributes -------------------------------------------------
+
+    # EVO-1751: set/update a custom attribute value from an automation action.
+    # Routes by the definition's attribute_model so a single action covers
+    # conversation, contact and pipeline-item custom attributes. The value is
+    # stored verbatim in the JSONB column (string contract); type casting is
+    # done at read/query time, consistent with the rest of the custom-attribute
+    # code. attribute_key is only unique per attribute_model, so the params
+    # carry the model to disambiguate the lookup and the write target.
+    def update_custom_attribute(params)
+      raw = Array(params).first
+      return unless raw.is_a?(Hash)
+
+      param = raw.with_indifferent_access
+      key = param[:custom_attribute_key].to_s
+      model = param[:custom_attribute_model].to_s
+      return if key.blank? || model.blank?
+      return unless CustomAttributeDefinition.exists?(attribute_key: key, attribute_model: model)
+
+      apply_custom_attribute(model, key, param[:custom_attribute_value])
+    end
+
+    def apply_custom_attribute(model, key, value)
+      case model
+      when 'conversation_attribute' then set_conversation_custom_attribute(key, value)
+      when 'contact_attribute' then set_contact_custom_attribute(key, value)
+      when 'pipeline_item_attribute' then set_pipeline_item_custom_field(key, value)
+      end
+    end
+
+    def set_conversation_custom_attribute(key, value)
+      return unless @conversation
+
+      attributes = (@conversation.custom_attributes || {}).merge(key => value)
+      @conversation.update!(custom_attributes: attributes)
+    end
+
+    def set_contact_custom_attribute(key, value)
+      contact = @contact || @conversation&.contact
+      return unless contact
+
+      Current.executed_by = @rule
+      attributes = (contact.custom_attributes || {}).merge(key => value)
+      contact.update!(custom_attributes: attributes)
+    end
+
+    def set_pipeline_item_custom_field(key, value)
+      return unless @conversation
+
+      pipeline_item = @conversation.pipeline_items.first
+      return unless pipeline_item
+
+      fields = (pipeline_item.custom_fields || {}).merge(key => value)
+      pipeline_item.update!(custom_fields: fields)
+    end
+
     # --- Messaging ---------------------------------------------------------
 
     def send_message(message)

--- a/spec/services/automation_rules/action_service_custom_attribute_spec.rb
+++ b/spec/services/automation_rules/action_service_custom_attribute_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1751: the update_custom_attribute automation action sets/updates a custom
+# attribute value, routing by the definition's attribute_model so one action
+# covers conversation, contact and pipeline-item attributes. Exercised through
+# the simple modal executor (AutomationRules::ActionService).
+RSpec.describe AutomationRules::ActionService do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  def build_rule(key:, model:, value:)
+    rule = AutomationRule.new(
+      name: "rule-#{SecureRandom.hex(4)}",
+      event_name: 'conversation_updated',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{
+        'action_name' => 'update_custom_attribute',
+        'action_params' => [{
+          'custom_attribute_key' => key,
+          'custom_attribute_model' => model,
+          'custom_attribute_value' => value
+        }]
+      }]
+    )
+    rule.save!
+    rule
+  end
+
+  after { Current.reset }
+
+  describe '#update_custom_attribute' do
+    it 'is accepted by the model action whitelist (AC1)' do
+      expect { build_rule(key: 'plan', model: 'conversation_attribute', value: 'premium') }.not_to raise_error
+    end
+
+    it 'sets a conversation custom attribute' do
+      CustomAttributeDefinition.create!(attribute_display_name: 'Plan', attribute_key: 'plan',
+                                        attribute_display_type: 'text', attribute_model: 'conversation_attribute')
+      rule = build_rule(key: 'plan', model: 'conversation_attribute', value: 'premium')
+
+      described_class.new(rule, nil, conversation).perform
+
+      expect(conversation.reload.custom_attributes['plan']).to eq('premium')
+    end
+
+    it 'sets a contact custom attribute via the conversation contact' do
+      CustomAttributeDefinition.create!(attribute_display_name: 'CPF', attribute_key: 'cpf',
+                                        attribute_display_type: 'text', attribute_model: 'contact_attribute')
+      rule = build_rule(key: 'cpf', model: 'contact_attribute', value: '123.456.789-00')
+
+      described_class.new(rule, nil, conversation).perform
+
+      expect(contact.reload.custom_attributes['cpf']).to eq('123.456.789-00')
+    end
+
+    it 'sets a pipeline-item custom field on the conversation pipeline item' do
+      pipeline = Pipeline.create!(name: 'Sales', pipeline_type: 'custom', created_by: user)
+      stage = PipelineStage.create!(pipeline: pipeline, name: 'New', position: 1)
+      PipelineItem.create!(pipeline: pipeline, pipeline_stage: stage, conversation: conversation)
+      CustomAttributeDefinition.create!(attribute_display_name: 'Deal value', attribute_key: 'deal_value',
+                                        attribute_display_type: 'number', attribute_model: 'pipeline_item_attribute')
+      rule = build_rule(key: 'deal_value', model: 'pipeline_item_attribute', value: '5000')
+
+      described_class.new(rule, nil, conversation).perform
+
+      expect(conversation.pipeline_items.first.reload.custom_fields['deal_value']).to eq('5000')
+    end
+
+    it 'is a no-op when no matching attribute definition exists' do
+      rule = build_rule(key: 'ghost', model: 'contact_attribute', value: 'x')
+
+      described_class.new(rule, nil, conversation).perform
+
+      expect(contact.reload.custom_attributes).to eq({})
+    end
+
+    it 'does not collide when the same key exists for a different model' do
+      CustomAttributeDefinition.create!(attribute_display_name: 'Score (contact)', attribute_key: 'score',
+                                        attribute_display_type: 'number', attribute_model: 'contact_attribute')
+      CustomAttributeDefinition.create!(attribute_display_name: 'Score (conversation)', attribute_key: 'score',
+                                        attribute_display_type: 'number', attribute_model: 'conversation_attribute')
+      rule = build_rule(key: 'score', model: 'conversation_attribute', value: '42')
+
+      described_class.new(rule, nil, conversation).perform
+
+      expect(conversation.reload.custom_attributes['score']).to eq('42')
+      expect(contact.reload.custom_attributes).to eq({})
+    end
+  end
+end

--- a/spec/services/automation_rules/action_service_custom_attribute_spec.rb
+++ b/spec/services/automation_rules/action_service_custom_attribute_spec.rb
@@ -94,5 +94,15 @@ RSpec.describe AutomationRules::ActionService do
       expect(conversation.reload.custom_attributes['score']).to eq('42')
       expect(contact.reload.custom_attributes).to eq({})
     end
+
+    it 'stores a checkbox attribute as a real boolean, not the string "false"' do
+      CustomAttributeDefinition.create!(attribute_display_name: 'Onboarded', attribute_key: 'onboarded',
+                                        attribute_display_type: 'checkbox', attribute_model: 'conversation_attribute')
+      rule = build_rule(key: 'onboarded', model: 'conversation_attribute', value: 'false')
+
+      described_class.new(rule, nil, conversation).perform
+
+      expect(conversation.reload.custom_attributes['onboarded']).to eq(false)
+    end
   end
 end

--- a/spec/services/automation_rules/contact_action_service_spec.rb
+++ b/spec/services/automation_rules/contact_action_service_spec.rb
@@ -89,6 +89,25 @@ RSpec.describe AutomationRules::ContactActionService do
         hash_including(level: 'warn', data: hash_including(reason: a_string_including('requires a conversation')))
       )
     end
+
+    it 'skips update_custom_attribute targeting a conversation attribute (no conversation in scope)' do
+      rule = build_rule(actions: [{
+                          'action_name' => 'update_custom_attribute',
+                          'action_params' => [{
+                            'custom_attribute_key' => 'plan',
+                            'custom_attribute_model' => 'conversation_attribute',
+                            'custom_attribute_value' => 'premium'
+                          }]
+                        }])
+
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      expect(recorder).to have_received(:add_step).with(
+        'Action skipped: update_custom_attribute',
+        hash_including(level: 'warn', data: hash_including(reason: a_string_including('requires a conversation')))
+      )
+      expect(recorder).not_to have_received(:add_step).with('Action: update_custom_attribute', anything)
+    end
   end
 
   describe 'robustness' do

--- a/spec/services/automation_rules/contact_action_service_spec.rb
+++ b/spec/services/automation_rules/contact_action_service_spec.rb
@@ -57,6 +57,24 @@ RSpec.describe AutomationRules::ContactActionService do
 
       expect(contact.reload.label_list).not_to include('vip')
     end
+
+    it 'updates a contact custom attribute (no conversation in scope)' do
+      CustomAttributeDefinition.create!(attribute_display_name: 'CPF', attribute_key: 'cpf',
+                                        attribute_display_type: 'text', attribute_model: 'contact_attribute')
+      rule = build_rule(actions: [{
+                          'action_name' => 'update_custom_attribute',
+                          'action_params' => [{
+                            'custom_attribute_key' => 'cpf',
+                            'custom_attribute_model' => 'contact_attribute',
+                            'custom_attribute_value' => '123.456.789-00'
+                          }]
+                        }])
+
+      described_class.new(rule, contact, recorder: recorder).perform
+
+      expect(contact.reload.custom_attributes['cpf']).to eq('123.456.789-00')
+      expect(recorder).to have_received(:add_step).with('Action: update_custom_attribute', hash_including(level: 'success'))
+    end
   end
 
   describe 'conversation-bound actions' do


### PR DESCRIPTION
## Summary
- New `update_custom_attribute` automation action: sets/updates a custom attribute value, routing by the definition's `attribute_model` so one action covers **contact**, **conversation** and **pipeline-item** attributes.
- Added to the model action whitelist; dispatched via `ActionService#send`; enabled for contact-triggered rules in `ContactActionService`.
- `attribute_key` is only unique per `attribute_model`, so `action_params` carry the model to disambiguate the lookup and the write target. Values are stored verbatim in the JSONB column (string contract), cast at read/query time — consistent with the journey/CRM convention.

## Security
- Single-tenant (no `account_id`); the handler writes only to records already in the rule's scope (`@conversation` / its contact / its pipeline_item).
- Validates that `(attribute_key, attribute_model)` exists before writing; no-op otherwise. JSONB merge, no raw SQL. `Current.executed_by = @rule` on the contact path (loop guard + dirty-tracking).

## Test plan
- `crm: bundle exec rspec spec/services/automation_rules/action_service_custom_attribute_spec.rb spec/services/automation_rules/contact_action_service_spec.rb`
- `crm: bundle exec rubocop app/models/automation_rule.rb app/services/automation_rules/conversation_action_handlers.rb app/services/automation_rules/contact_action_service.rb`
- Manual smoke: rule on `conversation_updated` (no conditions) → action wrote `onboarding_status` to the conversation's contact (verified in DB).

> Note: specs were authored + syntax/rubocop-validated but not executed locally — on this branch the `test` DB resolves to the shared dev DB (`maintain_test_schema!` risk); they run in CI.

## Changed Files
- `app/models/automation_rule.rb`
- `app/services/automation_rules/conversation_action_handlers.rb`
- `app/services/automation_rules/contact_action_service.rb`
- `spec/services/automation_rules/action_service_custom_attribute_spec.rb`
- `spec/services/automation_rules/contact_action_service_spec.rb`

## Related PRs
- frontend: _(see linked frontend PR for the builder UI)_

## Linked Issue
- EVO-1751

## Summary by Sourcery

Add a new automation action to update custom attributes across conversations, contacts, and pipeline items, and wire it into the automation rule and contact action handling.

New Features:
- Introduce an update_custom_attribute automation action that can modify conversation, contact, and pipeline-item custom attributes based on a provided model and key.

Enhancements:
- Extend automation rule action whitelisting and contact-native actions to include the new custom-attribute update action.

Tests:
- Add service specs to verify custom attribute updates via contact-triggered automation, including contact-only scenarios without a conversation context.