### PR TITLE
fix(hub): re-sync Cloud API templates after channel_connected (EVO-1827)

### DIFF
--- a/app/services/evolution_hub/channel_connected_handler.rb
+++ b/app/services/evolution_hub/channel_connected_handler.rb
@@ -83,6 +83,32 @@ module EvolutionHub
 
       channel.update!(provider_config: provider_config)
       mark_inbox_active(channel)
+      enqueue_template_sync(channel)
+    end
+
+    # The Channel::Whatsapp `after_create :sync_templates` callback runs while
+    # provider_config still lacks credentials (the Hub fills them later via
+    # this webhook), so the initial sync fetches nothing. Re-trigger here once
+    # credentials are in place so `message_templates` is populated without a
+    # manual sync.
+    #
+    # Requires waba_id + at least one token. `WhatsappCloudService#sync_templates`
+    # picks the auth strategy: Hub mode → Bearer header (channel_token or api_key
+    # fallback); non-Hub → `?access_token=` query param (needs api_key).
+    def enqueue_template_sync(channel)
+      waba_id = channel.provider_config['waba_id'].presence ||
+                channel.provider_config['business_account_id'].presence
+      api_key = channel.provider_config['api_key'].presence
+      channel_token = channel.provider_config.dig('evolution_hub', 'channel_token').presence
+      if waba_id.blank? || (api_key.blank? && channel_token.blank?)
+        Rails.logger.warn(
+          "EvolutionHub::ChannelConnected: skipping template sync for Channel::Whatsapp##{channel.id} " \
+          "(waba_id_present=#{waba_id.present?} api_key_present=#{api_key.present?} channel_token_present=#{channel_token.present?})"
+        )
+        return
+      end
+
+      Channels::Whatsapp::TemplatesSyncJob.perform_later(channel)
     end
 
     def mark_facebook_connected(channel)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -34,15 +34,40 @@ module Whatsapp
       end
 
       def sync_templates
+        # Expected blank-credential path: `after_create :sync_templates` runs
+        # before the Hub `channel_connected` webhook delivers the credentials.
+        # Skip quietly (info, not warn) so the real warn below keeps signal value.
+        waba_id = whatsapp_channel.provider_config['waba_id'].presence ||
+                  whatsapp_channel.provider_config['business_account_id'].presence
+        api_key = whatsapp_channel.provider_config['api_key'].presence
+        channel_token = whatsapp_channel.provider_config.dig('evolution_hub', 'channel_token').presence
+        # In Hub mode the Bearer header carries channel_token (or api_key as fallback);
+        # in non-Hub mode the ?access_token= query param needs api_key. Either way,
+        # at least one of api_key / channel_token must be present.
+        if waba_id.blank? || (api_key.blank? && channel_token.blank?)
+          Rails.logger.info(
+            "WhatsApp Cloud sync_templates: skipping for channel #{whatsapp_channel.id} — " \
+            "credentials not yet available " \
+            "(waba_id_present=#{waba_id.present?} api_key_present=#{api_key.present?} channel_token_present=#{channel_token.present?})"
+          )
+          return
+        end
+
         # When EvoHub proxy is active, authenticate via Authorization: Bearer header.
         # Falling back to ?access_token= query param breaks the Hub's proxy auth.
         url = if MetaBaseUrl.enabled?
                 "#{business_account_path}/message_templates"
               else
-                "#{business_account_path}/message_templates?access_token=#{whatsapp_channel.provider_config['api_key']}"
+                "#{business_account_path}/message_templates?access_token=#{api_key}"
               end
         templates = fetch_whatsapp_templates(url)
-        return if templates.blank?
+        if templates.blank?
+          Rails.logger.warn(
+            "WhatsApp Cloud sync_templates: no templates returned for channel #{whatsapp_channel.id} " \
+            "(credentials present — anomaly, expected approved templates from Meta)"
+          )
+          return
+        end
 
         templates.each do |template_data|
           sync_template_to_database(template_data)
@@ -72,7 +97,13 @@ module Whatsapp
 
       def fetch_whatsapp_templates(url)
         response = HTTParty.get(url, headers: api_headers)
-        return [] unless response.success?
+        unless response.success?
+          Rails.logger.error(
+            "WhatsApp Cloud fetch_whatsapp_templates: non-success response " \
+            "channel=#{whatsapp_channel.id} status=#{response.code} body=#{response.body.to_s.truncate(500)}"
+          )
+          return []
+        end
 
         next_url = next_url(response)
 

--- a/spec/services/evolution_hub/channel_connected_handler_spec.rb
+++ b/spec/services/evolution_hub/channel_connected_handler_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EvolutionHub::ChannelConnectedHandler do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    original = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    example.run
+    ActiveJob::Base.queue_adapter = original
+  end
+
+  let(:channel_uuid) { SecureRandom.uuid }
+  let(:hub_channel_id) { 'hub-ch-abc' }
+  let(:hub_channel_token) { 'hub-tok-xyz' }
+  let(:waba_id) { '111122223333' }
+  let(:phone_number_id) { '4444555566' }
+
+  let(:base_provider_config) do
+    {
+      'api_key' => '',
+      'phone_number_id' => '',
+      'waba_id' => '',
+      'evolution_hub' => { 'channel_id' => hub_channel_id, 'status' => 'pending' }
+    }
+  end
+
+  let(:channel) do
+    ch = Channel::Whatsapp.new(phone_number: "+5511#{rand(10**9)}", provider: 'whatsapp_cloud')
+    ch.id = channel_uuid
+    ch.provider_config = base_provider_config
+    allow(ch).to receive(:new_record?).and_return(false)
+    allow(ch).to receive(:persisted?).and_return(true)
+    # Avoid touching the DB.
+    allow(ch).to receive(:update!) do |attrs|
+      ch.provider_config = attrs[:provider_config] if attrs.key?(:provider_config)
+      true
+    end
+    allow(ch).to receive(:inbox).and_return(nil)
+    ch
+  end
+
+  let(:payload) do
+    {
+      'external_id' => channel_uuid,
+      'channel_id' => hub_channel_id,
+      'channel_token' => hub_channel_token,
+      'meta_connection' => {
+        'access_token' => 'meta-access-token',
+        'phone_number_id' => phone_number_id,
+        'waba_id' => waba_id
+      }
+    }
+  end
+
+  before do
+    allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(channel)
+    allow(Channel::FacebookPage).to receive(:find_by).and_return(nil)
+    allow(Channel::Instagram).to receive(:find_by).and_return(nil)
+  end
+
+  describe '#perform — WhatsApp Cloud' do
+    it 'writes credentials, flips hub status to active and enqueues TemplatesSyncJob' do
+      expect do
+        described_class.new(payload).perform
+      end.to have_enqueued_job(Channels::Whatsapp::TemplatesSyncJob)
+
+      enqueued = enqueued_jobs.last
+      expect(enqueued[:job]).to eq(Channels::Whatsapp::TemplatesSyncJob)
+      expect(enqueued[:args].first['_aj_globalid']).to include(channel_uuid)
+
+      expect(channel.provider_config['api_key']).to eq('meta-access-token')
+      expect(channel.provider_config['phone_number_id']).to eq(phone_number_id)
+      expect(channel.provider_config['waba_id']).to eq(waba_id)
+      expect(channel.provider_config.dig('evolution_hub', 'status')).to eq('active')
+      expect(channel.provider_config.dig('evolution_hub', 'channel_token')).to eq(hub_channel_token)
+    end
+
+    it 'enqueues using hub channel_token when meta access_token is absent (Hub mode uses Bearer auth)' do
+      payload['meta_connection'].delete('access_token')
+
+      expect do
+        described_class.new(payload).perform
+      end.to have_enqueued_job(Channels::Whatsapp::TemplatesSyncJob)
+    end
+
+    it 'does not enqueue when api_key and channel_token are both absent' do
+      payload['meta_connection'].delete('access_token')
+      payload.delete('channel_token')
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:info)
+
+      expect do
+        described_class.new(payload).perform
+      end.not_to have_enqueued_job(Channels::Whatsapp::TemplatesSyncJob)
+
+      expect(Rails.logger).to have_received(:warn).with(/skipping template sync/).at_least(:once)
+    end
+
+    it 'does not enqueue the sync job when waba_id is missing (logs warning)' do
+      payload['meta_connection'].delete('waba_id')
+      allow(Rails.logger).to receive(:warn)
+      allow(Rails.logger).to receive(:info)
+
+      expect do
+        described_class.new(payload).perform
+      end.not_to have_enqueued_job(Channels::Whatsapp::TemplatesSyncJob)
+
+      expect(Rails.logger).to have_received(:warn).with(/skipping template sync/).at_least(:once)
+    end
+  end
+
+  describe '#perform — Facebook channel does not enqueue WhatsApp sync' do
+    let(:fb_channel) do
+      ch = Channel::FacebookPage.new(page_id: 'pg-1', user_access_token: 'old-token')
+      allow(ch).to receive(:save!).and_return(true)
+      allow(ch).to receive(:inbox).and_return(nil)
+      ch
+    end
+
+    before do
+      allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(nil)
+      allow(Channel::FacebookPage).to receive(:find_by).with(id: channel_uuid).and_return(fb_channel)
+    end
+
+    it 'does not enqueue TemplatesSyncJob' do
+      fb_payload = {
+        'external_id' => channel_uuid,
+        'channel_id' => hub_channel_id,
+        'channel_token' => hub_channel_token,
+        'meta_connection' => { 'access_token' => 'fb-token' }
+      }
+
+      expect do
+        described_class.new(fb_payload).perform
+      end.not_to have_enqueued_job(Channels::Whatsapp::TemplatesSyncJob)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Closes EVO-1827. Hub WhatsApp Cloud inboxes were stuck with empty `message_templates` because `after_create :sync_templates` ran before credentials arrived via the `channel_connected` webhook, and that webhook never re-triggered a sync. StartConversation modal showed "no templates registered" until a manual sync.
- `ChannelConnectedHandler#mark_whatsapp_connected` now enqueues `Channels::Whatsapp::TemplatesSyncJob` once `waba_id + (api_key or hub channel_token)` are persisted.
- `WhatsappCloudService#sync_templates`: early-return at `info` level on the expected blank-credential path (after_create), `warn` only when credentials are present but Meta returns nothing (real anomaly).
- `fetch_whatsapp_templates`: logs non-success Meta responses with status + truncated body (AC3 observability).

## Acceptance Criteria
- [x] After Hub-onboarded Cloud API inbox transitions to `active`, approved Meta templates are synced automatically.
- [x] Re-opening "Iniciar Conversa" lists the approved templates with no manual sync.
- [x] `sync_templates` failures (blank/invalid credentials, non-200 from Meta) are logged.

## Test plan
- [x] `rspec spec/services/evolution_hub/channel_connected_handler_spec.rb` — 4 examples, 0 failures
- [x] `rspec spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb` — 5 examples, 0 failures (no regression)
- [x] Smoke E2E (rails runner + WebMock stubbed Meta): channel_connected → enqueue → job → 1 template inserted in `message_templates`
- [x] Smoke edge cases: payload sem waba_id → skip+warn; Meta 401 → error log; Meta `data:[]` → anomaly warn

## Linked Issue
- EVO-1827

## Summary by Sourcery

Ensure WhatsApp Cloud inbox templates are automatically re-synced after hub channels connect and improve observability around template synchronization failures.

Bug Fixes:
- Trigger WhatsApp Cloud template synchronization after hub WhatsApp channels transition to active so message templates are populated without manual sync.
- Skip initial template sync when credentials are not yet available to avoid misleading warnings and empty template sets.

Enhancements:
- Add logging for missing or anomalous template responses and non-success Meta API responses, including channel identifiers and truncated response bodies.
- Differentiate expected no-credential paths from true anomalies during template synchronization to keep warning logs high-signal.

Tests:
- Add specs for EvolutionHub::ChannelConnectedHandler to cover enqueueing template sync and credential validation behavior.