### PR TITLE
fix(crm): return structured field errors from products endpoints (EVO-1783)

### DIFF
--- a/app/controllers/api/v1/products/variants_controller.rb
+++ b/app/controllers/api/v1/products/variants_controller.rb
@@ -50,9 +50,9 @@ class Api::V1::Products::VariantsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Variant is in use and cannot be deleted',
-        details: @variant.errors.full_messages,
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Variant is in use and cannot be deleted',
+        details: format_validation_errors(@variant.errors),
         status: :unprocessable_entity
       )
     end
@@ -64,8 +64,8 @@ class Api::V1::Products::VariantsController < Api::V1::BaseController
     @product = Product.find(params[:product_id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-      message: "Product with id #{params[:product_id]} not found",
+      ApiErrorCodes::RESOURCE_NOT_FOUND,
+      "Product with id #{params[:product_id]} not found",
       status: :not_found
     )
   end
@@ -74,8 +74,8 @@ class Api::V1::Products::VariantsController < Api::V1::BaseController
     @variant = @product.variants.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-      message: "Variant with id #{params[:id]} not found",
+      ApiErrorCodes::RESOURCE_NOT_FOUND,
+      "Variant with id #{params[:id]} not found",
       status: :not_found
     )
   end
@@ -88,9 +88,9 @@ class Api::V1::Products::VariantsController < Api::V1::BaseController
 
   def validation_error_response(record)
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: 'Validation failed',
-      details: record.errors.full_messages,
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: format_validation_errors(record.errors),
       status: :unprocessable_entity
     )
   end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -91,9 +91,9 @@ class Api::V1::ProductsController < Api::V1::BaseController
     else
       # restrict_with_error on pipeline_item_products / variants in use
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Product is in use and cannot be deleted',
-        details: @product.errors.full_messages,
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Product is in use and cannot be deleted',
+        details: format_validation_errors(@product.errors),
         status: :unprocessable_entity
       )
     end
@@ -105,8 +105,8 @@ class Api::V1::ProductsController < Api::V1::BaseController
     @product = Product.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-      message: "Product with id #{params[:id]} not found",
+      ApiErrorCodes::RESOURCE_NOT_FOUND,
+      "Product with id #{params[:id]} not found",
       status: :not_found
     )
   end
@@ -212,9 +212,9 @@ class Api::V1::ProductsController < Api::V1::BaseController
 
   def validation_error_response(record)
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: 'Validation failed',
-      details: record.errors.full_messages,
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: format_validation_errors(record.errors),
       status: :unprocessable_entity
     )
   end

--- a/spec/requests/api/v1/products_validation_spec.rb
+++ b/spec/requests/api/v1/products_validation_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe 'Api::V1::ProductsController validation errors', type: :request do
+  let(:base_url) { 'http://auth.test' }
+  let(:validate_url) { "#{base_url}/api/v1/auth/validate" }
+  let(:token) { 'test-bearer-token' }
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+  let!(:user) { User.create!(name: 'Products Validation User', email: "products-val-#{SecureRandom.hex(4)}@example.com") }
+  let(:permission_check_url) { "#{base_url}/api/v1/users/#{user.id}/check_permission" }
+
+  around do |example|
+    original_base_url = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+    ENV['EVO_AUTH_SERVICE_URL'] = base_url
+    Rails.cache.clear
+    Current.reset
+    example.run
+    Rails.cache.clear
+    Current.reset
+    ENV['EVO_AUTH_SERVICE_URL'] = original_base_url
+  end
+
+  def stub_auth_ok
+    stub_request(:post, validate_url)
+      .with(headers: { 'Authorization' => "Bearer #{token}" })
+      .to_return(
+        status: 200,
+        body: { success: true, data: { user: { id: user.id, email: user.email } } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def stub_permission(granted:)
+    stub_request(:post, permission_check_url)
+      .to_return(
+        status: 200,
+        body: { success: true, data: { has_permission: granted } }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+  end
+
+  def product_payload(sku)
+    { name: 'Sample', kind: 'physical', default_price: 10, currency: 'BRL', sku: sku }
+  end
+
+  before do
+    stub_auth_ok
+    stub_permission(granted: true)
+    Current.user = user
+  end
+
+  context 'when SKU is already taken (AC4 inline field error)' do
+    let!(:existing) { Product.create!(product_payload('DUP-SKU')) }
+
+    it 'returns a 422 with details keyed by field so the frontend can render it inline' do
+      expect do
+        post '/api/v1/products', params: { product: product_payload('DUP-SKU') }, headers: headers, as: :json
+      end.not_to change(Product, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+
+      details = response.parsed_body.dig('error', 'details')
+      expect(details).to be_an(Array)
+
+      sku_error = details.find { |d| d['field'] == 'sku' }
+      expect(sku_error).to be_present
+      expect(sku_error['messages']).to include(match(/taken/i))
+      expect(sku_error['full_messages']).to include(match(/sku/i))
+    end
+  end
+
+  context 'when the create payload is otherwise invalid' do
+    it 'returns a 422 (not a 500) for a blank name' do
+      post '/api/v1/products',
+           params: { product: { kind: 'physical', default_price: 10, currency: 'BRL' } },
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      fields = response.parsed_body.dig('error', 'details').map { |d| d['field'] }
+      expect(fields).to include('name')
+    end
+  end
+
+  context 'when the product does not exist' do
+    it 'returns a 404 (not a 500) — the error_response call must be well-formed' do
+      get '/api/v1/products/00000000-0000-0000-0000-000000000000', headers: headers, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body.dig('error', 'code')).to eq('RESOURCE_NOT_FOUND')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Companion backend change for EVO-1783 (frontend PR #174 review). The products and variants controllers called `error_response` with keyword arguments (`code:`, `message:`) while the helper signature is positional `error_response(code, message, details:, status:)`. Every error path therefore raised `ArgumentError` and returned **500** instead of the intended 4xx — this is the real root cause behind the AC4 inline SKU-uniqueness error never reaching the form (the symptom looked like a generic toast either way).

- Fix all `error_response` calls in `products_controller` and `products/variants_controller` to positional `code`/`message`.
- `validation_error_response` now emits `format_validation_errors` — the structured `[{ field, messages, full_messages }]` shape already used across the CRM (labels, message_templates, inboxes, pipeline_items, and the global `RecordInvalid` rescue), so the frontend can key errors by field.
- Sibling latent 500s fixed in the same files: product/variant **not-found** now returns 404, product/variant **in-use** on delete returns 422.

## Security
- No auth/permission changes. Endpoints keep their existing `require_permissions` gates.
- No new inputs; only error-response formatting.

## Test plan
- `crm: ruby -c` on both controllers — Syntax OK
- `crm: bundle exec rspec spec/requests/api/v1/products_validation_spec.rb` — 3 examples, 0 failures (422 duplicate SKU with structured details, 422 blank name, 404 unknown id)
- `crm: bundle exec rspec spec/requests/api/v1/products_bulk_spec.rb spec/requests/api/v1/products_validation_spec.rb` — 35 examples, 0 failures
- `crm: bundle exec rubocop` on both files — only pre-existing offenses (ClassLength/MethodLength/permissions-hash alignment), none on changed lines

## Changed Files
- `app/controllers/api/v1/products_controller.rb`
- `app/controllers/api/v1/products/variants_controller.rb`
- `spec/requests/api/v1/products_validation_spec.rb` (new)

## Related PRs
- frontend: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/174

## Linked Issue
- EVO-1783