### PR TITLE
fix(contacts): backfill custom_attributes display-name keys to attribute_key (EVO-1850)

### DIFF
--- a/db/migrate/20260623110717_backfill_contact_custom_attribute_keys.rb
+++ b/db/migrate/20260623110717_backfill_contact_custom_attribute_keys.rb
@@ -1,0 +1,116 @@
+# Backfill contact custom_attributes keyed by attribute_display_name (written by
+# the journey "Update Custom Attribute" node before EVO-1850) so they are keyed
+# by the canonical attribute_key slug — matching the CRM contact UI/API/import
+# and the journey Conditional read path ({{contact.customAttributes.<slug>}}).
+class BackfillContactCustomAttributeKeys < ActiveRecord::Migration[7.1]
+  # custom_attribute_definitions.attribute_model enum → contact_attribute.
+  CONTACT_ATTRIBUTE_MODEL = 1
+
+  class CustomAttributeDefinition < ActiveRecord::Base
+    self.table_name = 'custom_attribute_definitions'
+  end
+
+  class Contact < ActiveRecord::Base
+    self.table_name = 'contacts'
+    # `contacts.type` is a contact_type_enum column, NOT Rails STI — disable the
+    # inheritance lookup so find_each/create don't choke on "person"/"company".
+    self.inheritance_column = :_type_disabled
+  end
+
+  def up
+    unless table_exists?(:custom_attribute_definitions) && table_exists?(:contacts)
+      say 'Required tables missing; skipping backfill', true
+      return
+    end
+
+    remap = build_remap
+    if remap.empty?
+      say 'No display-name → attribute_key remappings needed; skipping', true
+      return
+    end
+
+    say "Remapping #{remap.size} display-name key(s) to attribute_key slug(s)", true
+    moved = 0
+    skipped = 0
+    contacts_touched = 0
+
+    Contact.where.not(custom_attributes: nil).find_each(batch_size: 500) do |contact|
+      attrs = contact.custom_attributes
+      next unless attrs.is_a?(Hash) && attrs.any?
+
+      matched = attrs.keys & remap.keys
+      next if matched.empty?
+
+      changed = false
+      matched.each do |display_name|
+        slug = remap[display_name]
+        if attrs.key?(slug)
+          # Collision: the canonical slug value already exists — never clobber it.
+          say "  contact #{contact.id}: slug '#{slug}' already present; leaving '#{display_name}' untouched", true
+          skipped += 1
+          next
+        end
+        attrs[slug] = attrs.delete(display_name)
+        moved += 1
+        changed = true
+      end
+
+      next unless changed
+
+      # update_column bypasses validations/updated_at AND the Wisper
+      # custom_attributes diff publisher (Contact#publish_custom_attribute_changes),
+      # so a bulk backfill does not emit an event storm.
+      contact.update_column(:custom_attributes, attrs)
+      contacts_touched += 1
+    rescue StandardError => e
+      say "  ✗ contact #{contact.id}: #{e.message}", true
+    end
+
+    say "Backfill complete: #{moved} key(s) moved across #{contacts_touched} contact(s), #{skipped} skipped (collision)", true
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          'Original display-name keys are not recoverable once remapped to attribute_key.'
+  end
+
+  private
+
+  # Build { display_name => attribute_key } for contact attributes, dropping
+  # anything ambiguous so we never guess a key (attribute_display_name has NO
+  # DB uniqueness constraint — only (attribute_key, attribute_model) is unique):
+  #  - display_name == attribute_key (already aligned, no-op)
+  #  - a display_name mapping to >1 distinct attribute_key
+  #  - a display_name that collides with some OTHER def's attribute_key
+  def build_remap
+    defs = CustomAttributeDefinition
+           .where(attribute_model: CONTACT_ATTRIBUTE_MODEL)
+           .pluck(:attribute_display_name, :attribute_key)
+
+    all_keys = defs.map { |(_display_name, key)| key }.compact.to_set
+
+    grouped = Hash.new { |hash, key| hash[key] = [] }
+    defs.each do |(display_name, key)|
+      next if display_name.blank? || key.blank?
+      next if display_name == key
+
+      grouped[display_name] << key
+    end
+
+    remap = {}
+    grouped.each do |display_name, keys|
+      uniq_keys = keys.uniq
+      if uniq_keys.size > 1
+        say "  ambiguous display name '#{display_name}' → #{uniq_keys.inspect}; skipping", true
+        next
+      end
+      if all_keys.include?(display_name)
+        say "  display name '#{display_name}' collides with another attribute_key; skipping", true
+        next
+      end
+      remap[display_name] = uniq_keys.first
+    end
+
+    remap
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_19_150000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_23_110717) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"

--- a/spec/migrations/20260623110717_backfill_contact_custom_attribute_keys_spec.rb
+++ b/spec/migrations/20260623110717_backfill_contact_custom_attribute_keys_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+require_relative '../../db/migrate/20260623110717_backfill_contact_custom_attribute_keys'
+
+RSpec.describe BackfillContactCustomAttributeKeys, type: :migration do
+  let(:migration) { described_class.new.tap { |m| m.verbose = false } }
+
+  # Use the migration's validation-free inner models so seeding does not depend
+  # on app-model validations / associations.
+  let(:definition_model) { described_class::CustomAttributeDefinition }
+  let(:contact_model) { described_class::Contact }
+
+  def define_attr(display_name:, key:)
+    definition_model.create!(
+      attribute_display_name: display_name,
+      attribute_key: key,
+      attribute_display_type: 0,
+      attribute_model: described_class::CONTACT_ATTRIBUTE_MODEL,
+    )
+  end
+
+  def attrs_for(contact)
+    contact_model.find(contact.id).custom_attributes
+  end
+
+  describe '#up' do
+    it 'remaps a display-name key to its attribute_key slug' do
+      define_attr(display_name: 'Plan Interest', key: 'plan_interest')
+      contact = contact_model.create!(custom_attributes: { 'Plan Interest' => 'gold' })
+
+      migration.up
+
+      expect(attrs_for(contact)).to eq('plan_interest' => 'gold')
+    end
+
+    it 'preserves other custom attributes (no wipe)' do
+      define_attr(display_name: 'Plan Interest', key: 'plan_interest')
+      contact = contact_model.create!(
+        custom_attributes: { 'Plan Interest' => 'gold', 'other_key' => 'keep' },
+      )
+
+      migration.up
+
+      expect(attrs_for(contact)).to eq(
+        'plan_interest' => 'gold',
+        'other_key' => 'keep',
+      )
+    end
+
+    it 'is collision-safe: never clobbers an existing slug value' do
+      define_attr(display_name: 'Plan Interest', key: 'plan_interest')
+      contact = contact_model.create!(
+        custom_attributes: { 'Plan Interest' => 'old', 'plan_interest' => 'new' },
+      )
+
+      migration.up
+
+      result = attrs_for(contact)
+      expect(result['plan_interest']).to eq('new')
+      expect(result['Plan Interest']).to eq('old') # stray key left untouched
+    end
+
+    it 'is ambiguity-safe: skips display names that map to >1 key' do
+      define_attr(display_name: 'Duplicated', key: 'dup_a')
+      define_attr(display_name: 'Duplicated', key: 'dup_b')
+      contact = contact_model.create!(custom_attributes: { 'Duplicated' => 'x' })
+
+      migration.up
+
+      expect(attrs_for(contact)).to eq('Duplicated' => 'x') # untouched
+    end
+
+    it 'is idempotent: a second run is a no-op' do
+      define_attr(display_name: 'Plan Interest', key: 'plan_interest')
+      contact = contact_model.create!(custom_attributes: { 'Plan Interest' => 'gold' })
+
+      migration.up
+      first = attrs_for(contact)
+      migration.up
+
+      expect(attrs_for(contact)).to eq(first)
+      expect(attrs_for(contact)).to eq('plan_interest' => 'gold')
+    end
+  end
+
+  describe '#down' do
+    it 'is irreversible' do
+      expect { migration.down }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Data migration that heals contacts whose `custom_attributes` were written under `attribute_display_name` by the journey Update node before EVO-1850, remapping the keys to the canonical `attribute_key` slug (for the `contact_attribute` model).

Guards:
- Skips ambiguous display names — a name mapping to >1 distinct key, or a display name colliding with another def's key (`attribute_display_name` has no DB uniqueness; only `(attribute_key, attribute_model)` is unique). Never guesses.
- **Collision-safe:** never clobbers an existing slug value (mixed write paths).
- Uses `update_column` to bypass the Wisper `custom_attributes` diff publisher, avoiding an event storm on bulk backfill.
- `down` is `IrreversibleMigration` (original display-name keys aren't recoverable once remapped).

## Test plan
- New `spec/migrations/...backfill_contact_custom_attribute_keys_spec.rb` — heal, preserve-other-attributes, collision-safe, ambiguity-safe, idempotency, irreversible-down. **6/6 green** (`RAILS_ENV=test rspec`).
- Caught + fixed a real bug via the spec: `contacts.type` is a `contact_type_enum` (not Rails STI), so the migration's inner `Contact` model needs `self.inheritance_column = :_type_disabled` or `find_each`/`create` blow up on "person".

## Notas
- Part of EVO-1850 (FE + evo-flow + this backfill).
- `schema.rb` change is only the migration version bump.

## Summary by Sourcery

Add a data migration to backfill contact custom attribute keys from display names to canonical attribute_key slugs with safety guards and an irreversible rollback.

Bug Fixes:
- Correct contacts whose custom_attributes were stored under attribute_display_name so they align with the canonical attribute_key-based access paths without overwriting existing slug values.

Enhancements:
- Introduce a guarded backfill that skips ambiguous or colliding display names and bypasses event publishing to avoid emitting unnecessary custom attribute change events.

Build:
- Bump schema.rb to the new migration version.

Tests:
- Add migration specs covering successful backfill, preservation of existing attributes, collision and ambiguity handling, idempotency, and irreversible down behavior.