### PR TITLE
feat(crm): label usage_count + tagging cleanup on delete (EVO-1863)

### DIFF
--- a/app/controllers/api/v1/labels_controller.rb
+++ b/app/controllers/api/v1/labels_controller.rb
@@ -64,9 +64,13 @@ class Api::V1::LabelsController < Api::V1::BaseController
   end
 
   def destroy
-    @label.destroy
+    deleted_id = @label.id
+    ActiveRecord::Base.transaction do
+      Labels::DeleteService.new(label_title: @label.title).perform
+      @label.destroy!
+    end
     success_response(
-      data: { id: @label.id },
+      data: { id: deleted_id },
       message: 'Label deleted successfully'
     )
   end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -49,6 +49,23 @@ class Label < ApplicationRecord
     ReportingEvent.where(conversation_id: conversations.pluck(:id))
   end
 
+  # Number of records (contacts + conversations) currently tagged with this label.
+  def usage_count
+    self.class.usage_counts_for([title]).fetch(title, 0)
+  end
+
+  # Batched, N+1-free usage counts for a set of titles: { title => count }.
+  def self.usage_counts_for(titles)
+    names = Array(titles).compact
+    return {} if names.empty?
+
+    ActsAsTaggableOn::Tagging
+      .joins(:tag)
+      .where(taggings: { context: 'labels' }, tags: { name: names })
+      .group('tags.name')
+      .count
+  end
+
   private
 
   def update_associated_models

--- a/app/serializers/label_serializer.rb
+++ b/app/serializers/label_serializer.rb
@@ -16,13 +16,14 @@ module LabelSerializer
   #
   # @return [Hash] Serialized label ready for Oj
   #
-  def serialize(label)
+  def serialize(label, usage_count: nil)
     {
       id: label.id,
       title: label.title,
       description: label.description,
       color: label.color,
       show_on_sidebar: label.show_on_sidebar,
+      usage_count: usage_count.nil? ? label.usage_count : usage_count,
       created_at: label.created_at.to_i,
       updated_at: label.updated_at.to_i
     }
@@ -37,6 +38,8 @@ module LabelSerializer
   def serialize_collection(labels)
     return [] unless labels
 
-    labels.map { |label| serialize(label) }
+    labels = labels.to_a
+    counts = Label.usage_counts_for(labels.map(&:title))
+    labels.map { |label| serialize(label, usage_count: counts.fetch(label.title, 0)) }
   end
 end

--- a/app/services/labels/delete_service.rb
+++ b/app/services/labels/delete_service.rb
@@ -1,0 +1,30 @@
+class Labels::DeleteService
+  pattr_initialize [:label_title!]
+
+  def perform
+    tagged_conversations.find_in_batches do |conversation_batch|
+      conversation_batch.each do |conversation|
+        conversation.label_list.remove(label_title)
+        conversation.save!
+      end
+    end
+
+    tagged_contacts.find_in_batches do |contact_batch|
+      contact_batch.each do |contact|
+        # Route through the setter so saved_change_to_label_list? dirty-tracks
+        # the removal and Contact#publish_label_changes emits the remove event.
+        contact.update!(label_list: contact.label_list - [label_title])
+      end
+    end
+  end
+
+  private
+
+  def tagged_conversations
+    Conversation.tagged_with(label_title)
+  end
+
+  def tagged_contacts
+    Contact.tagged_with(label_title)
+  end
+end

--- a/spec/requests/api/v1/labels_spec.rb
+++ b/spec/requests/api/v1/labels_spec.rb
@@ -209,6 +209,40 @@ RSpec.describe 'POST /api/v1/labels', type: :request do
     end
   end
 
+  describe 'GET /api/v1/labels' do
+    it 'includes usage_count reflecting how many records use each label' do
+      used = Label.create!(title: 'vip')
+      Label.create!(title: 'unused')
+      contact = Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com")
+      contact.update!(label_list: ['vip'])
+
+      get '/api/v1/labels', headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      used_data = json_response['data'].find { |l| l['id'] == used.id.to_s }
+      unused_data = json_response['data'].find { |l| l['title'] == 'unused' }
+      expect(used_data['usage_count']).to eq(1)
+      expect(unused_data['usage_count']).to eq(0)
+    end
+  end
+
+  describe 'DELETE /api/v1/labels/:id' do
+    it 'deletes the label and cleans up orphaned taggings' do
+      label = Label.create!(title: 'vip')
+      contact = Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com")
+      contact.update!(label_list: ['vip'])
+
+      delete "/api/v1/labels/#{label.id}", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['success']).to be(true)
+      expect(json_response['data']['id']).to eq(label.id.to_s)
+      expect(Label.find_by(id: label.id)).to be_nil
+      expect(Contact.tagged_with('vip')).to be_empty
+      expect(contact.reload.label_list).not_to include('vip')
+    end
+  end
+
   describe 'PUT /api/v1/labels/:id' do
     let(:label) { Label.create!(title: 'original title') }
 

--- a/spec/services/labels/delete_service_spec.rb
+++ b/spec/services/labels/delete_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Labels::DeleteService do
+  let(:title) { 'vip' }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  before { Label.create!(title: title) }
+
+  it 'removes the label from tagged conversations and contacts' do
+    conversation.update!(label_list: [title])
+    contact.update!(label_list: [title])
+
+    described_class.new(label_title: title).perform
+
+    expect(conversation.reload.label_list).not_to include(title)
+    expect(contact.reload.label_list).not_to include(title)
+    expect(Conversation.tagged_with(title)).to be_empty
+    expect(Contact.tagged_with(title)).to be_empty
+  end
+
+  it 'is a no-op when the label is not in use' do
+    expect { described_class.new(label_title: title).perform }.not_to raise_error
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `usage_count` to `LabelSerializer` (batched, N+1-free in the collection via `Label.usage_counts_for`).
- New `Labels::DeleteService` removes the label from every tagged Contact/Conversation through the model setter, preserving the existing label-change dispatch events.
- `labels#destroy` now wraps cleanup + destroy in a transaction so deleting a label in use never leaves orphaned taggings.

## Security
- `destroy` stays gated by the `labels.delete` permission.
- Single-tenant community app — no account scoping needed; `usage_count` is an integer (no injection surface).

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/services/labels/delete_service_spec.rb spec/requests/api/v1/labels_spec.rb` (16 examples, 0 failures)
- Manual smoke: usage count in list + delete dialog; deleting an in-use label removes it from contacts/conversations with no orphan (single and bulk).

## Changed Files
- `app/services/labels/delete_service.rb`
- `app/models/label.rb`
- `app/serializers/label_serializer.rb`
- `app/controllers/api/v1/labels_controller.rb`
- `spec/services/labels/delete_service_spec.rb`
- `spec/requests/api/v1/labels_spec.rb`

## Related PRs
- frontend: paired UI PR (see Linked Issue)

## Linked Issue
- EVO-1863

## Summary by Sourcery

Add label usage count exposure in the labels API and ensure label deletions clean up taggings consistently and transactionally.

New Features:
- Expose a usage_count field for labels in the API list response, reflecting how many records use each label.

Bug Fixes:
- Ensure deleting a label removes it from all tagged contacts and conversations, preventing orphaned taggings and keeping tag lists in sync.

Enhancements:
- Introduce a Labels::DeleteService to centralize label cleanup logic and reuse model-level label change behavior.
- Batch-compute usage counts for label collections to avoid N+1 queries in label serialization.

Tests:
- Add request specs for labels index and destroy endpoints covering usage_count and tagging cleanup behavior.
- Add a service spec skeleton for Labels::DeleteService.