### PR TITLE
fix(crm): country_code contact filter on top-level column; remove dead company filter (EVO-1849)

### DIFF
--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -182,20 +182,12 @@ contacts:
       - "equal_to"
       - "not_equal_to"
   country_code:
-    attribute_type: "additional_attributes"
+    attribute_type: "standard"
     data_type: "text_case_insensitive"
     filter_operators:
       - "equal_to"
       - "not_equal_to"
   city:
-    attribute_type: "additional_attributes"
-    data_type: "text_case_insensitive"
-    filter_operators:
-      - "equal_to"
-      - "not_equal_to"
-      - "contains"
-      - "does_not_contain"
-  company:
     attribute_type: "additional_attributes"
     data_type: "text_case_insensitive"
     filter_operators:

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contacts::FilterService do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+
+  def cond(key, operator, values)
+    [{ 'attribute_key' => key, 'filter_operator' => operator, 'values' => values, 'query_operator' => nil }]
+  end
+
+  def run(rows)
+    params = ActionController::Parameters.new(payload: rows).permit!
+    described_class.new(nil, user, params).perform
+  end
+
+  describe 'country_code filter (EVO-1849 M1)' do
+    it 'matches on the top-level contacts.country_code column, case-insensitively' do
+      match = Contact.create!(name: 'C', email: "c-#{SecureRandom.hex(4)}@t.com")
+      match.update_column(:country_code, 'br')
+      other = Contact.create!(name: 'D', email: "d-#{SecureRandom.hex(4)}@t.com")
+      other.update_column(:country_code, 'us')
+
+      result = run(cond('country_code', 'equal_to', ['BR']))
+
+      expect(result[:contacts]).to include(match)
+      expect(result[:count]).to eq(1)
+    end
+  end
+
+  describe 'company filter (EVO-1849 B1 — removed; association-based filter tracked as follow-up)' do
+    it 'is no longer a valid contact filter attribute' do
+      expect { run(cond('company', 'contains', ['acme'])) }
+        .to raise_error(CustomExceptions::CustomFilter::InvalidAttribute)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `country_code` contact filter changed from `additional_attributes` to a **standard** filter on the top-level `contacts.country_code` column (broader coverage; case-insensitive).
- Removed the `company` contact filter key: it pointed at `additional_attributes ->> 'company'`, which no writer populates (the contact's company is the `ContactCompany` association set via the "Linked Companies" picker, not free text). The real association-based company filter is tracked as a follow-up.

## Security
- No new inputs/endpoints; filter framework unchanged. Single-tenant.

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/services/contacts/filter_service_spec.rb` (2 examples, 0 failures)

## Changed Files
- `lib/filters/filter_keys.yml`
- `spec/services/contacts/filter_service_spec.rb`

## Linked Issue
- EVO-1849

## Summary by Sourcery

Update CRM contact filters for country code and clean up unused company filter.

Bug Fixes:
- Ensure the contact country_code filter uses the standard top-level column with case-insensitive matching instead of additional_attributes.

Enhancements:
- Remove the unused company contact filter that referenced an unpopulated additional_attributes field.

Tests:
- Add or update specs for the contacts filter service to cover the revised country_code behavior and absence of the company filter.