### PR TITLE
fix(crm): emit label.removed for conversations on label delete (EVO-1863 review)

### DIFF
--- a/app/services/labels/delete_service.rb
+++ b/app/services/labels/delete_service.rb
@@ -4,8 +4,11 @@ class Labels::DeleteService
   def perform
     tagged_conversations.find_in_batches do |conversation_batch|
       conversation_batch.each do |conversation|
-        conversation.label_list.remove(label_title)
-        conversation.save!
+        # Route through the setter so the label_list change is dirty-tracked and
+        # Conversation#create_label_change / notify_conversation_updation emit the
+        # label.removed activity + CONVERSATION_UPDATED (a bare label_list.remove
+        # mutates the collection without populating previous_changes[:label_list]).
+        conversation.update!(label_list: conversation.label_list - [label_title])
       end
     end
 

--- a/spec/services/labels/delete_service_spec.rb
+++ b/spec/services/labels/delete_service_spec.rb
@@ -24,6 +24,23 @@ RSpec.describe Labels::DeleteService do
     expect(Contact.tagged_with(title)).to be_empty
   end
 
+  it 'dirty-tracks the conversation removal so CONVERSATION_UPDATED is dispatched (EVO-1863 review)' do
+    user = User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com")
+    Current.user = user
+    conversation.update!(label_list: [title])
+
+    dispatched = []
+    allow(Rails.configuration.dispatcher).to receive(:dispatch) do |event_name, *_args|
+      dispatched << event_name
+    end
+
+    described_class.new(label_title: title).perform
+
+    expect(dispatched).to include(Conversation::CONVERSATION_UPDATED)
+  ensure
+    Current.reset
+  end
+
   it 'is a no-op when the label is not in use' do
     expect { described_class.new(label_title: title).perform }.not_to raise_error
   end


### PR DESCRIPTION
## Summary
Addresses the MEDIUM review finding on EVO-1863: when a label in use was deleted, the **conversation** cleanup path used `label_list.remove + save!`, which mutates the tag collection without populating `previous_changes[:label_list]`. As a result `Conversation#create_label_change` / `notify_conversation_updation` never fired, so the `label.removed` activity and `CONVERSATION_UPDATED` event were skipped for conversations (the contact path already routed through the setter and was correct).

Fix: route the conversation cleanup through `update!(label_list: ...)` so the change is dirty-tracked and the events fire.

## Security
- No new inputs/endpoints; single-tenant.

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/services/labels/delete_service_spec.rb` (3 examples, 0 failures) — includes a dispatcher spy asserting `CONVERSATION_UPDATED` fires on conversation label removal.

## Changed Files
- `app/services/labels/delete_service.rb`
- `spec/services/labels/delete_service_spec.rb`

## Linked Issue
- EVO-1863 (follow-up fix; original backend PR #163 already merged)
