### PR TITLE
fix(crm): skip WhatsApp revoke/protocol messages on evolution_go inbound (EVO-1748)

### DIFF
--- a/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
@@ -8,6 +8,11 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
   private
 
   def handle_message
+    if protocol_message?
+      Rails.logger.info "Evolution Go API: Protocol message (control event, e.g. revoke) — skipping, not creating a message"
+      return
+    end
+
     return unless message_processable?
 
     Rails.logger.info "Evolution Go API: Creating new message #{raw_message_id}"
@@ -18,6 +23,10 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
     set_conversation
     update_conversation_status_if_needed
     create_message(attach_media: media_attachment?)
+  end
+
+  def protocol_message?
+    @evolution_go_message.is_a?(Hash) && @evolution_go_message[:protocolMessage].present?
   end
 
   def set_contact

--- a/spec/services/whatsapp/message_revoke_handling_spec.rb
+++ b/spec/services/whatsapp/message_revoke_handling_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1748: a WhatsApp revoke (delete-for-everyone) arrives via evolution_go as a
+# protocolMessage. It must NOT be processed as a regular message (which produced an
+# empty bubble). evolution v2 / baileys already skip protocol via ignore_message?.
+RSpec.describe 'WhatsApp evolution_go protocol message handling (EVO-1748)' do
+  let(:channel) { instance_double(Channel::Whatsapp, provider: 'evolution_go') }
+  let(:inbox) { instance_double(Inbox, id: 1, channel: channel) }
+  let(:service) { Whatsapp::IncomingMessageEvolutionGoService.new(inbox: inbox, params: { event: 'Message', data: {} }) }
+
+  before { service.instance_variable_set(:@inbox, inbox) }
+
+  describe '#protocol_message?' do
+    it 'is true for a revoke/protocol message' do
+      service.instance_variable_set(:@evolution_go_message, { protocolMessage: { type: 'REVOKE', key: { id: 'X' } } })
+      expect(service.send(:protocol_message?)).to be(true)
+    end
+
+    it 'is false for a normal text message' do
+      service.instance_variable_set(:@evolution_go_message, { conversation: 'hello' })
+      expect(service.send(:protocol_message?)).to be(false)
+    end
+  end
+
+  describe '#handle_message with a protocol message' do
+    before { service.instance_variable_set(:@evolution_go_message, { protocolMessage: { type: 'REVOKE', key: { id: 'X' } } }) }
+
+    it 'skips it without creating a message (no empty bubble)' do
+      expect(service).not_to receive(:message_processable?)
+      expect(service).not_to receive(:create_message)
+      service.send(:handle_message)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
When a WhatsApp contact deletes a message ("delete for everyone"), it arrives on the **evolution_go** inbound as a `Message` event carrying a `protocolMessage` (revoke). `message_processable?` passed because `@evolution_go_message` was present even though `message_content` was `nil`, so the revoke was created as an **empty-content message** ("the next message comes empty"). This skips protocol/control messages before message creation, so no empty bubble is created.

The `evolution` (v2) and `baileys` handlers already ignore protocol via `ignore_message?` — only evolution_go was affected, so the fix is scoped to it.

## Scope note (rescoped after smoke + product call with Daniel)
This card now covers ONLY the empty-bubble bug. Two distinct follow-ups were split out:
- Inbound revoke **visual feedback** (show "deleted by contact" while keeping the content) — separate UX card.
- Outbound delete **propagation** to the provider (delete-for-everyone) — separate card; only feasible on some providers (Baileys yes, evolution_go has no send-delete).

## Security
- No new inputs/endpoints; single-tenant.

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/services/whatsapp/message_revoke_handling_spec.rb` (3 examples, 0 failures)
- Manual smoke (evolution_go + live evolution-api): contact deletes a message → no empty bubble appears; following messages render normally.

## Changed Files
- `app/services/whatsapp/evolution_go_handlers/messages_upsert.rb`
- `spec/services/whatsapp/message_revoke_handling_spec.rb`

## Linked Issue
- EVO-1748

## Summary by Sourcery

Skip creation of CRM messages for WhatsApp protocol/control events on the evolution_go inbound handler to avoid empty bubbles when contacts delete messages.

Bug Fixes:
- Prevent empty WhatsApp message bubbles caused by processing evolution_go revoke/protocol messages as normal inbound messages.

Tests:
- Add specs covering WhatsApp message revoke handling to ensure protocol messages are skipped on evolution_go.