### PR TITLE
feat(crm): WhatsApp contact-revoke notice + agent-delete propagation (EVO-1890, EVO-1891)

### DIFF
--- a/app/controllers/api/v1/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/conversations/messages_controller.rb
@@ -47,6 +47,7 @@ class Api::V1::Conversations::MessagesController < Api::V1::Conversations::BaseC
   def destroy
     @message = message
     @message.update!(content_attributes: (@message.content_attributes || {}).merge(deleted: true))
+    enqueue_provider_delete(@message)
 
     success_response(
       data: MessageSerializer.serialize(@message, include_attachments: true, include_sender: true),
@@ -91,6 +92,18 @@ class Api::V1::Conversations::MessagesController < Api::V1::Conversations::BaseC
   end
 
   private
+
+  # EVO-1891: when an agent deletes an OUTGOING message, revoke it on the provider
+  # (delete-for-everyone) where supported. Done in a background job so a slow or
+  # unreachable provider never blocks/delays the CRM soft-delete response.
+  def enqueue_provider_delete(message)
+    return unless message.outgoing?
+
+    channel = message.conversation&.inbox&.channel
+    return unless channel.respond_to?(:delete_message)
+
+    Whatsapp::DeleteMessageOnProviderJob.perform_later(message.id)
+  end
 
   def perform_status_update(target_status)
     Messages::StatusUpdateService.new(@message, target_status, permitted_params[:external_error]).perform

--- a/app/jobs/whatsapp/delete_message_on_provider_job.rb
+++ b/app/jobs/whatsapp/delete_message_on_provider_job.rb
@@ -1,0 +1,18 @@
+# EVO-1891: propagate an agent's outgoing message deletion to the WhatsApp
+# provider (delete-for-everyone) OUTSIDE the request cycle, so a slow or
+# unreachable provider never blocks the CRM soft-delete. Records whether the
+# revoke actually propagated so the UI can flag CRM-only deletions.
+class Whatsapp::DeleteMessageOnProviderJob < ApplicationJob
+  queue_as :low
+
+  def perform(message_id)
+    message = Message.find_by(id: message_id)
+    return unless message&.outgoing?
+
+    channel = message.conversation&.inbox&.channel
+    return unless channel.respond_to?(:delete_message)
+
+    propagated = channel.delete_message(message)
+    message.update!(content_attributes: message.content_attributes.merge(revoke_propagated: propagated))
+  end
+end

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -85,6 +85,18 @@ class Channel::Whatsapp < ApplicationRecord
     end
   end
 
+  # Propagates an agent's message deletion to the provider (delete-for-everyone),
+  # where supported. Returns false (CRM-only) for providers without delete_message.
+  def delete_message(message)
+    service = provider_service
+    return false unless service.respond_to?(:delete_message)
+
+    service.delete_message(message)
+  rescue StandardError => e
+    Rails.logger.error("Channel::Whatsapp#delete_message failed: #{e.message}")
+    false
+  end
+
   def use_internal_host?
     provider == 'baileys' && ENV.fetch('BAILEYS_PROVIDER_USE_INTERNAL_HOST_URL', false)
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -97,12 +97,14 @@ class Message < ApplicationRecord
   # [:email] : Used by conversation_continuity incoming email messages
   # [:in_reply_to] : Used to reply to a particular tweet in threads
   # [:deleted] : Used to denote whether the message was deleted by the agent
+  # [:revoked_by_contact] : Contact deleted (revoked) the message on WhatsApp; content is kept and shown with a notice
   # [:external_created_at] : Can specify if the message was created at a different timestamp externally
   # [:external_error : Can specify if the message creation failed due to an error at external API
   # [:is_reaction] : Used to denote if the message is a reaction and differentiate it from a simple reply message
   # [:is_edited, :previous_content] : Used to indicated edited message and previous content (before edit)
 
   store :content_attributes, accessors: [:submitted_email, :items, :submitted_values, :email, :in_reply_to, :deleted,
+                                         :revoked_by_contact, :revoke_propagated,
                                          :external_created_at, :story_sender, :story_id, :external_error,
                                          :translations, :in_reply_to_external_id, :is_unsupported,
                                          :is_reaction, :is_edited, :previous_content], coder: JSON

--- a/app/services/whatsapp/baileys_handlers/messages_update.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_update.rb
@@ -19,6 +19,22 @@ module Whatsapp::BaileysHandlers::MessagesUpdate
     end
   end
 
+  # EVO-1890: contact revokes arrive as a messages.delete event; mark the original
+  # as revoked_by_contact (content kept + notice).
+  def process_messages_delete
+    data = processed_params[:data]
+    return if data.blank?
+
+    entries = data.is_a?(Array) ? data : [data]
+    entries.each do |entry|
+      source_id = entry[:id] || entry.dig(:key, :id)
+      next if source_id.blank?
+
+      Rails.logger.info "Baileys: messages.delete for #{source_id} — marking revoked_by_contact"
+      mark_message_revoked_by_source_id(source_id)
+    end
+  end
+
   def handle_update
     raise MessageNotFoundError unless find_message_by_source_id(raw_message_id)
 

--- a/app/services/whatsapp/baileys_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/baileys_handlers/messages_upsert.rb
@@ -22,6 +22,7 @@ module Whatsapp::BaileysHandlers::MessagesUpsert
 
   def handle_message
     return if jid_type != 'user'
+    return handle_revoke_protocol if message_type == 'protocol'
     return if ignore_message?
     return if find_message_by_source_id(raw_message_id) || message_under_process?
 
@@ -38,6 +39,15 @@ module Whatsapp::BaileysHandlers::MessagesUpsert
     set_conversation
     handle_create_message
     clear_message_source_id_from_redis
+  end
+
+  # A revoke arrives as a protocolMessage; mark the original as revoked-by-contact
+  # (the upsert path otherwise just ignores protocol via ignore_message?).
+  def handle_revoke_protocol
+    protocol = @raw_message.dig(:message, :protocolMessage)
+    source_id = revoked_message_source_id(protocol)
+    Rails.logger.info "Baileys: Protocol message (revoked id: #{source_id.inspect}) — marking original revoked"
+    mark_message_revoked_by_source_id(source_id)
   end
 
   def set_contact

--- a/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
@@ -9,7 +9,7 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
 
   def handle_message
     if protocol_message?
-      Rails.logger.info "Evolution Go API: Protocol message (control event, e.g. revoke) — skipping, not creating a message"
+      handle_revoke_protocol
       return
     end
 
@@ -27,6 +27,15 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
 
   def protocol_message?
     @evolution_go_message.is_a?(Hash) && @evolution_go_message[:protocolMessage].present?
+  end
+
+  # A revoke arrives as a protocolMessage; never create a message for it (that
+  # produced an empty bubble) and mark the original as revoked-by-contact.
+  def handle_revoke_protocol
+    protocol = @evolution_go_message[:protocolMessage]
+    source_id = revoked_message_source_id(protocol)
+    Rails.logger.info "Evolution Go API: Protocol message (type: #{protocol[:type].inspect}, revoked id: #{source_id.inspect}) — not creating a message; marking original revoked"
+    mark_message_revoked_by_source_id(source_id)
   end
 
   def set_contact

--- a/app/services/whatsapp/evolution_handlers/messages_update.rb
+++ b/app/services/whatsapp/evolution_handlers/messages_update.rb
@@ -38,6 +38,23 @@ module Whatsapp::EvolutionHandlers::MessagesUpdate
     end
   end
 
+  # EVO-1890: contact revokes (delete-for-everyone) arrive as a messages.delete
+  # event ({ ...key, status: 'DELETED' }). Mark the original as revoked_by_contact
+  # (content kept, shown with a notice) instead of letting it pass unhandled.
+  def process_messages_delete
+    data = processed_params[:data]
+    return if data.blank?
+
+    entries = data.is_a?(Array) ? data : [data]
+    entries.each do |entry|
+      source_id = entry[:id] || entry.dig(:key, :id)
+      next if source_id.blank?
+
+      Rails.logger.info "Evolution API: messages.delete for #{source_id} — marking revoked_by_contact"
+      mark_message_revoked_by_source_id(source_id)
+    end
+  end
+
   def handle_update
     unless find_message_by_source_id(raw_message_id)
       Rails.logger.warn "Evolution API: Message not found for update: #{raw_message_id}"

--- a/app/services/whatsapp/evolution_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_handlers/messages_upsert.rb
@@ -32,6 +32,8 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
   end
 
   def handle_message
+    return handle_revoke_protocol if message_type == 'protocol'
+
     return unless message_processable?
 
     Rails.logger.info "Evolution API: Creating new message #{raw_message_id}"
@@ -49,6 +51,15 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
     update_conversation_status_if_needed
     handle_create_message
     clear_message_source_id_from_redis
+  end
+
+  # A revoke arrives as a protocolMessage; mark the original as revoked-by-contact
+  # (the upsert path otherwise just ignores protocol via ignore_message?).
+  def handle_revoke_protocol
+    protocol = @raw_message.dig(:message, :protocolMessage)
+    source_id = revoked_message_source_id(protocol)
+    Rails.logger.info "Evolution API: Protocol message (revoked id: #{source_id.inspect}) — marking original revoked"
+    mark_message_revoked_by_source_id(source_id)
   end
 
   def set_contact

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -214,4 +214,31 @@ class Whatsapp::IncomingMessageBaseService
     end
   end
 
+  # Marks an existing inbound message as revoked-by-contact (the contact deleted
+  # it on WhatsApp). The content is kept; the frontend shows a "deleted by
+  # contact" notice. Reused across providers (evolution / evolution_go / baileys).
+  def mark_message_revoked_by_source_id(source_id)
+    return false if source_id.blank?
+
+    message = inbox.messages.find_by(source_id: source_id.to_s)
+    return false unless message
+    # Only the contact can revoke their own (incoming) messages. Guards against the
+    # provider echoing our own outbound delete-for-everyone back as a fromMe delete,
+    # which would otherwise mislabel the agent's message as "deleted by contact".
+    return false unless message.incoming?
+    return true if message.revoked_by_contact
+
+    message.revoked_by_contact = true
+    message.save!
+    Rails.logger.info "WhatsApp revoke: marked message #{message.id} (source_id #{source_id}) as revoked_by_contact"
+    true
+  end
+
+  def revoked_message_source_id(protocol_message)
+    return if protocol_message.blank?
+
+    key = protocol_message[:key] || protocol_message[:Key] || {}
+    key[:id] || key[:ID]
+  end
+
 end

--- a/app/services/whatsapp/incoming_message_evolution_service.rb
+++ b/app/services/whatsapp/incoming_message_evolution_service.rb
@@ -15,6 +15,8 @@ class Whatsapp::IncomingMessageEvolutionService < Whatsapp::IncomingMessageBaseS
       process_messages_upsert
     when 'messages.update'
       process_messages_update
+    when 'messages.delete'
+      process_messages_delete
     when 'contacts.update'
       process_contacts_update
     when 'chats.update', 'chats.upsert'

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -17,6 +17,27 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     end
   end
 
+  # Propagates an agent's message deletion to WhatsApp (delete-for-everyone).
+  # Returns true when the provider acknowledged the revoke.
+  def delete_message(message)
+    return false if api_base_path.blank? || instance_name.blank?
+    return false if message.source_id.blank?
+
+    remote_jid = remote_jid_for(message)
+    return false if remote_jid.blank?
+
+    response = HTTParty.delete(
+      "#{api_base_path}/chat/deleteMessageForEveryone/#{instance_name}",
+      headers: api_headers,
+      body: { id: message.source_id, remoteJid: remote_jid, fromMe: message.outgoing? }.to_json,
+      timeout: 10
+    )
+    return true if response.success?
+
+    Rails.logger.warn("Evolution API: deleteMessageForEveryone failed (#{response.code}) for source_id=#{message.source_id}")
+    false
+  end
+
   def send_template(phone_number, template_info)
     # Evolution API doesn't support template messages in the same way
     # For now, we'll send a regular text message
@@ -295,6 +316,14 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
 
   def instance_name
     whatsapp_channel.provider_config['instance_name']
+  end
+
+  def remote_jid_for(message)
+    source_id = message.conversation&.contact_inbox&.source_id.to_s
+    return nil if source_id.blank?
+    return source_id if source_id.include?('@')
+
+    "#{source_id.delete('+')}@s.whatsapp.net"
   end
 
   def send_interactive_message(phone_number, message)

--- a/spec/jobs/whatsapp/delete_message_on_provider_job_spec.rb
+++ b/spec/jobs/whatsapp/delete_message_on_provider_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Whatsapp::DeleteMessageOnProviderJob do
+  it 'propagates the delete and records revoke_propagated for an outgoing message' do
+    channel = double('channel', delete_message: true)
+    inbox = double('inbox', channel: channel)
+    conversation = double('conversation', inbox: inbox)
+    message = double('message', outgoing?: true, conversation: conversation, content_attributes: {})
+
+    allow(Message).to receive(:find_by).with(id: 1).and_return(message)
+    expect(channel).to receive(:delete_message).with(message).and_return(true)
+    expect(message).to receive(:update!).with(content_attributes: { revoke_propagated: true })
+
+    described_class.perform_now(1)
+  end
+
+  it 'does nothing for a non-outgoing message' do
+    message = double('message', outgoing?: false)
+    allow(Message).to receive(:find_by).with(id: 2).and_return(message)
+
+    expect { described_class.perform_now(2) }.not_to raise_error
+  end
+
+  it 'does nothing when the message no longer exists' do
+    allow(Message).to receive(:find_by).with(id: 3).and_return(nil)
+
+    expect { described_class.perform_now(3) }.not_to raise_error
+  end
+end

--- a/spec/services/whatsapp/evolution_revoke_integration_spec.rb
+++ b/spec/services/whatsapp/evolution_revoke_integration_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1890 — re-review: prove the contact-revoke flow end-to-end WITHOUT stubbing
+# the `inbox.messages.find_by(source_id:)` lookup. The earlier specs all stubbed
+# that lookup, so they never proved the id carried by the `messages.delete` event
+# actually matches the `source_id` stored on the original message.
+RSpec.describe 'WhatsApp evolution revoke — real source_id lookup (EVO-1890)' do # rubocop:disable RSpec/DescribeClass
+  let(:channel) do
+    ch = Channel::Whatsapp.new(phone_number: "+55119#{rand(10_000_000..99_999_999)}", provider: 'evolution')
+    ch.save!(validate: false)
+    ch
+  end
+  let(:inbox) { Inbox.create!(name: 'WA Evolution', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@t.com") }
+  let(:contact_inbox) do
+    ContactInbox.create!(inbox: inbox, contact: contact, source_id: '5511999999999')
+  end
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  # A realistic WhatsApp message id (the value stored as Message#source_id on inbound).
+  let(:wamid) { '3EB0C767D5F1A2B3C4D5' }
+
+  def run_delete(message_id, from_me: false)
+    Whatsapp::IncomingMessageEvolutionService.new(
+      inbox: inbox,
+      params: { event: 'messages.delete',
+                data: { id: message_id, remoteJid: '5511999999999@s.whatsapp.net', fromMe: from_me, status: 'DELETED' } }
+    ).perform
+  end
+
+  it 'marks the original incoming message revoked_by_contact via the real find_by, keeping content' do
+    message = conversation.messages.create!(
+      inbox: inbox, message_type: :incoming, content_type: 'text',
+      content: 'original message text', source_id: wamid
+    )
+
+    run_delete(wamid)
+
+    message.reload
+    expect(message.revoked_by_contact).to be(true)
+    expect(message.content).to eq('original message text')
+  end
+
+  it 'does NOT mark an outgoing message (our own delete echoing back as fromMe)' do
+    message = conversation.messages.create!(
+      inbox: inbox, message_type: :outgoing, content_type: 'text',
+      content: 'agent reply', source_id: wamid
+    )
+
+    run_delete(wamid, from_me: true)
+
+    expect(message.reload.revoked_by_contact).to be_falsey
+  end
+
+  it 'ingests via the real upsert then revokes by the same key id (proves inbound source_id == delete id)' do
+    Whatsapp::IncomingMessageEvolutionService.new(
+      inbox: inbox,
+      params: { event: 'messages.upsert',
+                data: { key: { id: wamid, remoteJid: '5511999999999@s.whatsapp.net', fromMe: false },
+                        pushName: 'Contact', message: { conversation: 'original via upsert' } } }
+    ).perform
+
+    created = inbox.messages.find_by(source_id: wamid)
+    expect(created).to be_present
+    expect(created).to be_incoming
+
+    run_delete(wamid)
+
+    expect(created.reload.revoked_by_contact).to be(true)
+    expect(created.content).to eq('original via upsert')
+  end
+
+  it 'is a no-op when no message matches the revoked id (no crash, nothing marked)' do
+    other = conversation.messages.create!(
+      inbox: inbox, message_type: :incoming, content_type: 'text',
+      content: 'unrelated', source_id: 'SOME_OTHER_ID'
+    )
+
+    expect { run_delete(wamid) }.not_to raise_error
+    expect(other.reload.revoked_by_contact).to be_falsey
+  end
+end

--- a/spec/services/whatsapp/message_revoke_handling_spec.rb
+++ b/spec/services/whatsapp/message_revoke_handling_spec.rb
@@ -2,10 +2,11 @@
 
 require 'rails_helper'
 
-# EVO-1748: a WhatsApp revoke (delete-for-everyone) arrives via evolution_go as a
-# protocolMessage. It must NOT be processed as a regular message (which produced an
-# empty bubble). evolution v2 / baileys already skip protocol via ignore_message?.
-RSpec.describe 'WhatsApp evolution_go protocol message handling (EVO-1748)' do
+# EVO-1748 (empty bubble) + EVO-1890 (inbound revoke notice): a WhatsApp
+# delete-for-everyone arrives via evolution_go as a protocolMessage. It must NOT
+# be created as a (empty) message, and the original must be marked
+# revoked_by_contact so the agent sees a notice while keeping the content.
+RSpec.describe 'WhatsApp revoke handling (EVO-1748 / EVO-1890)' do
   let(:channel) { instance_double(Channel::Whatsapp, provider: 'evolution_go') }
   let(:inbox) { instance_double(Inbox, id: 1, channel: channel) }
   let(:service) { Whatsapp::IncomingMessageEvolutionGoService.new(inbox: inbox, params: { event: 'Message', data: {} }) }
@@ -24,13 +25,71 @@ RSpec.describe 'WhatsApp evolution_go protocol message handling (EVO-1748)' do
     end
   end
 
-  describe '#handle_message with a protocol message' do
-    before { service.instance_variable_set(:@evolution_go_message, { protocolMessage: { type: 'REVOKE', key: { id: 'X' } } }) }
+  describe 'revoke handling via #handle_message' do
+    before { service.instance_variable_set(:@evolution_go_message, { protocolMessage: { type: 'REVOKE', key: { id: 'ABC' } } }) }
 
-    it 'skips it without creating a message (no empty bubble)' do
+    it 'does not create a message and marks the original revoked_by_contact' do
+      original = double('Message', id: 9, revoked_by_contact: false, incoming?: true)
+      messages = double('messages')
+      allow(inbox).to receive(:messages).and_return(messages)
+      allow(messages).to receive(:find_by).with(source_id: 'ABC').and_return(original)
+
       expect(service).not_to receive(:message_processable?)
-      expect(service).not_to receive(:create_message)
+      expect(original).to receive(:revoked_by_contact=).with(true)
+      expect(original).to receive(:save!)
+
       service.send(:handle_message)
+    end
+
+    it 'is a no-op (no empty message) when the original is not found' do
+      messages = double('messages')
+      allow(inbox).to receive(:messages).and_return(messages)
+      allow(messages).to receive(:find_by).and_return(nil)
+
+      expect(service).not_to receive(:message_processable?)
+      expect { service.send(:handle_message) }.not_to raise_error
+    end
+  end
+
+  describe '#revoked_message_source_id' do
+    it 'extracts the key id (camelCase or capitalized)' do
+      expect(service.send(:revoked_message_source_id, { key: { id: 'X1' } })).to eq('X1')
+      expect(service.send(:revoked_message_source_id, { Key: { ID: 'X2' } })).to eq('X2')
+    end
+  end
+
+  describe 'evolution provider messages.delete (the real revoke path for Baileys/evolution)' do
+    let(:ev_channel) { instance_double(Channel::Whatsapp, provider: 'evolution') }
+    let(:ev_inbox) { instance_double(Inbox, id: 1, channel: ev_channel) }
+    let(:ev_service) do
+      Whatsapp::IncomingMessageEvolutionService.new(
+        inbox: ev_inbox,
+        params: { event: 'messages.delete', data: { id: 'MID', remoteJid: '5511@s.whatsapp.net', fromMe: false, status: 'DELETED' } }
+      )
+    end
+
+    it 'marks the deleted message revoked_by_contact' do
+      msg = double('Message', id: 7, revoked_by_contact: false, incoming?: true)
+      messages = double('messages')
+      allow(ev_inbox).to receive(:messages).and_return(messages)
+      allow(messages).to receive(:find_by).with(source_id: 'MID').and_return(msg)
+
+      expect(msg).to receive(:revoked_by_contact=).with(true)
+      expect(msg).to receive(:save!)
+
+      ev_service.perform
+    end
+
+    it 'does NOT mark an outgoing message (echo of our own delete / fromMe=true)' do
+      outgoing = double('Message', id: 8, incoming?: false)
+      messages = double('messages')
+      allow(ev_inbox).to receive(:messages).and_return(messages)
+      allow(messages).to receive(:find_by).with(source_id: 'MID').and_return(outgoing)
+
+      expect(outgoing).not_to receive(:revoked_by_contact=)
+      expect(outgoing).not_to receive(:save!)
+
+      ev_service.perform
     end
   end
 end

--- a/spec/services/whatsapp/providers/evolution_service_delete_spec.rb
+++ b/spec/services/whatsapp/providers/evolution_service_delete_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1891: agent deletes an outgoing message in the CRM -> propagate a
+# delete-for-everyone to the provider (evolution-api).
+RSpec.describe Whatsapp::Providers::EvolutionService do
+  let(:channel) do
+    instance_double(Channel::Whatsapp,
+                    provider_config: { 'api_url' => 'http://localhost:8081', 'instance_name' => 'inst', 'admin_token' => 'tok' })
+  end
+  let(:service) { described_class.new(whatsapp_channel: channel) }
+
+  describe '#delete_message' do
+    let(:conversation) { double(contact_inbox: double(source_id: '5511999999999@s.whatsapp.net')) }
+    let(:message) { double(source_id: 'MSGID123', outgoing?: true, conversation: conversation) }
+
+    it 'calls deleteMessageForEveryone and returns true on success' do
+      expect(HTTParty).to receive(:delete) do |url, opts|
+        expect(url).to eq('http://localhost:8081/chat/deleteMessageForEveryone/inst')
+        body = JSON.parse(opts[:body])
+        expect(body).to include('id' => 'MSGID123', 'remoteJid' => '5511999999999@s.whatsapp.net', 'fromMe' => true)
+        expect(opts[:headers]['apikey']).to eq('tok')
+        double(success?: true, code: 200)
+      end
+      expect(service.delete_message(message)).to be(true)
+    end
+
+    it 'returns false on provider failure' do
+      allow(HTTParty).to receive(:delete).and_return(double(success?: false, code: 400, body: 'err'))
+      expect(service.delete_message(message)).to be(false)
+    end
+
+    it 'does not call the provider when source_id is blank' do
+      blank = double(source_id: nil, outgoing?: true, conversation: conversation)
+      expect(HTTParty).not_to receive(:delete)
+      expect(service.delete_message(blank)).to be(false)
+    end
+  end
+
+  describe '#remote_jid_for' do
+    it 'keeps an existing jid as-is' do
+      msg = double(conversation: double(contact_inbox: double(source_id: '12345-678@g.us')))
+      expect(service.send(:remote_jid_for, msg)).to eq('12345-678@g.us')
+    end
+
+    it 'builds an s.whatsapp.net jid from a bare number' do
+      msg = double(conversation: double(contact_inbox: double(source_id: '+5511999999999')))
+      expect(service.send(:remote_jid_for, msg)).to eq('5511999999999@s.whatsapp.net')
+    end
+  end
+end


### PR DESCRIPTION
Combined delivery for **EVO-1890** (inbound contact-revoke notice) + **EVO-1891** (outbound delete propagation). Pairs with the frontend PR (see Related PRs).

## Summary
- **EVO-1890 — inbound:** when a contact deletes a message ("delete for everyone"), the original message is **kept** and flagged `content_attributes.revoked_by_contact` (the frontend shows a "deleted by the contact" notice) instead of vanishing / leaving an empty bubble.
  - `evolution` + `baileys`: handled via the **`messages.delete`** webhook event (`process_messages_delete`). This is the real revoke path for Baileys-based gateways — confirmed live.
  - `evolution_go`: handled via the inline `protocolMessage` on the Message event.
  - Shared helper `mark_message_revoked_by_source_id` marks **only INCOMING** messages — guards against the provider echoing our own outbound delete back as a `fromMe` delete (which would mislabel the agent's own message).
- **EVO-1891 — outbound:** when an agent deletes an **outgoing** message, it is revoked on the provider (delete-for-everyone) where supported.
  - `Channel::Whatsapp#delete_message` → `EvolutionService#delete_message` → `DELETE /chat/deleteMessageForEveryone/{instance}`.
  - Runs in **`Whatsapp::DeleteMessageOnProviderJob`** (Sidekiq) so a slow/unreachable provider never blocks the CRM soft-delete. Records `revoke_propagated` for the UI.
  - `evolution_go` has no send-delete → stays CRM-only (`revoke_propagated=false`).

## Cross-channel feasibility (documented for the cards)
- ✅ WhatsApp via self-hosted gateways (evolution / baileys / evolution_go) — full WhatsApp client, surfaces revokes.
- ❌ WhatsApp Cloud (Meta official) — Meta does NOT webhook message deletions. Not possible.
- ❌ Telegram — Bot API does NOT notify the bot when a user deletes. Not possible.
- N/A email / SMS.

## Security
- No new untrusted inputs; revoke payload values are parameterized JSON to the provider. Single-tenant.

## Test plan
- `evo-ai-crm-community: bundle exec rspec spec/services/whatsapp/message_revoke_handling_spec.rb spec/services/whatsapp/providers/evolution_service_delete_spec.rb spec/jobs/whatsapp/delete_message_on_provider_job_spec.rb` (15 examples, 0 failures)
- Manual smoke (evolution provider, live evolution-api): contact deletes → message kept + "deleted by contact"; agent deletes own outgoing message → removed on WhatsApp; agent's own delete no longer mislabeled.

## Changed Files
- `app/services/whatsapp/incoming_message_base_service.rb`, `incoming_message_evolution_service.rb`
- `app/services/whatsapp/{evolution,baileys,evolution_go}_handlers/*`
- `app/services/whatsapp/providers/evolution_service.rb`
- `app/models/channel/whatsapp.rb`, `app/models/message.rb`
- `app/controllers/api/v1/conversations/messages_controller.rb`
- `app/jobs/whatsapp/delete_message_on_provider_job.rb`
- specs (revoke handling, evolution delete, job)

## Related PRs
- frontend: see EVO-1890

## Linked Issues
- EVO-1890, EVO-1891

## Summary by Sourcery

Handle WhatsApp message revocations end-to-end, keeping revoked inbound messages visible with a flag and propagating agent-initiated deletions to supported WhatsApp providers.

New Features:
- Mark inbound WhatsApp messages as revoked-by-contact while retaining their content so the UI can show a deletion notice instead of removing the message.
- Propagate agent-initiated deletions of outgoing WhatsApp messages to the Evolution provider as delete-for-everyone operations, recording whether revocation succeeded for UI display.

Enhancements:
- Share revoke-handling helpers across WhatsApp providers to extract revoked message IDs and mark only incoming messages as revoked.
- Extend Evolution, Baileys, and Evolution Go handlers to process protocol and messages.delete events as revocations instead of creating empty messages or ignoring them.

Tests:
- Expand WhatsApp revoke-handling specs to cover inbound revocation marking, protocol-message handling, and provider-specific delete events.
- Add specs for Evolution provider message deletion and the background job that propagates delete-for-everyone operations to WhatsApp.