### PR TITLE
fix(inboxes): set_agent_bot persiste binding (EVO-1900)

### DIFF
--- a/app/controllers/api/v1/inboxes_controller.rb
+++ b/app/controllers/api/v1/inboxes_controller.rb
@@ -562,7 +562,12 @@ module Api
         end
 
         def fetch_agent_bot
-          @agent_bot = AgentBot.find(params[:agent_bot]) if params[:agent_bot]
+          # The frontend posts the bot under `agent_bot`, but server-side callers
+          # (journeys / evo-flow assign-bot node) post it under `agent_bot_id`.
+          # Accept both so the binding actually persists instead of silently
+          # falling through to the no-op branch and returning 200. (EVO-1900)
+          bot_id = params[:agent_bot].presence || params[:agent_bot_id].presence
+          @agent_bot = AgentBot.find(bot_id) if bot_id
         rescue ActiveRecord::RecordNotFound
           @agent_bot = nil
         end

--- a/spec/controllers/api/v1/inboxes_controller_spec.rb
+++ b/spec/controllers/api/v1/inboxes_controller_spec.rb
@@ -68,4 +68,49 @@ RSpec.describe Api::V1::InboxesController, type: :controller do
       end
     end
   end
+
+  describe '#fetch_agent_bot' do
+    let(:agent_bot) { instance_double(AgentBot) }
+
+    before do
+      allow(AgentBot).to receive(:find).with('bot-123').and_return(agent_bot)
+    end
+
+    context 'when the bot id is sent under :agent_bot (frontend)' do
+      it 'resolves the agent bot' do
+        allow(controller).to receive(:params).and_return(
+          ActionController::Parameters.new(agent_bot: 'bot-123')
+        )
+
+        controller.send(:fetch_agent_bot)
+
+        expect(controller.instance_variable_get(:@agent_bot)).to eq(agent_bot)
+      end
+    end
+
+    context 'when the bot id is sent under :agent_bot_id (journeys / evo-flow)' do
+      it 'resolves the agent bot so the binding persists (EVO-1900)' do
+        allow(controller).to receive(:params).and_return(
+          ActionController::Parameters.new(agent_bot_id: 'bot-123')
+        )
+
+        controller.send(:fetch_agent_bot)
+
+        expect(controller.instance_variable_get(:@agent_bot)).to eq(agent_bot)
+      end
+    end
+
+    context 'when no bot id is provided' do
+      it 'leaves @agent_bot nil without hitting the database' do
+        allow(controller).to receive(:params).and_return(
+          ActionController::Parameters.new({})
+        )
+        expect(AgentBot).not_to receive(:find)
+
+        controller.send(:fetch_agent_bot)
+
+        expect(controller.instance_variable_get(:@agent_bot)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Resumo

`POST /api/v1/inboxes/:id/set_agent_bot` respondia `200` e o nó `assign-bot` logava "Bot assigned successfully", mas `agent_bot_inboxes` **não recebia linha** (D11 do e2e de jornadas — mesma classe do D8).

### Causa raiz
`fetch_agent_bot` resolvia o bot só a partir de `params[:agent_bot]` (chave usada pelo **frontend**). Os chamadores server-side — jornadas / nó `assign-bot` do evo-flow/evo-campaign — postam o bot sob `params[:agent_bot_id]`. Resultado: `@agent_bot` ficava `nil`, o `set_agent_bot` caía no ramo no-op (`elsif @inbox.agent_bot_inbox.present?`) e retornava `200` sem persistir → falso-positivo. Por isso funcionava na UI mas não nas jornadas.

### Correção
`fetch_agent_bot` agora aceita **ambas** as chaves (`agent_bot` e `agent_bot_id`), de modo que o binding é criado/atualizado e o inbox passa a ter `active_bot`.

## Test plan
- `spec/controllers/api/v1/inboxes_controller_spec.rb`: adicionado `#fetch_agent_bot` cobrindo as duas chaves + ausência de id. **6 examples, 0 failures** (rodado contra o Postgres de teste).

EVO-1900

## Summary by Sourcery

Ensure inbox agent bot assignment works for both frontend and server-side callers so bindings persist correctly (EVO-1900).

Bug Fixes:
- Fix agent bot assignment so requests using the agent_bot_id parameter correctly persist the inbox–bot binding instead of silently no-oping.

Tests:
- Add controller specs for fetch_agent_bot covering agent_bot, agent_bot_id, and missing bot id scenarios.