### PR TITLE
fix(labels): contacts labels#create persiste tagging (EVO-1897)

### DIFF
--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -22,6 +22,14 @@ module LabelConcern
   # compares against `tags.name`) could not match on the user-configured
   # title. Translate UUID-shaped inputs to titles here; leave other strings
   # untouched for back-compat with any caller that already sends titles.
+  #
+  # EVO-1897 (D8): a UUID that does NOT resolve to a `Label` row (e.g. a
+  # journey/evo-flow caller carrying an id that is absent from the local
+  # `labels` table) must NOT be silently dropped. Doing so made
+  # `update_labels([])` wipe the list and reply `200` with no tagging
+  # persisted — a false-success for add-label/remove-label nodes. Preserve
+  # the original token when it cannot be resolved so the caller's intent is
+  # always reflected as a real tagging.
   def resolve_label_titles(labels)
     return labels if labels.blank?
 
@@ -29,7 +37,7 @@ module LabelConcern
     return non_uuids if uuids.empty?
 
     titles_by_id = Label.where(id: uuids).pluck(:id, :title).to_h
-    resolved = uuids.filter_map { |id| titles_by_id[id] }
+    resolved = uuids.map { |id| titles_by_id[id] || id }
     (non_uuids + resolved).uniq
   end
 end

--- a/spec/requests/api/v1/contacts/labels_spec.rb
+++ b/spec/requests/api/v1/contacts/labels_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1897 (D8): `POST /api/v1/contacts/:id/labels` must persist a tagging.
+# The journeys/evo-flow add-label node authenticates server-side with the
+# service token, so the request is exercised through that path here.
+RSpec.describe 'Api::V1::Contacts::Labels', type: :request do
+  let(:contact) { Contact.create!(name: "Repro #{SecureRandom.hex(3)}", type: 'person') }
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+
+  before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  def taggings_for(record)
+    ActsAsTaggableOn::Tagging.where(taggable: record)
+  end
+
+  describe 'POST /api/v1/contacts/:id/labels' do
+    it 'persists a tagging when labels are sent as titles' do
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labels: ['vip'] }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['payload']).to contain_exactly('vip')
+      expect(taggings_for(contact).count).to eq(1)
+      expect(contact.reload.label_list).to contain_exactly('vip')
+    end
+
+    it 'translates a UUID that matches a Label into its title and persists it' do
+      label = Label.create!(title: 'Priority')
+
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labels: [label.id] }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['payload']).to contain_exactly('priority')
+      expect(taggings_for(contact).count).to eq(1)
+    end
+
+    # Regression: a UUID-shaped token that does not resolve to a Label row was
+    # silently dropped, so `update_labels([])` wiped the list and replied 200
+    # with no tagging persisted — the false-success reported in D8.
+    it 'still persists a tagging when a UUID does not match any Label' do
+      orphan_uuid = SecureRandom.uuid
+
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labels: [orphan_uuid] }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['payload']).to contain_exactly(orphan_uuid)
+      expect(taggings_for(contact).count).to eq(1)
+      expect(contact.reload.label_list).to contain_exactly(orphan_uuid)
+    end
+
+    it 'reflects the persisted label on the subsequent index read' do
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labels: ['support'] }, headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+
+      get "/api/v1/contacts/#{contact.id}/labels", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['payload']).to contain_exactly('support')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`POST /api/v1/contacts/:id/labels` respondia `200` (eco do request) e até enfileirava `AutomationContactEventJob`, mas **não criava a tagging** — `taggings` ficava sem linha para o contato e o `GET .../labels` voltava vazio. As jornadas (nós add-label / remove-label) só checam o status HTTP 200, então completavam com **falso-sucesso silencioso** sem aplicar a label. Reproduz independente de auth (X-Service-Token e super_admin Bearer).

## Causa raiz

`LabelConcern#resolve_label_titles` traduz UUIDs (PK de `Label`) para títulos antes de gravar via `acts_as_taggable_on`. Quando um UUID **não casava** com nenhuma linha `Label` (caso da chamada server-side de jornada que carrega um id ausente da tabela `labels` local), `uuids.filter_map { |id| titles_by_id[id] }` **descartava o token**, resultando em `update_labels([])` — que zera a lista e responde 200 sem persistir nada.

Confirmado via rails runner contra o DB de teste:
- título no array → tagging criada ✓
- UUID com Label correspondente → traduz para título, tagging criada ✓
- **UUID sem Label correspondente → `[]` → no-op (o bug)** ✗

## Fix

Em `resolve_label_titles`, preservar o token original quando o UUID não resolve (`titles_by_id[id] || id`), em vez de descartá-lo. Assim a intenção do chamador sempre vira uma tagging real. A tradução UUID→título (EVO-1001) continua intacta para UUIDs que casam.

## Test plan

Novo `spec/requests/api/v1/contacts/labels_spec.rb` (path service-token, igual ao usado pelas jornadas):
- persiste tagging quando labels são títulos
- traduz UUID que casa com Label para o título e persiste
- **regressão D8:** persiste tagging mesmo quando o UUID não casa com nenhuma Label
- o `GET` (index) reflete a label persistida

`4 examples, 0 failures`. Verificado que o teste de regressão **falha sem o fix** (payload vazio / 0 taggings) e passa com ele.

EVO-1897

## Summary by Sourcery

Ensure contact label assignments are always persisted when creating labels via the contacts labels API, even when UUID inputs do not resolve to existing Label records.

Bug Fixes:
- Prevent contact label creation requests from silently dropping UUID-based labels that do not match existing Label rows, which previously resulted in tags being cleared without error.

Tests:
- Add request specs for the contacts labels API to verify label persistence for title inputs, resolvable UUIDs, and non-resolvable UUIDs, and to confirm the index endpoint reflects persisted labels.