### PR TITLE
fix(pipeline_items): update no-op 200 (EVO-1915)

### DIFF
--- a/app/controllers/api/v1/pipeline_items_controller.rb
+++ b/app/controllers/api/v1/pipeline_items_controller.rb
@@ -164,6 +164,7 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
   def update
     new_stage_id = params[:pipeline_stage_id]
     stage_changed = false
+    wrote_anything = false
 
     if new_stage_id.present? && new_stage_id.to_s != @pipeline_item.pipeline_stage_id.to_s
       new_stage = @pipeline.pipeline_stages.find(new_stage_id)
@@ -177,13 +178,29 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
       end
 
       stage_changed = true
+      wrote_anything = true
     end
 
-    @pipeline_item.update!(custom_fields: params[:custom_fields]) if params[:custom_fields].present?
+    if params[:custom_fields].present?
+      @pipeline_item.update!(custom_fields: params[:custom_fields])
+      wrote_anything = true
+    end
 
-    if params[:notes].present? && stage_changed
-      latest_movement = @pipeline_item.stage_movements.order(:created_at).last
-      latest_movement&.update!(notes: params[:notes])
+    # Notes persist regardless of stage change: attach to the latest movement,
+    # creating one if the item has none yet (mirrors #update_conversation).
+    if params[:notes].present?
+      persist_notes(params[:notes])
+      wrote_anything = true
+    end
+
+    # Nothing changed → don't lie with "updated successfully". Signal an explicit
+    # no-op so journey/automation callers can tell a real write from an inert call.
+    unless wrote_anything
+      return error_response(
+        ApiErrorCodes::BUSINESS_RULE_VIOLATION,
+        'No changes provided; nothing was updated',
+        status: :unprocessable_entity
+      )
     end
 
     dispatch_conversation_updated_event(@pipeline_item.conversation) if stage_changed
@@ -523,6 +540,25 @@ class Api::V1::PipelineItemsController < Api::V1::BaseController
       ['same_pipeline', service.move_to_stage(current_item, stage)]
     else
       ['cross_pipeline', service.move_to_pipeline_stage(current_item, stage)]
+    end
+  end
+
+  # Attaches notes to the most recent stage_movement so a journey/manual note
+  # persists even when the stage didn't change. If the item somehow has no
+  # movement yet, create a manual one carrying the note (mirrors the
+  # #update_conversation fallback) so the note is never silently dropped.
+  def persist_notes(notes)
+    latest_movement = @pipeline_item.stage_movements.order(:created_at).last
+
+    if latest_movement
+      latest_movement.update!(notes: notes)
+    else
+      @pipeline_item.stage_movements.create!(
+        to_stage: @pipeline_item.pipeline_stage,
+        moved_by: Current.user,
+        movement_type: :manual,
+        notes: notes
+      )
     end
   end
 

--- a/spec/controllers/api/v1/pipeline_items_controller_spec.rb
+++ b/spec/controllers/api/v1/pipeline_items_controller_spec.rb
@@ -127,6 +127,55 @@ RSpec.describe Api::V1::PipelineItemsController, type: :controller do
         expect(pipeline_item.pipeline_stage_id).to eq(stage_one.id)
       end
     end
+
+    # EVO-1915 (e2e N7): notes must persist even when the stage is unchanged, and
+    # an update with nothing to write must NOT report "updated successfully".
+    context 'when notes are provided without a stage change (EVO-1915)' do
+      it 'persists the notes on the latest movement (200)' do
+        patch :update, params: {
+          pipeline_id: pipeline.id,
+          id: pipeline_item.id,
+          notes: 'Follow-up scheduled'
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(pipeline_item.stage_movements.order(:created_at).last.notes)
+          .to eq('Follow-up scheduled')
+      end
+
+      it 'does not create an extra movement just to carry the note' do
+        expect do
+          patch :update, params: {
+            pipeline_id: pipeline.id,
+            id: pipeline_item.id,
+            notes: 'Reuses the entry movement'
+          }
+        end.not_to(change { pipeline_item.stage_movements.count })
+      end
+    end
+
+    context 'when the request has no stage, custom_fields or notes (EVO-1915)' do
+      it 'returns an explicit no-op error instead of a false 200' do
+        patch :update, params: {
+          pipeline_id: pipeline.id,
+          id: pipeline_item.id
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        body = response.parsed_body
+        expect(body['success']).to be(false)
+        expect(body.dig('error', 'code')).to eq(ApiErrorCodes::BUSINESS_RULE_VIOLATION)
+      end
+
+      it 'writes nothing to the item' do
+        expect do
+          patch :update, params: {
+            pipeline_id: pipeline.id,
+            id: pipeline_item.id
+          }
+        end.not_to(change { pipeline_item.reload.updated_at })
+      end
+    end
   end
 
   # EVO-1272 [10.14]: endpoint consumed by the evo-flow Journey "Move to


### PR DESCRIPTION
## Resumo (EVO-1915 — e2e N7)

`PipelineItemsController#update` respondia `200 "updated successfully"` de forma **incondicional**, mas todas as escritas eram condicionais. Dois sintomas:

1. Request sem `pipeline_stage_id`/`custom_fields`/`notes` gravava **nada** e mesmo assim retornava 200 "updated" (classe "2xx sem efeito").
2. `notes` só persistia `if params[:notes].present? && stage_changed` → uma nota enviada **sem** mudança de stage era **descartada silenciosamente**.

## Correção

- **Notas independem de mudança de stage**: extraído helper `persist_notes` que anexa a nota ao último `stage_movement`, criando um movimento `manual` caso o item ainda não tenha nenhum (espelha a semântica de `#update_conversation`).
- **Resposta reflete a escrita real**: rastreio `wrote_anything` (stage / custom_fields / notes). Quando nada é escrito, retorna `error_response(BUSINESS_RULE_VIOLATION, 'No changes provided; nothing was updated', status: :unprocessable_entity)` em vez de um falso 200.
- `error_response` usado na forma **posicional** correta (não repete o bug keyword D10/EVO-1899).

## Test plan

`spec/controllers/api/v1/pipeline_items_controller_spec.rb` (`evolution_test`):
- Notas sem stage → 200 e nota persistida no último movimento; não cria movimento extra.
- Request vazio → `422` + `BUSINESS_RULE_VIOLATION`; não altera `updated_at`.
- Todos os casos `#update` pré-existentes seguem verdes.

`#update` EVO-1915: 4 novos exemplos verdes + os pré-existentes. Única falha do arquivo é `#move_conversation` auto-assign, **pré-existente** em `origin/develop` (poluição de ordenação de testes), não relacionada a esta mudança.

## Summary by Sourcery

Adjust pipeline item updates so that notes persist independently of stage changes and no-op requests return a business-rule error instead of a successful response.

New Features:
- Support persisting notes on pipeline items even when the stage is unchanged by attaching them to the latest movement or creating a manual movement when needed.

Bug Fixes:
- Prevent update requests with no stage, custom_fields, or notes from incorrectly returning a 200 success by responding with a BUSINESS_RULE_VIOLATION and unprocessable entity status instead.
- Ensure notes are no longer silently discarded when sent without a stage change on pipeline items.

Tests:
- Add controller specs covering note persistence without stage changes and explicit no-op error responses for empty update requests on pipeline items.