### PR TITLE
fix(conversations): POST /conversations 500 status_explicitly_set! (EVO-1898)

### DIFF
--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -200,8 +200,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   rescue StandardError => e
     Rails.logger.error "Conversation creation failed: #{e.message}"
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: 'Conversation creation failed',
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Conversation creation failed',
       details: e.message,
       status: :unprocessable_entity
     )

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -231,6 +231,14 @@ class Conversation < ApplicationRecord
     additional_attributes&.dig('is_boosted') == true
   end
 
+  # Helper method to mark status as explicitly set (used by builders and services)
+  # so that determine_conversation_status keeps the provided status instead of
+  # applying the inbox default. Must be public: it is invoked from ConversationBuilder
+  # and other collaborators on the instance.
+  def status_explicitly_set!
+    @status_explicitly_set = true
+  end
+
   private
 
   def ensure_display_id
@@ -281,11 +289,6 @@ class Conversation < ApplicationRecord
     end
 
     Rails.logger.info("[Conversation] determine_conversation_status - Final status: #{status}")
-  end
-
-  # Helper method to mark status as explicitly set (used by builders and services)
-  def status_explicitly_set!
-    @status_explicitly_set = true
   end
 
   def notify_conversation_creation

--- a/spec/builders/conversation_builder_spec.rb
+++ b/spec/builders/conversation_builder_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1898 (D9) — regression coverage for `ConversationBuilder`.
+#
+# `POST /api/v1/conversations` was returning 500 with:
+#   "private method 'status_explicitly_set!' called for an instance of Conversation"
+#
+# `Conversation#status_explicitly_set!` lived below the model's `private`
+# marker, so the builder's external call `conversation.status_explicitly_set!`
+# raised NoMethodError and rolled the creation transaction back.
+#
+# The method is part of the model's public collaborator API (it is invoked by
+# builders and services to opt out of the inbox default status), so it must be
+# public.
+RSpec.describe ConversationBuilder do
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://cbuilder.example.com') }
+  let(:inbox) { Inbox.create!(name: 'CB Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Lead', email: "lead-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(contact: contact, inbox: inbox, source_id: SecureRandom.hex(4)) }
+
+  describe 'Conversation#status_explicitly_set! visibility' do
+    it 'is a public method so external collaborators can call it' do
+      expect(Conversation.new).to respond_to(:status_explicitly_set!)
+      expect(Conversation.public_instance_methods).to include(:status_explicitly_set!)
+    end
+  end
+
+  describe '#perform with an explicit status (D9 reproduction)' do
+    let(:params) { ActionController::Parameters.new(status: 'pending') }
+
+    it 'creates the conversation without raising NoMethodError' do
+      expect do
+        described_class.new(params: params, contact_inbox: contact_inbox).perform
+      end.to change(Conversation, :count).by(1)
+    end
+
+    it 'honours the explicitly provided status instead of the inbox default' do
+      conversation = described_class.new(params: params, contact_inbox: contact_inbox).perform
+      expect(conversation.status).to eq('pending')
+    end
+  end
+
+  describe '#perform without an explicit status' do
+    let(:params) { ActionController::Parameters.new({}) }
+
+    it 'creates the conversation and lets the inbox default apply' do
+      expect do
+        described_class.new(params: params, contact_inbox: contact_inbox).perform
+      end.to change(Conversation, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Resumo

`POST /api/v1/conversations` retornava **500** ao criar conversa (e2e jornadas, defeito D9 — HIGH). Este PR corrige a causa raiz e o handler de erro que a mascarava.

## Causa raiz

`Conversation#status_explicitly_set!` foi declarado **abaixo** do marcador `private` no modelo. O `ConversationBuilder` o invoca de fora da instância (`conversation.status_explicitly_set!`), o que disparava:

> `private method 'status_explicitly_set!' called for an instance of Conversation` (NoMethodError)

dentro da transação de `#create`, causando rollback (sobrava só o `contact_inbox`). O método é parte da API pública de colaborador (usado por builders/services para optar por status explícito em vez do default do inbox), então a visibilidade correta é pública. O `DataImport::ConversationManager` já o chamava via `send(:...)`, contornando a privacidade — por isso só o builder quebrava.

## Mudanças

- **app/models/conversation.rb**: move `status_explicitly_set!` para acima do `private` (público), com comentário explicando o contrato.
- **app/controllers/api/v1/conversations_controller.rb** (`#create` rescue): corrige o call-site de `error_response` que passava `code:`/`message:` como **keywords** quando a assinatura é posicional (`error_response(code, message, details:, status:)`). Isso lançava `ArgumentError` dentro do próprio rescue, transformando o 422 em 500 e mascarando o erro real (D10 — apenas este call-site; o sweep dos demais é EVO-1899).
- **spec/builders/conversation_builder_spec.rb**: cobertura de regressão (visibilidade pública + criação com/sem status explícito).

## Testes

`bundle exec rspec spec/builders/conversation_builder_spec.rb` → **4 examples, 0 failures** (DB de teste real).

EVO-1898