### PR TITLE
fix(api): error_response keyword->posicional sweep (EVO-1899)

### DIFF
--- a/app/controllers/api/v1/agent_bots_controller.rb
+++ b/app/controllers/api/v1/agent_bots_controller.rb
@@ -43,8 +43,8 @@ class Api::V1::AgentBotsController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -58,8 +58,8 @@ class Api::V1::AgentBotsController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -88,8 +88,8 @@ class Api::V1::AgentBotsController < Api::V1::BaseController
         )
       else
         error_response(
-          code: ApiErrorCodes::CANNOT_DELETE_RESOURCE,
-          message: @agent_bot.errors.full_messages.join(', ')
+          ApiErrorCodes::CANNOT_DELETE_RESOURCE,
+          @agent_bot.errors.full_messages.join(', ')
         )
       end
     end
@@ -106,8 +106,8 @@ class Api::V1::AgentBotsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::INTERNAL_ERROR,
-        message: "Failed to delete agent bot: #{e.message}"
+        ApiErrorCodes::INTERNAL_ERROR,
+        "Failed to delete agent bot: #{e.message}"
       )
     end
   end
@@ -122,8 +122,8 @@ class Api::V1::AgentBotsController < Api::V1::BaseController
     )
   rescue StandardError => e
     error_response(
-      code: ApiErrorCodes::INTERNAL_ERROR,
-      message: e.message
+      ApiErrorCodes::INTERNAL_ERROR,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/ai_agents/products_controller.rb
+++ b/app/controllers/api/v1/ai_agents/products_controller.rb
@@ -22,8 +22,8 @@ class Api::V1::AiAgents::ProductsController < Api::V1::BaseController
     ids = Array(params[:product_ids] || params[:product_id]).map(&:to_s).reject(&:blank?)
     if ids.empty?
       return error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Provide product_ids or product_id',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Provide product_ids or product_id',
         status: :unprocessable_entity
       )
     end
@@ -32,8 +32,8 @@ class Api::V1::AiAgents::ProductsController < Api::V1::BaseController
     missing        = ids - found_products
     if missing.any?
       return error_response(
-        code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-        message: "Products not found: #{missing.join(', ')}",
+        ApiErrorCodes::RESOURCE_NOT_FOUND,
+        "Products not found: #{missing.join(', ')}",
         status: :not_found
       )
     end
@@ -58,8 +58,8 @@ class Api::V1::AiAgents::ProductsController < Api::V1::BaseController
     record = AiAgentProduct.find_by(ai_agent_id: ai_agent_id, product_id: params[:id])
     if record.nil?
       return error_response(
-        code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-        message: 'Attachment not found',
+        ApiErrorCodes::RESOURCE_NOT_FOUND,
+        'Attachment not found',
         status: :not_found
       )
     end

--- a/app/controllers/api/v1/automation_rules_controller.rb
+++ b/app/controllers/api/v1/automation_rules_controller.rb
@@ -20,8 +20,8 @@ class Api::V1::AutomationRulesController < Api::V1::BaseController
     @automation_rule = AutomationRule.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::AUTOMATION_RULE_NOT_FOUND,
-      message: "Automation rule with id #{params[:id]} not found",
+      ApiErrorCodes::AUTOMATION_RULE_NOT_FOUND,
+      "Automation rule with id #{params[:id]} not found",
       status: :not_found
     )
   end
@@ -55,8 +55,8 @@ class Api::V1::AutomationRulesController < Api::V1::BaseController
 
     unless @automation_rule.valid?
       return error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @automation_rule.errors.full_messages,
         status: :unprocessable_entity
       )
@@ -84,8 +84,8 @@ class Api::V1::AutomationRulesController < Api::V1::BaseController
     rescue StandardError => e
       Rails.logger.error e
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Update failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Update failed',
         details: @automation_rule.errors.full_messages,
         status: :unprocessable_entity
       )

--- a/app/controllers/api/v1/bulk_actions_controller.rb
+++ b/app/controllers/api/v1/bulk_actions_controller.rb
@@ -15,8 +15,8 @@ class Api::V1::BulkActionsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::INVALID_PARAMETER,
-        message: 'Invalid type. Must be Conversation or Contact'
+        ApiErrorCodes::INVALID_PARAMETER,
+        'Invalid type. Must be Conversation or Contact'
       )
     end
   end

--- a/app/controllers/api/v1/contact_inboxes_controller.rb
+++ b/app/controllers/api/v1/contact_inboxes_controller.rb
@@ -6,8 +6,8 @@ class Api::V1::ContactInboxesController < Api::V1::BaseController
     
     if contact_inbox.blank?
       error_response(
-        code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-        message: 'Contact inbox not found'
+        ApiErrorCodes::RESOURCE_NOT_FOUND,
+        'Contact inbox not found'
       )
       return
     end

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -200,8 +200,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   rescue StandardError => e
     Rails.logger.error "Conversation creation failed: #{e.message}"
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: 'Conversation creation failed',
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Conversation creation failed',
       details: e.message,
       status: :unprocessable_entity
     )
@@ -221,8 +221,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @conversation.errors.full_messages,
         status: :unprocessable_entity
       )
@@ -253,8 +253,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
          CustomExceptions::CustomFilter::InvalidQueryOperator,
          CustomExceptions::CustomFilter::InvalidValue => e
     error_response(
-      code: ApiErrorCodes::INVALID_PARAMETER,
-      message: 'Invalid filter parameters',
+      ApiErrorCodes::INVALID_PARAMETER,
+      'Invalid filter parameters',
       details: e.message,
       status: :bad_request
     )
@@ -322,8 +322,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
   def transcript
     if params[:email].blank?
       return error_response(
-        code: ApiErrorCodes::MISSING_REQUIRED_FIELD,
-        message: 'Email parameter is required',
+        ApiErrorCodes::MISSING_REQUIRED_FIELD,
+        'Email parameter is required',
         status: :bad_request
       )
     end
@@ -477,8 +477,8 @@ class Api::V1::ConversationsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @conversation.errors.full_messages,
         status: :unprocessable_entity
       )

--- a/app/controllers/api/v1/custom_filters_controller.rb
+++ b/app/controllers/api/v1/custom_filters_controller.rb
@@ -37,8 +37,8 @@ class Api::V1::CustomFiltersController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @custom_filter.errors.full_messages,
         status: :unprocessable_entity
       )
@@ -53,8 +53,8 @@ class Api::V1::CustomFiltersController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @custom_filter.errors.full_messages,
         status: :unprocessable_entity
       )
@@ -84,8 +84,8 @@ class Api::V1::CustomFiltersController < Api::V1::BaseController
     ).find(permitted_params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::CUSTOM_FILTER_NOT_FOUND,
-      message: "Custom filter with id #{permitted_params[:id]} not found",
+      ApiErrorCodes::CUSTOM_FILTER_NOT_FOUND,
+      "Custom filter with id #{permitted_params[:id]} not found",
       status: :not_found
     )
   end

--- a/app/controllers/api/v1/dashboard_apps_controller.rb
+++ b/app/controllers/api/v1/dashboard_apps_controller.rb
@@ -36,8 +36,8 @@ class Api::V1::DashboardAppsController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -50,8 +50,8 @@ class Api::V1::DashboardAppsController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -64,8 +64,8 @@ class Api::V1::DashboardAppsController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordNotDestroyed => e
     error_response(
-      code: ApiErrorCodes::CANNOT_DELETE_RESOURCE,
-      message: e.message
+      ApiErrorCodes::CANNOT_DELETE_RESOURCE,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/inbox_members_controller.rb
+++ b/app/controllers/api/v1/inbox_members_controller.rb
@@ -25,8 +25,8 @@ class Api::V1::InboxMembersController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -41,8 +41,8 @@ class Api::V1::InboxMembersController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -58,8 +58,8 @@ class Api::V1::InboxMembersController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/integrations/hooks_controller.rb
+++ b/app/controllers/api/v1/integrations/hooks_controller.rb
@@ -18,8 +18,8 @@ class Api::V1::Integrations::HooksController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -32,8 +32,8 @@ class Api::V1::Integrations::HooksController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -49,8 +49,8 @@ class Api::V1::Integrations::HooksController < Api::V1::BaseController
       )
     elsif response[:error]
       error_response(
-        code: ApiErrorCodes::BUSINESS_RULE_VIOLATION,
-        message: response[:error]
+        ApiErrorCodes::BUSINESS_RULE_VIOLATION,
+        response[:error]
       )
     else
       success_response(
@@ -69,8 +69,8 @@ class Api::V1::Integrations::HooksController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordNotDestroyed => e
     error_response(
-      code: ApiErrorCodes::CANNOT_DELETE_RESOURCE,
-      message: e.message
+      ApiErrorCodes::CANNOT_DELETE_RESOURCE,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/labels_controller.rb
+++ b/app/controllers/api/v1/labels_controller.rb
@@ -81,8 +81,8 @@ class Api::V1::LabelsController < Api::V1::BaseController
     @label = Label.all.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::LABEL_NOT_FOUND,
-      message: "Label with id #{params[:id]} not found",
+      ApiErrorCodes::LABEL_NOT_FOUND,
+      "Label with id #{params[:id]} not found",
       status: :not_found
     )
   end

--- a/app/controllers/api/v1/macros_controller.rb
+++ b/app/controllers/api/v1/macros_controller.rb
@@ -25,8 +25,8 @@ class Api::V1::MacrosController < Api::V1::BaseController
   def show
     if @macro.nil?
       return error_response(
-        code: ApiErrorCodes::MACRO_NOT_FOUND,
-        message: "Macro with id #{params[:id]} not found",
+        ApiErrorCodes::MACRO_NOT_FOUND,
+        "Macro with id #{params[:id]} not found",
         status: :not_found
       )
     end
@@ -45,8 +45,8 @@ class Api::V1::MacrosController < Api::V1::BaseController
 
     unless @macro.valid?
       return error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @macro.errors.full_messages,
         status: :unprocessable_entity
       )
@@ -77,8 +77,8 @@ class Api::V1::MacrosController < Api::V1::BaseController
     rescue StandardError => e
       Rails.logger.error e
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Update failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Update failed',
         details: @macro.errors.full_messages,
         status: :unprocessable_entity
       )

--- a/app/controllers/api/v1/notification_settings_controller.rb
+++ b/app/controllers/api/v1/notification_settings_controller.rb
@@ -19,8 +19,8 @@ class Api::V1::NotificationSettingsController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -112,8 +112,8 @@ class Api::V1::NotificationsController < Api::V1::BaseController
     @notification = current_user.notifications.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::NOTIFICATION_NOT_FOUND,
-      message: "Notification with id #{params[:id]} not found",
+      ApiErrorCodes::NOTIFICATION_NOT_FOUND,
+      "Notification with id #{params[:id]} not found",
       status: :not_found
     )
   end

--- a/app/controllers/api/v1/pipeline_items/products_controller.rb
+++ b/app/controllers/api/v1/pipeline_items/products_controller.rb
@@ -65,8 +65,8 @@ class Api::V1::PipelineItems::ProductsController < Api::V1::BaseController
     @pipeline_item = PipelineItem.find(params[:pipeline_item_id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-      message: "Pipeline item with id #{params[:pipeline_item_id]} not found",
+      ApiErrorCodes::RESOURCE_NOT_FOUND,
+      "Pipeline item with id #{params[:pipeline_item_id]} not found",
       status: :not_found
     )
   end
@@ -75,8 +75,8 @@ class Api::V1::PipelineItems::ProductsController < Api::V1::BaseController
     @link = @pipeline_item.pipeline_item_products.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::RESOURCE_NOT_FOUND,
-      message: "Pipeline item product link with id #{params[:id]} not found",
+      ApiErrorCodes::RESOURCE_NOT_FOUND,
+      "Pipeline item product link with id #{params[:id]} not found",
       status: :not_found
     )
   end
@@ -111,8 +111,8 @@ class Api::V1::PipelineItems::ProductsController < Api::V1::BaseController
 
   def validation_error_response(record)
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: 'Validation failed',
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
       details: record.errors.full_messages,
       status: :unprocessable_entity
     )

--- a/app/controllers/api/v1/scheduled_action_templates_controller.rb
+++ b/app/controllers/api/v1/scheduled_action_templates_controller.rb
@@ -34,8 +34,8 @@ class Api::V1::ScheduledActionTemplatesController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Template validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Template validation failed',
         details: @template.errors
       )
     end
@@ -49,8 +49,8 @@ class Api::V1::ScheduledActionTemplatesController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Template validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Template validation failed',
         details: @template.errors
       )
     end
@@ -65,8 +65,8 @@ class Api::V1::ScheduledActionTemplatesController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordNotDestroyed => e
     error_response(
-      code: ApiErrorCodes::CANNOT_DELETE_RESOURCE,
-      message: e.message
+      ApiErrorCodes::CANNOT_DELETE_RESOURCE,
+      e.message
     )
   end
 
@@ -94,8 +94,8 @@ class Api::V1::ScheduledActionTemplatesController < Api::V1::BaseController
     )
   rescue StandardError => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/scheduled_actions_controller.rb
+++ b/app/controllers/api/v1/scheduled_actions_controller.rb
@@ -36,8 +36,8 @@ class Api::V1::ScheduledActionsController < Api::V1::BaseController
       else
         Rails.logger.error "ScheduledAction: No system user or global admin found for service token auth"
         error_response(
-          code: ApiErrorCodes::INTERNAL_ERROR,
-          message: 'No system user available for service token authentication'
+          ApiErrorCodes::INTERNAL_ERROR,
+          'No system user available for service token authentication'
         )
         return
       end
@@ -75,8 +75,8 @@ class Api::V1::ScheduledActionsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Scheduled action validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Scheduled action validation failed',
         details: @scheduled_action.errors
       )
     end
@@ -91,8 +91,8 @@ class Api::V1::ScheduledActionsController < Api::V1::BaseController
     )
   rescue StandardError => e
     error_response(
-      code: ApiErrorCodes::INTERNAL_ERROR,
-      message: e.message
+      ApiErrorCodes::INTERNAL_ERROR,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -43,8 +43,8 @@ class Api::V1::TeamsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @team.errors.full_messages,
         status: :unprocessable_entity
       )
@@ -59,8 +59,8 @@ class Api::V1::TeamsController < Api::V1::BaseController
       )
     else
       error_response(
-        code: ApiErrorCodes::VALIDATION_ERROR,
-        message: 'Validation failed',
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
         details: @team.errors.full_messages,
         status: :unprocessable_entity
       )
@@ -81,8 +81,8 @@ class Api::V1::TeamsController < Api::V1::BaseController
     @team = Team.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     error_response(
-      code: ApiErrorCodes::TEAM_NOT_FOUND,
-      message: "Team with id #{params[:id]} not found",
+      ApiErrorCodes::TEAM_NOT_FOUND,
+      "Team with id #{params[:id]} not found",
       status: :not_found
     )
   end

--- a/app/controllers/api/v1/upload_controller.rb
+++ b/app/controllers/api/v1/upload_controller.rb
@@ -6,8 +6,8 @@ class Api::V1::UploadController < Api::V1::BaseController
                create_from_url
              else
                error_response(
-                 code: ApiErrorCodes::MISSING_REQUIRED_FIELD,
-                 message: 'No file or URL provided'
+                 ApiErrorCodes::MISSING_REQUIRED_FIELD,
+                 'No file or URL provided'
                )
                return
              end
@@ -44,8 +44,8 @@ class Api::V1::UploadController < Api::V1::BaseController
     uri
   rescue URI::InvalidURIError, SocketError
     error_response(
-      code: ApiErrorCodes::INVALID_PARAMETER,
-      message: 'Invalid URL provided'
+      ApiErrorCodes::INVALID_PARAMETER,
+      'Invalid URL provided'
     )
     nil
   end
@@ -60,18 +60,18 @@ class Api::V1::UploadController < Api::V1::BaseController
     end
   rescue OpenURI::HTTPError => e
     error_response(
-      code: ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
-      message: "Failed to fetch file from URL: #{e.message}"
+      ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
+      "Failed to fetch file from URL: #{e.message}"
     )
   rescue SocketError
     error_response(
-      code: ApiErrorCodes::INVALID_PARAMETER,
-      message: 'Invalid URL provided'
+      ApiErrorCodes::INVALID_PARAMETER,
+      'Invalid URL provided'
     )
   rescue StandardError => e
     error_response(
-      code: ApiErrorCodes::INTERNAL_ERROR,
-      message: 'An unexpected error occurred'
+      ApiErrorCodes::INTERNAL_ERROR,
+      'An unexpected error occurred'
     )
   end
 

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -31,8 +31,8 @@ class Api::V1::WebhooksController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -45,8 +45,8 @@ class Api::V1::WebhooksController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 
@@ -59,8 +59,8 @@ class Api::V1::WebhooksController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordNotDestroyed => e
     error_response(
-      code: ApiErrorCodes::CANNOT_DELETE_RESOURCE,
-      message: e.message
+      ApiErrorCodes::CANNOT_DELETE_RESOURCE,
+      e.message
     )
   end
 

--- a/app/controllers/api/v1/working_hours_controller.rb
+++ b/app/controllers/api/v1/working_hours_controller.rb
@@ -18,8 +18,8 @@ class Api::V1::WorkingHoursController < Api::V1::BaseController
     )
   rescue ActiveRecord::RecordInvalid => e
     error_response(
-      code: ApiErrorCodes::VALIDATION_ERROR,
-      message: e.message
+      ApiErrorCodes::VALIDATION_ERROR,
+      e.message
     )
   end
 


### PR DESCRIPTION
## Resumo

Sweep sistêmico do defeito **D10/N2** (e2e de Jornadas): o helper `error_response` é **posicional** — `error_response(code, message, details: nil, status: :bad_request)` (`app/controllers/concerns/api_response_helper.rb:82`) — mas dezenas de call-sites o chamavam com **keyword** (`code:`/`message:`). Em Ruby 3.4 isso levanta `ArgumentError: unknown keywords: :code, :message` dentro do próprio handler de erro, transformando todo caminho 4xx em **500 opaco** (foi o que mascarou o D9).

A correção converte cada call-site para a forma posicional, preservando `details:`/`status:` como keywords. Exemplo:

```ruby
# antes
error_response(code: ApiErrorCodes::VALIDATION_ERROR, message: 'msg', details: e.message, status: :unprocessable_entity)
# depois
error_response(ApiErrorCodes::VALIDATION_ERROR, 'msg', details: e.message, status: :unprocessable_entity)
```

A **definição** do helper (assinatura posicional) é mantida como verdade — não foi alterada.

## Contagem

- **59 call-sites** convertidos keyword -> posicional
- **21 arquivos** (todos controllers `app/controllers/api/v1/...`)
- Após o sweep: **0** call-sites de `error_response` ainda usando `code:`/`message:` como keyword.

Os 3 métodos locais homônimos `error_response(message)` em `app/services/contacts/{link,unlink,bulk_transfer}_company_service.rb` (assinatura diferente, retornam hash) foram deliberadamente **não tocados**.

## Testes

- `spec/requests/api/v1/labels_spec.rb` + `macros_spec.rb`: **15 examples, 0 failures** (exercitam controllers alterados; warnings `:unprocessable_entity` confirmam que os caminhos de erro agora renderizam o erro estruturado em vez de explodir).
- `spec/requests/api/v1/conversations_pin_archive_spec.rb` + `conversations_email_team_spec.rb`: verdes.
- `ruby -c` em todos os 21 arquivos: OK.
- 3 falhas em `spec/services/macros/execution_service_spec.rb` são **pré-existentes em origin/develop** (Redis `NOAUTH`, infra-only) — não relacionadas a esta mudança (confirmado rodando com as alterações stashed).

## Nota / follow-up (fora de escopo)

Durante a auditoria, descobri um bug latente **pré-existente** não relacionado à assinatura: vários códigos da família `*_NOT_FOUND` (e `CANNOT_DELETE_RESOURCE`) são referenciados em call-sites e no `case/when` de `api_error_codes.rb` mas **nunca são definidos** como constantes (só `RESOURCE_NOT_FOUND` existe). Antes deste fix esses sites já levantavam `NameError` antes mesmo de chamar `error_response`; este PR não os introduz nem os corrige (sugiro card separado para definir as ~32 constantes).

EVO-1899
