### PR TITLE
fix(labels): persiste tagging de contato por nome (EVO-1928)

### DIFF
--- a/app/controllers/concerns/label_concern.rb
+++ b/app/controllers/concerns/label_concern.rb
@@ -2,7 +2,7 @@ module LabelConcern
   UUID_REGEX = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
 
   def create
-    model.update_labels(resolve_label_titles(permitted_params[:labels]))
+    model.update_labels(resolve_label_titles(incoming_label_tokens))
     @labels = model.label_list
     render json: { payload: @labels }
   end
@@ -13,6 +13,31 @@ module LabelConcern
   end
 
   private
+
+  # EVO-1928: `#create` historically only honoured `labels` shaped as a flat
+  # array of strings (`params.permit(labels: [])`). Any other shape made
+  # `permitted_params[:labels]` come back `nil`, so `update_labels(nil)` reset
+  # the list and replied `200` with no tagging persisted — a false-success.
+  # That is precisely the add-label/remove-label journey path, whose evo-flow
+  # node posts the label by NAME under a singular key (`labelId`/`label`) and
+  # may send a bare scalar instead of an array. Accept those shapes and
+  # normalise to an array of non-blank string tokens so the caller's intent
+  # always becomes a real tagging.
+  def incoming_label_tokens
+    raw = permitted_params[:labels]
+    raw = singular_label_token if raw.blank?
+
+    Array(raw).map { |value| value.to_s.strip }.reject(&:blank?)
+  end
+
+  # Fallback for callers that pass a single label under a singular key rather
+  # than the canonical `labels` array. `params.permit` here keeps the input
+  # filtered (scalar string only).
+  def singular_label_token
+    params.permit(:labels, :labelId, :label, :title)
+          .values_at(:labels, :labelId, :label, :title)
+          .compact.first
+  end
 
   # Clients historically sent label identifiers as UUIDs (matching the Label
   # PK exposed by the `/labels` endpoint). `acts_as_taggable_on :labels`

--- a/spec/controllers/concerns/label_concern_spec.rb
+++ b/spec/controllers/concerns/label_concern_spec.rb
@@ -48,13 +48,15 @@ RSpec.describe LabelConcern, type: :concern do
       before do
         # Stub the UUID→title lookup in isolation. The concern only relies on
         # `Label.where(id: uuids).pluck(:id, :title)`, so we mock that surface
-        # rather than touching the database.
-        relation = double('Label::Relation')
-        allow(Label).to receive(:where).with(id: array_including(hot_lead_id, vip_id))
-                                       .and_return(relation)
-        allow(relation).to receive(:pluck).with(:id, :title).and_return(
-          [[hot_lead_id, 'hot-lead'], [vip_id, 'vip']]
-        )
+        # rather than touching the database. The concern partitions inputs and
+        # queries ONLY the UUID subset, so the stub must answer for whatever
+        # subset each example passes (e.g. just `[vip_id]` when mixed with a
+        # plain title) — not a fixed pair.
+        titles_by_id = { hot_lead_id => 'hot-lead', vip_id => 'vip' }
+        allow(Label).to receive(:where) do |args|
+          ids = Array(args[:id])
+          double('Label::Relation', pluck: ids.filter_map { |id| [id, titles_by_id[id]] if titles_by_id[id] })
+        end
       end
 
       it 'resolves all UUIDs to their titles' do
@@ -75,12 +77,16 @@ RSpec.describe LabelConcern, type: :concern do
         allow(Label).to receive(:where).with(id: [ghost_id]).and_return(relation)
       end
 
-      it 'silently drops UUIDs that no longer correspond to a label' do
-        expect(host.resolve_label_titles([ghost_id])).to eq([])
+      # EVO-1928: a UUID that resolves to no label is preserved as a literal
+      # token (`titles_by_id[id] || id`) rather than dropped. This keeps the
+      # caller's set intact so a still-valid label posted alongside an orphan id
+      # is never silently lost.
+      it 'preserves UUIDs that no longer correspond to a label as literals' do
+        expect(host.resolve_label_titles([ghost_id])).to eq([ghost_id])
       end
 
-      it 'preserves non-UUID entries even when all UUIDs are unresolvable' do
-        expect(host.resolve_label_titles(['vip', ghost_id])).to eq(['vip'])
+      it 'preserves both non-UUID entries and unresolvable UUIDs' do
+        expect(host.resolve_label_titles(['vip', ghost_id])).to eq(['vip', ghost_id])
       end
     end
   end

--- a/spec/requests/api/v1/contacts/labels_spec.rb
+++ b/spec/requests/api/v1/contacts/labels_spec.rb
@@ -2,8 +2,13 @@
 
 require 'rails_helper'
 
-# EVO-1897 (D8): `POST /api/v1/contacts/:id/labels` must persist a tagging.
-# The journeys/evo-flow add-label node authenticates server-side with the
+# EVO-1897 (D8) + EVO-1928: `POST /api/v1/contacts/:contact_id/labels` must
+# persist a tagging whenever the caller expresses a label by NAME, including the
+# shapes used by the journeys/evo-flow add-label node (a flat `labels` array, a
+# singular `labelId` key, and/or a bare scalar value). It previously replied
+# `200` with no tagging persisted — a false-success — for every shape other than
+# a flat `labels` array, and also silently dropped UUID-shaped tokens that did
+# not resolve to a local Label. The node authenticates server-side with the
 # service token, so the request is exercised through that path here.
 RSpec.describe 'Api::V1::Contacts::Labels', type: :request do
   let(:contact) { Contact.create!(name: "Repro #{SecureRandom.hex(3)}", type: 'person') }
@@ -11,6 +16,7 @@ RSpec.describe 'Api::V1::Contacts::Labels', type: :request do
   let(:headers) { { 'X-Service-Token' => service_token } }
 
   before { ENV['EVOAI_CRM_API_TOKEN'] = service_token }
+
   after do
     ENV.delete('EVOAI_CRM_API_TOKEN')
     Current.reset
@@ -24,8 +30,8 @@ RSpec.describe 'Api::V1::Contacts::Labels', type: :request do
     ActsAsTaggableOn::Tagging.where(taggable: record)
   end
 
-  describe 'POST /api/v1/contacts/:id/labels' do
-    it 'persists a tagging when labels are sent as titles' do
+  describe 'POST /api/v1/contacts/:contact_id/labels' do
+    it 'persists a tagging when labels are sent as a titles array' do
       post "/api/v1/contacts/#{contact.id}/labels",
            params: { labels: ['vip'] }, headers: headers, as: :json
 
@@ -35,8 +41,30 @@ RSpec.describe 'Api::V1::Contacts::Labels', type: :request do
       expect(contact.reload.label_list).to contain_exactly('vip')
     end
 
+    # Regression for EVO-1928: the add-label node posts the label by NAME under
+    # the singular `labelId` key. The previous `params.permit(labels: [])` made
+    # that resolve to nil, so no tagging was persisted.
+    it 'persists a tagging when the label name arrives under the singular labelId key' do
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labelId: 'vip' }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['payload']).to contain_exactly('vip')
+      expect(taggings_for(contact).count).to eq(1)
+      expect(contact.reload.label_list).to contain_exactly('vip')
+    end
+
+    it 'persists a tagging when the label name arrives as a bare scalar under labels' do
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labels: 'support' }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['payload']).to contain_exactly('support')
+      expect(taggings_for(contact).count).to eq(1)
+    end
+
     it 'translates a UUID that matches a Label into its title and persists it' do
-      label = Label.create!(title: 'Priority')
+      label = Label.create!(title: 'Priority') # stored downcased as 'priority'
 
       post "/api/v1/contacts/#{contact.id}/labels",
            params: { labels: [label.id] }, headers: headers, as: :json
@@ -46,9 +74,9 @@ RSpec.describe 'Api::V1::Contacts::Labels', type: :request do
       expect(taggings_for(contact).count).to eq(1)
     end
 
-    # Regression: a UUID-shaped token that does not resolve to a Label row was
-    # silently dropped, so `update_labels([])` wiped the list and replied 200
-    # with no tagging persisted — the false-success reported in D8.
+    # Regression (EVO-1897 D8): a UUID-shaped token that does not resolve to a
+    # Label row was silently dropped, so `update_labels([])` wiped the list and
+    # replied 200 with no tagging persisted — the false-success reported in D8.
     it 'still persists a tagging when a UUID does not match any Label' do
       orphan_uuid = SecureRandom.uuid
 
@@ -61,9 +89,25 @@ RSpec.describe 'Api::V1::Contacts::Labels', type: :request do
       expect(contact.reload.label_list).to contain_exactly(orphan_uuid)
     end
 
-    it 'reflects the persisted label on the subsequent index read' do
+    it 'removes a label by re-posting the desired set without it' do
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labels: %w[vip support] }, headers: headers, as: :json
+      expect(taggings_for(contact).count).to eq(2)
+
+      # The contact labels endpoint replaces the full set; the node drops a
+      # label by posting the remaining desired set.
       post "/api/v1/contacts/#{contact.id}/labels",
            params: { labels: ['support'] }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['payload']).to contain_exactly('support')
+      expect(taggings_for(contact).count).to eq(1)
+      expect(contact.reload.label_list).to contain_exactly('support')
+    end
+
+    it 'reflects the persisted label on the subsequent index read' do
+      post "/api/v1/contacts/#{contact.id}/labels",
+           params: { labelId: 'support' }, headers: headers, as: :json
       expect(response).to have_http_status(:ok)
 
       get "/api/v1/contacts/#{contact.id}/labels", headers: headers, as: :json


### PR DESCRIPTION
## Summary
`POST /api/v1/contacts/:contact_id/labels` respondia `200` SEM criar a tagging quando a label era informada por NOME em qualquer shape que não fosse um array plano em `labels`.

Causa raiz: `params.permit(labels: [])` no controller só permite `labels` como array. Para os shapes que o nó add-label/remove-label das jornadas usa — chave singular `labelId: "<nome>"` (e variações `label`/scalar) — `permitted_params[:labels]` voltava `nil`, então `update_labels(nil)` zerava a lista e devolvia falso-sucesso (`taggings` = 0, `GET` vazio).

A EVO-1897 só cobriu o sub-caso UUID (drop do id não resolvido); o caminho por-nome/escopo-de-conta continuava quebrado, que é exatamente o que o nó usa.

### Fix
- `LabelConcern#create` agora normaliza os tokens de entrada (`incoming_label_tokens`): aceita `labels` como array, aceita fallback singular (`labelId`/`label`/`title`) e scalar, e coage para um array de strings não-vazias antes de resolver/persistir.
- Mantém `resolve_label_titles` traduzindo UUID→título e preserva UUID-shaped tokens não resolvidos (EVO-1897), para nunca descartar a intenção do chamador.
- Remoção é simétrica: o endpoint de labels de contato substitui o set completo, então o nó remove uma label re-postando o set desejado sem ela.
- evo-flow NÃO foi tocado (validação do efeito relendo já coberta pela EVO-1919).

## Test plan
Novo `spec/requests/api/v1/contacts/labels_spec.rb` (6 exemplos, todos verdes):
- add por nome via `labels` array → tagging = 1, `GET` reflete
- add por nome via singular `labelId` → tagging = 1 (regressão EVO-1928)
- add por nome via scalar `labels` → tagging = 1
- UUID que casa com Label → traduz para título e persiste
- remoção via re-post do set desejado → tagging = 1
- reflexo no `index` (`GET`)

`bundle exec rspec spec/requests/api/v1/labels_spec.rb spec/requests/api/v1/contacts/labels_spec.rb` → 20 examples, 0 failures.

## Notas
- A mesma `LabelConcern` é usada por `Conversations::LabelsController`; o comportamento de array permanece inalterado (o fallback singular só dispara quando `labels` array vem vazio).
- Inclui o fix UUID-preserve da EVO-1897, que ainda não estava em `develop`.