### PR TITLE
fix(labels): harden Labelable write paths to always persist taggings (EVO-1932)

### DIFF
--- a/app/models/concerns/labelable.rb
+++ b/app/models/concerns/labelable.rb
@@ -9,13 +9,47 @@ module Labelable
   # (see `Contact#publish_label_changes`). Every write path that mutates
   # `label_list` and persists hits that callback, so update_labels/add_labels
   # no longer need to emit explicitly.
+  #
+  # EVO-1932: persistence robustness. `acts_as_taggable_on` only writes
+  # taggings when the `label_list` *setter* runs and dirty-tracks the virtual
+  # attribute — `update!(label_list: array)`/`record.label_list = array`. We
+  # deliberately keep that setter path (rather than in-place `label_list.add`)
+  # because Conversation/Contact callbacks key off `saved_change_to_label_list?`
+  # (cached label list, label activity messages, EvoFlow `label.added/removed`
+  # events); in-place mutation would persist the tagging but NOT dirty-track,
+  # silently dropping those side effects. To stop the setter receiving values
+  # the gem can't turn into a tagging — `nil`, blanks, `Tag` records, symbols —
+  # every entry point normalises to an array of non-blank strings first. The
+  # journey add-label/remove-label node reaches `update_labels` by NAME, so a
+  # malformed token must never become a false-success that fails to persist.
+
+  # REPLACE the contact/conversation/product label set with `labels`.
+  # `[]` (or all-blank input) clears the set — this is how the UI removes the
+  # last label and how a re-post of the desired set deletes a label.
   def update_labels(labels = nil)
-    update!(label_list: labels)
+    update!(label_list: normalize_label_tokens(labels))
   end
 
+  # ADD `new_labels` to the existing set (union, idempotent). Builds on
+  # `label_list` (the string TagList), NOT the `labels` Tag association, so the
+  # setter receives plain strings rather than `Tag` records.
   def add_labels(new_labels = nil)
-    new_labels = Array(new_labels)
-    combined_labels = labels + new_labels
-    update!(label_list: combined_labels)
+    combined = label_list.to_a + normalize_label_tokens(new_labels)
+    update!(label_list: combined.uniq)
+  end
+
+  # REMOVE `labels` from the existing set (idempotent). Symmetric counterpart
+  # to `add_labels`.
+  def remove_labels(labels = nil)
+    remaining = label_list.to_a - normalize_label_tokens(labels)
+    update!(label_list: remaining)
+  end
+
+  private
+
+  # Coerce arbitrary input (array, scalar, `Tag` record, symbol, nil) into a
+  # flat array of trimmed, non-blank strings the tagging setter accepts.
+  def normalize_label_tokens(tokens)
+    Array(tokens).map { |token| token.to_s.strip }.reject(&:blank?)
   end
 end

--- a/spec/models/concerns/labelable_spec.rb
+++ b/spec/models/concerns/labelable_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1932: regression coverage for the journey add-label/remove-label path.
+# The bug class is a label write that returns success but persists NO tagging
+# (`taggings.count == 0`). These specs assert PERSISTENCE through the public
+# `update_labels`/`add_labels`/`remove_labels` API — i.e. the assignment
+# (setter) path that `acts_as_taggable_on` dirty-tracks — rather than the
+# in-place `label_list.add` mutation, since the setter path is the one every
+# real caller (LabelConcern#create, journeys, bulk actions) actually uses.
+RSpec.describe Labelable, type: :model do
+  # Contact is the model the journey label nodes write to and includes
+  # Labelable. Using a real persisted record exercises the gem end to end.
+  let(:contact) do
+    Contact.create!(name: 'Labelable Spec', email: "labelable-#{SecureRandom.hex(4)}@example.com")
+  end
+
+  describe '#update_labels' do
+    it 'persists a tagging on a contact that had none (primary AC)' do
+      contact.update_labels(['teste label'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.taggings.count).to be >= 1
+      expect(reloaded.label_list).to contain_exactly('teste label')
+    end
+
+    it 'is idempotent — re-applying the same label does not duplicate taggings' do
+      contact.update_labels(['teste label'])
+      contact.update_labels(['teste label'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.taggings.count).to eq(1)
+      expect(reloaded.label_list).to contain_exactly('teste label')
+    end
+
+    it 'REPLACES the existing set' do
+      contact.update_labels(['old'])
+      contact.update_labels(['new'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.label_list).to contain_exactly('new')
+      expect(reloaded.taggings.count).to eq(1)
+    end
+
+    it 'clears the set when given an empty array (re-post removal)' do
+      contact.update_labels(['gone-soon'])
+      contact.update_labels([])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.label_list).to be_empty
+      expect(reloaded.taggings.count).to eq(0)
+    end
+
+    it 'normalises blank/whitespace tokens away rather than persisting them' do
+      contact.update_labels(['  spaced  ', '', '   ', nil])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.label_list).to contain_exactly('spaced')
+    end
+  end
+
+  describe '#add_labels' do
+    it 'persists a tagging when adding to a contact with no labels' do
+      contact.add_labels(['alpha'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.taggings.count).to eq(1)
+      expect(reloaded.label_list).to contain_exactly('alpha')
+    end
+
+    it 'unions with existing labels without dropping them' do
+      contact.update_labels(['existing'])
+      contact.add_labels(['added'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.taggings.count).to eq(2)
+      expect(reloaded.label_list).to contain_exactly('existing', 'added')
+    end
+
+    it 'is idempotent — adding an already-present label does not duplicate' do
+      contact.update_labels(['existing'])
+      contact.add_labels(['existing'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.taggings.count).to eq(1)
+      expect(reloaded.label_list).to contain_exactly('existing')
+    end
+
+    it 'accepts a bare scalar (non-array) token' do
+      contact.add_labels('scalar')
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.label_list).to contain_exactly('scalar')
+    end
+  end
+
+  describe '#remove_labels' do
+    it 'removes the given label and persists the smaller set' do
+      contact.update_labels(%w[keep drop])
+      contact.remove_labels(['drop'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.label_list).to contain_exactly('keep')
+      expect(reloaded.taggings.count).to eq(1)
+    end
+
+    it 'is a no-op when removing a label that is not present' do
+      contact.update_labels(['keep'])
+      contact.remove_labels(['never-had'])
+
+      reloaded = Contact.find(contact.id)
+      expect(reloaded.label_list).to contain_exactly('keep')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Contact#update_labels`/`#add_labels` live in `Labelable` (shared by **Contact, Conversation, Product**). They could return success while persisting **no tagging** (`save` => true, `taggings.count == 0`) — the journey add-label/remove-label false-success EVO-1932 isolated.

Root cause (model layer):
- The `acts_as_taggable_on` `label_list=` setter only writes taggings for inputs it can coerce to tag names. Any malformed token routed straight into the setter — `nil`, blank/whitespace strings, a `Tag` record, a symbol — became a silent no-op while `save` still returned true.
- `add_labels` made it worse: it unioned against `labels` (the **Tag association**, returning `ActsAsTaggableOn::Tag` records) instead of `label_list` (the string TagList), feeding `Tag` objects into the setter.

Note: EVO-1928 fixed this at the **controller** seam (`LabelConcern#create` normalising singular/scalar shapes so `update_labels(nil)` no longer wiped the list). EVO-1932 hardens the **model** so the contract holds for every caller (journeys, bulk actions, products, imports), not just the HTTP path.

## What changed
- `update_labels` / `add_labels` now normalise input to an array of non-blank strings before assigning.
- `add_labels` builds on `label_list` (strings), not the `labels` Tag association; union is deduped/idempotent.
- Added a symmetric `remove_labels`.
- Kept the **dirty-tracking setter path** (`update!(label_list: ...)`) rather than in-place `label_list.add`, so Conversation/Contact callbacks keyed off `saved_change_to_label_list?` (cached label list, label activity messages, EvoFlow `label.added/removed`) keep firing. In-place mutation would persist the tagging but NOT dirty-track, regressing those side effects.

## Test plan
New `spec/models/concerns/labelable_spec.rb` (11 examples, all green) asserts persistence through the public API:
- `update_labels(["teste label"])` on a fresh contact → reload `taggings.count >= 1` (primary AC); idempotency; REPLACE; `[]` clears; blank/whitespace normalised away.
- `add_labels` persists, unions without dropping existing, idempotent, accepts a bare scalar.
- `remove_labels` removes + persists smaller set; no-op for absent label.

```
$ bundle exec rspec spec/models/concerns/labelable_spec.rb
11 examples, 0 failures
```

rails runner evidence (patched model, new contact, before/after taggings):
```
NEW contact taggings(before)=0
after update_labels(['teste label']): reload taggings=1 label_list=["teste label"]
after add_labels(['extra']):          taggings=2 label_list=["teste label", "extra"]
after remove_labels(['teste label']): taggings=1 label_list=["extra"]
```

## Notes
- `Labelable` is shared by Conversation/Product; the normalise-then-assign approach preserves their existing setter-path semantics and dirty-tracking.
- The pre-existing `spec/controllers/concerns/label_concern_spec.rb:64` failure on develop is unrelated (an over-strict `array_including` matcher in a UUID-merge case) and untouched by this PR — EVO-1932 is model-only.