### PR TITLE
feat(crm): contacts filter by company via contact_companies association (EVO-1887)

### DIFF
--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -316,7 +316,11 @@ class Api::V1::ContactsController < Api::V1::BaseController
   end
 
   def companies_list
-    companies = Contact.all.resolved_contacts.where(type: 'company').select(:id, :name, :type, :location, :country_code).order(:name)
+    # A company is a deliberately-created structural entity (Contact type=company),
+    # so it must be selectable even without email/phone/identifier. Bypassing
+    # resolved_contacts keeps newly-created companies visible in the linked-companies
+    # picker and the contacts company filter (EVO-1887).
+    companies = Contact.companies.select(:id, :name, :type, :location, :country_code).order(:name)
 
     success_response(
       data: companies.map { |company| { id: company.id, name: company.name } },

--- a/app/helpers/filters/filter_helper.rb
+++ b/app/helpers/filters/filter_helper.rb
@@ -63,6 +63,8 @@ module Filters::FilterHelper
       tag_filter_query(query_hash, current_index)
     when 'pipeline'
       pipeline_filter_query(query_hash, current_index)
+    when 'company'
+      company_filter_query(query_hash, current_index)
     when 'text_case_insensitive'
       text_case_insensitive_filter(query_hash, filter_operator_value)
     else

--- a/app/services/filter_service.rb
+++ b/app/services/filter_service.rb
@@ -128,6 +128,28 @@ class FilterService
     end
   end
 
+  def company_filter_query(query_hash, current_index)
+    table_name = filter_config[:table_name]
+    query_operator = query_hash[:query_operator]
+    @filter_values["value_#{current_index}"] = query_hash['values']
+
+    base_relation_query =
+      "SELECT 1 FROM contact_companies WHERE contact_companies.contact_id = #{table_name}.id"
+    id_filter =
+      "AND contact_companies.company_id IN (:value_#{current_index})"
+
+    case query_hash[:filter_operator]
+    when 'equal_to'
+      "EXISTS (#{base_relation_query} #{id_filter}) #{query_operator}"
+    when 'not_equal_to'
+      "NOT EXISTS (#{base_relation_query} #{id_filter}) #{query_operator}"
+    when 'is_present'
+      "EXISTS (#{base_relation_query}) #{query_operator}"
+    when 'is_not_present'
+      "NOT EXISTS (#{base_relation_query}) #{query_operator}"
+    end
+  end
+
   def tag_filter_query(query_hash, current_index)
     model_name = filter_config[:entity]
     table_name = filter_config[:table_name]

--- a/lib/filters/filter_keys.yml
+++ b/lib/filters/filter_keys.yml
@@ -203,6 +203,14 @@ contacts:
       - "not_equal_to"
       - "is_present"
       - "is_not_present"
+  company:
+    attribute_type: "standard"
+    data_type: "company"
+    filter_operators:
+      - "equal_to"
+      - "not_equal_to"
+      - "is_present"
+      - "is_not_present"
   created_at:
     attribute_type: "standard"
     data_type: "date"

--- a/spec/requests/api/v1/contacts_spec.rb
+++ b/spec/requests/api/v1/contacts_spec.rb
@@ -398,3 +398,35 @@ RSpec.describe 'Api::V1::ContactsController', type: :request do
     end
   end
 end
+
+RSpec.describe 'GET /api/v1/contacts/companies_list', type: :request do
+  let(:user) { User.create!(email: "companies-list-#{SecureRandom.hex(4)}@example.com", name: 'Test User') }
+  let(:headers) { { 'X-Service-Token' => 'spec-service-token' } }
+
+  before do
+    ENV['EVOAI_CRM_API_TOKEN'] = 'spec-service-token'
+    Current.user = user
+  end
+
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    Current.reset
+  end
+
+  # EVO-1887: a company is a structural entity, so it must be selectable even
+  # without email/phone/identifier (previously hidden by resolved_contacts).
+  it 'returns companies without contact info' do
+    bare = Contact.create!(name: 'Bare Co', type: 'company')
+    Contact.create!(name: 'Just a person', email: "p-#{SecureRandom.hex(4)}@example.com", type: 'person')
+
+    get '/api/v1/contacts/companies_list', headers: headers
+
+    expect(response).to have_http_status(:ok)
+    payload = JSON.parse(response.body)['data']
+    names = payload.map { |c| c['name'] }
+    ids = payload.map { |c| c['id'] }
+    expect(names).to include('Bare Co')
+    expect(names).not_to include('Just a person')
+    expect(ids).to include(bare.id)
+  end
+end

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -28,10 +28,43 @@ RSpec.describe Contacts::FilterService do
     end
   end
 
-  describe 'company filter (EVO-1849 B1 — removed; association-based filter tracked as follow-up)' do
-    it 'is no longer a valid contact filter attribute' do
-      expect { run(cond('company', 'contains', ['acme'])) }
-        .to raise_error(CustomExceptions::CustomFilter::InvalidAttribute)
+  describe 'company filter (EVO-1887 — association-based)' do
+    let(:company) { Contact.create!(name: 'Acme', email: "acme-#{SecureRandom.hex(4)}@t.com", type: 'company') }
+    let(:other_company) { Contact.create!(name: 'Globex', email: "globex-#{SecureRandom.hex(4)}@t.com", type: 'company') }
+
+    def person_with_company(company_record)
+      person = Contact.create!(name: 'P', email: "p-#{SecureRandom.hex(4)}@t.com", type: 'person')
+      person.contact_companies.create!(company_id: company_record.id)
+      person
+    end
+
+    it 'returns contacts associated with the selected company via contact_companies (equal_to)' do
+      match = person_with_company(company)
+      person_with_company(other_company)
+
+      result = run(cond('company', 'equal_to', [company.id]))
+
+      expect(result[:contacts]).to include(match)
+      expect(result[:count]).to eq(1)
+    end
+
+    it 'excludes contacts associated with the selected company (not_equal_to)' do
+      excluded = person_with_company(company)
+      kept = person_with_company(other_company)
+
+      result = run(cond('company', 'not_equal_to', [company.id]))
+
+      expect(result[:contacts]).to include(kept)
+      expect(result[:contacts]).not_to include(excluded)
+    end
+
+    it 'matches contacts having any company association (is_present)' do
+      with_company = person_with_company(company)
+      Contact.create!(name: 'NoCompany', email: "nc-#{SecureRandom.hex(4)}@t.com", type: 'person')
+
+      result = run(cond('company', 'is_present', []))
+
+      expect(result[:contacts]).to include(with_company)
     end
   end
 end

--- a/spec/services/contacts/filter_service_spec.rb
+++ b/spec/services/contacts/filter_service_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe Contacts::FilterService do
       expect(result[:contacts]).not_to include(excluded)
     end
 
+    it 'includes contacts with no company association in not_equal_to results' do
+      excluded = person_with_company(company)
+      no_company = Contact.create!(name: 'NoCo', email: "noco-#{SecureRandom.hex(4)}@t.com", type: 'person')
+
+      result = run(cond('company', 'not_equal_to', [company.id]))
+
+      expect(result[:contacts]).to include(no_company)
+      expect(result[:contacts]).not_to include(excluded)
+    end
+
     it 'matches contacts having any company association (is_present)' do
       with_company = person_with_company(company)
       Contact.create!(name: 'NoCompany', email: "nc-#{SecureRandom.hex(4)}@t.com", type: 'person')


### PR DESCRIPTION
## Summary
- Re-add the Contacts **company** filter removed in EVO-1849 (which queried a free-text JSONB key no writer populates). It now resolves the structured **ContactCompany** association.
- `data_type: company` routes to a new `company_filter_query` (EXISTS subquery on `contact_companies`); the value is a **company_id (UUID)**. Operators: `equal_to` / `not_equal_to` / `is_present` / `is_not_present`.
- `companies_list` now returns **all** `type=company` contacts (dropped `resolved_contacts`) so a registered company is selectable even without email/phone — it was hidden from both the filter picker and the linked-companies picker.

## Security
- Filter value passed as a bind param (`:value_N`); `query_operator` validated upstream (`validate_query_operator`); table name is hardcoded — no SQL injection. Mirrors the existing `tag_filter_query`/`pipeline_filter_query` pattern.

## Test plan
- `crm: bundle exec rspec spec/services/contacts/filter_service_spec.rb spec/requests/api/v1/contacts_spec.rb` → 24 examples, 0 failures
- Manual smoke: filter Contacts by company → returns the contacts linked via `contact_companies`.

## Changed Files
- `app/services/filter_service.rb`
- `app/helpers/filters/filter_helper.rb`
- `lib/filters/filter_keys.yml`
- `app/controllers/api/v1/contacts_controller.rb`
- `spec/services/contacts/filter_service_spec.rb`
- `spec/requests/api/v1/contacts_spec.rb`

## Related PRs
- frontend: company picker + chip (same EVO-1887)

## Linked Issue
- EVO-1887

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore company-based contact filtering using the structured contact_companies association and ensure companies without contact info are exposed in the companies list.

New Features:
- Add a company attribute to contact filters backed by the contact_companies association with support for equality and presence operators.
- Expose companies without email or phone in the companies_list endpoint so they can be selected in company pickers and filters.

Enhancements:
- Wire the new company data_type into the standard filter handling and query-building pipeline.

Tests:
- Add service-level specs covering company filter behavior for equal_to, not_equal_to, is_present, and is_not_present operators.
- Add request specs verifying that companies_list returns company contacts even when they lack contact information.