### PR TITLE
feat(admin): permitir configurar OAuth das integrações de agente no superadmin (allowlist app_configs)

### DIFF
--- a/app/controllers/api/v1/admin/app_configs_controller.rb
+++ b/app/controllers/api/v1/admin/app_configs_controller.rb
@@ -29,10 +29,30 @@ module Api
             OPENAI_PROMPT_FIX_GRAMMAR OPENAI_PROMPT_SHORTEN OPENAI_PROMPT_EXPAND
             OPENAI_PROMPT_FRIENDLY OPENAI_PROMPT_FORMAL OPENAI_PROMPT_SIMPLIFY
           ],
+          # Agent/MCP OAuth integrations. The KEY names MUST match what each
+          # integration's credentials_controller serves to the processor via
+          # GlobalConfigService.load(...) — otherwise the superadmin saves a value
+          # the OAuth flow never reads. Naming is intentionally per-integration
+          # (some `<SVC>_OAUTH_CLIENT_ID`, some `<SVC>_CLIENT_ID`) to mirror those
+          # controllers; do not "normalize" without changing them in lockstep.
           'linear' => %w[LINEAR_CLIENT_ID LINEAR_CLIENT_SECRET],
+          # NOTE: `hubspot` here is the CRM-NATIVE HubSpot integration
+          # (HUBSPOT_CLIENT_ID, read by app/controllers/hubspot/* and
+          # integrations/app.rb). The agent/MCP HubSpot OAuth flow uses a SEPARATE
+          # key (HUBSPOT_OAUTH_CLIENT_ID, served by integrations/hubspot/credentials_controller)
+          # and is intentionally not exposed here — leaving native config untouched.
           'hubspot' => %w[HUBSPOT_CLIENT_ID HUBSPOT_CLIENT_SECRET],
           'shopify' => %w[SHOPIFY_CLIENT_ID SHOPIFY_CLIENT_SECRET],
           'slack' => %w[SLACK_CLIENT_ID SLACK_CLIENT_SECRET],
+          'github' => %w[GITHUB_OAUTH_CLIENT_ID GITHUB_OAUTH_CLIENT_SECRET],
+          'notion' => %w[NOTION_OAUTH_CLIENT_ID NOTION_OAUTH_CLIENT_SECRET],
+          'asana' => %w[ASANA_OAUTH_CLIENT_ID ASANA_OAUTH_CLIENT_SECRET],
+          'canva' => %w[CANVA_OAUTH_CLIENT_ID CANVA_OAUTH_CLIENT_SECRET],
+          'google_calendar' => %w[GOOGLE_CALENDAR_CLIENT_ID GOOGLE_CALENDAR_CLIENT_SECRET],
+          'google_sheets' => %w[GOOGLE_SHEETS_CLIENT_ID GOOGLE_SHEETS_CLIENT_SECRET],
+          'monday' => %w[MONDAY_OAUTH_CLIENT_ID MONDAY_OAUTH_CLIENT_SECRET],
+          'paypal' => %w[PAYPAL_OAUTH_CLIENT_ID PAYPAL_OAUTH_CLIENT_SECRET],
+          'atlassian' => %w[ATLASSIAN_OAUTH_CLIENT_ID ATLASSIAN_OAUTH_CLIENT_SECRET],
           'microsoft' => %w[AZURE_APP_ID AZURE_APP_SECRET],
           'twitter' => %w[TWITTER_APP_ID TWITTER_CONSUMER_KEY TWITTER_CONSUMER_SECRET TWITTER_ENVIRONMENT],
           'inbound_email' => %w[


### PR DESCRIPTION
## O quê

Backend que destrava a tela de Integrations no superadmin (front: evolution-foundation/evo-ai-frontend-community#203).

`POST /admin/app_configs/:config_type` tem uma allowlist estrita (`CONFIG_TYPES`). Entre as integrações, só linear/hubspot/shopify/slack estavam liberadas — github/notion/etc retornavam **`Unknown config type`**, então o superadmin não conseguia configurar o OAuth app delas, apesar de cada uma já ter `credentials_controller` servindo as credenciais ao processor.

- Adiciona 9 config_types: **github, notion, asana, canva, google_calendar, google_sheets, monday, paypal, atlassian**.
- As keys batem **exatamente** com o que cada `api/v1/integrations/<svc>/credentials_controller.rb` lê via `GlobalConfigService.load` — senão o valor salvo nunca seria lido pelo fluxo OAuth.
- Rotas são genéricas (`app_configs/:config_type`) → sem mudança de rotas. Sem required-keys novas (paridade com linear).
- `hubspot` mantido na key nativa (`HUBSPOT_CLIENT_ID`); o HubSpot de agente/MCP usa `HUBSPOT_OAUTH_*` e fica fora desta tela de propósito (são dois fluxos distintos).

## Verificação
`ruby -c` ✅. O spec existente do controller não cobre os novos types (o loop só itera integrações com required-keys), então sem quebra.