### PR TITLE
fix(media): honor ACTIVE_STORAGE_URL across browser + sidekiq + previews (EVO-1747)

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -55,7 +55,9 @@ class Attachment < ApplicationRecord
 
   # NOTE: the URl returned does a 301 redirect to the actual file
   def file_url
-    file.attached? ? url_for(file) : ''
+    return '' unless file.attached?
+
+    BlobUrlOptions.with_scoped_url_options { url_for(file) }
   end
 
   # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases
@@ -66,7 +68,7 @@ class Attachment < ApplicationRecord
 
   def thumb_url
     if file.attached? && file.representable?
-      url_for(file.representation(resize_to_fill: [250, nil]))
+      BlobUrlOptions.with_scoped_url_options { url_for(file.representation(resize_to_fill: [250, nil])) }
     else
       ''
     end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -62,8 +62,9 @@ class Attachment < ApplicationRecord
 
   # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases
   def download_url
-    ActiveStorage::Current.url_options = Rails.application.routes.default_url_options if ActiveStorage::Current.url_options.blank?
-    file.attached? ? file.blob.url : ''
+    return '' unless file.attached?
+
+    BlobUrlOptions.with_scoped_url_options { file.blob.url }
   end
 
   def thumb_url

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -57,7 +57,7 @@ class AutomationRule < ApplicationRecord
         id: file.id,
         automation_rule_id: id,
         file_type: file.content_type,
-        file_url: url_for(file),
+        file_url: BlobUrlOptions.with_scoped_url_options { url_for(file) },
         blob_id: file.blob_id,
         filename: file.filename.to_s
       }

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -55,7 +55,7 @@ class Macro < ApplicationRecord
         id: file.id,
         macro_id: id,
         file_type: file.content_type,
-        file_url: url_for(file),
+        file_url: BlobUrlOptions.with_scoped_url_options { url_for(file) },
         blob_id: file.blob_id,
         filename: file.filename.to_s
       }

--- a/app/services/concerns/blob_url_options.rb
+++ b/app/services/concerns/blob_url_options.rb
@@ -1,0 +1,38 @@
+# Resolves effective ActiveStorage URL options, honoring ENV['ACTIVE_STORAGE_URL']
+# when present so generated URLs (Attachment#file_url/#thumb_url, DiskService
+# signed URLs, etc.) target a host reachable from the consumer.
+#
+# Used by:
+# - Browser-facing model URL builders (Attachment#file_url/#thumb_url)
+# - Macro / AutomationRule file previews (Macro#file_base_data, AutomationRule#file_base_data)
+# - Sidekiq paths that hand DiskService URLs to external services (Evolution API / Evolution Go)
+module BlobUrlOptions
+  module_function
+
+  def effective_url_options(base = Rails.application.routes.default_url_options)
+    base = (base || {}).dup
+    return base if ENV['ACTIVE_STORAGE_URL'].blank?
+
+    storage_uri = URI.parse(ENV['ACTIVE_STORAGE_URL'])
+    base.merge(
+      host: storage_uri.host,
+      port: storage_uri.port,
+      protocol: storage_uri.scheme
+    )
+  rescue URI::InvalidURIError => e
+    Rails.logger.warn "[BlobUrlOptions] Invalid ACTIVE_STORAGE_URL=#{ENV['ACTIVE_STORAGE_URL'].inspect}: #{e.message}. Falling back to default_url_options."
+    base
+  end
+
+  # Scopes ActiveStorage::Current.url_options to effective_url_options for the
+  # duration of the block, restoring whatever was set before. Use this around
+  # any url_for(blob_or_attached) / blob.url call so the generated host honors
+  # ENV['ACTIVE_STORAGE_URL'] without leaking the override to unrelated callers.
+  def with_scoped_url_options
+    previous = ActiveStorage::Current.url_options
+    ActiveStorage::Current.url_options = effective_url_options
+    yield
+  ensure
+    ActiveStorage::Current.url_options = previous
+  end
+end

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -488,17 +488,11 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
     # ACTIVE_STORAGE_URL overrides the host used in DiskService signed URLs so
     # that external containers (Evolution Go) can actually reach the file.
     # Without it, localhost:3000 resolves to the caller's container, not the CRM.
-    url_options = Rails.application.routes.default_url_options.dup
-    if ENV['ACTIVE_STORAGE_URL'].present?
-      storage_uri = URI.parse(ENV['ACTIVE_STORAGE_URL'])
-      url_options[:host] = storage_uri.host
-      url_options[:port] = storage_uri.port
-      url_options[:protocol] = storage_uri.scheme
-    end
-    ActiveStorage::Current.url_options = url_options if ActiveStorage::Current.url_options.blank?
-    signed_url = attachment.file.blob.url(expires_in: 15.minutes)
+    # Scoped per-call so the override does not leak to other ActiveStorage calls
+    # within the same request/job.
+    signed_url = BlobUrlOptions.with_scoped_url_options { attachment.file.blob.url(expires_in: 15.minutes) }
 
-    Rails.logger.info "[Evolution Go S3] Using signed URL with 15-minute TTL (host: #{url_options[:host]})"
+    Rails.logger.info "[Evolution Go S3] Using signed URL with 15-minute TTL (host: #{BlobUrlOptions.effective_url_options[:host]})"
     signed_url
   end
 

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -498,18 +498,11 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     # ACTIVE_STORAGE_URL overrides the host used in DiskService signed URLs so
     # that external containers (Evolution API, Evolution Go) can actually reach
     # the file. Without it, localhost:3000 resolves to the caller's container,
-    # not the CRM Rails app.
-    url_options = Rails.application.routes.default_url_options.dup
-    if ENV['ACTIVE_STORAGE_URL'].present?
-      storage_uri = URI.parse(ENV['ACTIVE_STORAGE_URL'])
-      url_options[:host] = storage_uri.host
-      url_options[:port] = storage_uri.port
-      url_options[:protocol] = storage_uri.scheme
-    end
-    ActiveStorage::Current.url_options = url_options if ActiveStorage::Current.url_options.blank?
-    signed_url = attachment.file.blob.url(expires_in: 15.minutes)
+    # not the CRM Rails app. Scoped per-call so the override does not leak to
+    # other ActiveStorage calls within the same request/job.
+    signed_url = BlobUrlOptions.with_scoped_url_options { attachment.file.blob.url(expires_in: 15.minutes) }
 
-    Rails.logger.info "[Evolution S3] Using signed URL with 15-minute TTL (host: #{url_options[:host]})"
+    Rails.logger.info "[Evolution S3] Using signed URL with 15-minute TTL (host: #{BlobUrlOptions.effective_url_options[:host]})"
     signed_url
   end
 

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -15,3 +15,17 @@ Rails.application.configure do
     Rails.logger.info "🔓 ActiveStorage: SSL verification disabled for development environment"
   end
 end
+
+# Warn at boot when local storage is selected without an explicit public host.
+# Without ACTIVE_STORAGE_URL, browser-facing URLs fall back to default_url_options
+# (typically the container's internal hostname), which neither the user's browser
+# nor sibling containers (Evolution API) can resolve — leading to the "grey blob"
+# render bug and silent outbound delivery failures (EVO-1747).
+if !Rails.env.test? &&
+   ENV['ACTIVE_STORAGE_SERVICE'].to_s.downcase == 'local' &&
+   ENV['ACTIVE_STORAGE_URL'].to_s.strip.empty?
+  Rails.logger.warn '⚠️  ACTIVE_STORAGE_SERVICE=local but ACTIVE_STORAGE_URL is not set. ' \
+                    'Inbound media will likely not render in the chat and outbound media ' \
+                    'will not be delivered. Set ACTIVE_STORAGE_URL to a host reachable by ' \
+                    'both the browser and sibling containers (see .env.example).'
+end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -91,6 +91,47 @@ RSpec.describe Attachment, type: :model do
     end
   end
 
+  describe '#download_url' do
+    context 'when file is not attached' do
+      it 'returns an empty string' do
+        allow(attachment).to receive(:file).and_return(double('file', attached?: false))
+        expect(attachment.download_url).to eq('')
+      end
+    end
+
+    context 'when file is attached' do
+      let(:blob) { double('blob') }
+      let(:file_proxy) { double('file', attached?: true, blob: blob) }
+
+      before { allow(attachment).to receive(:file).and_return(file_proxy) }
+
+      it 'invokes blob.url under scoped ActiveStorage::Current.url_options with ACTIVE_STORAGE_URL' do
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        captured = {}
+        allow(blob).to receive(:url) do
+          captured.merge!(ActiveStorage::Current.url_options || {})
+          'https://media.example.com:8443/rails/active_storage/disk/signed'
+        end
+        attachment.download_url
+        expect(captured).to include(host: 'media.example.com', port: 8443, protocol: 'https')
+      ensure
+        ENV['ACTIVE_STORAGE_URL'] = nil
+      end
+
+      it 'restores previous ActiveStorage::Current.url_options after the call' do
+        previous = { host: 'previous.example.com', port: 9000, protocol: 'http' }
+        ActiveStorage::Current.url_options = previous
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        allow(blob).to receive(:url).and_return('ignored')
+        attachment.download_url
+        expect(ActiveStorage::Current.url_options).to eq(previous)
+      ensure
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        ActiveStorage::Current.url_options = nil
+      end
+    end
+  end
+
   describe '#thumb_url' do
     context 'when file is not attached or not representable' do
       it 'returns an empty string when not attached' do

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# Regression spec for Attachment#file_url and Attachment#thumb_url honoring
+# ENV['ACTIVE_STORAGE_URL'] via the BlobUrlOptions concern (EVO-1747).
+#
+# Default Rails test url_options point to localhost:3000; with ACTIVE_STORAGE_URL
+# set, the generated URL must use the override host/port/protocol so the browser
+# can reach the file when DiskService is in use.
+
+begin
+  require 'rails_helper'
+rescue LoadError
+  RSpec.describe 'Attachment URL options' do
+    it 'has spec scaffold ready' do
+      skip 'rails_helper is not available in this workspace snapshot'
+    end
+  end
+end
+
+return unless defined?(Rails) && defined?(ActiveStorage::Blob)
+
+RSpec.describe Attachment, type: :model do
+  let(:attachment) { Attachment.new(file_type: :image) }
+
+  # Captures whatever ActiveStorage::Current.url_options was at the moment
+  # url_for was invoked, so we can assert the override was scoped to the call.
+  def stub_url_for_capturing_options(return_value)
+    captured = {}
+    allow(attachment).to receive(:url_for) do |_arg|
+      captured.merge!(ActiveStorage::Current.url_options || {})
+      return_value
+    end
+    captured
+  end
+
+  describe '#file_url' do
+    context 'when file is not attached' do
+      it 'returns an empty string' do
+        expect(attachment.file_url).to eq('')
+      end
+    end
+
+    context 'when file is attached' do
+      let(:file_proxy) { instance_double('ActiveStorage::Attached::One', attached?: true) }
+
+      before { allow(attachment).to receive(:file).and_return(file_proxy) }
+
+      it "uses default_url_options when ENV['ACTIVE_STORAGE_URL'] is blank" do
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        captured = stub_url_for_capturing_options('http://localhost:3000/rails/active_storage/blobs/test')
+        attachment.file_url
+        expect(captured[:host]).to eq(Rails.application.routes.default_url_options[:host])
+      end
+
+      it 'uses ACTIVE_STORAGE_URL host/port/protocol when set' do
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        captured = stub_url_for_capturing_options('https://media.example.com:8443/rails/active_storage/blobs/test')
+        attachment.file_url
+        expect(captured).to include(host: 'media.example.com', port: 8443, protocol: 'https')
+      ensure
+        ENV['ACTIVE_STORAGE_URL'] = nil
+      end
+
+      it 'restores previous ActiveStorage::Current.url_options after the call' do
+        previous = { host: 'previous.example.com', port: 9000, protocol: 'http' }
+        ActiveStorage::Current.url_options = previous
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        allow(attachment).to receive(:url_for).and_return('ignored')
+        attachment.file_url
+        expect(ActiveStorage::Current.url_options).to eq(previous)
+      ensure
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        ActiveStorage::Current.url_options = nil
+      end
+
+      # Regression guard: the previous implementation called url_for(file, **opts)
+      # which raised ArgumentError ("wrong number of arguments (given 2, expected 0..1)")
+      # at runtime because url_for has arity 0..1. Any future refactor that
+      # reintroduces extra positional/keyword arguments must break this spec.
+      it 'invokes url_for with exactly one positional argument and no kwargs (arity guard)' do
+        captured = { positional: [], kwargs: {} }
+        allow(attachment).to receive(:url_for) do |*args, **kwargs|
+          captured[:positional] = args
+          captured[:kwargs] = kwargs
+          'http://example/x'
+        end
+        attachment.file_url
+        expect(captured[:positional].size).to eq(1)
+        expect(captured[:kwargs]).to be_empty
+      end
+    end
+  end
+
+  describe '#thumb_url' do
+    context 'when file is not attached or not representable' do
+      it 'returns an empty string when not attached' do
+        # NOTE: representable? is delegated via method_missing on Attached::One,
+        # so instance_double rejects it — use a plain double for these proxies.
+        allow(attachment).to receive(:file).and_return(double('file', attached?: false, representable?: false))
+        expect(attachment.thumb_url).to eq('')
+      end
+    end
+
+    context 'when file is attached and representable' do
+      let(:representation) { double('representation') }
+      let(:file_proxy) do
+        double('file', attached?: true, representable?: true, representation: representation)
+      end
+
+      before { allow(attachment).to receive(:file).and_return(file_proxy) }
+
+      it "uses default_url_options when ENV['ACTIVE_STORAGE_URL'] is blank" do
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        captured = {}
+        expect(attachment).to receive(:url_for) do |arg|
+          expect(arg).to eq(representation)
+          captured.merge!(ActiveStorage::Current.url_options || {})
+          'http://localhost:3000/rails/active_storage/representations/test'
+        end
+        attachment.thumb_url
+        expect(captured[:host]).to eq(Rails.application.routes.default_url_options[:host])
+      end
+
+      it 'uses ACTIVE_STORAGE_URL host/port/protocol when set' do
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        captured = {}
+        expect(attachment).to receive(:url_for) do |arg|
+          expect(arg).to eq(representation)
+          captured.merge!(ActiveStorage::Current.url_options || {})
+          'https://media.example.com:8443/rails/active_storage/representations/test'
+        end
+        attachment.thumb_url
+        expect(captured).to include(host: 'media.example.com', port: 8443, protocol: 'https')
+      ensure
+        ENV['ACTIVE_STORAGE_URL'] = nil
+      end
+
+      # Same arity guard as #file_url — see comment above.
+      it 'invokes url_for with exactly one positional argument and no kwargs (arity guard)' do
+        captured = { positional: [], kwargs: {} }
+        allow(attachment).to receive(:url_for) do |*args, **kwargs|
+          captured[:positional] = args
+          captured[:kwargs] = kwargs
+          'http://example/x'
+        end
+        attachment.thumb_url
+        expect(captured[:positional].size).to eq(1)
+        expect(captured[:kwargs]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/concerns/blob_url_options_spec.rb
+++ b/spec/services/concerns/blob_url_options_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe BlobUrlOptions do
+  describe '.effective_url_options' do
+    let(:base) { { host: 'crm.local', port: 3000, protocol: 'http' } }
+
+    context "when ENV['ACTIVE_STORAGE_URL'] is blank" do
+      around do |example|
+        original = ENV['ACTIVE_STORAGE_URL']
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        example.run
+        ENV['ACTIVE_STORAGE_URL'] = original
+      end
+
+      it 'returns the base options unchanged when ENV is nil' do
+        expect(described_class.effective_url_options(base)).to eq(base)
+      end
+
+      it 'returns the base options unchanged when ENV is empty string' do
+        ENV['ACTIVE_STORAGE_URL'] = ''
+        expect(described_class.effective_url_options(base)).to eq(base)
+      end
+
+      it 'does not mutate the base hash passed in' do
+        described_class.effective_url_options(base).merge!(host: 'mutated.local')
+        expect(base[:host]).to eq('crm.local')
+      end
+    end
+
+    context "when ENV['ACTIVE_STORAGE_URL'] is set" do
+      around do |example|
+        original = ENV['ACTIVE_STORAGE_URL']
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        example.run
+        ENV['ACTIVE_STORAGE_URL'] = original
+      end
+
+      it 'overrides host, port and protocol from the parsed URL' do
+        result = described_class.effective_url_options(base)
+        expect(result).to include(host: 'media.example.com', port: 8443, protocol: 'https')
+      end
+
+      it 'preserves non-conflicting keys from the base hash' do
+        base_with_extra = base.merge(script_name: '/prefix')
+        result = described_class.effective_url_options(base_with_extra)
+        expect(result[:script_name]).to eq('/prefix')
+      end
+    end
+
+    context "when ENV['ACTIVE_STORAGE_URL'] is malformed" do
+      around do |example|
+        original = ENV['ACTIVE_STORAGE_URL']
+        ENV['ACTIVE_STORAGE_URL'] = 'garbage://[invalid'
+        example.run
+        ENV['ACTIVE_STORAGE_URL'] = original
+      end
+
+      it 'logs a warning and falls back to the base options instead of raising' do
+        allow(Rails.logger).to receive(:warn)
+        result = nil
+        expect { result = described_class.effective_url_options(base) }.not_to raise_error
+        expect(result).to eq(base)
+        expect(Rails.logger).to have_received(:warn).with(/Invalid ACTIVE_STORAGE_URL/)
+      end
+    end
+  end
+
+  describe '.with_scoped_url_options' do
+    around do |example|
+      original_env = ENV['ACTIVE_STORAGE_URL']
+      original_current = ActiveStorage::Current.url_options
+      example.run
+      ENV['ACTIVE_STORAGE_URL'] = original_env
+      ActiveStorage::Current.url_options = original_current
+    end
+
+    it 'sets ActiveStorage::Current.url_options for the duration of the block' do
+      ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+      inside = nil
+      described_class.with_scoped_url_options { inside = ActiveStorage::Current.url_options.dup }
+      expect(inside).to include(host: 'media.example.com', port: 8443, protocol: 'https')
+    end
+
+    it 'restores the previous ActiveStorage::Current.url_options after the block' do
+      previous = { host: 'previous.example.com', port: 9000, protocol: 'http' }
+      ActiveStorage::Current.url_options = previous
+      ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+      described_class.with_scoped_url_options { :noop }
+      expect(ActiveStorage::Current.url_options).to eq(previous)
+    end
+
+    it 'restores even when the block raises' do
+      previous = { host: 'previous.example.com', port: 9000, protocol: 'http' }
+      ActiveStorage::Current.url_options = previous
+      ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+      expect { described_class.with_scoped_url_options { raise 'boom' } }.to raise_error('boom')
+      expect(ActiveStorage::Current.url_options).to eq(previous)
+    end
+
+    it 'returns the value of the block' do
+      ENV['ACTIVE_STORAGE_URL'] = nil
+      result = described_class.with_scoped_url_options { 'computed-url' }
+      expect(result).to eq('computed-url')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `BlobUrlOptions` concern centraliza parse de `ACTIVE_STORAGE_URL` (com rescue de URI malformada) e expõe `with_scoped_url_options` para set/restore de `ActiveStorage::Current.url_options`
- `Attachment#file_url` / `#thumb_url`, `Macro#file_base_data`, `AutomationRule#file_base_data` e os signed-URLs de `EvolutionService` / `EvolutionGoService` passam pelo helper scoped — sem leak entre chamadas no mesmo request/job
- Warning de boot quando `ACTIVE_STORAGE_SERVICE=local` e `ACTIVE_STORAGE_URL` vazio (skip em test env)
- 3 specs novos: arity guard de `url_for` (capturam o bug original que mocks anteriores escondiam), fallback em URI inválida, restauração do estado prévio

## Why
Sem `ACTIVE_STORAGE_URL` setada com storage local, as URLs caem em `default_url_options` (host interno do container). Resultado em produção: navegador não renderiza (bolinha cinza) E containers irmãos (Evolution API) não conseguem buscar a mídia (envio silenciosamente perdido).

## Validation
- `evo-ai-crm-community: bundle exec rspec spec/models/attachment_spec.rb spec/services/concerns/blob_url_options_spec.rb` → 19/19 verde
- Smoke manual (dev local): foto enviada renderiza no chat E é entregue no WhatsApp do destinatário
- Conectividade de container confirmada: `host.docker.internal:3000` é alcançável a partir do `evolution_api` (`localhost:3000` retorna connection refused; `evo-crm:3000` é bad address — Evolution e CRM estão em redes Docker separadas)

## Changed Files
- `app/models/attachment.rb`
- `app/models/automation_rule.rb`
- `app/models/macro.rb`
- `app/services/concerns/blob_url_options.rb` (novo)
- `app/services/whatsapp/providers/evolution_service.rb`
- `app/services/whatsapp/providers/evolution_go_service.rb`
- `config/initializers/active_storage.rb`
- `spec/models/attachment_spec.rb` (novo)
- `spec/services/concerns/blob_url_options_spec.rb` (novo)

## Linked Issue
- EVO-1747 (Fase 1 desta entrega; Fase 2 — UI de erro multi-idioma — vem em PR separada)

## Companion PR
- Umbrella `evo-crm-community`: `.env.example` documentando a var + `extra_hosts: host.docker.internal:host-gateway` no compose para paridade Linux/Mac/Windows