### PR TITLE
fix(spec): stub Meta Graph API in Channel::Whatsapp spec (EVO-1678)

### DIFF
--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'webmock/rspec'
 
 RSpec.describe Channel::Whatsapp, type: :model do
   describe '#merge_evolution_go_global_config' do
@@ -59,6 +60,10 @@ RSpec.describe Channel::Whatsapp, type: :model do
 
     context 'when provider is not evolution_go' do
       it 'does not call GlobalConfigService for evolution_go keys' do
+        # Stub the Meta Graph API health check that whatsapp_cloud#validate_provider_config? issues.
+        # Without this, the example makes a real outbound HTTP call and fails under WebMock.
+        stub_request(:get, %r{https://graph\.facebook\.com/}).to_return(status: 200, body: '{"data":[]}')
+
         expect(GlobalConfigService).not_to receive(:load).with('EVOLUTION_GO_API_URL', anything)
         expect(GlobalConfigService).not_to receive(:load).with('EVOLUTION_GO_ADMIN_SECRET', anything)
 


### PR DESCRIPTION
## Summary
- Stub the Meta Graph API health-check call in the `Channel::Whatsapp` spec example that was issuing a real `HTTParty.get` to `https://graph.facebook.com/v23.0//message_templates`.
- Add `require 'webmock/rspec'` at the top of `spec/models/channel/whatsapp_spec.rb` so the example is hermetic regardless of seed/order — without it the example only failed when another spec earlier in the run had already loaded webmock.

## Root cause
`spec/models/channel/whatsapp_spec.rb:61` builds a `Channel::Whatsapp` with `provider: 'whatsapp_cloud'` and calls `.valid?`. That triggers `validate_provider_config` → `WhatsappCloudService#validate_provider_config?` → `HTTParty.get` to graph.facebook.com (`whatsapp_cloud_service.rb:128`). Under WebMock with `disable_net_connect!`, this raises `WebMock::NetConnectNotAllowedError`, making the channel model suite order/seed-dependent and flaky in CI.

## Out of scope
Global test-suite WebMock/net-connect policy (could be a separate hardening task — noted in the issue).

## Test plan
- [x] Baseline (fix stashed): `bundle exec rspec spec/services/evo_auth_service_spec.rb spec/models/channel/whatsapp_spec.rb:61 --seed 0` → **1 failure** with the documented `NetConnectNotAllowedError` stack.
- [x] With fix: same command → **8 examples, 0 failures**.
- [x] `bundle exec rspec spec/models/channel/whatsapp_spec.rb` (standalone) → **4/4** — proves AC2: no real outbound HTTP even without another spec loading webmock first.
- [x] `bundle exec rspec spec/models/channel/` → **49/49** — no regression in sibling channel specs.

## Acceptance Criteria
- [x] `spec/models/channel/whatsapp_spec.rb:61` passes regardless of execution order/seed and with WebMock active.
- [x] No real outbound HTTP is issued from the channel model specs.

## Linked Issue
- [EVO-1678](https://linear.app/evoai/issue/EVO-1678/test-hygiene-whatsapp-spec-makes-a-real-graphfacebookcom-call-fails)

## Summary by Sourcery

Tests:
- Stub the Meta Graph API health-check request in the Whatsapp channel spec to avoid real outbound HTTP and flakiness under WebMock.