### PR TITLE
fix(crm): map 'file' mediatype to 'document' for Evolution API media send (EVO-1940)

### DIFF
--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -463,7 +463,7 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
       headers: api_headers,
       body: {
         number: phone_number.delete('+'),
-        mediatype: attachment.file_type,
+        mediatype: map_file_type_to_evolution_media_type(attachment.file_type),
         media: media_url,
         caption: html_to_whatsapp(message.content.to_s),
         fileName: attachment.file.filename.to_s
@@ -471,6 +471,19 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     )
 
     process_response(response)
+  end
+
+  # Evolution API/Baileys only accepts document/image/video/audio as mediatype.
+  # The 'file' enum value (PDF/Word/etc.) must be sent as 'document', mirroring
+  # EvolutionGoService#map_file_type_to_evolution_go and NotificameService.
+  def map_file_type_to_evolution_media_type(file_type)
+    case file_type
+    when 'image' then 'image'
+    when 'audio' then 'audio'
+    when 'video' then 'video'
+    when 'file' then 'document'
+    else 'document'
+    end
   end
 
   def send_audio_message(phone_number, message)

--- a/spec/services/whatsapp/providers/evolution_service_spec.rb
+++ b/spec/services/whatsapp/providers/evolution_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
 
   describe '#send_text_message (HTML to WhatsApp formatting)' do
     it 'converts bold HTML to WhatsApp bold' do
-      message = instance_double('Message', content: '<strong>Hello</strong> World', attachments: double(present?: false))
+      message = instance_double('Message', content: '<strong>Hello</strong> World', attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -100,7 +100,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     end
 
     it 'converts italic HTML to WhatsApp italic' do
-      message = instance_double('Message', content: '<em>italic</em> text', attachments: double(present?: false))
+      message = instance_double('Message', content: '<em>italic</em> text', attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -113,7 +113,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     end
 
     it 'converts code HTML to WhatsApp monospace' do
-      message = instance_double('Message', content: 'use <code>method()</code> here', attachments: double(present?: false))
+      message = instance_double('Message', content: 'use <code>method()</code> here', attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -128,7 +128,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     it 'converts mixed formatting correctly' do
       message = instance_double('Message',
                                 content: '<p><strong>Title</strong></p><p>Some <em>italic</em> and <code>code</code></p>',
-                                attachments: double(present?: false))
+                                attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -144,7 +144,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     end
 
     it 'preserves plain text content unchanged' do
-      message = instance_double('Message', content: 'Hello World', attachments: double(present?: false))
+      message = instance_double('Message', content: 'Hello World', attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -157,7 +157,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     end
 
     it 'converts <br> tags to newlines' do
-      message = instance_double('Message', content: 'Line 1<br>Line 2<br/>Line 3', attachments: double(present?: false))
+      message = instance_double('Message', content: 'Line 1<br>Line 2<br/>Line 3', attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -170,7 +170,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     end
 
     it 'converts <p> blocks to double newlines' do
-      message = instance_double('Message', content: '<p>Paragraph 1</p><p>Paragraph 2</p>', attachments: double(present?: false))
+      message = instance_double('Message', content: '<p>Paragraph 1</p><p>Paragraph 2</p>', attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -185,7 +185,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     it 'converts list items to dashes' do
       message = instance_double('Message',
                                 content: '<ul><li>Item 1</li><li>Item 2</li></ul>',
-                                attachments: double(present?: false))
+                                attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -199,7 +199,7 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
     end
 
     it 'strips HTML-only content to empty string' do
-      message = instance_double('Message', content: '<p></p>', attachments: double(present?: false))
+      message = instance_double('Message', content: '<p></p>', attachments: double(present?: false), content_type: 'text')
 
       allow(HTTParty).to receive(:post).and_return(success_response)
 
@@ -243,6 +243,63 @@ RSpec.describe Whatsapp::Providers::EvolutionService do
         expect(body['caption']).to include('*image*')
         expect(body['caption']).not_to match(/<[^>]+>/)
       end
+    end
+  end
+
+  describe '#send_media_message (mediatype mapping — EVO-1940)' do
+    def attachment_double(file_type)
+      file_double = instance_double('AttachmentFile', filename: double(to_s: "f.#{file_type}"), attached?: false)
+      instance_double('Attachment', file_type: file_type, file: file_double,
+                                    file_url: "https://s3.example.com/f.#{file_type}")
+    end
+
+    def send_attachment_of(file_type)
+      message = instance_double('Message', content: 'caption',
+                                           attachments: double(present?: true, first: attachment_double(file_type)))
+      allow(HTTParty).to receive(:post).and_return(success_response)
+      service.send_message(phone_number, message)
+    end
+
+    it "maps a 'file' attachment (PDF/Word) to mediatype 'document'" do
+      send_attachment_of('file')
+
+      expect(HTTParty).to have_received(:post) do |_url, opts|
+        expect(JSON.parse(opts[:body])['mediatype']).to eq('document')
+      end
+    end
+
+    it "keeps 'image' as mediatype 'image' (no regression)" do
+      send_attachment_of('image')
+
+      expect(HTTParty).to have_received(:post) do |_url, opts|
+        expect(JSON.parse(opts[:body])['mediatype']).to eq('image')
+      end
+    end
+
+    it "keeps 'video' as mediatype 'video' (no regression)" do
+      send_attachment_of('video')
+
+      expect(HTTParty).to have_received(:post) do |_url, opts|
+        expect(JSON.parse(opts[:body])['mediatype']).to eq('video')
+      end
+    end
+
+    it 'maps the full enum to canonical Evolution API media types' do
+      expect(service.send(:map_file_type_to_evolution_media_type, 'file')).to eq('document')
+      expect(service.send(:map_file_type_to_evolution_media_type, 'image')).to eq('image')
+      expect(service.send(:map_file_type_to_evolution_media_type, 'audio')).to eq('audio')
+      expect(service.send(:map_file_type_to_evolution_media_type, 'video')).to eq('video')
+      expect(service.send(:map_file_type_to_evolution_media_type, 'fallback')).to eq('document')
+    end
+
+    it 'returns false when the provider rejects the media send (surfaces failure to caller)' do
+      message = instance_double('Message', content: 'caption',
+                                           attachments: double(present?: true, first: attachment_double('file')))
+      allow(HTTParty).to receive(:post).and_return(
+        instance_double(HTTParty::Response, success?: false, code: 400, body: 'invalid mediatype')
+      )
+
+      expect(service.send_message(phone_number, message)).to be(false)
     end
   end
 end


### PR DESCRIPTION
## Summary

Sending a PDF/Word/document via the **Evolution API** provider (`provider: evolution`) silently failed — the document never reached WhatsApp.

Root cause: `send_media_message` sent `mediatype: attachment.file_type` raw. For documents `file_type == 'file'`, but Baileys (Evolution API) only accepts `document/image/video/audio`. Every other provider already translates this (`EvolutionGoService#map_file_type_to_evolution_go`, `NotificameService`); only Evolution API was missing it. Line untouched since 2026-05-13 → live bug on `develop`.

Fix: a private `map_file_type_to_evolution_media_type` helper (mirroring the Evolution Go one) maps `file -> document` and passes image/video/audio through. `send_media_message` now uses it.

## Changes

- `app/services/whatsapp/providers/evolution_service.rb` — add `map_file_type_to_evolution_media_type`; use it in `send_media_message`.
- `spec/services/whatsapp/providers/evolution_service_spec.rb` — regression specs (mediatype mapping + failure-surfacing path); also un-break 9 pre-existing `send_text_message` specs that lacked a `content_type` stub after `send_message` started reading it (unrelated to this fix, repaired in passing).

## Validation

- `crm: ruby -c app/services/whatsapp/providers/evolution_service.rb` → Syntax OK
- `crm: bundle exec rspec spec/services/whatsapp/providers/evolution_service_spec.rb` → 22 examples, 0 failures
- `crm: bundle exec rubocop` (changed files) → no new offenses (only pre-existing file-style cops)
- **Live smoke:** PDF sent via the Evolution API channel was delivered to WhatsApp; message got `status: sent` and a provider `source_id` — confirmed with the Sidekiq worker restarted on the new code.

## Acceptance Criteria

- [x] PDF/Word via Evolution API delivers the document on WhatsApp
- [x] `send_media_message` uses canonical mediatype (`document` for `file`; image/video/audio otherwise)
- [x] Images/videos/audios still work (no regression)
- [x] Parity with Evolution Go / Cloud API for documents
- [x] Provider error surfaces as failure (HTTP error → `false` → message marked `failed` by `SendOnWhatsappService`)

> Note: the id-less `2xx` edge of `process_response` (a `200`-with-error-body stays `sent`) is pre-existing and explicitly deferred by the card's open question; out of scope here.

## Linked Issue

- EVO-1940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzVxXUXPKJQy4m5WuJEjgz
