### PR TITLE
fix(crm): enforce permissions on the Segments proxy endpoints (EVO-1938)

### DIFF
--- a/app/controllers/api/v1/evo_flow/segments_controller.rb
+++ b/app/controllers/api/v1/evo_flow/segments_controller.rb
@@ -1,4 +1,20 @@
 class Api::V1::EvoFlow::SegmentsController < Api::V1::BaseController
+  # EVO-1938: gate every proxied action by permission. Without this, the segments
+  # endpoints were reachable by any authenticated user (incl. the default agent)
+  # even though the Settings UI hides Segments — so revoking segments.* from the
+  # agent only closed the leak in the UI, not at the API. Mirrors teams_controller.
+  require_permissions({
+    index: 'segments.read',
+    show: 'segments.read',
+    contact_ids: 'segments.read',
+    preview: 'segments.read',
+    create: 'segments.create',
+    update: 'segments.update',
+    destroy: 'segments.delete',
+    recompute: 'segments.recompute',
+    recompute_all: 'segments.recompute'
+  })
+
   # Bound the opaque definition we forward to evo-flow (it is passed through with
   # to_unsafe_h, so without a cap a client could amplify an arbitrarily
   # large/deep payload against evo-flow).

--- a/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
@@ -9,6 +9,52 @@ RSpec.describe Api::V1::EvoFlow::SegmentsController, type: :controller do
   before do
     allow(controller).to receive(:authenticate_request!).and_return(true)
     allow(EvoFlow::Client).to receive(:new).and_return(fake_client)
+    # EVO-1938: these existing specs cover the proxy behavior, not authorization —
+    # authenticate as a service token so the new require_permissions gate bypasses.
+    Current.service_authenticated = true
+  end
+
+  after { Current.reset }
+
+  # EVO-1938: the segments endpoints proxy to evo-flow and previously had NO
+  # permission gate, so revoking segments.* from the agent only hid the Settings UI
+  # while the API stayed open. These assert the require_permissions gate now 403s a
+  # user that lacks the segment permission (the default agent) and lets an admin in.
+  describe 'permission gating (EVO-1938)' do
+    let(:current_user) { double('User', id: 'user-1') }
+
+    before do
+      Current.service_authenticated = false
+      Current.user = current_user
+      Current.evo_permission_cache = {}
+    end
+
+    it 'returns 403 on #index when the user lacks segments.read (the default agent)' do
+      Current.evo_permission_cache['user:user-1:segments.read'] = false
+      expect(fake_client).not_to receive(:get)
+
+      get :index
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'returns 403 on #destroy when the user lacks segments.delete' do
+      Current.evo_permission_cache['user:user-1:segments.delete'] = false
+      expect(fake_client).not_to receive(:delete)
+
+      delete :destroy, params: { id: 'seg-1' }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'allows #index when the user holds segments.read (an administrator)' do
+      Current.evo_permission_cache['user:user-1:segments.read'] = true
+      allow(fake_client).to receive(:get).and_return({ 'segments' => [] })
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
## Summary

EVO-1938 — the default `agent` (support attendant) role could see and in many cases manage admin-only Settings screens. This closes the **user-facing** leak end-to-end (menu + route + the segments backend) and fixes the permission-cache-on-logout that made it look unfixed when switching users.

The fix spans three repos (cross-linked below). The core change is the **auth seed/migration** (the agent role no longer holds the admin resources); the frontend/CRM gates already read those permissions, so they hide/403 automatically.

## What changed (per repo)
- **auth:** `db/seeds/rbac.rb` trims the agent role to operational resources only; idempotent data-migration strips the admin keys from the existing system `agent` role; RSpec for both.
- **frontend:** Atendentes (`/settings/users`) re-gated on `users.manage`; `permissionsService.clearCache()` on logout (was leaking the prior user's permissions for 30 min); vitest for menu + route gating.
- **crm:** `Api::V1::EvoFlow::SegmentsController` given `require_permissions` (it proxied to evo-flow with no gate); controller spec for the 403.

## Kept by design (deferred to EVO-1955)
`labels`, `canned_responses`, `macros`, `message_templates`, `teams`/`team_members` stay with the agent — their `.read` powers in-chat features (quick-replies, labels, macros, the "Assign team" picker). Their Settings use-vs-manage split is EVO-1955.

## Validation
- auth: `RAILS_ENV=test bundle exec rspec spec/db/seeds/rbac_spec.rb spec/db/migrate/revoke_admin_settings_permissions_from_agent_role_spec.rb` → 41 examples, 0 failures
- crm: `RAILS_ENV=test bundle exec rspec spec/controllers/api/v1/evo_flow/segments_controller_spec.rb` → 23 examples, 0 failures
- frontend: `pnpm exec vitest run` (menuItems + PermissionRoute) → 11 passed · `pnpm exec tsc -b --noEmit` → 0
- Manual smoke (with PM): default agent — admin Settings screens gone from menu + "Access Denied" on direct URL + 403 from API; Conversations works incl. "Assign team"; admin sees everything.

## QA / audit
A multi-agent adversarial review caught + fixed two issues before ship (teams broke the in-chat picker → kept; segments had no backend gate → added). A follow-up exhaustive RBAC audit found other **pre-existing** backend-only enforcement gaps (integration/oauth/AI endpoints missing permission gates) — tracked in **EVO-1956** (frontend is clean; those are direct-API only).

## Related PRs / Issues
- EVO-1938 (this) · EVO-1955 (use-vs-manage split) · EVO-1956 (backend enforcement audit gaps)
- Cross-repo: auth + frontend + crm PRs on `fix/EVO-1938`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzVxXUXPKJQy4m5WuJEjgz
