### PR TITLE
fix(dev): disable schema dump after migration (EVO-1966)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,6 +58,14 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  # Do not regenerate db/schema.rb after migrations in development (mirrors
+  # production.rb). The dev stack runs `db:prepare` on every container boot and
+  # the source is bind-mounted, so an automatic dump here rewrites the
+  # version-controlled schema.rb from the container's Postgres — corrupting it
+  # and breaking `db:schema:load` based seeds (EVO-1966). Schema changes must be
+  # dumped intentionally by a developer, not as a runtime side effect.
+  config.active_record.dump_schema_after_migration = false
+
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 


### PR DESCRIPTION
## Problema

O stack de dev roda `db:prepare` em **todo boot** do container do CRM e bind-monta o
source (`./evo-ai-crm-community:/app`). Com o default de development
`dump_schema_after_migration = true`, cada boot **regenera `db/schema.rb`** a partir do
Postgres do container e grava por cima do arquivo versionado. Isso corrompe o schema
(ex.: derruba `messages.source`), e como o seed usa `db:schema:load`, um checkout limpo
constrói o banco **sem a coluna** enquanto carimba a migration como aplicada → **500 no
dashboard** (`Undeclared attribute type for enum 'source' in Message`).

## Fix

Espelha o `production.rb`: `config.active_record.dump_schema_after_migration = false` em
development. O `schema.rb` só é dumpado intencionalmente por um dev, nunca como efeito
colateral de runtime.

## Validação (clean-room, zero patch)

`git clone --recurse-submodules` fresco + este commit + `make setup` do zero (build novo +
volumes novos). Resultado: `messages.source` presente, `Message` carrega sem erro de enum,
`schema.rb` permanece pristino após build+seed+boot, e o dashboard abre sem o 500.

Relacionado: EVO-1966 (prontidão de deploy de checkout limpo do `evo-crm-community`).

## Summary by Sourcery

Enhancements:
- Align development Active Record schema dump behavior with production by turning off dump_schema_after_migration, requiring intentional schema dumps by developers.