### PR TITLE
feat(crm): conversation-list backend — sort parity, chips, archived (EVO-1960 +2)

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -104,6 +104,11 @@ class ConversationFinder
     # Apply assignee type filter
     query = apply_assignee_type_filter(query)
 
+    # Apply chip filters (unread / groups / archived) — list-only, não afetam as contagens
+    query = apply_unread_filter(query)
+    query = apply_is_group_filter(query)
+    query = apply_archived_filter(query)
+
     # Apply search filter if needed
     query = apply_query_filter(query) if @params[:q].present?
 
@@ -192,6 +197,37 @@ class ConversationFinder
       query.assigned
     else
       query
+    end
+  end
+
+  # Chip "Não lidas": conversas com mensagens incoming não lidas pelo agente.
+  def apply_unread_filter(query)
+    return query unless ActiveModel::Type::Boolean.new.cast(@params[:unread])
+
+    query.unread
+  end
+
+  # Chip "Grupos": conversas cujo contato é um grupo (contact.type = 'group').
+  # Naturalmente vazio em canais sem grupos (cloud/Telegram). O contato já está
+  # joined em build_base_filter_query.
+  def apply_is_group_filter(query)
+    return query unless ActiveModel::Type::Boolean.new.cast(@params[:is_group])
+
+    query.where(contacts: { type: 'group' })
+  end
+
+  # Aba "Arquivadas": archived vive em custom_attributes.archived (jsonb boolean).
+  # archived=true  -> só arquivadas; archived=false -> exclui arquivadas.
+  # Param ausente = sem filtro (lista padrão inalterada; o front esconde as
+  # arquivadas client-side na visão normal). `->>'archived'` extrai o boolean JSON
+  # como texto ('true'); IS DISTINCT FROM cobre null/false/ausente.
+  def apply_archived_filter(query)
+    return query if @params[:archived].blank?
+
+    if ActiveModel::Type::Boolean.new.cast(@params[:archived])
+      query.where("conversations.custom_attributes->>'archived' = 'true'")
+    else
+      query.where("conversations.custom_attributes->>'archived' IS DISTINCT FROM 'true'")
     end
   end
 

--- a/app/models/concerns/sort_handler.rb
+++ b/app/models/concerns/sort_handler.rb
@@ -3,7 +3,10 @@ module SortHandler
 
   class_methods do
     def sort_on_last_activity_at(sort_direction = :desc)
-      order(last_activity_at: sort_direction)
+      # Tiebreaker determinístico por id: evita troca de posição / duplicatas na
+      # borda de página quando last_activity_at empata. Estabiliza a paginação
+      # nos dois caminhos (index e POST /conversations/filter).
+      order(last_activity_at: sort_direction, id: :desc)
     end
 
     def sort_on_created_at(sort_direction = :asc)

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -74,6 +74,16 @@ class Conversation < ApplicationRecord
   scope :assigned, -> { where.not(assignee_id: nil) }
   scope :assigned_to, ->(agent) { where(assignee_id: agent.id) }
   scope :unattended, -> { where(first_reply_created_at: nil).or(where.not(waiting_since: nil)) }
+  # Conversas com mensagens incoming não lidas pelo agente (espelha
+  # unread_incoming_messages_count > 0): sem agent_last_seen_at = qualquer incoming;
+  # senão, incoming com created_at depois do último seen. Usado pelo chip "Não lidas".
+  scope :unread, lambda {
+    where(
+      'EXISTS (SELECT 1 FROM messages WHERE messages.conversation_id = conversations.id ' \
+      "AND messages.message_type = #{Message.message_types[:incoming]} " \
+      'AND (conversations.agent_last_seen_at IS NULL OR messages.created_at > conversations.agent_last_seen_at))'
+    )
+  }
   scope :resolvable_not_waiting, lambda { |auto_resolve_after|
     return none if auto_resolve_after.to_i.zero?
 

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -13,6 +13,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
       meta: push_meta,
       status: status,
       custom_attributes: custom_attributes,
+      is_group: contact&.group? || false,
       snoozed_until: snoozed_until,
       unread_count: unread_incoming_messages_count,
       first_reply_created_at: first_reply_created_at,

--- a/app/serializers/conversation_serializer.rb
+++ b/app/serializers/conversation_serializer.rb
@@ -57,6 +57,9 @@ module ConversationSerializer
       result['unread_count'] = conversation.unread_incoming_messages_count
     end
     result['custom_attributes'] = conversation.custom_attributes || {}
+    # Sinaliza conversa de grupo (contact.type == 'group') para o front filtrar e
+    # reconciliar a aba "Grupos" no realtime sem outra request.
+    result['is_group'] = conversation.contact&.group? || false
 
     # Include contact
     if include_contact && conversation.contact.present?

--- a/app/services/conversations/filter_service.rb
+++ b/app/services/conversations/filter_service.rb
@@ -55,6 +55,12 @@ class Conversations::FilterService < FilterService
   end
 
   def conversations
-    @conversations.sort_on_last_activity_at(:desc).page(current_page)
+    # Honra sort_by igual ao index (ConversationFinder), em vez de hard-codar
+    # last_activity_at DESC — elimina a divergência index vs filtro. Default
+    # continua last_activity_at_desc (agora com tiebreaker estável via SortHandler).
+    sort_method, sort_order =
+      ConversationFinder::SORT_OPTIONS[@params[:sort_by]] ||
+      ConversationFinder::SORT_OPTIONS['last_activity_at_desc']
+    @conversations.send(sort_method, sort_order).page(current_page)
   end
 end

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ConversationFinder do
   describe '#apply_sorting' do
     it 'defaults to last_activity_at desc when sort_by is missing' do
-      user = instance_double(User, id: 1)
+      user = instance_double(User, id: 1, administrator?: false)
       finder = described_class.new(user, {})
       relation = double('Relation')
 
@@ -15,7 +15,7 @@ RSpec.describe ConversationFinder do
     end
 
     it 'uses provided sort_by when available' do
-      user = instance_double(User, id: 1)
+      user = instance_double(User, id: 1, administrator?: false)
       finder = described_class.new(user, { sort_by: 'created_at_asc' })
       relation = double('Relation')
 

--- a/spec/services/conversations/filter_service_spec.rb
+++ b/spec/services/conversations/filter_service_spec.rb
@@ -4,14 +4,29 @@ require 'rails_helper'
 
 RSpec.describe Conversations::FilterService do
   describe '#conversations' do
-    it 'orders by last_activity_at desc and paginates' do
+    it 'orders by last_activity_at desc by default and paginates' do
       user = instance_double(User)
       service = described_class.new({}, user)
 
       relation = double('Relation')
       service.instance_variable_set(:@conversations, relation)
 
-      expect(relation).to receive(:sort_on_last_activity_at).with(:desc).and_return(relation)
+      # Resolvido via ConversationFinder::SORT_OPTIONS (paridade com o index),
+      # que passa a direção como string 'desc'.
+      expect(relation).to receive(:sort_on_last_activity_at).with('desc').and_return(relation)
+      expect(relation).to receive(:page).with(1).and_return(relation)
+
+      service.conversations
+    end
+
+    it 'honors sort_by (parity with the index) when provided' do
+      user = instance_double(User)
+      service = described_class.new({ sort_by: 'created_at_asc' }, user)
+
+      relation = double('Relation')
+      service.instance_variable_set(:@conversations, relation)
+
+      expect(relation).to receive(:sort_on_created_at).with('asc').and_return(relation)
       expect(relation).to receive(:page).with(1).and_return(relation)
 
       service.conversations


### PR DESCRIPTION
## Summary

Conversation-list backend for the chat-perf overhaul.

- **EVO-1960** — deterministic `last_activity_at` + `id` tiebreaker in `sort_handler`, and `filter_service` resolves sort via `ConversationFinder::SORT_OPTIONS` so index and POST `/conversations/filter` order identically (removes page-edge row swap/duplication).
- **EVO-1975** — `unread` scope on `Conversation`, `is_group` flag on the serializer, and finder chip filters (`apply_unread_filter` / `apply_is_group_filter`) wired into `build_conversations_query`.
- **EVO-1977** — `apply_archived_filter` over `custom_attributes->>'archived'` (jsonb), `blank?`-guarded so an absent/empty param is a no-op.

## Validation

- `ruby -c` on all changed files — Syntax OK
- `bundle exec rspec spec/services/conversations/filter_service_spec.rb` — 6 examples, 0 failures
- `bundle exec rspec spec/finders/conversation_finder_spec.rb` — 4 examples, 0 failures
- Adversarial code review verified filter scoping/injection-safety, the `unread` EXISTS subquery, sort resolution, and count queries.

## Notes

- Drive-by: stubbed `administrator?` on the `instance_double(User)` in `conversation_finder_spec` — a pre-existing failure introduced by commit `5237b34` (assigned_inboxes), unrelated to this change; left the suite green.
- No collision with EVO-1958 (Marcelo): my finder/serializer edits are in disjoint regions from the planned `preload(inbox: :agent_bot_inbox)` and the `agent_bot_active` line.

## Linked Issues

- EVO-1960, EVO-1975, EVO-1977

## Related PRs

- Frontend (EVO-1960 / EVO-1975 / EVO-1977): sibling PR in `evo-ai-frontend-community` (branch `fix/EVO-1960`).

## Summary by Sourcery

Align conversation list backend sorting with index behavior and add chip-based filters for unread, group, and archived conversations.

New Features:
- Add chip-driven unread, group, and archived filters to conversation queries for the conversation list.
- Expose an is_group flag on the conversation serializer for frontend group-conversation handling.

Enhancements:
- Resolve filter endpoint sorting via ConversationFinder::SORT_OPTIONS to match index sorting, including honoring sort_by when provided.
- Make last_activity_at sorting deterministic by adding an id tiebreaker to stabilize pagination across index and filter.
- Add an unread scope on Conversation to encapsulate unread incoming message logic.

Tests:
- Extend ConversationFinder and Conversations::FilterService specs to cover sort parity and new sort_by behaviors.
- Adjust ConversationFinder specs to stub administrator? on the User double to keep the suite green.