### PR TITLE
...

### DIFF
--- a/app/models/pipeline_stage.rb
+++ b/app/models/pipeline_stage.rb
@@ -26,6 +26,11 @@ class PipelineStage < ApplicationRecord
   has_many :stage_movements_from, class_name: 'StageMovement', foreign_key: 'from_stage_id', dependent: :destroy, inverse_of: :from_stage
   has_many :stage_movements_to, class_name: 'StageMovement', foreign_key: 'to_stage_id', dependent: :destroy, inverse_of: :to_stage
 
+  # Alinea con el vocabulario que el frontend ya envía (CreateStageData:
+  # active | completed | cancelled). Sin este enum, el string se casteaba
+  # a 0 y la semántica se perdía silenciosamente.
+  enum stage_type: { active: 0, completed: 1, cancelled: 2 }
+
   validates :name, presence: true
   validates :position, presence: true, uniqueness: { scope: :pipeline_id }
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: :invalid_hex_color }

--- a/spec/models/pipeline_stage_spec.rb
+++ b/spec/models/pipeline_stage_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PipelineStage, 'stage_type enum' do
+  let(:creador) { User.create!(name: 'Spec User', email: "spec-#{SecureRandom.hex(4)}@test.local") }
+  let(:pipeline) { Pipeline.create!(name: "Enum #{SecureRandom.hex(4)}", created_by: creador) }
+
+  it 'persiste el string enviado por el frontend en su valor de enum, no coercionado a 0' do
+    stage = pipeline.pipeline_stages.create!(name: 'x', position: 1, stage_type: 'cancelled')
+    expect(stage.reload.cancelled?).to be true
+    expect(stage.read_attribute_before_type_cast(:stage_type)).to eq(2)
+  end
+
+  it 'mantiene active como default (compatible con filas preexistentes en 0)' do
+    stage = pipeline.pipeline_stages.create!(name: 'y', position: 2)
+    expect(stage.active?).to be true
+  end
+
+  it 'rechaza valores fuera del vocabulario del frontend' do
+    expect do
+      pipeline.pipeline_stages.new(name: 'z', position: 3, stage_type: 'archived')
+    end.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
'cancelled'.to_i coercía silenciosamente a 0 (active) por falta de enum en el modelo. El frontend ya declaraba stage_type como string (CreateStageData: active | completed | cancelled); el backend solo se alinea. Compatible hacia atrás: filas existentes (0) → active. Sin migración: la columna ya existía.

Nota: los serializers ahora devuelven stage_type como string, no integer.

## Summary by Sourcery

Define an enum for pipeline stage_type to align backend semantics with frontend-provided string values and prevent silent coercion, and add tests to verify the new behavior and defaults.

New Features:
- Introduce a stage_type enum on PipelineStage with active, completed, and cancelled values.

Tests:
- Add model specs ensuring stage_type correctly maps string inputs to enum values, preserves active as the default, and rejects unsupported values.