### PR TITLE
ci: build por PR (:pr-N) pro ambiente de review (EVO-1998)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,9 @@ jobs:
   # docs/pr-review-testing-workflow.md §6.1.
   # ---------------------------------------------------------------------------
   build-pr:
-    if: github.event_name == 'pull_request'
+    # Só PR interna (mesmo repo): PR de fork não tem os secrets DOCKERHUB_* e
+    # não deve buildar/pushar código não-confiável com nossas credenciais.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     name: Build PR image (amd64)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,15 +4,79 @@ on:
   push:
     branches: [main, develop]
     tags: ["v*.*.*"]
+  pull_request:
+    branches: [main, develop]
 
 permissions:
   contents: read
+
+# PR builds move the mutable :pr-<N> tag on every push — cancel superseded
+# runs so a retest always reflects the latest commit. Never cancel a
+# push-to-develop/main build (those promote real tags).
+concurrency:
+  group: docker-publish-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   IMAGE_NAME: evoapicloud/evo-ai-crm-community
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # PR builds: single-arch amd64 (review env is one machine — half the cost of
+  # multi-arch), pushed to the ephemeral :pr-<N> (mutable, for the reviewer) and
+  # :sha-<sha7> (immutable, from the PR head, for audit). See
+  # docs/pr-review-testing-workflow.md §6.1.
+  # ---------------------------------------------------------------------------
+  build-pr:
+    if: github.event_name == 'pull_request'
+    name: Build PR image (amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve PR tags
+        id: tags
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          IMAGE="${{ env.IMAGE_NAME }}"
+          SHA_SHORT="${HEAD_SHA:0:7}"
+          echo "tags=${IMAGE}:pr-${PR_NUMBER},${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push (amd64)
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            RAILS_ENV=production
+            BUNDLE_WITHOUT=development:test
+            RAILS_SERVE_STATIC_FILES=true
+            GIT_SHA=${{ github.sha }}
+          tags: ${{ steps.tags.outputs.tags }}
+          # Shares the amd64 scope with the branch build so PRs warm off
+          # develop's cache. GHA ref-scoping keeps PR writes isolated from base.
+          cache-from: type=gha,scope=linux/amd64
+          cache-to: type=gha,scope=linux/amd64,mode=max
+
+  # ---------------------------------------------------------------------------
+  # Branch/tag builds: multi-arch (amd64 + arm64) by digest, merged into a
+  # manifest and pushed to the promoted tags (:develop, :latest, :vX.Y.Z).
+  # ---------------------------------------------------------------------------
   build:
+    if: github.event_name != 'pull_request'
     name: Build ${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -67,6 +131,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: github.event_name != 'pull_request'
     name: Merge Manifests & Tag
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## O que

Adiciona **build por PR** à CI deste serviço: no `pull_request` (main/develop), builda a imagem **amd64** e publica `:pr-<N>` (mutável, pro revisor) + `:sha-<sha7>` (imutável, do head do PR). Os builds de branch/tag (multi-arch → `:latest`/`:develop`/`:vX`) passam a ser guardados por `if: github.event_name != 'pull_request'`.

## Por que

Habilita o **ambiente de review por PR** (EVO-1998): o `review.sh` (no umbrella `evo-crm-community`) sobe a stack com cada serviço na imagem do seu PR (`:pr-N`). Sem o `:pr-N`, o revisor não consegue testar um PR aberto rodando. Espelha o padrão **já em produção no `evo-flow-community`**.

## Detalhes

- `build-pr`: single-arch **amd64** (o ambiente de review é uma máquina só; ~metade do custo do multi-arch). `context`/`Dockerfile`/`build-args` **idênticos** ao job de build existente deste serviço.
- `concurrency`: cancela builds de PR superseded (retest reflete o último commit); nunca cancela push em main/develop.
- **Nada mais alterado** — `IMAGE_NAME`, lógica de tags de branch/tag e matriz multi-arch intactos.

Ref: **EVO-1998**.

## Summary by Sourcery

Add pull request-specific Docker image builds to support per-PR review environments while preserving existing branch/tag multi-arch builds.

New Features:
- Build and push single-arch amd64 Docker images on pull_request events, tagged as :pr-<N> and :sha-<sha7> for each PR.

Enhancements:
- Introduce workflow concurrency controls so superseded PR builds are canceled while main/develop push builds are never canceled.
- Restrict existing multi-arch branch/tag build and manifest merge jobs to non-pull_request events only.