### PR TITLE
fix(db): bump schema.rb para incluir encrypt_evolution_hub_api_key_at_rest

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_25_190000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_01_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"


### PR DESCRIPTION
## Problema
O check **"Verify EvoExtensionPoints contract"** está vermelho em **todo PR novo de CRM**. Não é dos PRs — é o `db/schema.rb` do `develop` desatualizado.

O commit `9bc8059` (mask/encrypt `EVOLUTION_HUB_API_KEY`) adicionou a migration `20260701120000_encrypt_evolution_hub_api_key_at_rest` **sem dumpar o `schema.rb`** — o schema ficou em `2026_06_25_190000`. Aí o `rails_helper` aborta no load com `ActiveRecord::PendingMigrationError`, e como os checks de PR rodam no ref *PR-merged-with-develop*, todos herdam o vermelho.

## Correção
Bump da versão do `schema.rb`: `2026_06_25_190000` → `2026_07_01_120000`.

A migration é **data-only** (re-salva `installation_configs` para criptografar em repouso — zero DDL), então a **estrutura do schema não muda**; só a versão precisa avançar. É idêntico ao que `db:migrate` + dump geraria (CI reclama de exatamente **1** migration pendente).

## Efeito
Destrava o check de pending-migration para este e todos os PRs de CRM. Não altera comportamento de runtime.

> Follow-up (fora deste PR): discutir prevenção — tornar o check obrigatório no `develop` (branch protection) e/ou um check dedicado de "schema atualizado" (`db:migrate` + `git diff --exit-code db/schema.rb`).

## Summary by Sourcery

Bug Fixes:
- Advance db/schema.rb version to match the latest applied migration so CI no longer reports a pending migration on CRM pull requests.