### PR TITLE
perf(crm): preload inbox.agent_bot_inbox on conversation list (EVO-1958)

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -120,7 +120,7 @@ class ConversationFinder
     # chip only appears later if some other action triggers a refetch with the
     # association eager-loaded.
     query = query.preload(
-      :inbox,
+      { inbox: :agent_bot_inbox },
       :contact,
       :assignee,
       :team,

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -147,9 +147,7 @@ class Inbox < ApplicationRecord
   end
 
   def active_bot?
-    result = agent_bot_inbox&.active?
-    Rails.logger.info "[Inbox] active_bot? - inbox_id: #{id}, agent_bot_inbox present?: #{agent_bot_inbox.present?}, agent_bot_inbox&.active?: #{agent_bot_inbox&.active?}, result: #{result}"
-    result
+    agent_bot_inbox&.active?
   end
 
   def inbox_type

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -26,10 +26,11 @@ RSpec.describe ConversationFinder do
   end
 
   # EVO-1958: `agent_bot_inbox` must be preloaded off `inbox` so the serializer
-  # can resolve `Inbox#active_bot?` (called per conversation in the list serializer,
-  # see conversation_serializer.rb:84) in memory rather than firing a per-inbox
-  # SELECT against agent_bot_inboxes.
-  describe '#perform preload' do
+  # can resolve `Inbox#active_bot?` (called per conversation in the list
+  # serializer, see conversation_serializer.rb:84) in memory rather than firing
+  # a per-inbox SELECT against agent_bot_inboxes — and without re-emitting the
+  # per-conversation INFO log that used to live in `Inbox#active_bot?`.
+  describe 'conversation list eager-loading (agent_bot_inbox)' do
     let(:channel) { Channel::Api.create! }
     let(:inbox) { Inbox.create!(name: 'Inbox', channel: channel) }
     let(:contact) { Contact.create!(name: 'C', email: "c-#{SecureRandom.hex(4)}@example.com") }
@@ -44,15 +45,55 @@ RSpec.describe ConversationFinder do
       allow(user).to receive(:administrator?).and_return(true)
     end
 
+    # Build the relation directly instead of via #perform: #perform wraps the
+    # query in `rescue StandardError => empty_result`, so a broken/renamed
+    # preload would be swallowed and surface only as a misleading
+    # "expected [] not to be empty". Loading the relation here lets an
+    # AssociationNotFound raise loudly at its real site.
+    #
+    # status: 'all' bypasses the status filter — the active AgentBotInbox flips
+    # new conversations to `pending` via Inbox#default_conversation_status_value,
+    # so the default 'open' filter would return [].
+    def list_conversations
+      described_class.new(user, { status: 'all' }).send(:build_conversations_query).to_a
+    end
+
     it 'eager-loads inbox.agent_bot_inbox on the conversation list query' do
-      # status: 'all' bypasses the status filter — the setup creates an active
-      # AgentBotInbox which flips new conversations to `pending` via
-      # Inbox#default_conversation_status_value, so filtering by 'open' returns [].
-      result = described_class.new(user, { status: 'all' }).perform
-      conversations = result[:conversations].to_a
+      conversations = list_conversations
 
       expect(conversations).not_to be_empty
       expect(conversations.first.inbox.association(:agent_bot_inbox).loaded?).to be(true)
+    end
+
+    # AC1, literally: reading `active_bot?` per conversation (as the serializer
+    # does) must not fire a SELECT against agent_bot_inboxes once preloaded.
+    it 'reads active_bot? without firing a per-inbox agent_bot_inboxes query' do
+      conversations = list_conversations
+      expect(conversations).not_to be_empty
+
+      agent_bot_inbox_queries = []
+      subscriber = lambda do |*args|
+        sql = args.last[:sql]
+        agent_bot_inbox_queries << sql if sql =~ /agent_bot_inboxes/i
+      end
+
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') do
+        conversations.each { |conversation| conversation.inbox.active_bot? }
+      end
+
+      expect(agent_bot_inbox_queries).to be_empty
+    end
+
+    # AC2: reading `active_bot?` in the list path must not re-emit the debug
+    # INFO log that previously fired once per conversation on every list render.
+    it 'does not re-emit the per-conversation active_bot? INFO log' do
+      conversations = list_conversations
+      expect(conversations).not_to be_empty
+
+      allow(Rails.logger).to receive(:info).and_call_original
+      conversations.each { |conversation| conversation.inbox.active_bot? }
+
+      expect(Rails.logger).not_to have_received(:info).with(/\[Inbox\] active_bot\?/)
     end
   end
 

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -25,6 +25,37 @@ RSpec.describe ConversationFinder do
     end
   end
 
+  # EVO-1958: `agent_bot_inbox` must be preloaded off `inbox` so the serializer
+  # can resolve `Inbox#active_bot?` (called per conversation in the list serializer,
+  # see conversation_serializer.rb:84) in memory rather than firing a per-inbox
+  # SELECT against agent_bot_inboxes.
+  describe '#perform preload' do
+    let(:channel) { Channel::Api.create! }
+    let(:inbox) { Inbox.create!(name: 'Inbox', channel: channel) }
+    let(:contact) { Contact.create!(name: 'C', email: "c-#{SecureRandom.hex(4)}@example.com") }
+    let(:contact_inbox) { ContactInbox.create!(contact: contact, inbox: inbox, source_id: SecureRandom.hex(8)) }
+    let(:user) { User.create!(name: 'Admin', email: "a-#{SecureRandom.hex(4)}@example.com") }
+
+    before do
+      AgentBot.create!(name: 'Bot', outgoing_url: 'https://example.test/bot').tap do |bot|
+        AgentBotInbox.create!(agent_bot: bot, inbox: inbox, status: :active)
+      end
+      Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+      allow(user).to receive(:administrator?).and_return(true)
+    end
+
+    it 'eager-loads inbox.agent_bot_inbox on the conversation list query' do
+      # status: 'all' bypasses the status filter — the setup creates an active
+      # AgentBotInbox which flips new conversations to `pending` via
+      # Inbox#default_conversation_status_value, so filtering by 'open' returns [].
+      result = described_class.new(user, { status: 'all' }).perform
+      conversations = result[:conversations].to_a
+
+      expect(conversations).not_to be_empty
+      expect(conversations.first.inbox.association(:agent_bot_inbox).loaded?).to be(true)
+    end
+  end
+
   describe '#apply_permission_filter' do
     let(:relation) { double('Relation') }
 


### PR DESCRIPTION
## Summary
- ConversationFinder passa a fazer `preload({ inbox: :agent_bot_inbox }, ...)` no `build_conversations_query`, para que `ConversationSerializer` (chamado por conversa via payload de inbox) resolva `Inbox#active_bot?` em memória em vez de disparar 1 SELECT por inbox no `agent_bot_inboxes`.
- Remove `Rails.logger.info` de `Inbox#active_bot?` que estava sendo emitido 1x por conversa em cada request de lista, poluindo os logs de prod.
- Adiciona spec de regressão que verifica `inbox.association(:agent_bot_inbox).loaded?` sobre a relation retornada pelo finder.

## Test plan
- [x] `docker exec evo-crm-community-evo-crm-1 bundle exec rspec spec/finders/conversation_finder_spec.rb` — 5/5 green
- [ ] Validar em dev que a página `/conversations` não emite mais o log `[Inbox] active_bot?`
- [ ] Confirmar via `rack-mini-profiler`/log que a query `SELECT ... FROM agent_bot_inboxes` some da lista

## Linked Issue
- EVO-1958

## Summary by Sourcery

Preload inbox agent bot associations on conversation listing to avoid per-inbox queries and clean up related logging.

Enhancements:
- Ensure conversation queries eager-load inbox.agent_bot_inbox so serializers can resolve active bot status without extra database calls.
- Remove verbose logging from Inbox#active_bot? to reduce noise in production logs.

Tests:
- Add regression spec asserting that inbox.agent_bot_inbox is preloaded in ConversationFinder results.