### PR TITLE
fix(media): default ActiveStorage to :local and fall back when bucket missing (EVO-1961)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,7 +113,13 @@ MANDRILL_INGRESS_API_KEY=
 # For Postmark
 # Ensure the 'Include raw email content in JSON payload' checkbox is selected in the inbound webhook section.
 # Storage
-ACTIVE_STORAGE_SERVICE=s3_compatible
+# `local` = disk-backed (default, works out-of-the-box for self-hosted).
+# `s3_compatible` / `amazon` / `google` / `microsoft` = external buckets.
+# When `local`, set ACTIVE_STORAGE_URL to a host reachable by both the browser
+# and sibling containers (Evolution API, Sidekiq) — otherwise media URLs will
+# resolve to the container's internal hostname and render as grey blobs.
+ACTIVE_STORAGE_SERVICE=local
+# ACTIVE_STORAGE_URL=http://localhost:3000
 # Amazon S3
 # documentation: https://www.chatwoot.com/docs/configuring-s3-bucket-as-cloud-storage
 STORAGE_BUCKET_NAME=

--- a/config/initializers/active_storage_dynamic_service.rb
+++ b/config/initializers/active_storage_dynamic_service.rb
@@ -14,6 +14,8 @@ Rails.application.config.after_initialize do
   next if ActiveStorage::Blob.respond_to?(:_static_service)
 
   ActiveStorage::Blob.class_eval do
+    BUCKET_BACKED_SERVICES = %w[s3_compatible amazon google microsoft].freeze
+
     class << self
       alias_method :_static_service, :service
 
@@ -22,8 +24,18 @@ Rails.application.config.after_initialize do
           'ACTIVE_STORAGE_SERVICE',
           ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')
         ).presence || 'local'
+
+        # Fail-safe: if a bucket-backed service is selected but no bucket is
+        # configured, aws-sdk raises at every request and self-hosted stacks
+        # become unusable. Fall back to :local so the CRM stays functional
+        # instead of crashing (EVO-1961).
+        if BUCKET_BACKED_SERVICES.include?(service_name) && !bucket_configured?(service_name)
+          Rails.logger.warn("[ActiveStorage] '#{service_name}' selected but bucket not configured; falling back to :local")
+          service_name = 'local'
+        end
+
         key = service_name.to_sym
-        resolved = respond_to?(:services) && services[key]
+        resolved = respond_to?(:services) ? services.fetch(key) { nil } : nil
         unless resolved
           Rails.logger.warn("[ActiveStorage] service '#{service_name}' not registered (built at boot); falling back to boot-time default")
         end
@@ -31,6 +43,18 @@ Rails.application.config.after_initialize do
       rescue StandardError => e
         Rails.logger.warn("[ActiveStorage] failed to resolve dynamic service: #{e.message}; falling back to boot-time default")
         _static_service
+      end
+
+      private
+
+      def bucket_configured?(service_name)
+        bucket_env = service_name == 'amazon' ? 'S3_BUCKET_NAME' : 'STORAGE_BUCKET_NAME'
+        bucket = begin
+          GlobalConfigService.load(bucket_env, ENV.fetch(bucket_env, nil))
+        rescue StandardError
+          ENV.fetch(bucket_env, nil)
+        end
+        bucket.to_s.strip.present?
       end
     end
   end

--- a/config/initializers/active_storage_dynamic_service.rb
+++ b/config/initializers/active_storage_dynamic_service.rb
@@ -14,7 +14,18 @@ Rails.application.config.after_initialize do
   next if ActiveStorage::Blob.respond_to?(:_static_service)
 
   ActiveStorage::Blob.class_eval do
-    BUCKET_BACKED_SERVICES = %w[s3_compatible amazon google microsoft].freeze
+    # Each bucket-backed service reads its bucket/container name from a
+    # DIFFERENT ENV/GlobalConfig key (see config/storage.yml). Map them
+    # explicitly so the fail-safe below checks the right key per provider —
+    # e.g. google uses GCS_BUCKET and microsoft uses AZURE_STORAGE_CONTAINER,
+    # NOT STORAGE_BUCKET_NAME.
+    BUCKET_ENV_BY_SERVICE = {
+      's3_compatible' => 'STORAGE_BUCKET_NAME',
+      'amazon'        => 'S3_BUCKET_NAME',
+      'google'        => 'GCS_BUCKET',
+      'microsoft'     => 'AZURE_STORAGE_CONTAINER'
+    }.freeze
+    BUCKET_BACKED_SERVICES = BUCKET_ENV_BY_SERVICE.keys.freeze
 
     class << self
       alias_method :_static_service, :service
@@ -30,7 +41,7 @@ Rails.application.config.after_initialize do
         # become unusable. Fall back to :local so the CRM stays functional
         # instead of crashing (EVO-1961).
         if BUCKET_BACKED_SERVICES.include?(service_name) && !bucket_configured?(service_name)
-          Rails.logger.warn("[ActiveStorage] '#{service_name}' selected but bucket not configured; falling back to :local")
+          warn_bucket_fallback(service_name)
           service_name = 'local'
         end
 
@@ -48,13 +59,26 @@ Rails.application.config.after_initialize do
       private
 
       def bucket_configured?(service_name)
-        bucket_env = service_name == 'amazon' ? 'S3_BUCKET_NAME' : 'STORAGE_BUCKET_NAME'
+        bucket_env = BUCKET_ENV_BY_SERVICE[service_name]
+        # Unknown/unmapped service: don't second-guess it — let it resolve.
+        return true if bucket_env.nil?
+
         bucket = begin
           GlobalConfigService.load(bucket_env, ENV.fetch(bucket_env, nil))
         rescue StandardError
           ENV.fetch(bucket_env, nil)
         end
         bucket.to_s.strip.present?
+      end
+
+      # `service` is a hot path — it runs for every attachment URL and blob
+      # operation — so warning on each call would flood the logs on a
+      # media-heavy page. Only warn when the offending service changes.
+      def warn_bucket_fallback(service_name)
+        return if @warned_bucket_fallback == service_name
+
+        @warned_bucket_fallback = service_name
+        Rails.logger.warn("[ActiveStorage] '#{service_name}' selected but bucket not configured; falling back to :local")
       end
     end
   end

--- a/spec/initializers/active_storage_dynamic_service_spec.rb
+++ b/spec/initializers/active_storage_dynamic_service_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-1961: the dynamic service resolver must keep the CRM usable when a
+# bucket-backed provider is selected but not fully configured. Instead of
+# letting aws-sdk raise on every request (which is what makes self-hosted
+# stacks unusable without S3), we fall back to :local and warn.
+RSpec.describe 'ActiveStorage dynamic service resolver' do
+  around do |example|
+    original_service_env = ENV['ACTIVE_STORAGE_SERVICE']
+    original_bucket_env = ENV['STORAGE_BUCKET_NAME']
+    original_amazon_bucket_env = ENV['S3_BUCKET_NAME']
+    example.run
+  ensure
+    ENV['ACTIVE_STORAGE_SERVICE'] = original_service_env
+    ENV['STORAGE_BUCKET_NAME'] = original_bucket_env
+    ENV['S3_BUCKET_NAME'] = original_amazon_bucket_env
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load) do |key, default|
+      ENV.fetch(key.to_s, default)
+    end
+  end
+
+  describe 'bucket-backed fallback (AC4)' do
+    it 'falls back to :local when s3_compatible is selected but STORAGE_BUCKET_NAME is blank' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 's3_compatible'
+      ENV['STORAGE_BUCKET_NAME'] = ''
+
+      expect(Rails.logger).to receive(:warn).with(/'s3_compatible' selected but bucket not configured/)
+      expect(ActiveStorage::Blob.service).to eq(ActiveStorage::Blob.services.fetch(:local))
+    end
+
+    it 'falls back to :local when amazon is selected but S3_BUCKET_NAME is blank' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 'amazon'
+      ENV['S3_BUCKET_NAME'] = nil
+      ENV['STORAGE_BUCKET_NAME'] = nil
+
+      expect(Rails.logger).to receive(:warn).with(/'amazon' selected but bucket not configured/)
+      expect(ActiveStorage::Blob.service).to eq(ActiveStorage::Blob.services.fetch(:local))
+    end
+
+    it 'keeps s3_compatible when bucket is configured (does not fall back)' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 's3_compatible'
+      ENV['STORAGE_BUCKET_NAME'] = 'my-bucket'
+
+      # Stub the registry so we don't lazy-build a real S3 client at test time.
+      fake_s3 = instance_double(ActiveStorage::Service, name: :s3_compatible)
+      allow(ActiveStorage::Blob.services).to receive(:fetch).with(:s3_compatible).and_return(fake_s3)
+
+      expect(Rails.logger).not_to receive(:warn).with(/bucket not configured/)
+      expect(ActiveStorage::Blob.service.name).to eq(:s3_compatible)
+    end
+  end
+
+  describe ':local as the default (AC1)' do
+    it 'resolves :local when ACTIVE_STORAGE_SERVICE is unset' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = nil
+
+      expect(ActiveStorage::Blob.service).to eq(ActiveStorage::Blob.services.fetch(:local))
+    end
+  end
+end

--- a/spec/initializers/active_storage_dynamic_service_spec.rb
+++ b/spec/initializers/active_storage_dynamic_service_spec.rb
@@ -8,20 +8,23 @@ require 'rails_helper'
 # stacks unusable without S3), we fall back to :local and warn.
 RSpec.describe 'ActiveStorage dynamic service resolver' do
   around do |example|
-    original_service_env = ENV['ACTIVE_STORAGE_SERVICE']
-    original_bucket_env = ENV['STORAGE_BUCKET_NAME']
-    original_amazon_bucket_env = ENV['S3_BUCKET_NAME']
+    saved_env = %w[
+      ACTIVE_STORAGE_SERVICE STORAGE_BUCKET_NAME S3_BUCKET_NAME
+      GCS_BUCKET AZURE_STORAGE_CONTAINER
+    ].to_h { |k| [k, ENV[k]] }
     example.run
   ensure
-    ENV['ACTIVE_STORAGE_SERVICE'] = original_service_env
-    ENV['STORAGE_BUCKET_NAME'] = original_bucket_env
-    ENV['S3_BUCKET_NAME'] = original_amazon_bucket_env
+    saved_env.each { |k, v| v.nil? ? ENV.delete(k) : (ENV[k] = v) }
   end
 
   before do
     allow(GlobalConfigService).to receive(:load) do |key, default|
       ENV.fetch(key.to_s, default)
     end
+
+    # Reset the hot-path warn dedupe so each example observes warns cleanly,
+    # independent of ordering or state leaked from other specs.
+    ActiveStorage::Blob.instance_variable_set(:@warned_bucket_fallback, nil)
   end
 
   describe 'bucket-backed fallback (AC4)' do
@@ -42,6 +45,27 @@ RSpec.describe 'ActiveStorage dynamic service resolver' do
       expect(ActiveStorage::Blob.service).to eq(ActiveStorage::Blob.services.fetch(:local))
     end
 
+    it 'falls back to :local when google is selected but GCS_BUCKET is blank' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 'google'
+      ENV['GCS_BUCKET'] = nil
+      # A stray STORAGE_BUCKET_NAME must NOT count as a configured GCS bucket
+      # (regression guard: the old code checked the wrong key).
+      ENV['STORAGE_BUCKET_NAME'] = 'stray-value-should-be-ignored'
+
+      expect(Rails.logger).to receive(:warn).with(/'google' selected but bucket not configured/)
+      expect(ActiveStorage::Blob.service).to eq(ActiveStorage::Blob.services.fetch(:local))
+    end
+
+    it 'falls back to :local when microsoft is selected but AZURE_STORAGE_CONTAINER is blank' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 'microsoft'
+      ENV['AZURE_STORAGE_CONTAINER'] = nil
+      # Same regression guard for Azure's container key.
+      ENV['STORAGE_BUCKET_NAME'] = 'stray-value-should-be-ignored'
+
+      expect(Rails.logger).to receive(:warn).with(/'microsoft' selected but bucket not configured/)
+      expect(ActiveStorage::Blob.service).to eq(ActiveStorage::Blob.services.fetch(:local))
+    end
+
     it 'keeps s3_compatible when bucket is configured (does not fall back)' do
       ENV['ACTIVE_STORAGE_SERVICE'] = 's3_compatible'
       ENV['STORAGE_BUCKET_NAME'] = 'my-bucket'
@@ -52,6 +76,19 @@ RSpec.describe 'ActiveStorage dynamic service resolver' do
 
       expect(Rails.logger).not_to receive(:warn).with(/bucket not configured/)
       expect(ActiveStorage::Blob.service.name).to eq(:s3_compatible)
+    end
+
+    it 'keeps google when GCS_BUCKET is configured (does not fall back)' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 'google'
+      ENV['GCS_BUCKET'] = 'my-gcs-bucket'
+      ENV['STORAGE_BUCKET_NAME'] = nil
+
+      # Stub the registry so we don't lazy-build a real GCS client at test time.
+      fake_gcs = instance_double(ActiveStorage::Service, name: :google)
+      allow(ActiveStorage::Blob.services).to receive(:fetch).with(:google).and_return(fake_gcs)
+
+      expect(Rails.logger).not_to receive(:warn).with(/bucket not configured/)
+      expect(ActiveStorage::Blob.service.name).to eq(:google)
     end
   end
 


### PR DESCRIPTION
## Summary
- Trocado default do `.env.example` de `s3_compatible` → `local` para que self-hosted funcione out-of-the-box sem exigir bucket.
- Fallback defensivo no `active_storage_dynamic_service.rb`: quando service bucket-backed (`s3_compatible`/`amazon`/`google`/`microsoft`) está selecionado mas `STORAGE_BUCKET_NAME` está vazio, cai para `:local` com warn em vez de crashar aws-sdk a cada request.
- Fix de bug latente do EVO-1747 F1: `services[key]` sempre raise no Rails 7.1 (Registry não tem `[]`); trocado para `services.fetch(key){ nil }`. Dynamic switching via Admin Settings agora realmente funciona.
- 4 examples novos cobrindo AC1 (default local) e AC4 (fallback bucket vazio).

## Root cause
`.env.example` shippava `ACTIVE_STORAGE_SERVICE=s3_compatible` como default. Usuário self-hosted que clonasse e subisse sem tocar em `STORAGE_BUCKET_NAME` caía num loop de erros aws-sdk — CRM inutilizável sem antes configurar S3. Runtime já suportava `local` (`environments/*.rb` + `installation_config.yml` seed), só a config de exemplo estava contrária.

## Validation
- `evo-ai-crm-community: docker exec evo-crm-community-evo-crm-1 bundle exec rspec spec/initializers/active_storage_dynamic_service_spec.rb` → 4/4
- `evo-ai-crm-community: docker exec evo-crm-community-evo-crm-1 bundle exec rspec spec/services/config_test/storage_test_service_spec.rb` → 16/16 (regressão EVO-1747)
- Runtime smoke no container: 4 cenários (`nil`, `s3_compatible+empty`, `amazon+empty`, `local`) resolvem para `local` corretamente
- Smoke manual: stack local com `SERVICE=local` enviou e recebeu mídia sem grey blob

## Changed Files
- `.env.example`
- `config/initializers/active_storage_dynamic_service.rb`
- `spec/initializers/active_storage_dynamic_service_spec.rb`

## Linked Issue
- EVO-1961

## Summary by Sourcery

Ensure ActiveStorage uses a safe default service and remains functional when bucket-backed storage is misconfigured.

Bug Fixes:
- Fix dynamic ActiveStorage service lookup so switching services at runtime works correctly under Rails 7.1.

Enhancements:
- Default the example ActiveStorage configuration to the local service to make self-hosted setups work out of the box.
- Add a defensive fallback so bucket-backed ActiveStorage services automatically revert to :local when no bucket is configured, logging a warning instead of raising on each request.

Tests:
- Add specs covering the default local ActiveStorage service and the fallback behavior when bucket-backed services lack a configured bucket.

Chores:
- Update .env.example to reflect the new local-first ActiveStorage default.