### PR TITLE
fix(media): serve attachments via ActiveStorage proxy for S3/MinIO (EVO-2006)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,10 +115,16 @@ MANDRILL_INGRESS_API_KEY=
 # Storage
 # `local` = disk-backed (default, works out-of-the-box for self-hosted).
 # `s3_compatible` / `amazon` / `google` / `microsoft` = external buckets.
-# When `local`, set ACTIVE_STORAGE_URL to a host reachable by both the browser
-# and sibling containers (Evolution API, Sidekiq) — otherwise media URLs will
-# resolve to the container's internal hostname and render as grey blobs.
+# Attachment delivery mode (EVO-2006):
+# `proxy` (default) = the app serves the file bytes; media URLs use the app
+#   host (BACKEND_URL), so the storage endpoint (S3/MinIO/disk) stays private.
+# `redirect` = legacy behavior: media URLs redirect to the storage service,
+#   which then must be reachable by browsers and sibling containers.
+# ATTACHMENT_DELIVERY=proxy
 ACTIVE_STORAGE_SERVICE=local
+# Optional host override for media URLs handed to sibling containers
+# (Evolution API / Evolution Go) and for redirect-mode DiskService URLs —
+# e.g. when they cannot resolve BACKEND_URL (http://host.docker.internal:3000).
 # ACTIVE_STORAGE_URL=http://localhost:3000
 # Amazon S3
 # documentation: https://www.chatwoot.com/docs/configuring-s3-bucket-as-cloud-storage

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -53,20 +53,27 @@ class Attachment < ApplicationRecord
     base_data.merge(metadata_for_file_type)
   end
 
-  # NOTE: the URl returned does a 301 redirect to the actual file
+  # EVO-2006: com `resolve_model_to_route = :rails_storage_proxy`, esta URL aponta
+  # para a app (/rails/active_storage/.../proxy/...), que le do storage e SERVE o
+  # arquivo direto. Assim o endpoint interno do S3/MinIO nunca chega ao browser —
+  # ao contrario do redirect, cujo 2o hop expunha a presigned do STORAGE_ENDPOINT.
   def file_url
     return '' unless file.attached?
 
     BlobUrlOptions.with_scoped_url_options { url_for(file) }
   end
 
-  # NOTE: for External services use this methods since redirect doesn't work effectively in a lot of cases
+  # EVO-2006: servido pela app via proxy (mesma rota do file_url). Antes usava
+  # `file.blob.url`, que com S3/MinIO gera uma presigned do endpoint interno
+  # (host inalcancavel pelo browser e nao reescrevivel — faz parte da assinatura
+  # SigV4). Com proxy, o download passa sempre pelo host publico da app.
   def download_url
     return '' unless file.attached?
 
-    BlobUrlOptions.with_scoped_url_options { file.blob.url }
+    BlobUrlOptions.with_scoped_url_options { url_for(file) }
   end
 
+  # EVO-2006: representation tambem via proxy (url_for + resolve_model_to_route).
   def thumb_url
     if file.attached? && file.representable?
       BlobUrlOptions.with_scoped_url_options { url_for(file.representation(resize_to_fill: [250, nil])) }

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -53,30 +53,27 @@ class Attachment < ApplicationRecord
     base_data.merge(metadata_for_file_type)
   end
 
-  # EVO-2006: com `resolve_model_to_route = :rails_storage_proxy`, esta URL aponta
-  # para a app (/rails/active_storage/.../proxy/...), que le do storage e SERVE o
-  # arquivo direto. Assim o endpoint interno do S3/MinIO nunca chega ao browser —
-  # ao contrario do redirect, cujo 2o hop expunha a presigned do STORAGE_ENDPOINT.
+  # Attachment URLs route through ActiveStorage's resolve_model_to_route
+  # (:rails_storage_proxy by default — see config/environments): the app serves
+  # the bytes, so the storage endpoint (S3/MinIO/Disk) never reaches the
+  # browser (EVO-2006). Hosts come from routes.default_url_options (BACKEND_URL);
+  # ActiveStorage::Current.url_options / ACTIVE_STORAGE_URL do not apply to
+  # route helpers, so these URLs must not be wrapped in BlobUrlOptions scoping.
   def file_url
     return '' unless file.attached?
 
-    BlobUrlOptions.with_scoped_url_options { url_for(file) }
+    url_for(file)
   end
 
-  # EVO-2006: servido pela app via proxy (mesma rota do file_url). Antes usava
-  # `file.blob.url`, que com S3/MinIO gera uma presigned do endpoint interno
-  # (host inalcancavel pelo browser e nao reescrevivel — faz parte da assinatura
-  # SigV4). Com proxy, o download passa sempre pelo host publico da app.
   def download_url
     return '' unless file.attached?
 
-    BlobUrlOptions.with_scoped_url_options { url_for(file) }
+    url_for(file)
   end
 
-  # EVO-2006: representation tambem via proxy (url_for + resolve_model_to_route).
   def thumb_url
     if file.attached? && file.representable?
-      BlobUrlOptions.with_scoped_url_options { url_for(file.representation(resize_to_fill: [250, nil])) }
+      url_for(file.representation(resize_to_fill: [250, nil]))
     else
       ''
     end

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -57,7 +57,7 @@ class AutomationRule < ApplicationRecord
         id: file.id,
         automation_rule_id: id,
         file_type: file.content_type,
-        file_url: BlobUrlOptions.with_scoped_url_options { url_for(file) },
+        file_url: url_for(file),
         blob_id: file.blob_id,
         filename: file.filename.to_s
       }

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -55,7 +55,7 @@ class Macro < ApplicationRecord
         id: file.id,
         macro_id: id,
         file_type: file.content_type,
-        file_url: BlobUrlOptions.with_scoped_url_options { url_for(file) },
+        file_url: url_for(file),
         blob_id: file.blob_id,
         filename: file.filename.to_s
       }

--- a/app/services/concerns/blob_url_options.rb
+++ b/app/services/concerns/blob_url_options.rb
@@ -1,11 +1,14 @@
 # Resolves effective ActiveStorage URL options, honoring ENV['ACTIVE_STORAGE_URL']
-# when present so generated URLs (Attachment#file_url/#thumb_url, DiskService
-# signed URLs, etc.) target a host reachable from the consumer.
+# when present so generated URLs target a host reachable from the consumer.
+#
+# CAUTION: ActiveStorage::Current.url_options (with_scoped_url_options) only
+# affects service-generated URLs (blob.url on DiskService). Rails route helpers
+# (url_for, rails_storage_proxy_url) ignore it — pass effective_url_options as
+# explicit route options instead.
 #
 # Used by:
-# - Browser-facing model URL builders (Attachment#file_url/#thumb_url)
-# - Macro / AutomationRule file previews (Macro#file_base_data, AutomationRule#file_base_data)
-# - Sidekiq paths that hand DiskService URLs to external services (Evolution API / Evolution Go)
+# - Outbound media URLs handed to Evolution API / Evolution Go (outbound_media_url)
+# - Redirect-mode DiskService signed URLs (with_scoped_url_options around blob.url)
 module BlobUrlOptions
   module_function
 
@@ -34,5 +37,26 @@ module BlobUrlOptions
     yield
   ensure
     ActiveStorage::Current.url_options = previous
+  end
+
+  # Media URL handed to external providers (Evolution API / Evolution Go).
+  #
+  # Proxy mode (default): app-served route with an EXPIRING signed id — the
+  # storage endpoint stays private and the provider only needs to reach the
+  # app host (ACTIVE_STORAGE_URL overrides it; falls back to BACKEND_URL).
+  # Redirect mode (ATTACHMENT_DELIVERY=redirect): presigned storage URL, which
+  # requires the storage host itself to be reachable by the provider — with
+  # S3/MinIO the host is part of the SigV4 signature and cannot be rewritten.
+  #
+  # The TTL is 15 minutes (not the Rails default of 5) so slow providers have
+  # time to fetch large video/PDF files; expired links return 404.
+  def outbound_media_url(blob, expires_in: 15.minutes)
+    if ActiveStorage.resolve_model_to_route == :rails_storage_proxy
+      Rails.application.routes.url_helpers.rails_storage_proxy_url(
+        blob, expires_in: expires_in, **effective_url_options
+      )
+    else
+      with_scoped_url_options { blob.url(expires_in: expires_in) }
+    end
   end
 end

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -406,8 +406,7 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
 
     Rails.logger.info "[Evolution Go] Sending #{attachment.file_type} message to #{phone_number}"
 
-    # Use direct S3 URL for media
-    media_url = generate_direct_s3_url(attachment)
+    media_url = generate_media_url(attachment)
 
     # Map file types to Evolution Go types
     evolution_go_type = map_file_type_to_evolution_go(attachment.file_type)
@@ -471,29 +470,17 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
     end
   end
 
-  def generate_direct_s3_url(attachment)
+  def generate_media_url(attachment)
     return attachment.file_url unless attachment.file.attached?
 
-    # Always use a signed URL — never the bare object URL.
-    #
-    # Private buckets (Cloudflare R2, S3 restricted ACLs, MinIO) return an XML
-    # error to unauthenticated GETs; Evolution Go then rejects the upload with
-    # "Invalid file format: 'text/xml; charset=utf-8'".
-    #
-    # TTL is set to 15 minutes instead of the Rails default of 5 minutes because
-    # Evolution Go may take several minutes to fetch large video/PDF files under
-    # provider load. A 5-minute window is too tight and causes silent delivery
-    # failures when the provider is slow.
-    #
-    # ACTIVE_STORAGE_URL overrides the host used in DiskService signed URLs so
-    # that external containers (Evolution Go) can actually reach the file.
-    # Without it, localhost:3000 resolves to the caller's container, not the CRM.
-    # Scoped per-call so the override does not leak to other ActiveStorage calls
-    # within the same request/job.
-    signed_url = BlobUrlOptions.with_scoped_url_options { attachment.file.blob.url(expires_in: 15.minutes) }
+    # App-proxied by default (EVO-2006): a presigned S3/MinIO URL carries the
+    # STORAGE_ENDPOINT host inside the SigV4 signature, so an internal endpoint
+    # is unreachable by the Evolution Go container and cannot be rewritten.
+    # See BlobUrlOptions.outbound_media_url for the delivery-mode/TTL rules.
+    media_url = BlobUrlOptions.outbound_media_url(attachment.file.blob)
 
-    Rails.logger.info "[Evolution Go S3] Using signed URL with 15-minute TTL (host: #{BlobUrlOptions.effective_url_options[:host]})"
-    signed_url
+    Rails.logger.info "[Evolution Go] Outbound media URL with 15-minute TTL (host: #{BlobUrlOptions.effective_url_options[:host]})"
+    media_url
   end
 
   def build_quoted_info(message)

--- a/app/services/whatsapp/providers/evolution_service.rb
+++ b/app/services/whatsapp/providers/evolution_service.rb
@@ -453,10 +453,9 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
   def send_media_message(phone_number, message, endpoint)
     attachment = message.attachments.first
 
-    # Use direct S3 URL for media
-    media_url = generate_direct_s3_url(attachment)
+    media_url = generate_media_url(attachment)
 
-    Rails.logger.info "[Evolution Media] Sending #{attachment.file_type} with direct URL: #{media_url}"
+    Rails.logger.info "[Evolution Media] Sending #{attachment.file_type} with URL: #{media_url}"
 
     response = HTTParty.post(
       "#{api_base_path}/message/#{endpoint}/#{instance_name}",
@@ -502,11 +501,9 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
   end
 
   def send_audio_with_direct_url(phone_number, attachment)
-    # Generate direct public URL for S3 bucket
-    audio_url = generate_direct_s3_url(attachment)
+    audio_url = generate_media_url(attachment)
 
-    # Debug log
-    Rails.logger.info "[Evolution Audio] Trying direct URL: #{audio_url}"
+    Rails.logger.info "[Evolution Audio] Trying URL: #{audio_url}"
 
     body_data = {
       number: phone_number.delete('+'),
@@ -528,24 +525,17 @@ class Whatsapp::Providers::EvolutionService < Whatsapp::Providers::BaseService
     process_response(response)
   end
 
-  def generate_direct_s3_url(attachment)
+  def generate_media_url(attachment)
     return attachment.file_url unless attachment.file.attached?
 
-    # Always use a signed URL — never the bare object URL.
-    # Private buckets (Cloudflare R2, S3 restricted ACLs, MinIO) return an XML
-    # error to unauthenticated GETs; Evolution API then rejects with a MIME-type
-    # error. TTL is 15 minutes (instead of the Rails default of 5 minutes) so
-    # slow providers have enough time to fetch large video/PDF files.
-    #
-    # ACTIVE_STORAGE_URL overrides the host used in DiskService signed URLs so
-    # that external containers (Evolution API, Evolution Go) can actually reach
-    # the file. Without it, localhost:3000 resolves to the caller's container,
-    # not the CRM Rails app. Scoped per-call so the override does not leak to
-    # other ActiveStorage calls within the same request/job.
-    signed_url = BlobUrlOptions.with_scoped_url_options { attachment.file.blob.url(expires_in: 15.minutes) }
+    # App-proxied by default (EVO-2006): a presigned S3/MinIO URL carries the
+    # STORAGE_ENDPOINT host inside the SigV4 signature, so an internal endpoint
+    # is unreachable by the Evolution API container and cannot be rewritten.
+    # See BlobUrlOptions.outbound_media_url for the delivery-mode/TTL rules.
+    media_url = BlobUrlOptions.outbound_media_url(attachment.file.blob)
 
-    Rails.logger.info "[Evolution S3] Using signed URL with 15-minute TTL (host: #{BlobUrlOptions.effective_url_options[:host]})"
-    signed_url
+    Rails.logger.info "[Evolution Media] Outbound media URL with 15-minute TTL (host: #{BlobUrlOptions.effective_url_options[:host]})"
+    media_url
   end
 
   def send_audio_with_base64(phone_number, attachment)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,9 +41,11 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local').to_sym
-  # EVO-2006: serve anexos via proxy (a app le do storage e serve os bytes), para
-  # nao expor o endpoint interno do S3/MinIO nem depender de reescrever presigned.
-  config.active_storage.resolve_model_to_route = :rails_storage_proxy
+  # Attachments are served by the app (ActiveStorage proxy) so the internal
+  # S3/MinIO endpoint never reaches the browser (EVO-2006).
+  # ATTACHMENT_DELIVERY=redirect rolls back to storage redirects.
+  config.active_storage.resolve_model_to_route =
+    ENV.fetch('ATTACHMENT_DELIVERY', 'proxy').casecmp('redirect').zero? ? :rails_storage_redirect : :rails_storage_proxy
 
   config.active_job.queue_adapter = :sidekiq
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,6 +41,9 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local').to_sym
+  # EVO-2006: serve anexos via proxy (a app le do storage e serve os bytes), para
+  # nao expor o endpoint interno do S3/MinIO nem depender de reescrever presigned.
+  config.active_storage.resolve_model_to_route = :rails_storage_proxy
 
   config.active_job.queue_adapter = :sidekiq
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,10 +40,16 @@ Rails.application.configure do
     ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')
   end.to_sym
 
-  # EVO-2006: serve anexos via proxy (a app le do storage e serve os bytes), para
-  # nao expor o endpoint interno do S3/MinIO nem depender de reescrever presigned
-  # (o host faz parte da assinatura SigV4). Vale p/ browser e containers irmaos.
-  config.active_storage.resolve_model_to_route = :rails_storage_proxy
+  # Attachments are served by the app (ActiveStorage proxy) so the internal
+  # S3/MinIO endpoint never reaches the browser — presigned URLs embed the host
+  # in the SigV4 signature and cannot be rewritten (EVO-2006).
+  # ATTACHMENT_DELIVERY=redirect rolls back to storage redirects (requires a
+  # storage host reachable by browsers and sibling containers).
+  # Security note: proxy blob URLs carry a permanent signed id (anyone with the
+  # link can fetch the file, same as a leaked presigned URL but without expiry);
+  # outbound URLs handed to providers keep a 15-minute TTL (BlobUrlOptions).
+  config.active_storage.resolve_model_to_route =
+    ENV.fetch('ATTACHMENT_DELIVERY', 'proxy').casecmp('redirect').zero? ? :rails_storage_redirect : :rails_storage_proxy
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = ActiveModel::Type::Boolean.new.cast(ENV.fetch('FORCE_SSL', false))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,6 +40,11 @@ Rails.application.configure do
     ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local')
   end.to_sym
 
+  # EVO-2006: serve anexos via proxy (a app le do storage e serve os bytes), para
+  # nao expor o endpoint interno do S3/MinIO nem depender de reescrever presigned
+  # (o host faz parte da assinatura SigV4). Vale p/ browser e containers irmaos.
+  config.active_storage.resolve_model_to_route = :rails_storage_proxy
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = ActiveModel::Type::Boolean.new.cast(ENV.fetch('FORCE_SSL', false))
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,9 +41,11 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local').to_sym
-  # EVO-2006: serve anexos via proxy (a app le do storage e serve os bytes), para
-  # nao expor o endpoint interno do S3/MinIO nem depender de reescrever presigned.
-  config.active_storage.resolve_model_to_route = :rails_storage_proxy
+  # Attachments are served by the app (ActiveStorage proxy) so the internal
+  # S3/MinIO endpoint never reaches the browser (EVO-2006).
+  # ATTACHMENT_DELIVERY=redirect rolls back to storage redirects.
+  config.active_storage.resolve_model_to_route =
+    ENV.fetch('ATTACHMENT_DELIVERY', 'proxy').casecmp('redirect').zero? ? :rails_storage_redirect : :rails_storage_proxy
 
   config.active_job.queue_adapter = :sidekiq
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,6 +41,9 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local').to_sym
+  # EVO-2006: serve anexos via proxy (a app le do storage e serve os bytes), para
+  # nao expor o endpoint interno do S3/MinIO nem depender de reescrever presigned.
+  config.active_storage.resolve_model_to_route = :rails_storage_proxy
 
   config.active_job.queue_adapter = :sidekiq
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,12 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # Keep attachment delivery in test aligned with dev/staging/production
+  # (proxy by default, ATTACHMENT_DELIVERY=redirect to roll back) so specs
+  # exercise the same URL generation used at runtime (EVO-2006).
+  config.active_storage.resolve_model_to_route =
+    ENV.fetch('ATTACHMENT_DELIVERY', 'proxy').casecmp('redirect').zero? ? :rails_storage_redirect : :rails_storage_proxy
+
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -16,16 +16,20 @@ Rails.application.configure do
   end
 end
 
-# Warn at boot when local storage is selected without an explicit public host.
-# Without ACTIVE_STORAGE_URL, browser-facing URLs fall back to default_url_options
-# (typically the container's internal hostname), which neither the user's browser
-# nor sibling containers (Evolution API) can resolve — leading to the "grey blob"
-# render bug and silent outbound delivery failures (EVO-1747).
+# Warn at boot when storage redirects are used with local storage and no
+# explicit public host. In redirect mode, media URLs point at the storage
+# service: DiskService falls back to default_url_options (often the container's
+# internal hostname), which neither the user's browser nor sibling containers
+# (Evolution API) can resolve — the "grey blob" render bug and silent outbound
+# delivery failures (EVO-1747). The default proxy mode (EVO-2006) serves files
+# through the app, so reachability follows BACKEND_URL and this does not apply.
 if !Rails.env.test? &&
+   ENV.fetch('ATTACHMENT_DELIVERY', 'proxy').casecmp('redirect').zero? &&
    ENV['ACTIVE_STORAGE_SERVICE'].to_s.downcase == 'local' &&
    ENV['ACTIVE_STORAGE_URL'].to_s.strip.empty?
-  Rails.logger.warn '⚠️  ACTIVE_STORAGE_SERVICE=local but ACTIVE_STORAGE_URL is not set. ' \
-                    'Inbound media will likely not render in the chat and outbound media ' \
-                    'will not be delivered. Set ACTIVE_STORAGE_URL to a host reachable by ' \
-                    'both the browser and sibling containers (see .env.example).'
+  Rails.logger.warn '⚠️  ATTACHMENT_DELIVERY=redirect with ACTIVE_STORAGE_SERVICE=local but ' \
+                    'ACTIVE_STORAGE_URL is not set. Inbound media will likely not render in ' \
+                    'the chat and outbound media will not be delivered. Set ACTIVE_STORAGE_URL ' \
+                    'to a host reachable by both the browser and sibling containers, or unset ' \
+                    'ATTACHMENT_DELIVERY to use the default proxy mode (see .env.example).'
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -99,18 +99,19 @@ RSpec.describe Attachment, type: :model do
       end
     end
 
+    # EVO-2006: download_url passou a servir via proxy (url_for + resolve_model_to_route),
+    # em vez de file.blob.url — que com S3/MinIO gerava presigned de host interno.
     context 'when file is attached' do
-      let(:blob) { double('blob') }
-      let(:file_proxy) { double('file', attached?: true, blob: blob) }
+      let(:file_proxy) { instance_double('ActiveStorage::Attached::One', attached?: true) }
 
       before { allow(attachment).to receive(:file).and_return(file_proxy) }
 
-      it 'invokes blob.url under scoped ActiveStorage::Current.url_options with ACTIVE_STORAGE_URL' do
+      it 'uses ACTIVE_STORAGE_URL host/port/protocol when set (scoped url_for/proxy)' do
         ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
         captured = {}
-        allow(blob).to receive(:url) do
+        allow(attachment).to receive(:url_for) do |_arg|
           captured.merge!(ActiveStorage::Current.url_options || {})
-          'https://media.example.com:8443/rails/active_storage/disk/signed'
+          'https://media.example.com:8443/rails/active_storage/blobs/proxy/x'
         end
         attachment.download_url
         expect(captured).to include(host: 'media.example.com', port: 8443, protocol: 'https')
@@ -122,12 +123,24 @@ RSpec.describe Attachment, type: :model do
         previous = { host: 'previous.example.com', port: 9000, protocol: 'http' }
         ActiveStorage::Current.url_options = previous
         ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
-        allow(blob).to receive(:url).and_return('ignored')
+        allow(attachment).to receive(:url_for).and_return('ignored')
         attachment.download_url
         expect(ActiveStorage::Current.url_options).to eq(previous)
       ensure
         ENV['ACTIVE_STORAGE_URL'] = nil
         ActiveStorage::Current.url_options = nil
+      end
+
+      it 'invokes url_for with exactly one positional argument and no kwargs (arity guard)' do
+        captured = { positional: [], kwargs: {} }
+        allow(attachment).to receive(:url_for) do |*args, **kwargs|
+          captured[:positional] = args
+          captured[:kwargs] = kwargs
+          'http://example/x'
+        end
+        attachment.download_url
+        expect(captured[:positional].size).to eq(1)
+        expect(captured[:kwargs]).to be_empty
       end
     end
   end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-# Regression spec for Attachment#file_url and Attachment#thumb_url honoring
-# ENV['ACTIVE_STORAGE_URL'] via the BlobUrlOptions concern (EVO-1747).
+# Attachment URL generation (EVO-1747 / EVO-2006).
 #
-# Default Rails test url_options point to localhost:3000; with ACTIVE_STORAGE_URL
-# set, the generated URL must use the override host/port/protocol so the browser
-# can reach the file when DiskService is in use.
+# file_url/download_url/thumb_url route through ActiveStorage's
+# resolve_model_to_route: proxy mode (default) serves the bytes through the
+# app so the storage endpoint stays private; ATTACHMENT_DELIVERY=redirect
+# restores storage redirects. These specs assert the URLs actually generated
+# for a real blob — route helpers ignore ActiveStorage::Current.url_options,
+# so ACTIVE_STORAGE_URL must have no effect here.
 
 begin
   require 'rails_helper'
@@ -20,186 +22,83 @@ end
 return unless defined?(Rails) && defined?(ActiveStorage::Blob)
 
 RSpec.describe Attachment, type: :model do
-  let(:attachment) { Attachment.new(file_type: :image) }
+  let(:blob) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new('attachment-bytes'),
+      filename: 'picture.png',
+      content_type: 'image/png'
+    )
+  end
+  let(:attachment) do
+    described_class.new(file_type: :image).tap { |record| record.file.attach(blob) }
+  end
 
-  # Captures whatever ActiveStorage::Current.url_options was at the moment
-  # url_for was invoked, so we can assert the override was scoped to the call.
-  def stub_url_for_capturing_options(return_value)
-    captured = {}
-    allow(attachment).to receive(:url_for) do |_arg|
-      captured.merge!(ActiveStorage::Current.url_options || {})
-      return_value
-    end
-    captured
+  def with_redirect_mode
+    previous = ActiveStorage.resolve_model_to_route
+    ActiveStorage.resolve_model_to_route = :rails_storage_redirect
+    yield
+  ensure
+    ActiveStorage.resolve_model_to_route = previous
   end
 
   describe '#file_url' do
-    context 'when file is not attached' do
-      it 'returns an empty string' do
-        expect(attachment.file_url).to eq('')
-      end
+    it 'returns an empty string when no file is attached' do
+      expect(described_class.new(file_type: :image).file_url).to eq('')
     end
 
-    context 'when file is attached' do
-      let(:file_proxy) { instance_double('ActiveStorage::Attached::One', attached?: true) }
+    it 'returns an app-served proxy URL for the blob' do
+      url = attachment.file_url
+      expect(url).to include('/rails/active_storage/blobs/proxy/')
+      expect(url).to end_with('/picture.png')
+    end
 
-      before { allow(attachment).to receive(:file).and_return(file_proxy) }
+    it 'uses the app host from routes.default_url_options' do
+      expected = Rails.application.routes.url_helpers.rails_storage_proxy_url(
+        blob, **Rails.application.routes.default_url_options
+      )
+      expect(attachment.file_url).to eq(expected)
+    end
 
-      it "uses default_url_options when ENV['ACTIVE_STORAGE_URL'] is blank" do
-        ENV['ACTIVE_STORAGE_URL'] = nil
-        captured = stub_url_for_capturing_options('http://localhost:3000/rails/active_storage/blobs/test')
-        attachment.file_url
-        expect(captured[:host]).to eq(Rails.application.routes.default_url_options[:host])
-      end
+    it 'is not affected by ACTIVE_STORAGE_URL (route helpers ignore Current.url_options)' do
+      base = attachment.file_url
+      ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+      expect(attachment.file_url).to eq(base)
+    ensure
+      ENV['ACTIVE_STORAGE_URL'] = nil
+    end
 
-      it 'uses ACTIVE_STORAGE_URL host/port/protocol when set' do
-        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
-        captured = stub_url_for_capturing_options('https://media.example.com:8443/rails/active_storage/blobs/test')
-        attachment.file_url
-        expect(captured).to include(host: 'media.example.com', port: 8443, protocol: 'https')
-      ensure
-        ENV['ACTIVE_STORAGE_URL'] = nil
-      end
-
-      it 'restores previous ActiveStorage::Current.url_options after the call' do
-        previous = { host: 'previous.example.com', port: 9000, protocol: 'http' }
-        ActiveStorage::Current.url_options = previous
-        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
-        allow(attachment).to receive(:url_for).and_return('ignored')
-        attachment.file_url
-        expect(ActiveStorage::Current.url_options).to eq(previous)
-      ensure
-        ENV['ACTIVE_STORAGE_URL'] = nil
-        ActiveStorage::Current.url_options = nil
-      end
-
-      # Regression guard: the previous implementation called url_for(file, **opts)
-      # which raised ArgumentError ("wrong number of arguments (given 2, expected 0..1)")
-      # at runtime because url_for has arity 0..1. Any future refactor that
-      # reintroduces extra positional/keyword arguments must break this spec.
-      it 'invokes url_for with exactly one positional argument and no kwargs (arity guard)' do
-        captured = { positional: [], kwargs: {} }
-        allow(attachment).to receive(:url_for) do |*args, **kwargs|
-          captured[:positional] = args
-          captured[:kwargs] = kwargs
-          'http://example/x'
-        end
-        attachment.file_url
-        expect(captured[:positional].size).to eq(1)
-        expect(captured[:kwargs]).to be_empty
+    it 'falls back to a redirect URL when ATTACHMENT_DELIVERY=redirect' do
+      with_redirect_mode do
+        expect(attachment.file_url).to include('/rails/active_storage/blobs/redirect/')
       end
     end
   end
 
   describe '#download_url' do
-    context 'when file is not attached' do
-      it 'returns an empty string' do
-        allow(attachment).to receive(:file).and_return(double('file', attached?: false))
-        expect(attachment.download_url).to eq('')
-      end
+    it 'returns an empty string when no file is attached' do
+      expect(described_class.new(file_type: :image).download_url).to eq('')
     end
 
-    # EVO-2006: download_url passou a servir via proxy (url_for + resolve_model_to_route),
-    # em vez de file.blob.url — que com S3/MinIO gerava presigned de host interno.
-    context 'when file is attached' do
-      let(:file_proxy) { instance_double('ActiveStorage::Attached::One', attached?: true) }
-
-      before { allow(attachment).to receive(:file).and_return(file_proxy) }
-
-      it 'uses ACTIVE_STORAGE_URL host/port/protocol when set (scoped url_for/proxy)' do
-        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
-        captured = {}
-        allow(attachment).to receive(:url_for) do |_arg|
-          captured.merge!(ActiveStorage::Current.url_options || {})
-          'https://media.example.com:8443/rails/active_storage/blobs/proxy/x'
-        end
-        attachment.download_url
-        expect(captured).to include(host: 'media.example.com', port: 8443, protocol: 'https')
-      ensure
-        ENV['ACTIVE_STORAGE_URL'] = nil
-      end
-
-      it 'restores previous ActiveStorage::Current.url_options after the call' do
-        previous = { host: 'previous.example.com', port: 9000, protocol: 'http' }
-        ActiveStorage::Current.url_options = previous
-        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
-        allow(attachment).to receive(:url_for).and_return('ignored')
-        attachment.download_url
-        expect(ActiveStorage::Current.url_options).to eq(previous)
-      ensure
-        ENV['ACTIVE_STORAGE_URL'] = nil
-        ActiveStorage::Current.url_options = nil
-      end
-
-      it 'invokes url_for with exactly one positional argument and no kwargs (arity guard)' do
-        captured = { positional: [], kwargs: {} }
-        allow(attachment).to receive(:url_for) do |*args, **kwargs|
-          captured[:positional] = args
-          captured[:kwargs] = kwargs
-          'http://example/x'
-        end
-        attachment.download_url
-        expect(captured[:positional].size).to eq(1)
-        expect(captured[:kwargs]).to be_empty
-      end
+    it 'returns the same app-served proxy URL as file_url' do
+      expect(attachment.download_url).to eq(attachment.file_url)
+      expect(attachment.download_url).to include('/rails/active_storage/blobs/proxy/')
     end
   end
 
   describe '#thumb_url' do
-    context 'when file is not attached or not representable' do
-      it 'returns an empty string when not attached' do
-        # NOTE: representable? is delegated via method_missing on Attached::One,
-        # so instance_double rejects it — use a plain double for these proxies.
-        allow(attachment).to receive(:file).and_return(double('file', attached?: false, representable?: false))
-        expect(attachment.thumb_url).to eq('')
-      end
+    it 'returns an empty string when no file is attached' do
+      expect(described_class.new(file_type: :image).thumb_url).to eq('')
     end
 
-    context 'when file is attached and representable' do
-      let(:representation) { double('representation') }
-      let(:file_proxy) do
-        double('file', attached?: true, representable?: true, representation: representation)
-      end
+    it 'returns an app-served proxy URL for the representation' do
+      url = attachment.thumb_url
+      expect(url).to include('/rails/active_storage/representations/proxy/')
+      expect(url).to end_with('/picture.png')
+    end
 
-      before { allow(attachment).to receive(:file).and_return(file_proxy) }
-
-      it "uses default_url_options when ENV['ACTIVE_STORAGE_URL'] is blank" do
-        ENV['ACTIVE_STORAGE_URL'] = nil
-        captured = {}
-        expect(attachment).to receive(:url_for) do |arg|
-          expect(arg).to eq(representation)
-          captured.merge!(ActiveStorage::Current.url_options || {})
-          'http://localhost:3000/rails/active_storage/representations/test'
-        end
-        attachment.thumb_url
-        expect(captured[:host]).to eq(Rails.application.routes.default_url_options[:host])
-      end
-
-      it 'uses ACTIVE_STORAGE_URL host/port/protocol when set' do
-        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
-        captured = {}
-        expect(attachment).to receive(:url_for) do |arg|
-          expect(arg).to eq(representation)
-          captured.merge!(ActiveStorage::Current.url_options || {})
-          'https://media.example.com:8443/rails/active_storage/representations/test'
-        end
-        attachment.thumb_url
-        expect(captured).to include(host: 'media.example.com', port: 8443, protocol: 'https')
-      ensure
-        ENV['ACTIVE_STORAGE_URL'] = nil
-      end
-
-      # Same arity guard as #file_url — see comment above.
-      it 'invokes url_for with exactly one positional argument and no kwargs (arity guard)' do
-        captured = { positional: [], kwargs: {} }
-        allow(attachment).to receive(:url_for) do |*args, **kwargs|
-          captured[:positional] = args
-          captured[:kwargs] = kwargs
-          'http://example/x'
-        end
-        attachment.thumb_url
-        expect(captured[:positional].size).to eq(1)
-        expect(captured[:kwargs]).to be_empty
+    it 'falls back to a redirect URL when ATTACHMENT_DELIVERY=redirect' do
+      with_redirect_mode do
+        expect(attachment.thumb_url).to include('/rails/active_storage/representations/redirect/')
       end
     end
   end

--- a/spec/requests/active_storage_proxy_spec.rb
+++ b/spec/requests/active_storage_proxy_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Integration coverage for ActiveStorage proxy delivery (EVO-2006): the app
+# must serve the blob bytes itself so the storage endpoint can stay private.
+# Also exercises the test-environment parity with dev/staging/production
+# (resolve_model_to_route defaults to :rails_storage_proxy in all of them).
+
+require 'rails_helper'
+
+RSpec.describe 'ActiveStorage proxy delivery', type: :request do
+  let(:content) { 'proxied-file-bytes' }
+  let(:blob) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(content),
+      filename: 'attachment.txt',
+      content_type: 'text/plain'
+    )
+  end
+
+  it 'serves the blob bytes through the app on the browser-facing proxy URL' do
+    get rails_storage_proxy_path(blob)
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq(content)
+    expect(response.headers['Content-Type']).to include('text/plain')
+  end
+
+  describe 'outbound URLs with expiring signed ids (Evolution API / Go)' do
+    let(:expiring_path) do
+      rails_service_blob_proxy_path(blob.signed_id(expires_in: 15.minutes), blob.filename)
+    end
+
+    it 'serves the file while the signed id is valid' do
+      get expiring_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(content)
+    end
+
+    it 'returns 404 once the 15-minute TTL has elapsed' do
+      # Force the memoized path (and its signed id) to be generated NOW,
+      # before the clock moves — inside the travel block it would be signed
+      # at t+16min and still be valid.
+      path = expiring_path
+
+      travel(16.minutes) do
+        get path
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/services/concerns/blob_url_options_spec.rb
+++ b/spec/services/concerns/blob_url_options_spec.rb
@@ -103,4 +103,69 @@ RSpec.describe BlobUrlOptions do
       expect(result).to eq('computed-url')
     end
   end
+
+  describe '.outbound_media_url' do
+    let(:blob) do
+      ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new('outbound-bytes'),
+        filename: 'doc.pdf',
+        content_type: 'application/pdf'
+      )
+    end
+
+    around do |example|
+      original = ENV.fetch('ACTIVE_STORAGE_URL', nil)
+      example.run
+      ENV['ACTIVE_STORAGE_URL'] = original
+    end
+
+    context 'when delivering via proxy (default)' do
+      it 'returns an app-served proxy URL instead of a storage URL' do
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        url = described_class.outbound_media_url(blob)
+        expect(url).to include('/rails/active_storage/blobs/proxy/')
+        expect(url).to end_with('/doc.pdf')
+      end
+
+      it 'honors the ACTIVE_STORAGE_URL host override' do
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        url = described_class.outbound_media_url(blob)
+        expect(url).to start_with('https://media.example.com:8443/rails/active_storage/blobs/proxy/')
+      end
+
+      it 'embeds a signed id that expires after the 15-minute TTL' do
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        url = described_class.outbound_media_url(blob)
+        signed_id = url[%r{/blobs/proxy/([^/]+)/}, 1]
+
+        expect(ActiveStorage::Blob.find_signed(signed_id)).to eq(blob)
+        travel(16.minutes) do
+          expect(ActiveStorage::Blob.find_signed(signed_id)).to be_nil
+        end
+      end
+    end
+
+    context 'when delivering via redirect (ATTACHMENT_DELIVERY=redirect)' do
+      around do |example|
+        previous = ActiveStorage.resolve_model_to_route
+        ActiveStorage.resolve_model_to_route = :rails_storage_redirect
+        example.run
+      ensure
+        ActiveStorage.resolve_model_to_route = previous
+      end
+
+      it 'returns the storage service URL, not an app proxy route' do
+        ENV['ACTIVE_STORAGE_URL'] = nil
+        url = described_class.outbound_media_url(blob)
+        expect(url).to include('/rails/active_storage/disk/')
+        expect(url).not_to include('/blobs/proxy/')
+      end
+
+      it 'honors the ACTIVE_STORAGE_URL host override on the storage URL' do
+        ENV['ACTIVE_STORAGE_URL'] = 'https://media.example.com:8443'
+        url = described_class.outbound_media_url(blob)
+        expect(url).to start_with('https://media.example.com:8443/rails/active_storage/disk/')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Contexto
Com S3/MinIO, `blob.url` gera uma presigned URL do `STORAGE_ENDPOINT` — o host integra a assinatura SigV4 e **não pode ser reescrito** (`ACTIVE_STORAGE_URL`/EVO-1747 não se aplica a S3). Endpoint interno ⇒ browser não abre o anexo e o outbound (Evolution API/Go) falha; endpoint público ⇒ MinIO exposto na internet. Esta PR adota o **ActiveStorage proxy mode**: as URLs de anexo apontam para a app (`BACKEND_URL`), que lê do storage por dentro e serve os bytes — o storage permanece privado.

## Mudança
- `config.active_storage.resolve_model_to_route = :rails_storage_proxy` em development/staging/production/**test**, controlado pela flag **`ATTACHMENT_DELIVERY=proxy|redirect`** (rollback para redirects de storage sem redeploy).
- **Outbound (AC 2):** `Whatsapp::Providers::EvolutionService`/`EvolutionGoService` não entregam mais presigned ao provider; usam `BlobUrlOptions.outbound_media_url` — rota de proxy da app com **signed id expirável (TTL de 15 min mantido)**, honrando `ACTIVE_STORAGE_URL` como override de host para containers irmãos que não resolvem o `BACKEND_URL`.
- `Attachment#file_url/#download_url/#thumb_url` e `Macro`/`AutomationRule#file_base_data`: removido o wrapper `BlobUrlOptions.with_scoped_url_options` (era no-op — route helpers ignoram `ActiveStorage::Current.url_options`); os hosts dessas URLs seguem `routes.default_url_options` (`BACKEND_URL`).
- Warning de boot do initializer agora condicionado ao modo `redirect` (única situação em que a premissa dele vale); `.env.example` documenta o modo de entrega e o papel atual de `ACTIVE_STORAGE_URL`.
- **Nota de segurança (DoD):** URLs de proxy do browser usam signed id permanente — "quem tem o link acessa", igual à presigned de antes, porém sem expirar (registrado em `production.rb`); as URLs de outbound expiram em 15 min.

## Testes
- `spec/models/attachment_spec.rb` reescrito para assertar as **URLs realmente geradas** com blob real (a versão anterior provava apenas que o wrapper tinha rodado): proxy por default, fallback redirect via flag, e `ACTIVE_STORAGE_URL` comprovadamente sem efeito em route helpers.
- `spec/services/concerns/blob_url_options_spec.rb`: `outbound_media_url` — proxy path, override de host, **signed id expira após o TTL** (`travel 16.minutes`), branch redirect.
- `spec/requests/active_storage_proxy_spec.rb` (integração pedida no plano de teste): GET na rota de proxy → **200** com os bytes; URL expirável → **404 pós-TTL**.
- 28/28 nos specs acima; `spec/models` completo: 409 exemplos / 30 falhas **pré-existentes** (mesmo baseline do develop — obs.: o CI deste repo não roda RSpec). Rubocop sem ofensa nova.
- **E2E com MinIO real**: presigned do comportamento antigo → host do MinIO (`localhost:59000`); com o fix, `file_url`/`download_url`/outbound → host da app; `curl` nas duas rotas (permanente e expirável) → **HTTP 200** com os bytes lidos do MinIO, sem o endpoint jamais aparecer ao cliente.

**Teste manual (revisor):**
1. `ACTIVE_STORAGE_SERVICE=s3_compatible` + `STORAGE_ENDPOINT` interno: anexo abre no browser via host da app (200, sem 403 SignatureDoesNotMatch).
2. Enviar mídia outbound: a URL entregue ao Evolution API/Go tem host da app e expira em 15 min.
3. `ATTACHMENT_DELIVERY=redirect`: volta ao comportamento antigo (redirect/presigned).

Closes EVO-2006
