### PR TITLE
refactor(models): migrate enums to positional syntax for Rails 7.1+ (EVO-2007)

### DIFF
--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -28,8 +28,8 @@ class AgentBot < ApplicationRecord
   has_many :messages, as: :sender, dependent: :nullify
 
   before_destroy :cleanup_associations
-  enum bot_type: { webhook: 0 }
-  enum bot_provider: { webhook_provider: 'webhook', evo_ai_provider: 'evo_ai', n8n_provider: 'n8n' }
+  enum :bot_type, { webhook: 0 }
+  enum :bot_provider, { webhook_provider: 'webhook', evo_ai_provider: 'evo_ai', n8n_provider: 'n8n' }
 
   validates :outgoing_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
   validates :api_key, length: { maximum: 1000 }, allow_blank: true

--- a/app/models/agent_bot_inbox.rb
+++ b/app/models/agent_bot_inbox.rb
@@ -51,7 +51,7 @@ class AgentBotInbox < ApplicationRecord
   belongs_to :inbox
   belongs_to :agent_bot
   belongs_to :facebook_comment_agent_bot, class_name: 'AgentBot', optional: true, foreign_key: 'facebook_comment_agent_bot_id'
-  enum status: { active: 0, inactive: 1 }
+  enum :status, { active: 0, inactive: 1 }
 
   # Valid conversation statuses
   VALID_CONVERSATION_STATUSES = %w[open resolved pending snoozed].freeze

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -36,7 +36,7 @@ class Attachment < ApplicationRecord
   has_one_attached :file
   validate :acceptable_file
   validates :external_url, length: { maximum: Limits::URL_LENGTH_LIMIT }
-  enum file_type: { :image => 0, :audio => 1, :video => 2, :file => 3, :location => 4, :fallback => 5, :share => 6, :story_mention => 7,
+  enum :file_type, { :image => 0, :audio => 1, :video => 2, :file => 3, :location => 4, :fallback => 5, :share => 6, :story_mention => 7,
                     :contact => 8, :ig_reel => 9 }
 
   def message

--- a/app/models/channel/twilio_sms.rb
+++ b/app/models/channel/twilio_sms.rb
@@ -40,7 +40,7 @@ class Channel::TwilioSms < ApplicationRecord
   validates :phone_number, absence: true, if: :messaging_service_sid?
   validates :phone_number, uniqueness: true, allow_nil: true
 
-  enum medium: { sms: 0, whatsapp: 1 }
+  enum :medium, { sms: 0, whatsapp: 1 }
 
   def name
     medium == 'sms' ? 'Twilio SMS' : 'Whatsapp'

--- a/app/models/channel/web_widget.rb
+++ b/app/models/channel/web_widget.rb
@@ -72,7 +72,7 @@ class Channel::WebWidget < ApplicationRecord
     self.use_inbox_avatar_for_bot = flags_array.include?(:use_inbox_avatar_for_bot)
   end
 
-  enum reply_time: { in_a_few_minutes: 0, in_a_few_hours: 1, in_a_day: 2 }
+  enum :reply_time, { in_a_few_minutes: 0, in_a_few_hours: 1, in_a_day: 2 }
 
   def name
     'Website'

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -84,7 +84,7 @@ class Contact < ApplicationRecord
   before_destroy :ensure_pipeline_items_cleanup, :publish_contact_deleted
   after_destroy_commit :dispatch_destroy_event
 
-  enum contact_type: { visitor: 0, lead: 1, customer: 2 }
+  enum :contact_type, { visitor: 0, lead: 1, customer: 2 }
 
   scope :persons, -> { where(type: 'person') }
   scope :companies, -> { where(type: 'company') }

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -68,6 +68,10 @@ class Conversation < ApplicationRecord
 
   enum :status, { open: 0, resolved: 1, pending: 2, snoozed: 3 }
   enum :priority, { low: 0, medium: 1, high: 2, urgent: 3 }
+  # Explicit attribute keeps the model bootable when the source column has not been
+  # migrated yet (EVO-1999 deploy scenario: Puma boots before db:migrate runs).
+  # Type/default must stay in sync with db/migrate/20260623120000_add_source_to_conversations.rb.
+  attribute :source, :integer, default: 0
   enum :source, { live: 0, imported: 1 }
 
   scope :unassigned, -> { where(assignee_id: nil) }

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -66,9 +66,9 @@ class Conversation < ApplicationRecord
   validates :uuid, uniqueness: true
   validate :validate_referer_url
 
-  enum status: { open: 0, resolved: 1, pending: 2, snoozed: 3 }
-  enum priority: { low: 0, medium: 1, high: 2, urgent: 3 }
-  enum source: { live: 0, imported: 1 }
+  enum :status, { open: 0, resolved: 1, pending: 2, snoozed: 3 }
+  enum :priority, { low: 0, medium: 1, high: 2, urgent: 3 }
+  enum :source, { live: 0, imported: 1 }
 
   scope :unassigned, -> { where(assignee_id: nil) }
   scope :assigned, -> { where.not(assignee_id: nil) }

--- a/app/models/custom_attribute_definition.rb
+++ b/app/models/custom_attribute_definition.rb
@@ -43,14 +43,14 @@ class CustomAttributeDefinition < ApplicationRecord
   validates :attribute_model, presence: true
   validate :attribute_must_not_conflict, on: :create
 
-  enum attribute_model: {
+  enum :attribute_model, {
     conversation_attribute: 0,
     contact_attribute: 1,
     pipeline_attribute: 2,
     pipeline_stage_attribute: 3,
     pipeline_item_attribute: 4
   }
-  enum attribute_display_type: { text: 0, number: 1, currency: 2, percent: 3, link: 4, date: 5, list: 6, checkbox: 7, datetime: 8 }
+  enum :attribute_display_type, { text: 0, number: 1, currency: 2, percent: 3, link: 4, date: 5, list: 6, checkbox: 7, datetime: 8 }
 
   # Widget pre-chat sync trigger chain:
   # - create: sync metadata to matching pre-chat fields (if any) + dispatch event

--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -18,7 +18,7 @@ class CustomFilter < ApplicationRecord
   MAX_FILTER_PER_USER = 50
   belongs_to :user
 
-  enum filter_type: { conversation: 0, contact: 1, report: 2 }
+  enum :filter_type, { conversation: 0, contact: 1, report: 2 }
   validate :validate_number_of_filters
 
   def validate_number_of_filters

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -15,7 +15,7 @@ class DataImport < ApplicationRecord
   DATA_TYPES = %w[contacts conversations].freeze
 
   validates :data_type, inclusion: { in: DATA_TYPES, message: I18n.t('errors.data_import.data_type.invalid') }
-  enum status: { pending: 0, processing: 1, completed: 2, failed: 3 }
+  enum :status, { pending: 0, processing: 1, completed: 2, failed: 3 }
 
   has_one_attached :import_file
   has_one_attached :failed_records

--- a/app/models/inbox.rb
+++ b/app/models/inbox.rb
@@ -65,7 +65,7 @@ class Inbox < ApplicationRecord
   has_many :webhooks, dependent: :destroy_async
   has_many :hooks, dependent: :destroy_async, class_name: 'Integrations::Hook'
 
-  enum sender_name_type: { friendly: 0, professional: 1 }
+  enum :sender_name_type, { friendly: 0, professional: 1 }
 
   after_destroy :delete_round_robin_agents
 

--- a/app/models/integrations/hook.rb
+++ b/app/models/integrations/hook.rb
@@ -28,12 +28,12 @@ class Integrations::Hook < ApplicationRecord
 
   # TODO: This seems to be only used for slack at the moment
   # We can add a validator when storing the integration settings and toggle this in future
-  enum status: { disabled: 0, enabled: 1 }
+  enum :status, { disabled: 0, enabled: 1 }
 
   belongs_to :inbox, optional: true
   has_secure_token :access_token
 
-  enum hook_type: { account: 0, inbox: 1 }
+  enum :hook_type, { account: 0, inbox: 1 }
 
   scope :account_hooks, -> { where(hook_type: 'account') }
   scope :inbox_hooks, -> { where(hook_type: 'inbox') }

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -20,7 +20,7 @@ class Macro < ApplicationRecord
              class_name: :User, optional: true
   has_many_attached :files
 
-  enum visibility: { personal: 0, global: 1 }
+  enum :visibility, { personal: 0, global: 1 }
 
   validate :json_actions_format
 

--- a/app/models/macro_execution.rb
+++ b/app/models/macro_execution.rb
@@ -32,7 +32,7 @@ class MacroExecution < ApplicationRecord
   belongs_to :conversation
   belongs_to :user
 
-  enum status: { pending: 0, success: 1, failed: 2 }
+  enum :status, { pending: 0, success: 1, failed: 2 }
 
   scope :recent, -> { order(created_at: :desc) }
   scope :for_conversation, ->(conversation) { where(conversation: conversation) }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -76,8 +76,8 @@ class Message < ApplicationRecord
   # when you have a temperory id in your frontend and want it echoed back via action cable
   attr_accessor :echo_id
 
-  enum message_type: { incoming: 0, outgoing: 1, activity: 2, template: 3 }
-  enum content_type: {
+  enum :message_type, { incoming: 0, outgoing: 1, activity: 2, template: 3 }
+  enum :content_type, {
     text: 0,
     input_text: 1,
     input_textarea: 2,
@@ -91,8 +91,8 @@ class Message < ApplicationRecord
     integrations: 10,
     sticker: 11
   }
-  enum status: { sent: 0, delivered: 1, read: 2, failed: 3 }
-  enum source: { live: 0, imported: 1 }
+  enum :status, { sent: 0, delivered: 1, read: 2, failed: 3 }
+  enum :source, { live: 0, imported: 1 }
   # [:submitted_email, :items, :submitted_values] : Used for bot message types
   # [:email] : Used by conversation_continuity incoming email messages
   # [:in_reply_to] : Used to reply to a particular tweet in threads

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -92,6 +92,10 @@ class Message < ApplicationRecord
     sticker: 11
   }
   enum :status, { sent: 0, delivered: 1, read: 2, failed: 3 }
+  # Explicit attribute keeps the model bootable when the source column has not been
+  # migrated yet (EVO-1999 deploy scenario: Puma boots before db:migrate runs).
+  # Type/default must stay in sync with db/migrate/20260622120000_add_source_to_messages.rb.
+  attribute :source, :integer, default: 0
   enum :source, { live: 0, imported: 1 }
   # [:submitted_email, :items, :submitted_values] : Used for bot message types
   # [:email] : Used by conversation_continuity incoming email messages

--- a/app/models/message_template.rb
+++ b/app/models/message_template.rb
@@ -72,21 +72,21 @@ class MessageTemplate < ApplicationRecord
   before_save :extract_variables_from_content
   after_initialize :set_defaults
 
-  enum template_type: {
+  enum :template_type, {
     text: 'text',
     media: 'media',
     interactive: 'interactive',
     location: 'location',
     contact: 'contact',
     product: 'product'
-  }, _prefix: true
+  }, prefix: true
 
-  enum media_type: {
+  enum :media_type, {
     image: 'image',
     video: 'video',
     document: 'document',
     audio: 'audio'
-  }, _prefix: true
+  }, prefix: true
 
   # Scopes
   scope :active, -> { where(active: true) }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,7 +41,7 @@ class Notification < ApplicationRecord
     pipeline_task_completed: 23
   }.freeze
 
-  enum notification_type: NOTIFICATION_TYPES
+  enum :notification_type, NOTIFICATION_TYPES
 
   before_create :set_last_activity_at
   after_create_commit :process_notification_delivery, :dispatch_create_event

--- a/app/models/notification_subscription.rb
+++ b/app/models/notification_subscription.rb
@@ -24,5 +24,5 @@ class NotificationSubscription < ApplicationRecord
     fcm: 2
   }.freeze
 
-  enum subscription_type: SUBSCRIPTION_TYPES
+  enum :subscription_type, SUBSCRIPTION_TYPES
 end

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -35,7 +35,7 @@ class Pipeline < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :pipeline_type, inclusion: { in: VALID_TYPES }
 
-  enum visibility: { private: 0, team: 1, public: 2 }, _prefix: :visibility
+  enum :visibility, { private: 0, team: 1, public: 2 }, prefix: :visibility
 
   scope :active, -> { where(is_active: true) }
   scope :default, -> { where(is_default: true) }

--- a/app/models/pipeline_task.rb
+++ b/app/models/pipeline_task.rb
@@ -56,28 +56,28 @@ class PipelineTask < ApplicationRecord
   has_one :contact, through: :pipeline_item
 
   # Enums
-  enum task_type: {
+  enum :task_type, {
     call: 0,
     email: 1,
     meeting: 2,
     follow_up: 3,
     note: 4,
     other: 5
-  }, _prefix: true
+  }, prefix: true
 
-  enum status: {
+  enum :status, {
     pending: 0,
     completed: 1,
     cancelled: 2,
     overdue: 3
-  }, _prefix: true
+  }, prefix: true
 
-  enum priority: {
+  enum :priority, {
     low: 0,
     medium: 1,
     high: 2,
     urgent: 3
-  }, _prefix: true
+  }, prefix: true
 
   # Validations
   validates :title, presence: true, length: { maximum: 255 }

--- a/app/models/scheduled_action_execution_log.rb
+++ b/app/models/scheduled_action_execution_log.rb
@@ -38,7 +38,7 @@ class ScheduledActionExecutionLog < ApplicationRecord
     error: 'error'
   }.freeze
 
-  enum status: STATUSES, _prefix: true
+  enum :status, STATUSES, prefix: true
 
   # Scopes
   scope :recent, -> { order(created_at: :desc) }

--- a/app/models/stage_movement.rb
+++ b/app/models/stage_movement.rb
@@ -28,7 +28,7 @@ class StageMovement < ApplicationRecord
   belongs_to :to_stage, class_name: 'PipelineStage'
   belongs_to :moved_by, class_name: 'User', optional: true
 
-  enum movement_type: {
+  enum :movement_type, {
     manual: 0,         # Movido manualmente por um usuário
     automated: 1,      # Movido por automação/regra
     system: 2,         # Movido pelo sistema (entrada no funil, etc)

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -20,7 +20,7 @@ class Webhook < ApplicationRecord
 
   validates :url, uniqueness: true, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])
   validate :validate_webhook_subscriptions
-  enum webhook_type: { account_type: 0, inbox_type: 1 }
+  enum :webhook_type, { account_type: 0, inbox_type: 1 }
 
   ALLOWED_WEBHOOK_EVENTS = %w[conversation_status_changed conversation_updated conversation_created contact_created contact_updated
                               message_created message_updated webwidget_triggered inbox_created inbox_updated

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -39,9 +39,8 @@ RSpec.describe Conversation, type: :model do
 
   describe '#assign_to_default_pipeline' do
     context 'quando o contato não está em nenhum pipeline' do
-      before { default_stage } # garante que o pipeline padrão existe com stage
-
       it 'adiciona a conversa ao pipeline padrão' do
+        default_stage # garante que o pipeline padrão existe com stage
         conversation = create_conversation
         expect(PipelineItem.where(conversation: conversation, pipeline: default_pipeline)).to exist
       end
@@ -259,6 +258,31 @@ RSpec.describe Conversation, type: :model do
       expect do
         conv.send(:assign_to_default_pipeline)
       end.to change { PipelineItem.where(conversation: conv).count }.from(0).to(1)
+    end
+  end
+
+  describe 'creation callbacks vs source enum (EVO-2007 AC 2)' do
+    before { default_stage } # default pipeline exists, so a skip is meaningful
+
+    it 'skips the three creation callbacks for imported conversations' do
+      conversation = described_class.new(inbox: inbox, contact: contact, contact_inbox: contact_inbox, source: :imported)
+
+      expect(conversation).not_to receive(:notify_conversation_creation)
+      expect(conversation).not_to receive(:publish_conversation_created)
+      conversation.save!
+
+      expect(PipelineItem.where(conversation: conversation)).not_to exist
+    end
+
+    it 'runs the three creation callbacks for live (default source) conversations' do
+      conversation = described_class.new(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+
+      expect(conversation).to receive(:notify_conversation_creation)
+      expect(conversation).to receive(:publish_conversation_created)
+      conversation.save!
+
+      expect(conversation.live?).to be(true)
+      expect(PipelineItem.where(conversation: conversation)).to exist
     end
   end
 end

--- a/spec/models/enum_positional_syntax_spec.rb
+++ b/spec/models/enum_positional_syntax_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Regression spec for the enum syntax migration (EVO-2007).
+#
+# Todos os modelos migraram da sintaxe keyword depreciada `enum nome: {...}` para
+# a posicional do Rails 7.1 `enum :nome, {...}`, e as opções `_prefix:`/`_suffix:`
+# viraram `prefix:`/`suffix:`. Este spec garante que:
+#   1) os enums continuam mapeando os mesmos valores;
+#   2) os enums com prefix ainda geram os métodos prefixados (regressão do _prefix);
+#   3) a coluna nova `source` (Conversation/Message) funciona — foco do incidente.
+
+begin
+  require 'rails_helper'
+rescue LoadError
+  RSpec.describe 'Enum positional syntax' do
+    it 'has spec scaffold ready' do
+      skip 'rails_helper is not available in this workspace snapshot'
+    end
+  end
+end
+
+return unless defined?(Rails)
+
+RSpec.describe 'Enum positional syntax (EVO-2007)', type: :model do
+  describe 'mapeamento preservado' do
+    it 'Conversation.sources / Message.sources mantêm live/imported' do
+      expect(Conversation.sources).to eq('live' => 0, 'imported' => 1)
+      expect(Message.sources).to eq('live' => 0, 'imported' => 1)
+    end
+
+    it 'Conversation.statuses e priorities intactos' do
+      expect(Conversation.statuses).to eq('open' => 0, 'resolved' => 1, 'pending' => 2, 'snoozed' => 3)
+      expect(Conversation.priorities).to include('low' => 0, 'urgent' => 3)
+    end
+
+    it 'AgentBot.bot_providers (valores string) intactos' do
+      expect(AgentBot.bot_providers).to include('evo_ai_provider' => 'evo_ai', 'webhook_provider' => 'webhook')
+    end
+  end
+
+  describe 'métodos de source (foco do incidente)' do
+    it 'instância responde a live?/imported? e query methods' do
+      conv = Conversation.new(source: :imported)
+      expect(conv.imported?).to be(true)
+      expect(conv.live?).to be(false)
+      expect(Conversation).to respond_to(:imported)
+      expect(Message).to respond_to(:imported)
+    end
+  end
+
+  describe 'enums com prefix (regressão do _prefix -> prefix:)' do
+    it 'PipelineTask gera métodos prefixados (task_type_/status_/priority_)' do
+      task = PipelineTask.new
+      expect(task).to respond_to(:task_type_call?)
+      expect(task).to respond_to(:status_pending?)
+      expect(task).to respond_to(:priority_urgent?)
+    end
+
+    it 'Pipeline gera métodos com prefix :visibility' do
+      expect(Pipeline.new).to respond_to(:visibility_private?)
+    end
+
+    it 'MessageTemplate gera métodos prefixados (template_type_/media_type_)' do
+      tmpl = MessageTemplate.new
+      expect(tmpl).to respond_to(:template_type_text?)
+      expect(tmpl).to respond_to(:media_type_image?)
+    end
+
+    it 'ScheduledActionExecutionLog gera status_ prefixado' do
+      log = ScheduledActionExecutionLog.new
+      expect(log).to respond_to(:status_completed?)
+      expect(log).to respond_to(:status_retry_pending?)
+    end
+  end
+end

--- a/spec/models/enum_positional_syntax_spec.rb
+++ b/spec/models/enum_positional_syntax_spec.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
-# Regression spec for the enum syntax migration (EVO-2007).
+# Regression spec for the enum hardening (EVO-2007).
 #
-# Todos os modelos migraram da sintaxe keyword depreciada `enum nome: {...}` para
-# a posicional do Rails 7.1 `enum :nome, {...}`, e as opções `_prefix:`/`_suffix:`
-# viraram `prefix:`/`suffix:`. Este spec garante que:
-#   1) os enums continuam mapeando os mesmos valores;
-#   2) os enums com prefix ainda geram os métodos prefixados (regressão do _prefix);
-#   3) a coluna nova `source` (Conversation/Message) funciona — foco do incidente.
+# All models were migrated from the keyword enum syntax `enum name: {...}` to the
+# Rails 7.1 positional form `enum :name, {...}`, converting `_prefix:`/`_suffix:`
+# into `prefix:`/`suffix:`. On top of that, Conversation#source and Message#source
+# declare an explicit `attribute :source, :integer, default: 0` so the models stay
+# bootable when the column has not been migrated yet (EVO-1999 deploy scenario).
+#
+# This spec guarantees that:
+#   1) the enums keep mapping the same values;
+#   2) enums with prefix still generate the prefixed methods (`_prefix:` regression);
+#   3) the new `source` column (Conversation/Message) works — focus of the incident;
+#   4) Conversation/Message boot without the source column (EVO-2007 AC 3).
 
 begin
   require 'rails_helper'
@@ -22,54 +27,100 @@ end
 return unless defined?(Rails)
 
 RSpec.describe 'Enum positional syntax (EVO-2007)', type: :model do
-  describe 'mapeamento preservado' do
-    it 'Conversation.sources / Message.sources mantêm live/imported' do
+  describe 'mappings preserved' do
+    it 'keeps live/imported on Conversation.sources and Message.sources' do
       expect(Conversation.sources).to eq('live' => 0, 'imported' => 1)
       expect(Message.sources).to eq('live' => 0, 'imported' => 1)
     end
 
-    it 'Conversation.statuses e priorities intactos' do
+    it 'keeps Conversation.statuses and priorities intact' do
       expect(Conversation.statuses).to eq('open' => 0, 'resolved' => 1, 'pending' => 2, 'snoozed' => 3)
-      expect(Conversation.priorities).to include('low' => 0, 'urgent' => 3)
+      expect(Conversation.priorities).to eq('low' => 0, 'medium' => 1, 'high' => 2, 'urgent' => 3)
     end
 
-    it 'AgentBot.bot_providers (valores string) intactos' do
+    it 'keeps AgentBot.bot_providers (string-backed values) intact' do
       expect(AgentBot.bot_providers).to include('evo_ai_provider' => 'evo_ai', 'webhook_provider' => 'webhook')
     end
   end
 
-  describe 'métodos de source (foco do incidente)' do
-    it 'instância responde a live?/imported? e query methods' do
-      conv = Conversation.new(source: :imported)
-      expect(conv.imported?).to be(true)
-      expect(conv.live?).to be(false)
-      expect(Conversation).to respond_to(:imported)
-      expect(Message).to respond_to(:imported)
+  describe 'source predicate and scope methods (incident focus)' do
+    it 'answers live?/imported? on instances' do
+      conversation = Conversation.new(source: :imported)
+      expect(conversation.imported?).to be(true)
+      expect(conversation.live?).to be(false)
+
+      message = Message.new(source: :live)
+      expect(message.live?).to be(true)
+      expect(message.imported?).to be(false)
+    end
+
+    it 'defaults source to live' do
+      expect(Conversation.new.source).to eq('live')
+      expect(Message.new.source).to eq('live')
+    end
+
+    it 'generates the live/imported scopes' do
+      expect(Conversation.imported.to_sql).to include('source')
+      expect(Message.live.to_sql).to include('source')
     end
   end
 
-  describe 'enums com prefix (regressão do _prefix -> prefix:)' do
-    it 'PipelineTask gera métodos prefixados (task_type_/status_/priority_)' do
-      task = PipelineTask.new
-      expect(task).to respond_to(:task_type_call?)
-      expect(task).to respond_to(:status_pending?)
-      expect(task).to respond_to(:priority_urgent?)
+  describe 'prefixed enums (_prefix -> prefix: regression)' do
+    it 'generates PipelineTask task_type_/status_/priority_ methods that answer correctly' do
+      task = PipelineTask.new(task_type: :call, status: :pending, priority: :urgent)
+      expect(task.task_type_call?).to be(true)
+      expect(task.task_type_email?).to be(false)
+      expect(task.status_pending?).to be(true)
+      expect(task.priority_urgent?).to be(true)
     end
 
-    it 'Pipeline gera métodos com prefix :visibility' do
-      expect(Pipeline.new).to respond_to(:visibility_private?)
+    it 'generates Pipeline methods with the :visibility prefix' do
+      expect(Pipeline.new(visibility: :private).visibility_private?).to be(true)
+      expect(Pipeline.new(visibility: :team).visibility_private?).to be(false)
     end
 
-    it 'MessageTemplate gera métodos prefixados (template_type_/media_type_)' do
-      tmpl = MessageTemplate.new
-      expect(tmpl).to respond_to(:template_type_text?)
-      expect(tmpl).to respond_to(:media_type_image?)
+    it 'generates MessageTemplate template_type_/media_type_ methods' do
+      expect(MessageTemplate.new.template_type_text?).to be(true) # set_defaults assigns 'text'
+      expect(MessageTemplate.new(media_type: 'image').media_type_image?).to be(true)
     end
 
-    it 'ScheduledActionExecutionLog gera status_ prefixado' do
-      log = ScheduledActionExecutionLog.new
-      expect(log).to respond_to(:status_completed?)
-      expect(log).to respond_to(:status_retry_pending?)
+    it 'generates ScheduledActionExecutionLog status_ prefixed methods' do
+      log = ScheduledActionExecutionLog.new(status: :retry_pending)
+      expect(log.status_retry_pending?).to be(true)
+      expect(log.status_completed?).to be(false)
+    end
+  end
+
+  describe 'boot safety without the source column (EVO-1999 scenario, AC 3)' do
+    # `ignored_columns` removes the column from the in-memory schema, which is
+    # exactly what the model sees when Puma boots before db:migrate has run.
+    def model_without_source_column(table, declare_attribute:)
+      Class.new(ApplicationRecord) do
+        self.table_name = table
+        self.ignored_columns += %w[source]
+
+        attribute :source, :integer, default: 0 if declare_attribute
+        enum :source, { live: 0, imported: 1 }
+      end
+    end
+
+    %w[conversations messages].each do |table|
+      it "boots #{table} model and answers imported? when the column is absent" do
+        klass = model_without_source_column(table, declare_attribute: true)
+        stub_const('BootSafetyModel', klass)
+
+        expect { klass.new }.not_to raise_error
+        expect(klass.new.source).to eq('live')
+        expect(klass.new.imported?).to be(false)
+        expect(klass.new(source: :imported).imported?).to be(true)
+      end
+    end
+
+    it 'still raises Undeclared attribute type without the explicit attribute (control)' do
+      klass = model_without_source_column('conversations', declare_attribute: false)
+      stub_const('BootSafetyControlModel', klass)
+
+      expect { klass.new }.to raise_error(RuntimeError, /Undeclared attribute type for enum 'source'/)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  # Enables travel_to / freeze_time in specs.
+  config.include ActiveSupport::Testing::TimeHelpers
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 


### PR DESCRIPTION
## Contexto
A sintaxe keyword `enum nome: {...}` foi **depreciada no Rails 7.2 e removida no Rails 8.0** — ao atualizar o Rails, o boot quebra se ela permanecer. Esta PR migra todos os enums do CRM para a forma **posicional** (recomendada desde o Rails 7.1) e **endurece o enum `source`** contra o cenário da EVO-1999.

## Mudança
- `enum nome: {...}` → `enum :nome, {...}` em **23 models** (transformação puramente mecânica; semântica idêntica).
- Opções `_prefix:`/`_suffix:` (keyword) → `prefix:`/`suffix:` (posicional).
- **Hardening (AC 3):** `Conversation#source` e `Message#source` agora declaram `attribute :source, :integer, default: 0` antes do enum. Com isso o modelo **boota mesmo sem a coluna migrada** (cenário EVO-1999: Puma sobe antes do `db:migrate` — origem do 500 em `/conversations/unread_count`). É o escape hatch que o próprio erro do Rails indica (*"...or declared with an explicit type via `attribute`"*). A troca de sintaxe sozinha não resolvia esse cenário: as duas formas falham igual sem a coluna.

## Testes
- [x] `spec/models/enum_positional_syntax_spec.rb` — 13 exemplos: mapeamentos preservados, predicados/scopes de `source` exercitados de verdade, métodos prefixados chamados (não só `respond_to?`), e **regressão de boot-safety** simulando a coluna ausente via `ignored_columns` (com exemplo de controle provando o modo de falha sem o fix).
- [x] `spec/models/conversation_spec.rb` — cobre os 3 `after_create_commit ... unless: :imported?` (AC 2) e conserta 2 exemplos pré-existentes quebrados (`before` que contradizia a premissa do teste; `travel_to` sem `TimeHelpers` incluído no `rails_helper`).
- [x] `spec/models` completo local: **zero regressão** — as 30 falhas restantes são pré-existentes no branch/develop (baseline no commit anterior: mesmas 30 + as 2 consertadas aqui). Obs.: o CI deste repo não roda RSpec.
- [x] `rubocop` limpo nas linhas alteradas.

**Teste manual (revisor):**
1. `Conversation.sources` → `{"live"=>0,"imported"=>1}`; `AgentBot.bot_providers` intacto.
2. `PipelineTask.new(task_type: :call).task_type_call?` → `true`; `Pipeline.new(visibility: :private).visibility_private?` → `true`.
3. Cenário EVO-1999: com a coluna `source` fora do schema em memória, `Conversation.new.imported?` responde sem `Undeclared attribute type`.

Closes EVO-2007
