### PR TITLE
fix(deploy): run migrations on image boot for CapRover (EVO-1999)

### DIFF
--- a/db/migrate/20250113000002_add_display_name_to_inboxes.rb
+++ b/db/migrate/20250113000002_add_display_name_to_inboxes.rb
@@ -1,6 +1,6 @@
 class AddDisplayNameToInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :inboxes, :display_name, :string
+    add_column :inboxes, :display_name, :string, if_not_exists: true
   end
 end
 

--- a/db/migrate/20250128000000_remove_sla_system.rb
+++ b/db/migrate/20250128000000_remove_sla_system.rb
@@ -4,27 +4,27 @@ class RemoveSlaSystem < ActiveRecord::Migration[7.0]
   def up
     # Remove foreign key constraints first
     if foreign_key_exists?(:conversations, :sla_policies)
-      remove_foreign_key :conversations, :sla_policies
+      remove_foreign_key :conversations, :sla_policies, if_exists: true
     end
 
     if foreign_key_exists?(:sla_events, :sla_policies)
-      remove_foreign_key :sla_events, :sla_policies
+      remove_foreign_key :sla_events, :sla_policies, if_exists: true
     end
 
     if foreign_key_exists?(:sla_events, :applied_slas)
-      remove_foreign_key :sla_events, :applied_slas
+      remove_foreign_key :sla_events, :applied_slas, if_exists: true
     end
 
     if foreign_key_exists?(:sla_events, :conversations)
-      remove_foreign_key :sla_events, :conversations
+      remove_foreign_key :sla_events, :conversations, if_exists: true
     end
 
     if foreign_key_exists?(:applied_slas, :sla_policies)
-      remove_foreign_key :applied_slas, :sla_policies
+      remove_foreign_key :applied_slas, :sla_policies, if_exists: true
     end
 
     if foreign_key_exists?(:applied_slas, :conversations)
-      remove_foreign_key :applied_slas, :conversations
+      remove_foreign_key :applied_slas, :conversations, if_exists: true
     end
 
     # Remove indexes
@@ -36,12 +36,12 @@ class RemoveSlaSystem < ActiveRecord::Migration[7.0]
     remove_index :applied_slas, :conversation_id if index_exists?(:applied_slas, :conversation_id)
     remove_index :applied_slas, :sla_policy_id if index_exists?(:applied_slas, :sla_policy_id)
     # Drop tables
-    drop_table :sla_events if table_exists?(:sla_events)
-    drop_table :applied_slas if table_exists?(:applied_slas)
-    drop_table :sla_policies if table_exists?(:sla_policies)
+    drop_table :sla_events, if_exists: true if table_exists?(:sla_events)
+    drop_table :applied_slas, if_exists: true if table_exists?(:applied_slas)
+    drop_table :sla_policies, if_exists: true if table_exists?(:sla_policies)
 
     # Remove column from conversations table
-    remove_column :conversations, :sla_policy_id, :uuid if column_exists?(:conversations, :sla_policy_id)
+    remove_column :conversations, :sla_policy_id, :uuid, if_exists: true if column_exists?(:conversations, :sla_policy_id)
   end
 
   def down

--- a/db/migrate/20251114000001_add_configuration_fields_to_agent_bot_inboxes.rb
+++ b/db/migrate/20251114000001_add_configuration_fields_to_agent_bot_inboxes.rb
@@ -1,10 +1,10 @@
 class AddConfigurationFieldsToAgentBotInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :agent_bot_inboxes, :allowed_conversation_statuses, :jsonb, default: [], null: false
-    add_column :agent_bot_inboxes, :allowed_label_ids, :jsonb, default: [], null: false
+    add_column :agent_bot_inboxes, :allowed_conversation_statuses, :jsonb, default: [], null: false, if_not_exists: true
+    add_column :agent_bot_inboxes, :allowed_label_ids, :jsonb, default: [], null: false, if_not_exists: true
 
-    add_index :agent_bot_inboxes, :allowed_conversation_statuses, using: :gin
-    add_index :agent_bot_inboxes, :allowed_label_ids, using: :gin
+    add_index :agent_bot_inboxes, :allowed_conversation_statuses, using: :gin, if_not_exists: true
+    add_index :agent_bot_inboxes, :allowed_label_ids, using: :gin, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251114000002_add_facebook_comment_config_to_agent_bot_inboxes.rb
+++ b/db/migrate/20251114000002_add_facebook_comment_config_to_agent_bot_inboxes.rb
@@ -1,10 +1,10 @@
 class AddFacebookCommentConfigToAgentBotInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :agent_bot_inboxes, :facebook_comment_replies_enabled, :boolean, default: false, null: false
-    add_column :agent_bot_inboxes, :facebook_comment_agent_bot_id, :uuid, null: true
+    add_column :agent_bot_inboxes, :facebook_comment_replies_enabled, :boolean, default: false, null: false, if_not_exists: true
+    add_column :agent_bot_inboxes, :facebook_comment_agent_bot_id, :uuid, null: true, if_not_exists: true
 
-    add_index :agent_bot_inboxes, :facebook_comment_agent_bot_id
-    add_foreign_key :agent_bot_inboxes, :agent_bots, column: :facebook_comment_agent_bot_id, on_delete: :nullify
+    add_index :agent_bot_inboxes, :facebook_comment_agent_bot_id, if_not_exists: true
+    add_foreign_key :agent_bot_inboxes, :agent_bots, column: :facebook_comment_agent_bot_id, on_delete: :nullify, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251114000003_add_default_conversation_status_to_inboxes.rb
+++ b/db/migrate/20251114000003_add_default_conversation_status_to_inboxes.rb
@@ -1,7 +1,7 @@
 class AddDefaultConversationStatusToInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :inboxes, :default_conversation_status, :string, default: nil, null: true
-    add_index :inboxes, :default_conversation_status
+    add_column :inboxes, :default_conversation_status, :string, default: nil, null: true, if_not_exists: true
+    add_index :inboxes, :default_conversation_status, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251114000004_add_ignored_label_ids_to_agent_bot_inboxes.rb
+++ b/db/migrate/20251114000004_add_ignored_label_ids_to_agent_bot_inboxes.rb
@@ -1,7 +1,7 @@
 class AddIgnoredLabelIdsToAgentBotInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :agent_bot_inboxes, :ignored_label_ids, :jsonb, default: [], null: false
-    add_index :agent_bot_inboxes, :ignored_label_ids, using: :gin
+    add_column :agent_bot_inboxes, :ignored_label_ids, :jsonb, default: [], null: false, if_not_exists: true
+    add_index :agent_bot_inboxes, :ignored_label_ids, using: :gin, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251114000005_add_facebook_interaction_type_and_allowed_posts_to_agent_bot_inboxes.rb
+++ b/db/migrate/20251114000005_add_facebook_interaction_type_and_allowed_posts_to_agent_bot_inboxes.rb
@@ -1,10 +1,10 @@
 class AddFacebookInteractionTypeAndAllowedPostsToAgentBotInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :agent_bot_inboxes, :facebook_interaction_type, :string, default: 'both', null: false
-    add_column :agent_bot_inboxes, :facebook_allowed_post_ids, :jsonb, default: [], null: false
+    add_column :agent_bot_inboxes, :facebook_interaction_type, :string, default: 'both', null: false, if_not_exists: true
+    add_column :agent_bot_inboxes, :facebook_allowed_post_ids, :jsonb, default: [], null: false, if_not_exists: true
 
-    add_index :agent_bot_inboxes, :facebook_interaction_type
-    add_index :agent_bot_inboxes, :facebook_allowed_post_ids, using: :gin
+    add_index :agent_bot_inboxes, :facebook_interaction_type, if_not_exists: true
+    add_index :agent_bot_inboxes, :facebook_allowed_post_ids, using: :gin, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251114140049_add_moderation_fields_to_agent_bot_inboxes.rb
+++ b/db/migrate/20251114140049_add_moderation_fields_to_agent_bot_inboxes.rb
@@ -1,12 +1,12 @@
 class AddModerationFieldsToAgentBotInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :agent_bot_inboxes, :moderation_enabled, :boolean, default: false, null: false
-    add_column :agent_bot_inboxes, :explicit_words_filter, :jsonb, default: [], null: false
-    add_column :agent_bot_inboxes, :sentiment_analysis_enabled, :boolean, default: false, null: false
-    add_column :agent_bot_inboxes, :auto_approve_responses, :boolean, default: false, null: false
+    add_column :agent_bot_inboxes, :moderation_enabled, :boolean, default: false, null: false, if_not_exists: true
+    add_column :agent_bot_inboxes, :explicit_words_filter, :jsonb, default: [], null: false, if_not_exists: true
+    add_column :agent_bot_inboxes, :sentiment_analysis_enabled, :boolean, default: false, null: false, if_not_exists: true
+    add_column :agent_bot_inboxes, :auto_approve_responses, :boolean, default: false, null: false, if_not_exists: true
 
-    add_index :agent_bot_inboxes, :moderation_enabled
-    add_index :agent_bot_inboxes, :explicit_words_filter, using: :gin
+    add_index :agent_bot_inboxes, :moderation_enabled, if_not_exists: true
+    add_index :agent_bot_inboxes, :explicit_words_filter, using: :gin, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251114140050_create_facebook_comment_moderations.rb
+++ b/db/migrate/20251114140050_create_facebook_comment_moderations.rb
@@ -2,7 +2,7 @@ class CreateFacebookCommentModerations < ActiveRecord::Migration[7.1]
   def change
     return if table_exists?(:facebook_comment_moderations)
 
-    create_table :facebook_comment_moderations, id: :uuid do |t|
+    create_table :facebook_comment_moderations, id: :uuid, if_not_exists: true do |t|
       t.references :conversation, null: false, foreign_key: true, type: :uuid
       t.references :message, null: false, foreign_key: true, type: :uuid
       t.string :comment_id, null: false # Facebook comment ID
@@ -17,10 +17,10 @@ class CreateFacebookCommentModerations < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :facebook_comment_moderations, :status unless index_exists?(:facebook_comment_moderations, :status)
-    add_index :facebook_comment_moderations, :moderation_type unless index_exists?(:facebook_comment_moderations, :moderation_type)
-    add_index :facebook_comment_moderations, :comment_id unless index_exists?(:facebook_comment_moderations, :comment_id)
-    add_index :facebook_comment_moderations, [:status, :moderation_type] unless index_exists?(:facebook_comment_moderations, [:status, :moderation_type])
-    add_index :facebook_comment_moderations, :moderated_by_id unless index_exists?(:facebook_comment_moderations, :moderated_by_id)
+    add_index :facebook_comment_moderations, :status, if_not_exists: true unless index_exists?(:facebook_comment_moderations, :status)
+    add_index :facebook_comment_moderations, :moderation_type, if_not_exists: true unless index_exists?(:facebook_comment_moderations, :moderation_type)
+    add_index :facebook_comment_moderations, :comment_id, if_not_exists: true unless index_exists?(:facebook_comment_moderations, :comment_id)
+    add_index :facebook_comment_moderations, [:status, :moderation_type], if_not_exists: true unless index_exists?(:facebook_comment_moderations, [:status, :moderation_type])
+    add_index :facebook_comment_moderations, :moderated_by_id, if_not_exists: true unless index_exists?(:facebook_comment_moderations, :moderated_by_id)
   end
 end

--- a/db/migrate/20251114160000_add_auto_reject_fields_to_agent_bot_inboxes.rb
+++ b/db/migrate/20251114160000_add_auto_reject_fields_to_agent_bot_inboxes.rb
@@ -1,10 +1,10 @@
 class AddAutoRejectFieldsToAgentBotInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :agent_bot_inboxes, :auto_reject_explicit_words, :boolean, default: false, null: false
-    add_column :agent_bot_inboxes, :auto_reject_offensive_sentiment, :boolean, default: false, null: false
+    add_column :agent_bot_inboxes, :auto_reject_explicit_words, :boolean, default: false, null: false, if_not_exists: true
+    add_column :agent_bot_inboxes, :auto_reject_offensive_sentiment, :boolean, default: false, null: false, if_not_exists: true
 
-    add_index :agent_bot_inboxes, :auto_reject_explicit_words
-    add_index :agent_bot_inboxes, :auto_reject_offensive_sentiment
+    add_index :agent_bot_inboxes, :auto_reject_explicit_words, if_not_exists: true
+    add_index :agent_bot_inboxes, :auto_reject_offensive_sentiment, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251117132621_add_type_to_contacts.rb
+++ b/db/migrate/20251117132621_add_type_to_contacts.rb
@@ -11,10 +11,10 @@ class AddTypeToContacts < ActiveRecord::Migration[7.1]
 
     # Adicionar coluna com ENUM
     unless column_exists?(:contacts, :type)
-      add_column :contacts, :type, :contact_type_enum, default: 'person', null: false
+      add_column :contacts, :type, :contact_type_enum, default: 'person', null: false, if_not_exists: true
     end
 
-    add_index :contacts, :type unless index_exists?(:contacts, :type)
+    add_index :contacts, :type, if_not_exists: true unless index_exists?(:contacts, :type)
 
     # Composite index from OptimizeContactsPerformance (20241020000100). That migration
     # has an earlier timestamp than this one, so on fresh installs it ran before `type`

--- a/db/migrate/20251117132725_create_contact_companies.rb
+++ b/db/migrate/20251117132725_create_contact_companies.rb
@@ -1,6 +1,6 @@
 class CreateContactCompanies < ActiveRecord::Migration[7.1]
   def change
-    create_table :contact_companies, id: :uuid do |t|
+    create_table :contact_companies, id: :uuid, if_not_exists: true do |t|
       t.uuid :contact_id, null: false
       t.uuid :company_id, null: false
 
@@ -9,11 +9,11 @@ class CreateContactCompanies < ActiveRecord::Migration[7.1]
     end
     
     # Foreign keys
-    add_foreign_key :contact_companies, :contacts, column: :contact_id
-    add_foreign_key :contact_companies, :contacts, column: :company_id
+    add_foreign_key :contact_companies, :contacts, column: :contact_id, if_not_exists: true
+    add_foreign_key :contact_companies, :contacts, column: :company_id, if_not_exists: true
     # Índices para performance e unicidade
-    add_index :contact_companies, [:contact_id, :company_id], unique: true
-    add_index :contact_companies, [:company_id, :contact_id]
-    add_index :contact_companies, :deleted_at
+    add_index :contact_companies, [:contact_id, :company_id], unique: true, if_not_exists: true
+    add_index :contact_companies, [:company_id, :contact_id], if_not_exists: true
+    add_index :contact_companies, :deleted_at, if_not_exists: true
   end
 end

--- a/db/migrate/20251117181534_add_company_fields_to_contacts.rb
+++ b/db/migrate/20251117181534_add_company_fields_to_contacts.rb
@@ -1,10 +1,10 @@
 class AddCompanyFieldsToContacts < ActiveRecord::Migration[7.1]
   def change
-    add_column :contacts, :tax_id, :string, limit: 14
-    add_column :contacts, :website, :string
-    add_column :contacts, :industry, :string
-    
+    add_column :contacts, :tax_id, :string, limit: 14, if_not_exists: true
+    add_column :contacts, :website, :string, if_not_exists: true
+    add_column :contacts, :industry, :string, if_not_exists: true
+
     # Índice para tax_id (CNPJ/CPF)
-    add_index :contacts, [:tax_id], unique: true, where: "tax_id IS NOT NULL"
+    add_index :contacts, [:tax_id], unique: true, where: "tax_id IS NOT NULL", if_not_exists: true
   end
 end

--- a/db/migrate/20251119113455_add_contact_to_pipeline_conversations.rb
+++ b/db/migrate/20251119113455_add_contact_to_pipeline_conversations.rb
@@ -3,8 +3,8 @@
 class AddContactToPipelineConversations < ActiveRecord::Migration[7.1]
   def change
     # Add contact_id column to support leads without conversations
-    add_column :pipeline_conversations, :contact_id, :uuid
-    add_index :pipeline_conversations, :contact_id
+    add_column :pipeline_conversations, :contact_id, :uuid, if_not_exists: true
+    add_index :pipeline_conversations, :contact_id, if_not_exists: true
 
     # Make conversation_id optional (allow NULL)
     change_column_null :pipeline_conversations, :conversation_id, true
@@ -16,16 +16,18 @@ class AddContactToPipelineConversations < ActiveRecord::Migration[7.1]
     add_index :pipeline_conversations, [:conversation_id, :pipeline_id],
               unique: true,
               name: 'index_pipeline_conversations_on_conversation_id_and_pipeline_id',
-              where: 'conversation_id IS NOT NULL'
+              where: 'conversation_id IS NOT NULL',
+              if_not_exists: true
 
     # Add conditional unique index for contact-based pipeline (leads)
     add_index :pipeline_conversations, [:contact_id, :pipeline_id],
               unique: true,
               name: 'index_pipeline_conversations_on_contact_id_and_pipeline_id',
-              where: 'conversation_id IS NULL'
+              where: 'conversation_id IS NULL',
+              if_not_exists: true
 
     # Add foreign key constraint
-    add_foreign_key :pipeline_conversations, :contacts, column: :contact_id
+    add_foreign_key :pipeline_conversations, :contacts, column: :contact_id, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251119155458_make_attachment_polymorphic.rb
+++ b/db/migrate/20251119155458_make_attachment_polymorphic.rb
@@ -1,8 +1,8 @@
 class MakeAttachmentPolymorphic < ActiveRecord::Migration[7.1]
   def up
     # Adicionar colunas polimórficas
-    add_column :attachments, :attachable_type, :string unless column_exists?(:attachments, :attachable_type)
-    add_column :attachments, :attachable_id, :uuid unless column_exists?(:attachments, :attachable_id)
+    add_column :attachments, :attachable_type, :string, if_not_exists: true unless column_exists?(:attachments, :attachable_type)
+    add_column :attachments, :attachable_id, :uuid, if_not_exists: true unless column_exists?(:attachments, :attachable_id)
 
     # Migrar dados existentes (Message -> attachable)
     if column_exists?(:attachments, :message_id)
@@ -16,13 +16,13 @@ class MakeAttachmentPolymorphic < ActiveRecord::Migration[7.1]
 
     # Adicionar índice polimórfico
     if column_exists?(:attachments, :attachable_type) && column_exists?(:attachments, :attachable_id)
-      add_index :attachments, [:attachable_type, :attachable_id] unless index_exists?(:attachments, [:attachable_type, :attachable_id])
+      add_index :attachments, [:attachable_type, :attachable_id], if_not_exists: true unless index_exists?(:attachments, [:attachable_type, :attachable_id])
     end
 
     # Remover coluna antiga e índice antigo
     if column_exists?(:attachments, :message_id)
       remove_index :attachments, :message_id if index_exists?(:attachments, :message_id)
-      remove_column :attachments, :message_id
+      remove_column :attachments, :message_id, if_exists: true
     end
   end
 

--- a/db/migrate/20251119174000_rename_pipeline_conversations_indexes_and_foreign_keys.rb
+++ b/db/migrate/20251119174000_rename_pipeline_conversations_indexes_and_foreign_keys.rb
@@ -22,34 +22,34 @@ class RenamePipelineConversationsIndexesAndForeignKeys < ActiveRecord::Migration
 
     # Remover foreign keys antigas
     if foreign_key_exists?(:pipeline_items, name: 'fk_rails_pipeline_conversations_conversations')
-      remove_foreign_key :pipeline_items, name: 'fk_rails_pipeline_conversations_conversations'
+      remove_foreign_key :pipeline_items, name: 'fk_rails_pipeline_conversations_conversations', if_exists: true
     elsif foreign_key_exists?(:pipeline_items, :conversations)
-      remove_foreign_key :pipeline_items, :conversations
+      remove_foreign_key :pipeline_items, :conversations, if_exists: true
     end
 
     if foreign_key_exists?(:pipeline_items, name: 'fk_rails_pipeline_conversations_pipeline_stages')
-      remove_foreign_key :pipeline_items, name: 'fk_rails_pipeline_conversations_pipeline_stages'
+      remove_foreign_key :pipeline_items, name: 'fk_rails_pipeline_conversations_pipeline_stages', if_exists: true
     elsif foreign_key_exists?(:pipeline_items, :pipeline_stages)
-      remove_foreign_key :pipeline_items, :pipeline_stages
+      remove_foreign_key :pipeline_items, :pipeline_stages, if_exists: true
     end
 
     if foreign_key_exists?(:pipeline_items, name: 'fk_rails_pipeline_conversations_pipelines')
-      remove_foreign_key :pipeline_items, name: 'fk_rails_pipeline_conversations_pipelines'
+      remove_foreign_key :pipeline_items, name: 'fk_rails_pipeline_conversations_pipelines', if_exists: true
     elsif foreign_key_exists?(:pipeline_items, :pipelines)
-      remove_foreign_key :pipeline_items, :pipelines
+      remove_foreign_key :pipeline_items, :pipelines, if_exists: true
     end
 
     if foreign_key_exists?(:stage_movements, name: 'fk_rails_stage_movements_pipeline_conversations')
-      remove_foreign_key :stage_movements, name: 'fk_rails_stage_movements_pipeline_conversations'
+      remove_foreign_key :stage_movements, name: 'fk_rails_stage_movements_pipeline_conversations', if_exists: true
     elsif foreign_key_exists?(:stage_movements, column: :pipeline_conversation_id)
-      remove_foreign_key :stage_movements, column: :pipeline_conversation_id
+      remove_foreign_key :stage_movements, column: :pipeline_conversation_id, if_exists: true
     end
 
     # Adicionar foreign keys com novo nome
-    add_foreign_key :pipeline_items, :conversations, column: :conversation_id unless foreign_key_exists?(:pipeline_items, :conversations)
-    add_foreign_key :pipeline_items, :pipeline_stages, column: :pipeline_stage_id unless foreign_key_exists?(:pipeline_items, :pipeline_stages)
-    add_foreign_key :pipeline_items, :pipelines, column: :pipeline_id unless foreign_key_exists?(:pipeline_items, :pipelines)
-    add_foreign_key :pipeline_items, :contacts, column: :contact_id unless foreign_key_exists?(:pipeline_items, :contacts)
-    add_foreign_key :stage_movements, :pipeline_items, column: :pipeline_item_id unless foreign_key_exists?(:stage_movements, :pipeline_items)
+    add_foreign_key :pipeline_items, :conversations, column: :conversation_id, if_not_exists: true unless foreign_key_exists?(:pipeline_items, :conversations)
+    add_foreign_key :pipeline_items, :pipeline_stages, column: :pipeline_stage_id, if_not_exists: true unless foreign_key_exists?(:pipeline_items, :pipeline_stages)
+    add_foreign_key :pipeline_items, :pipelines, column: :pipeline_id, if_not_exists: true unless foreign_key_exists?(:pipeline_items, :pipelines)
+    add_foreign_key :pipeline_items, :contacts, column: :contact_id, if_not_exists: true unless foreign_key_exists?(:pipeline_items, :contacts)
+    add_foreign_key :stage_movements, :pipeline_items, column: :pipeline_item_id, if_not_exists: true unless foreign_key_exists?(:stage_movements, :pipeline_items)
   end
 end

--- a/db/migrate/20251121132530_create_scheduled_actions.rb
+++ b/db/migrate/20251121132530_create_scheduled_actions.rb
@@ -2,7 +2,7 @@
 
 class CreateScheduledActions < ActiveRecord::Migration[7.0]
   def change
-    create_table :scheduled_actions do |t|
+    create_table :scheduled_actions, if_not_exists: true do |t|
       t.bigint :deal_id
       t.uuid :contact_id
       t.uuid :conversation_id
@@ -22,18 +22,18 @@ class CreateScheduledActions < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :scheduled_actions, :deal_id
-    add_index :scheduled_actions, :contact_id
-    add_index :scheduled_actions, :conversation_id
-    add_index :scheduled_actions, :scheduled_for
-    add_index :scheduled_actions, :status
-    add_index :scheduled_actions, :action_type
-    add_index :scheduled_actions, [:status, :scheduled_for], name: 'idx_scheduled_actions_status_time'
-    add_index :scheduled_actions, [:deal_id, :status], name: 'idx_scheduled_actions_deal_status'
-    add_index :scheduled_actions, [:contact_id, :status], name: 'idx_scheduled_actions_contact_status'
+    add_index :scheduled_actions, :deal_id, if_not_exists: true
+    add_index :scheduled_actions, :contact_id, if_not_exists: true
+    add_index :scheduled_actions, :conversation_id, if_not_exists: true
+    add_index :scheduled_actions, :scheduled_for, if_not_exists: true
+    add_index :scheduled_actions, :status, if_not_exists: true
+    add_index :scheduled_actions, :action_type, if_not_exists: true
+    add_index :scheduled_actions, [:status, :scheduled_for], name: 'idx_scheduled_actions_status_time', if_not_exists: true
+    add_index :scheduled_actions, [:deal_id, :status], name: 'idx_scheduled_actions_deal_status', if_not_exists: true
+    add_index :scheduled_actions, [:contact_id, :status], name: 'idx_scheduled_actions_contact_status', if_not_exists: true
 
-    add_foreign_key :scheduled_actions, :contacts, on_delete: :cascade
-    add_foreign_key :scheduled_actions, :conversations, on_delete: :cascade
+    add_foreign_key :scheduled_actions, :contacts, on_delete: :cascade, if_not_exists: true
+    add_foreign_key :scheduled_actions, :conversations, on_delete: :cascade, if_not_exists: true
   end
 end
 

--- a/db/migrate/20251124163127_create_pipeline_tasks.rb
+++ b/db/migrate/20251124163127_create_pipeline_tasks.rb
@@ -1,6 +1,6 @@
 class CreatePipelineTasks < ActiveRecord::Migration[7.0]
   def change
-    create_table :pipeline_tasks, id: :uuid do |t|
+    create_table :pipeline_tasks, id: :uuid, if_not_exists: true do |t|
       t.references :pipeline_item, type: :uuid, null: false, foreign_key: true
       t.uuid :created_by_id, null: false
       t.uuid :assigned_to_id
@@ -26,10 +26,10 @@ class CreatePipelineTasks < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :pipeline_tasks, [:pipeline_item_id, :status]
-    add_index :pipeline_tasks, [:assigned_to_id, :status, :due_date]
-    add_index :pipeline_tasks, :created_by_id
-    add_index :pipeline_tasks, [:due_date]
-    add_index :pipeline_tasks, [:status, :due_date], where: "status = 0", name: 'index_pipeline_tasks_on_pending_status_and_due_date'
+    add_index :pipeline_tasks, [:pipeline_item_id, :status], if_not_exists: true
+    add_index :pipeline_tasks, [:assigned_to_id, :status, :due_date], if_not_exists: true
+    add_index :pipeline_tasks, :created_by_id, if_not_exists: true
+    add_index :pipeline_tasks, [:due_date], if_not_exists: true
+    add_index :pipeline_tasks, [:status, :due_date], where: "status = 0", name: 'index_pipeline_tasks_on_pending_status_and_due_date', if_not_exists: true
   end
 end

--- a/db/migrate/20251124220146_create_scheduled_action_execution_logs.rb
+++ b/db/migrate/20251124220146_create_scheduled_action_execution_logs.rb
@@ -2,7 +2,7 @@
 
 class CreateScheduledActionExecutionLogs < ActiveRecord::Migration[7.1]
   def change
-    create_table :scheduled_action_execution_logs do |t|
+    create_table :scheduled_action_execution_logs, if_not_exists: true do |t|
       t.references :scheduled_action, null: false, foreign_key: true
       t.string :status, null: false, default: 'completed', limit: 50
       t.text :result_message
@@ -15,8 +15,8 @@ class CreateScheduledActionExecutionLogs < ActiveRecord::Migration[7.1]
 
     # Indexes for querying
     add_index :scheduled_action_execution_logs, [:scheduled_action_id, :created_at],
-      name: 'idx_exec_logs_action_created'
-    add_index :scheduled_action_execution_logs, :status
-    add_index :scheduled_action_execution_logs, :created_at
+      name: 'idx_exec_logs_action_created', if_not_exists: true
+    add_index :scheduled_action_execution_logs, :status, if_not_exists: true
+    add_index :scheduled_action_execution_logs, :created_at, if_not_exists: true
   end
 end

--- a/db/migrate/20251125120000_create_scheduled_action_templates.rb
+++ b/db/migrate/20251125120000_create_scheduled_action_templates.rb
@@ -2,7 +2,7 @@
 
 class CreateScheduledActionTemplates < ActiveRecord::Migration[7.0]
   def change
-    create_table :scheduled_action_templates do |t|
+    create_table :scheduled_action_templates, if_not_exists: true do |t|
       t.string :name, null: false
       t.text :description
       t.string :action_type, null: false, limit: 50
@@ -15,8 +15,8 @@ class CreateScheduledActionTemplates < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :scheduled_action_templates, :action_type
-    add_index :scheduled_action_templates, :is_default, name: 'idx_templates_default'
-    add_index :scheduled_action_templates, :is_public, name: 'idx_templates_public'
+    add_index :scheduled_action_templates, :action_type, if_not_exists: true
+    add_index :scheduled_action_templates, :is_default, name: 'idx_templates_default', if_not_exists: true
+    add_index :scheduled_action_templates, :is_public, name: 'idx_templates_public', if_not_exists: true
   end
 end

--- a/db/migrate/20251125120001_add_notification_fields_to_scheduled_actions.rb
+++ b/db/migrate/20251125120001_add_notification_fields_to_scheduled_actions.rb
@@ -2,9 +2,9 @@
 
 class AddNotificationFieldsToScheduledActions < ActiveRecord::Migration[7.0]
   def change
-    add_column :scheduled_actions, :notify_user_id, :uuid
-    add_column :scheduled_actions, :notification_sent_at, :datetime
+    add_column :scheduled_actions, :notify_user_id, :uuid, if_not_exists: true
+    add_column :scheduled_actions, :notification_sent_at, :datetime, if_not_exists: true
 
-    add_index :scheduled_actions, :notify_user_id
+    add_index :scheduled_actions, :notify_user_id, if_not_exists: true
   end
 end

--- a/db/migrate/20251125120002_create_scheduled_action_notifications.rb
+++ b/db/migrate/20251125120002_create_scheduled_action_notifications.rb
@@ -2,7 +2,7 @@
 
 class CreateScheduledActionNotifications < ActiveRecord::Migration[7.0]
   def change
-    create_table :scheduled_action_notifications do |t|
+    create_table :scheduled_action_notifications, if_not_exists: true do |t|
       t.bigint :scheduled_action_id, null: false
       t.uuid :user_id, null: false
       t.string :notification_type, null: false, limit: 20  # 'success', 'failure', 'retry'
@@ -13,13 +13,13 @@ class CreateScheduledActionNotifications < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :scheduled_action_notifications, :scheduled_action_id
-    add_index :scheduled_action_notifications, :user_id
-    add_index :scheduled_action_notifications, :notification_type
-    add_index :scheduled_action_notifications, :status
-    add_index :scheduled_action_notifications, [:user_id, :created_at], name: 'idx_notifications_user_date'
-    add_index :scheduled_action_notifications, [:scheduled_action_id, :notification_type], name: 'idx_notifications_action_type'
+    add_index :scheduled_action_notifications, :scheduled_action_id, if_not_exists: true
+    add_index :scheduled_action_notifications, :user_id, if_not_exists: true
+    add_index :scheduled_action_notifications, :notification_type, if_not_exists: true
+    add_index :scheduled_action_notifications, :status, if_not_exists: true
+    add_index :scheduled_action_notifications, [:user_id, :created_at], name: 'idx_notifications_user_date', if_not_exists: true
+    add_index :scheduled_action_notifications, [:scheduled_action_id, :notification_type], name: 'idx_notifications_action_type', if_not_exists: true
 
-    add_foreign_key :scheduled_action_notifications, :scheduled_actions, on_delete: :cascade
+    add_foreign_key :scheduled_action_notifications, :scheduled_actions, on_delete: :cascade, if_not_exists: true
   end
 end

--- a/db/migrate/20251127131457_add_hierarchy_to_pipeline_tasks.rb
+++ b/db/migrate/20251127131457_add_hierarchy_to_pipeline_tasks.rb
@@ -1,14 +1,15 @@
 class AddHierarchyToPipelineTasks < ActiveRecord::Migration[7.1]
   def change
-    add_reference :pipeline_tasks, :parent_task, 
-                  type: :uuid, 
-                  foreign_key: { to_table: :pipeline_tasks }, 
-                  null: true
+    add_reference :pipeline_tasks, :parent_task,
+                  type: :uuid,
+                  foreign_key: { to_table: :pipeline_tasks },
+                  null: true,
+                  if_not_exists: true
     
-    add_column :pipeline_tasks, :position, :integer, default: 0, null: false
-    add_column :pipeline_tasks, :depth, :integer, default: 0, null: false
-    
-    add_index :pipeline_tasks, [:parent_task_id, :position]
-    add_index :pipeline_tasks, [:pipeline_item_id, :parent_task_id]
+    add_column :pipeline_tasks, :position, :integer, default: 0, null: false, if_not_exists: true
+    add_column :pipeline_tasks, :depth, :integer, default: 0, null: false, if_not_exists: true
+
+    add_index :pipeline_tasks, [:parent_task_id, :position], if_not_exists: true
+    add_index :pipeline_tasks, [:pipeline_item_id, :parent_task_id], if_not_exists: true
   end
 end

--- a/db/migrate/20251128160529_create_inactivity_action_executions.rb
+++ b/db/migrate/20251128160529_create_inactivity_action_executions.rb
@@ -1,6 +1,6 @@
 class CreateInactivityActionExecutions < ActiveRecord::Migration[7.1]
   def change
-    create_table :inactivity_action_executions, id: :uuid do |t|
+    create_table :inactivity_action_executions, id: :uuid, if_not_exists: true do |t|
       t.uuid :conversation_id, null: false
       t.uuid :agent_bot_id, null: false
       t.integer :action_index, null: false
@@ -12,9 +12,9 @@ class CreateInactivityActionExecutions < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :inactivity_action_executions, :conversation_id
-    add_index :inactivity_action_executions, :agent_bot_id
-    add_index :inactivity_action_executions, [:conversation_id, :action_index], unique: true, name: 'index_inactivity_executions_on_conv_and_action'
-    add_index :inactivity_action_executions, :executed_at
+    add_index :inactivity_action_executions, :conversation_id, if_not_exists: true
+    add_index :inactivity_action_executions, :agent_bot_id, if_not_exists: true
+    add_index :inactivity_action_executions, [:conversation_id, :action_index], unique: true, name: 'index_inactivity_executions_on_conv_and_action', if_not_exists: true
+    add_index :inactivity_action_executions, :executed_at, if_not_exists: true
   end
 end

--- a/db/migrate/20251201132258_create_message_templates.rb
+++ b/db/migrate/20251201132258_create_message_templates.rb
@@ -1,6 +1,6 @@
 class CreateMessageTemplates < ActiveRecord::Migration[7.1]
   def change
-    create_table :message_templates, id: :uuid do |t|
+    create_table :message_templates, id: :uuid, if_not_exists: true do |t|
       t.references :channel, polymorphic: true, null: false, type: :uuid, index: true
       
       t.string :name, null: false

--- a/db/migrate/20251201133832_remove_old_template_columns.rb
+++ b/db/migrate/20251201133832_remove_old_template_columns.rb
@@ -1,22 +1,22 @@
 class RemoveOldTemplateColumns < ActiveRecord::Migration[7.1]
   def up
-    remove_column :channel_whatsapp, :message_templates, :jsonb
-    remove_column :channel_whatsapp, :message_templates_last_updated, :datetime
-    
-    remove_column :channel_facebook_pages, :message_templates, :jsonb
-    remove_column :channel_facebook_pages, :message_templates_last_updated, :datetime
-    
-    remove_column :channel_instagram, :message_templates, :jsonb
-    remove_column :channel_instagram, :message_templates_last_updated, :datetime
-    
-    remove_column :channel_line, :message_templates, :jsonb
-    remove_column :channel_line, :message_templates_last_updated, :datetime
-    
-    remove_column :channel_telegram, :message_templates, :jsonb
-    remove_column :channel_telegram, :message_templates_last_updated, :datetime
-    
-    remove_column :channel_twilio_sms, :message_templates, :jsonb
-    remove_column :channel_twilio_sms, :message_templates_last_updated, :datetime
+    remove_column :channel_whatsapp, :message_templates, :jsonb, if_exists: true
+    remove_column :channel_whatsapp, :message_templates_last_updated, :datetime, if_exists: true
+
+    remove_column :channel_facebook_pages, :message_templates, :jsonb, if_exists: true
+    remove_column :channel_facebook_pages, :message_templates_last_updated, :datetime, if_exists: true
+
+    remove_column :channel_instagram, :message_templates, :jsonb, if_exists: true
+    remove_column :channel_instagram, :message_templates_last_updated, :datetime, if_exists: true
+
+    remove_column :channel_line, :message_templates, :jsonb, if_exists: true
+    remove_column :channel_line, :message_templates_last_updated, :datetime, if_exists: true
+
+    remove_column :channel_telegram, :message_templates, :jsonb, if_exists: true
+    remove_column :channel_telegram, :message_templates_last_updated, :datetime, if_exists: true
+
+    remove_column :channel_twilio_sms, :message_templates, :jsonb, if_exists: true
+    remove_column :channel_twilio_sms, :message_templates_last_updated, :datetime, if_exists: true
   end
 
   def down

--- a/db/migrate/20251201134940_drop_email_templates_table.rb
+++ b/db/migrate/20251201134940_drop_email_templates_table.rb
@@ -1,6 +1,6 @@
 class DropEmailTemplatesTable < ActiveRecord::Migration[7.1]
   def up
-    drop_table :email_templates
+    drop_table :email_templates, if_exists: true
   end
 
   def down

--- a/db/migrate/20251210132544_remove_portal_system.rb
+++ b/db/migrate/20251210132544_remove_portal_system.rb
@@ -4,13 +4,13 @@ class RemovePortalSystem < ActiveRecord::Migration[7.0]
   def up
     # Remove foreign key constraint from inboxes first
     if foreign_key_exists?(:inboxes, :portals)
-      remove_foreign_key :inboxes, :portals
+      remove_foreign_key :inboxes, :portals, if_exists: true
     end
 
     # Remove portal_id column from inboxes
     if column_exists?(:inboxes, :portal_id)
       remove_index :inboxes, :portal_id if index_exists?(:inboxes, :portal_id)
-      remove_column :inboxes, :portal_id
+      remove_column :inboxes, :portal_id, if_exists: true
     end
 
     # Drop join table first

--- a/db/migrate/20260105122008_add_custom_fields_to_pipelines_and_pipeline_stages.rb
+++ b/db/migrate/20260105122008_add_custom_fields_to_pipelines_and_pipeline_stages.rb
@@ -1,12 +1,12 @@
 class AddCustomFieldsToPipelinesAndPipelineStages < ActiveRecord::Migration[7.1]
   def up
     # Add custom_fields to pipelines
-    add_column :pipelines, :custom_fields, :jsonb, default: {}, null: false
-    add_index :pipelines, :custom_fields, using: :gin
+    add_column :pipelines, :custom_fields, :jsonb, default: {}, null: false, if_not_exists: true
+    add_index :pipelines, :custom_fields, using: :gin, if_not_exists: true
 
     # Add custom_fields to pipeline_stages
-    add_column :pipeline_stages, :custom_fields, :jsonb, default: {}, null: false
-    add_index :pipeline_stages, :custom_fields, using: :gin
+    add_column :pipeline_stages, :custom_fields, :jsonb, default: {}, null: false, if_not_exists: true
+    add_index :pipeline_stages, :custom_fields, using: :gin, if_not_exists: true
   end
 
   def down

--- a/db/migrate/20260209134608_add_is_default_to_pipelines.rb
+++ b/db/migrate/20260209134608_add_is_default_to_pipelines.rb
@@ -2,9 +2,9 @@
 
 class AddIsDefaultToPipelines < ActiveRecord::Migration[7.1]
   def change
-    add_column :pipelines, :is_default, :boolean, default: false, null: false
+    add_column :pipelines, :is_default, :boolean, default: false, null: false, if_not_exists: true
     add_index :pipelines, :is_default,
               where: "is_default = true",
-              name: "index_pipelines_on_is_default_unique"
+              name: "index_pipelines_on_is_default_unique", if_not_exists: true
   end
 end

--- a/db/migrate/20260212183241_add_email_signature_to_channel_email.rb
+++ b/db/migrate/20260212183241_add_email_signature_to_channel_email.rb
@@ -1,5 +1,5 @@
 class AddEmailSignatureToChannelEmail < ActiveRecord::Migration[7.0]
   def change
-    add_column :channel_email, :email_signature, :text
+    add_column :channel_email, :email_signature, :text, if_not_exists: true
   end
 end

--- a/db/migrate/20260223150500_add_locale_to_channel_web_widgets.rb
+++ b/db/migrate/20260223150500_add_locale_to_channel_web_widgets.rb
@@ -1,5 +1,5 @@
 class AddLocaleToChannelWebWidgets < ActiveRecord::Migration[7.0]
   def change
-    add_column :channel_web_widgets, :locale, :string
+    add_column :channel_web_widgets, :locale, :string, if_not_exists: true
   end
 end

--- a/db/migrate/20260223163244_create_pipeline_service_definitions.rb
+++ b/db/migrate/20260223163244_create_pipeline_service_definitions.rb
@@ -1,6 +1,6 @@
 class CreatePipelineServiceDefinitions < ActiveRecord::Migration[7.1]
   def change
-    create_table :pipeline_service_definitions, id: :uuid do |t|
+    create_table :pipeline_service_definitions, id: :uuid, if_not_exists: true do |t|
       t.references :pipeline, type: :uuid, null: false, foreign_key: true
       t.string :name, null: false, limit: 255
       t.decimal :default_value, precision: 10, scale: 2, null: false, default: 0.0
@@ -12,7 +12,7 @@ class CreatePipelineServiceDefinitions < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :pipeline_service_definitions, [:pipeline_id, :name], unique: true, name: 'index_pipeline_service_definitions_on_pipeline_and_name'
-    add_index :pipeline_service_definitions, :active
+    add_index :pipeline_service_definitions, [:pipeline_id, :name], unique: true, name: 'index_pipeline_service_definitions_on_pipeline_and_name', if_not_exists: true
+    add_index :pipeline_service_definitions, :active, if_not_exists: true
   end
 end

--- a/db/migrate/20260407120000_add_bsuid_and_username_to_contact_inboxes.rb
+++ b/db/migrate/20260407120000_add_bsuid_and_username_to_contact_inboxes.rb
@@ -1,7 +1,7 @@
 class AddBsuidAndUsernameToContactInboxes < ActiveRecord::Migration[7.0]
   def change
-    add_column :contact_inboxes, :bsuid, :text
-    add_column :contact_inboxes, :whatsapp_username, :text
-    add_index :contact_inboxes, %i[inbox_id bsuid], unique: true, where: 'bsuid IS NOT NULL', name: 'index_contact_inboxes_on_inbox_id_and_bsuid'
+    add_column :contact_inboxes, :bsuid, :text, if_not_exists: true
+    add_column :contact_inboxes, :whatsapp_username, :text, if_not_exists: true
+    add_index :contact_inboxes, %i[inbox_id bsuid], unique: true, where: 'bsuid IS NOT NULL', name: 'index_contact_inboxes_on_inbox_id_and_bsuid', if_not_exists: true
   end
 end

--- a/db/migrate/20260414120000_create_user_tours.rb
+++ b/db/migrate/20260414120000_create_user_tours.rb
@@ -1,7 +1,7 @@
 class CreateUserTours < ActiveRecord::Migration[7.1]
   def change
     unless table_exists?(:user_tours)
-      create_table :user_tours do |t|
+      create_table :user_tours, if_not_exists: true do |t|
         t.uuid :user_id, null: false
         t.string :tour_key, null: false
         t.string :status, null: false, default: 'completed'

--- a/db/migrate/20260512170000_create_automation_rule_runs.rb
+++ b/db/migrate/20260512170000_create_automation_rule_runs.rb
@@ -1,6 +1,6 @@
 class CreateAutomationRuleRuns < ActiveRecord::Migration[7.1]
   def change
-    create_table :automation_rule_runs, id: :uuid do |t|
+    create_table :automation_rule_runs, id: :uuid, if_not_exists: true do |t|
       t.references :automation_rule, type: :uuid, null: false, foreign_key: { on_delete: :cascade }
       t.string :event_name, null: false
       t.string :status, null: false
@@ -16,8 +16,8 @@ class CreateAutomationRuleRuns < ActiveRecord::Migration[7.1]
 
     add_index :automation_rule_runs, [:automation_rule_id, :started_at],
               order: { started_at: :desc },
-              name: 'index_automation_rule_runs_on_rule_and_started_at'
-    add_index :automation_rule_runs, :started_at
-    add_index :automation_rule_runs, :status
+              name: 'index_automation_rule_runs_on_rule_and_started_at', if_not_exists: true
+    add_index :automation_rule_runs, :started_at, if_not_exists: true
+    add_index :automation_rule_runs, :status, if_not_exists: true
   end
 end

--- a/db/migrate/20260513150000_create_products.rb
+++ b/db/migrate/20260513150000_create_products.rb
@@ -1,6 +1,6 @@
 class CreateProducts < ActiveRecord::Migration[7.1]
   def change
-    create_table :products, id: :uuid do |t|
+    create_table :products, id: :uuid, if_not_exists: true do |t|
       t.string :name, null: false, limit: 255
       t.string :slug, limit: 255
       t.string :kind, null: false, default: 'physical', limit: 20
@@ -16,14 +16,14 @@ class CreateProducts < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :products, :sku, unique: true, where: 'sku IS NOT NULL'
-    add_index :products, :status
-    add_index :products, :kind
-    add_index :products, :metadata, using: :gin
+    add_index :products, :sku, unique: true, where: 'sku IS NOT NULL', if_not_exists: true
+    add_index :products, :status, if_not_exists: true
+    add_index :products, :kind, if_not_exists: true
+    add_index :products, :metadata, using: :gin, if_not_exists: true
 
-    add_check_constraint :products, "kind IN ('physical', 'digital')", name: 'products_kind_check'
-    add_check_constraint :products, "status IN ('active', 'inactive', 'draft')", name: 'products_status_check'
-    add_check_constraint :products, 'default_price >= 0', name: 'products_default_price_non_negative'
-    add_check_constraint :products, '(stock_quantity IS NULL) OR (stock_quantity >= 0)', name: 'products_stock_quantity_non_negative'
+    add_check_constraint :products, "kind IN ('physical', 'digital')", name: 'products_kind_check', if_not_exists: true
+    add_check_constraint :products, "status IN ('active', 'inactive', 'draft')", name: 'products_status_check', if_not_exists: true
+    add_check_constraint :products, 'default_price >= 0', name: 'products_default_price_non_negative', if_not_exists: true
+    add_check_constraint :products, '(stock_quantity IS NULL) OR (stock_quantity >= 0)', name: 'products_stock_quantity_non_negative', if_not_exists: true
   end
 end

--- a/db/migrate/20260513150100_create_product_variants.rb
+++ b/db/migrate/20260513150100_create_product_variants.rb
@@ -1,6 +1,6 @@
 class CreateProductVariants < ActiveRecord::Migration[7.1]
   def change
-    create_table :product_variants, id: :uuid do |t|
+    create_table :product_variants, id: :uuid, if_not_exists: true do |t|
       t.references :product, type: :uuid, null: false, foreign_key: { on_delete: :cascade }
       t.string :name, null: false, limit: 255
       t.string :sku, limit: 100
@@ -12,11 +12,11 @@ class CreateProductVariants < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :product_variants, [:product_id, :name], unique: true, name: 'index_product_variants_on_product_and_name'
-    add_index :product_variants, :sku, unique: true, where: 'sku IS NOT NULL'
-    add_index :product_variants, :attributes_data, using: :gin
+    add_index :product_variants, [:product_id, :name], unique: true, name: 'index_product_variants_on_product_and_name', if_not_exists: true
+    add_index :product_variants, :sku, unique: true, where: 'sku IS NOT NULL', if_not_exists: true
+    add_index :product_variants, :attributes_data, using: :gin, if_not_exists: true
 
-    add_check_constraint :product_variants, '(price_override IS NULL) OR (price_override >= 0)', name: 'product_variants_price_override_non_negative'
-    add_check_constraint :product_variants, '(stock_quantity IS NULL) OR (stock_quantity >= 0)', name: 'product_variants_stock_quantity_non_negative'
+    add_check_constraint :product_variants, '(price_override IS NULL) OR (price_override >= 0)', name: 'product_variants_price_override_non_negative', if_not_exists: true
+    add_check_constraint :product_variants, '(stock_quantity IS NULL) OR (stock_quantity >= 0)', name: 'product_variants_stock_quantity_non_negative', if_not_exists: true
   end
 end

--- a/db/migrate/20260513150200_create_ai_agent_products.rb
+++ b/db/migrate/20260513150200_create_ai_agent_products.rb
@@ -4,14 +4,14 @@ class CreateAiAgentProducts < ActiveRecord::Migration[7.1]
     # possible at the database level) to a Product in this CRM. The agent
     # association is validated via API in the application layer; only the
     # product side has a foreign key here.
-    create_table :ai_agent_products, id: :uuid do |t|
+    create_table :ai_agent_products, id: :uuid, if_not_exists: true do |t|
       t.uuid :ai_agent_id, null: false
       t.references :product, type: :uuid, null: false, foreign_key: { on_delete: :cascade }
 
       t.timestamps
     end
 
-    add_index :ai_agent_products, [:ai_agent_id, :product_id], unique: true, name: 'index_ai_agent_products_unique'
-    add_index :ai_agent_products, :ai_agent_id
+    add_index :ai_agent_products, [:ai_agent_id, :product_id], unique: true, name: 'index_ai_agent_products_unique', if_not_exists: true
+    add_index :ai_agent_products, :ai_agent_id, if_not_exists: true
   end
 end

--- a/db/migrate/20260513150300_create_pipeline_item_products.rb
+++ b/db/migrate/20260513150300_create_pipeline_item_products.rb
@@ -1,6 +1,6 @@
 class CreatePipelineItemProducts < ActiveRecord::Migration[7.1]
   def change
-    create_table :pipeline_item_products, id: :uuid do |t|
+    create_table :pipeline_item_products, id: :uuid, if_not_exists: true do |t|
       t.references :pipeline_item, type: :uuid, null: false, foreign_key: { on_delete: :cascade }
       t.references :product, type: :uuid, null: false, foreign_key: { on_delete: :restrict }
       t.references :product_variant, type: :uuid, null: true, foreign_key: { on_delete: :restrict }
@@ -18,10 +18,10 @@ class CreatePipelineItemProducts < ActiveRecord::Migration[7.1]
 
     add_index :pipeline_item_products, [:pipeline_item_id, :product_id, :product_variant_id],
               name: 'index_pipeline_item_products_unique_combo',
-              unique: false
-    add_index :pipeline_item_products, [:created_by_type, :created_by_id], name: 'index_pipeline_item_products_on_creator'
+              unique: false, if_not_exists: true
+    add_index :pipeline_item_products, [:created_by_type, :created_by_id], name: 'index_pipeline_item_products_on_creator', if_not_exists: true
 
-    add_check_constraint :pipeline_item_products, 'quantity > 0', name: 'pipeline_item_products_quantity_positive'
-    add_check_constraint :pipeline_item_products, 'locked_unit_price >= 0', name: 'pipeline_item_products_locked_unit_price_non_negative'
+    add_check_constraint :pipeline_item_products, 'quantity > 0', name: 'pipeline_item_products_quantity_positive', if_not_exists: true
+    add_check_constraint :pipeline_item_products, 'locked_unit_price >= 0', name: 'pipeline_item_products_locked_unit_price_non_negative', if_not_exists: true
   end
 end

--- a/db/migrate/20260517000001_allow_re_pipeline_for_completed_items.rb
+++ b/db/migrate/20260517000001_allow_re_pipeline_for_completed_items.rb
@@ -9,12 +9,12 @@ class AllowRePipelineForCompletedItems < ActiveRecord::Migration[7.0]
     add_index :pipeline_items, [:conversation_id, :pipeline_id],
               unique: true,
               where: 'conversation_id IS NOT NULL AND completed_at IS NULL',
-              name: :idx_pipeline_items_active_conversation_per_pipeline
+              name: :idx_pipeline_items_active_conversation_per_pipeline, if_not_exists: true
 
     add_index :pipeline_items, [:contact_id, :pipeline_id],
               unique: true,
               where: 'conversation_id IS NULL AND completed_at IS NULL',
-              name: :idx_pipeline_items_active_contact_per_pipeline
+              name: :idx_pipeline_items_active_contact_per_pipeline, if_not_exists: true
   end
 
   def down
@@ -24,11 +24,11 @@ class AllowRePipelineForCompletedItems < ActiveRecord::Migration[7.0]
     add_index :pipeline_items, [:conversation_id, :pipeline_id],
               unique: true,
               where: 'conversation_id IS NOT NULL',
-              name: :index_pipeline_items_on_conversation_id_and_pipeline_id
+              name: :index_pipeline_items_on_conversation_id_and_pipeline_id, if_not_exists: true
 
     add_index :pipeline_items, [:contact_id, :pipeline_id],
               unique: true,
               where: 'conversation_id IS NULL',
-              name: :index_pipeline_items_on_contact_id_and_pipeline_id
+              name: :index_pipeline_items_on_contact_id_and_pipeline_id, if_not_exists: true
   end
 end

--- a/db/migrate/20260518000001_create_macro_executions.rb
+++ b/db/migrate/20260518000001_create_macro_executions.rb
@@ -1,6 +1,6 @@
 class CreateMacroExecutions < ActiveRecord::Migration[7.0]
   def change
-    create_table :macro_executions, id: :uuid do |t|
+    create_table :macro_executions, id: :uuid, if_not_exists: true do |t|
       t.references :macro, type: :uuid, null: false, foreign_key: true
       t.references :conversation, type: :uuid, null: false, foreign_key: true
       t.references :user, type: :uuid, null: false, foreign_key: { to_table: :users }
@@ -12,7 +12,7 @@ class CreateMacroExecutions < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :macro_executions, [:conversation_id, :created_at]
-    add_index :macro_executions, :status
+    add_index :macro_executions, [:conversation_id, :created_at], if_not_exists: true
+    add_index :macro_executions, :status, if_not_exists: true
   end
 end

--- a/db/migrate/20260520192951_add_evolution_hub_meta_to_channels.rb
+++ b/db/migrate/20260520192951_add_evolution_hub_meta_to_channels.rb
@@ -7,7 +7,7 @@
 # the key `evolution_hub` inside it — no schema change needed there.
 class AddEvolutionHubMetaToChannels < ActiveRecord::Migration[7.1]
   def change
-    add_column :channel_facebook_pages, :evolution_hub_meta, :jsonb, default: {}, null: false
-    add_column :channel_instagram, :evolution_hub_meta, :jsonb, default: {}, null: false
+    add_column :channel_facebook_pages, :evolution_hub_meta, :jsonb, default: {}, null: false, if_not_exists: true
+    add_column :channel_instagram, :evolution_hub_meta, :jsonb, default: {}, null: false, if_not_exists: true
   end
 end

--- a/db/migrate/20260608194533_create_channel_sendgrid.rb
+++ b/db/migrate/20260608194533_create_channel_sendgrid.rb
@@ -1,6 +1,6 @@
 class CreateChannelSendgrid < ActiveRecord::Migration[7.1]
   def change
-    create_table :channel_sendgrid, id: :uuid, default: -> { 'gen_random_uuid()' } do |t|
+    create_table :channel_sendgrid, id: :uuid, default: -> { 'gen_random_uuid()' }, if_not_exists: true do |t|
       t.text :api_key_encrypted, null: false
       t.string :from_email, null: false
       t.string :from_name
@@ -10,6 +10,6 @@ class CreateChannelSendgrid < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :channel_sendgrid, :from_email
+    add_index :channel_sendgrid, :from_email, if_not_exists: true
   end
 end

--- a/db/migrate/20260609120000_add_webhook_registration_status_to_channel_sendgrid.rb
+++ b/db/migrate/20260609120000_add_webhook_registration_status_to_channel_sendgrid.rb
@@ -1,5 +1,5 @@
 class AddWebhookRegistrationStatusToChannelSendgrid < ActiveRecord::Migration[7.1]
   def change
-    add_column :channel_sendgrid, :webhook_registration_status, :string, null: false, default: 'pending'
+    add_column :channel_sendgrid, :webhook_registration_status, :string, null: false, default: 'pending', if_not_exists: true
   end
 end

--- a/db/migrate/20260609130000_add_email_suppression_to_contacts.rb
+++ b/db/migrate/20260609130000_add_email_suppression_to_contacts.rb
@@ -2,7 +2,7 @@
 
 class AddEmailSuppressionToContacts < ActiveRecord::Migration[7.1]
   def change
-    add_column :contacts, :email_suppressed, :boolean, default: false, null: false
-    add_column :contacts, :email_suppression_reason, :string
+    add_column :contacts, :email_suppressed, :boolean, default: false, null: false, if_not_exists: true
+    add_column :contacts, :email_suppression_reason, :string, if_not_exists: true
   end
 end

--- a/db/migrate/20260609140000_decouple_message_templates_channel.rb
+++ b/db/migrate/20260609140000_decouple_message_templates_channel.rb
@@ -11,7 +11,7 @@ class DecoupleMessageTemplatesChannel < ActiveRecord::Migration[7.1]
     add_index :message_templates, :name,
               unique: true,
               where: 'channel_id IS NULL',
-              name: 'idx_message_templates_global_name'
+              name: 'idx_message_templates_global_name', if_not_exists: true
   end
 
   def down

--- a/db/migrate/20260611120000_add_external_legacy_id_to_message_templates.rb
+++ b/db/migrate/20260611120000_add_external_legacy_id_to_message_templates.rb
@@ -6,11 +6,11 @@
 # can never insert a duplicate global counterpart for the same source row.
 class AddExternalLegacyIdToMessageTemplates < ActiveRecord::Migration[7.1]
   def change
-    add_column :message_templates, :external_legacy_id, :string
+    add_column :message_templates, :external_legacy_id, :string, if_not_exists: true
 
     add_index :message_templates, :external_legacy_id,
               unique: true,
               where: 'external_legacy_id IS NOT NULL',
-              name: 'idx_message_templates_external_legacy_id'
+              name: 'idx_message_templates_external_legacy_id', if_not_exists: true
   end
 end

--- a/db/migrate/20260611130000_add_template_refs_to_inboxes.rb
+++ b/db/migrate/20260611130000_add_template_refs_to_inboxes.rb
@@ -8,7 +8,7 @@
 # string column on an unresolvable id).
 class AddTemplateRefsToInboxes < ActiveRecord::Migration[7.1]
   def change
-    add_column :inboxes, :greeting_message_template_id, :uuid, null: true
-    add_column :inboxes, :out_of_office_message_template_id, :uuid, null: true
+    add_column :inboxes, :greeting_message_template_id, :uuid, null: true, if_not_exists: true
+    add_column :inboxes, :out_of_office_message_template_id, :uuid, null: true, if_not_exists: true
   end
 end

--- a/db/migrate/20260612000000_create_stage_inactivity_executions.rb
+++ b/db/migrate/20260612000000_create_stage_inactivity_executions.rb
@@ -1,6 +1,6 @@
 class CreateStageInactivityExecutions < ActiveRecord::Migration[7.1]
   def change
-    create_table :stage_inactivity_executions, id: :uuid do |t|
+    create_table :stage_inactivity_executions, id: :uuid, if_not_exists: true do |t|
       t.uuid :pipeline_item_id, null: false
       t.uuid :pipeline_stage_id, null: false
       t.string :rule_id, null: false      # rule['id'] (uuid) ou hash estável de fallback
@@ -13,12 +13,12 @@ class CreateStageInactivityExecutions < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :stage_inactivity_executions, :pipeline_item_id
-    add_index :stage_inactivity_executions, :executed_at
+    add_index :stage_inactivity_executions, :pipeline_item_id, if_not_exists: true
+    add_index :stage_inactivity_executions, :executed_at, if_not_exists: true
     # Barra a SEGUNDA mensagem (reserva-antes-de-enviar): índice único por (item, regra).
     add_index :stage_inactivity_executions, %i[pipeline_item_id rule_id],
-              unique: true, name: 'index_stage_inactivity_on_item_and_rule'
+              unique: true, name: 'index_stage_inactivity_on_item_and_rule', if_not_exists: true
 
-    add_foreign_key :stage_inactivity_executions, :pipeline_items, on_delete: :cascade
+    add_foreign_key :stage_inactivity_executions, :pipeline_items, on_delete: :cascade, if_not_exists: true
   end
 end

--- a/db/migrate/20260619120000_create_crm_forms.rb
+++ b/db/migrate/20260619120000_create_crm_forms.rb
@@ -1,6 +1,6 @@
 class CreateCrmForms < ActiveRecord::Migration[7.1]
   def change
-    create_table :crm_forms, id: :uuid do |t|
+    create_table :crm_forms, id: :uuid, if_not_exists: true do |t|
       t.string :name, null: false, limit: 255
       t.string :slug, null: false, limit: 255
       t.string :title, limit: 255
@@ -15,15 +15,15 @@ class CreateCrmForms < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :crm_forms, :slug, unique: true
-    add_index :crm_forms, :published
-    add_index :crm_forms, :fields, using: :gin
-    add_index :crm_forms, :routing_rules, using: :gin
+    add_index :crm_forms, :slug, unique: true, if_not_exists: true
+    add_index :crm_forms, :published, if_not_exists: true
+    add_index :crm_forms, :fields, using: :gin, if_not_exists: true
+    add_index :crm_forms, :routing_rules, using: :gin, if_not_exists: true
 
-    add_foreign_key :crm_forms, :pipelines, column: :default_pipeline_id
-    add_foreign_key :crm_forms, :pipeline_stages, column: :default_stage_id
+    add_foreign_key :crm_forms, :pipelines, column: :default_pipeline_id, if_not_exists: true
+    add_foreign_key :crm_forms, :pipeline_stages, column: :default_stage_id, if_not_exists: true
 
-    add_check_constraint :crm_forms, "name != ''", name: 'crm_forms_name_not_empty'
-    add_check_constraint :crm_forms, "slug != ''", name: 'crm_forms_slug_not_empty'
+    add_check_constraint :crm_forms, "name != ''", name: 'crm_forms_name_not_empty', if_not_exists: true
+    add_check_constraint :crm_forms, "slug != ''", name: 'crm_forms_slug_not_empty', if_not_exists: true
   end
 end

--- a/db/migrate/20260619130000_create_chat_pages.rb
+++ b/db/migrate/20260619130000_create_chat_pages.rb
@@ -1,6 +1,6 @@
 class CreateChatPages < ActiveRecord::Migration[7.1]
   def change
-    create_table :chat_pages, id: :uuid do |t|
+    create_table :chat_pages, id: :uuid, if_not_exists: true do |t|
       t.string :slug, null: false, limit: 255
       t.string :title, limit: 255
       t.text :description
@@ -11,11 +11,11 @@ class CreateChatPages < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :chat_pages, :slug, unique: true
-    add_index :chat_pages, :published
-    add_index :chat_pages, :website_token
+    add_index :chat_pages, :slug, unique: true, if_not_exists: true
+    add_index :chat_pages, :published, if_not_exists: true
+    add_index :chat_pages, :website_token, if_not_exists: true
 
-    add_check_constraint :chat_pages, "slug != ''", name: 'chat_pages_slug_not_empty'
-    add_check_constraint :chat_pages, "website_token != ''", name: 'chat_pages_website_token_not_empty'
+    add_check_constraint :chat_pages, "slug != ''", name: 'chat_pages_slug_not_empty', if_not_exists: true
+    add_check_constraint :chat_pages, "website_token != ''", name: 'chat_pages_website_token_not_empty', if_not_exists: true
   end
 end

--- a/db/migrate/20260622120000_add_source_to_messages.rb
+++ b/db/migrate/20260622120000_add_source_to_messages.rb
@@ -1,5 +1,5 @@
 class AddSourceToMessages < ActiveRecord::Migration[7.0]
   def change
-    add_column :messages, :source, :integer, default: 0, null: false
+    add_column :messages, :source, :integer, default: 0, null: false, if_not_exists: true
   end
 end

--- a/db/migrate/20260623120000_add_source_to_conversations.rb
+++ b/db/migrate/20260623120000_add_source_to_conversations.rb
@@ -1,5 +1,5 @@
 class AddSourceToConversations < ActiveRecord::Migration[7.0]
   def change
-    add_column :conversations, :source, :integer, default: 0, null: false
+    add_column :conversations, :source, :integer, default: 0, null: false, if_not_exists: true
   end
 end

--- a/db/migrate/20260625190000_add_email_signature_to_channel_sendgrid.rb
+++ b/db/migrate/20260625190000_add_email_signature_to_channel_sendgrid.rb
@@ -1,5 +1,5 @@
 class AddEmailSignatureToChannelSendgrid < ActiveRecord::Migration[7.1]
   def change
-    add_column :channel_sendgrid, :email_signature, :text
+    add_column :channel_sendgrid, :email_signature, :text, if_not_exists: true
   end
 end

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -164,10 +164,11 @@ WORKDIR /app
 
 EXPOSE 3000
 
-# EVO-1999: a imagem sobe pelo rails.sh, que prepara o banco no boot (gate
-# RUN_MIGRATIONS, default true) — assim qualquer orquestrador que ignore o
-# command/entrypoint do compose (CapRover) ainda migra e sobe o schema atualizado.
-# O CMD default sobe o server; o serviço sidekiq sobrescreve o command (e deve
-# setar RUN_MIGRATIONS=false para não preparar o banco em duplicado).
+# EVO-1999: the image boots via rails.sh, which prepares the database on boot
+# (RUN_MIGRATIONS gate, default true) — so any orchestrator that ignores the
+# compose command/entrypoint (CapRover) still migrates and brings up an
+# up-to-date schema. The default CMD starts the server; the sidekiq service
+# overrides the command (and must set RUN_MIGRATIONS=false to avoid preparing
+# the database twice).
 ENTRYPOINT ["/app/docker/entrypoints/rails.sh"]
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -163,3 +163,11 @@ RUN dos2unix /app/docker/entrypoints/*.sh \
 WORKDIR /app
 
 EXPOSE 3000
+
+# EVO-1999: a imagem sobe pelo rails.sh, que prepara o banco no boot (gate
+# RUN_MIGRATIONS, default true) — assim qualquer orquestrador que ignore o
+# command/entrypoint do compose (CapRover) ainda migra e sobe o schema atualizado.
+# O CMD default sobe o server; o serviço sidekiq sobrescreve o command (e deve
+# setar RUN_MIGRATIONS=false para não preparar o banco em duplicado).
+ENTRYPOINT ["/app/docker/entrypoints/rails.sh"]
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -23,8 +23,17 @@ echo "Database ready to accept connections."
 # Ensure gems are installed and up-to-date
 bundle check || bundle install
 
-# Prepare the database (create if missing, run migrations)
-bundle exec rails db:prepare
+# Prepare the database (create if missing, run migrations).
+# EVO-1999: gate RUN_MIGRATIONS (default 'true' = fail-safe) para que o serviço web
+# sempre migre no boot, inclusive em orquestradores que ignoram o command/entrypoint
+# do compose (CapRover). Defina RUN_MIGRATIONS=false nos *-sidekiq para evitar
+# preparar o banco em duplicado (o db:prepare do web já cobre, via advisory lock).
+if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
+  echo "Preparing database (RUN_MIGRATIONS=${RUN_MIGRATIONS:-true})..."
+  bundle exec rails db:prepare
+else
+  echo "Skipping database preparation (RUN_MIGRATIONS=${RUN_MIGRATIONS})."
+fi
 
 # Execute the main process of the container
 exec "$@"

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -24,13 +24,16 @@ echo "Database ready to accept connections."
 bundle check || bundle install
 
 # Prepare the database (create if missing, run migrations).
-# EVO-1999: gate RUN_MIGRATIONS (default 'true' = fail-safe) para que o serviço web
-# sempre migre no boot, inclusive em orquestradores que ignoram o command/entrypoint
-# do compose (CapRover). Defina RUN_MIGRATIONS=false nos *-sidekiq para evitar
-# preparar o banco em duplicado (o db:prepare do web já cobre, via advisory lock).
-if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
+# EVO-1999: RUN_MIGRATIONS gate (default 'true' = fail-safe) so the web service
+# always migrates on boot, including on orchestrators that ignore the compose
+# command/entrypoint (CapRover). Set RUN_MIGRATIONS=false on *-sidekiq services to
+# avoid preparing the database twice (the web's db:prepare covers it, via advisory
+# lock). Compared against "false" (not == "true") so TRUE/1/typos still migrate.
+if [ "${RUN_MIGRATIONS:-true}" != "false" ]; then
   echo "Preparing database (RUN_MIGRATIONS=${RUN_MIGRATIONS:-true})..."
-  bundle exec rails db:prepare
+  # Fail-safe: abort the boot if db:prepare fails, instead of starting the server
+  # against a stale/half-migrated schema. Lets the orchestrator restart and retry.
+  bundle exec rails db:prepare || exit 1
 else
   echo "Skipping database preparation (RUN_MIGRATIONS=${RUN_MIGRATIONS})."
 fi


### PR DESCRIPTION
## Problema
Orquestradores como o CapRover deployam pela imagem e sobem o container com o `ENTRYPOINT`/`CMD` da imagem, **ignorando o `command:`/`entrypoint:` do docker-compose** — onde hoje o `db:migrate` acontece. Cada atualização de imagem deixa migrations pendentes e o web sobe com schema desatualizado (ex.: 500 `Undeclared attribute type for enum 'source'` numa rota que usa coluna nova).

## Solução
- **`docker/Dockerfile`**: `ENTRYPOINT ["/app/docker/entrypoints/rails.sh"]` + `CMD` server — a imagem migra no boot em qualquer orquestrador.
- **`docker/entrypoints/rails.sh`**: gate `RUN_MIGRATIONS` (default `true` = fail-safe) em volta do `db:prepare`. O serviço sidekiq seta `false` (não prepara em duplicado).
- **Migrations 2026 idempotentes** (`if_not_exists` em `add_column`/`create_table`/`add_index`/`add_check_constraint`/`add_foreign_key`) — para não travar em upgrade dessincronizado (schema já existente + version faltando em `schema_migrations` → `DuplicateColumn`/`DuplicateObject`).

## Config no deploy
- web: `RUN_MIGRATIONS=true` · sidekiq: `RUN_MIGRATIONS=false`.
- Advisory lock do Postgres protege múltiplas réplicas migrando ao mesmo tempo.

## Testes
- [x] Imagem pura (`docker run` sem command) migra no boot + Puma sobe.
- [x] Sidekiq com `RUN_MIGRATIONS=false` pula a preparação.
- [x] Migrate de upgrade (version removida de `schema_migrations`, coluna já existente) re-aplica **sem** `DuplicateColumn`/`DuplicateObject`.
- [x] **Validado no CapRover real**: trocar a tag da imagem migra sozinho, 0 pendentes, sem `db:migrate` manual.

Closes EVO-1999
