### PR TITLE
fix(boot): guard facebook_webhook_logger middleware insert (EVO-2012)

### DIFF
--- a/config/initializers/facebook_webhook_logger.rb
+++ b/config/initializers/facebook_webhook_logger.rb
@@ -3,5 +3,13 @@
 # Require the middleware class explicitly before registering
 require_relative '../../app/middleware/facebook_webhook_logger'
 
-Rails.application.config.middleware.insert_before ActionDispatch::Static, FacebookWebhookLogger
+# Insere antes do ActionDispatch::Static quando ele existe (RAILS_SERVE_STATIC_FILES=true).
+# Com static desabilitado (=false) esse middleware NAO esta na stack, e o insert_before
+# quebra o boot ("No such middleware to insert before: ActionDispatch::Static") -> nesse
+# caso inserimos no topo da stack, mantendo o logger cedo o suficiente.
+if Rails.application.config.public_file_server.enabled
+  Rails.application.config.middleware.insert_before ActionDispatch::Static, FacebookWebhookLogger
+else
+  Rails.application.config.middleware.insert_before 0, FacebookWebhookLogger
+end
 

--- a/config/initializers/facebook_webhook_logger.rb
+++ b/config/initializers/facebook_webhook_logger.rb
@@ -3,10 +3,10 @@
 # Require the middleware class explicitly before registering
 require_relative '../../app/middleware/facebook_webhook_logger'
 
-# Insere antes do ActionDispatch::Static quando ele existe (RAILS_SERVE_STATIC_FILES=true).
-# Com static desabilitado (=false) esse middleware NAO esta na stack, e o insert_before
-# quebra o boot ("No such middleware to insert before: ActionDispatch::Static") -> nesse
-# caso inserimos no topo da stack, mantendo o logger cedo o suficiente.
+# Insert before ActionDispatch::Static when it exists (RAILS_SERVE_STATIC_FILES=true).
+# With static files disabled (=false) that middleware is NOT in the stack and insert_before
+# breaks the boot ("No such middleware to insert before: ActionDispatch::Static") -> in that
+# case insert at the top of the stack, keeping the logger early enough.
 if Rails.application.config.public_file_server.enabled
   Rails.application.config.middleware.insert_before ActionDispatch::Static, FacebookWebhookLogger
 else


### PR DESCRIPTION
## Problema
`config/initializers/facebook_webhook_logger.rb` fazia `insert_before ActionDispatch::Static` **sem guarda**. Com `RAILS_SERVE_STATIC_FILES=false` (comum em deploy atrás de CDN/Nginx), o `ActionDispatch::Static` **não está** na stack de middleware → o boot quebra com `No such middleware to insert before: ActionDispatch::Static`.

## Solução
Guarda em `Rails.application.config.public_file_server.enabled`: insere antes do `ActionDispatch::Static` quando ele existe; senão insere no topo da stack (`insert_before 0`), mantendo o logger cedo o suficiente.

## Testes
- [x] Boot com `RAILS_SERVE_STATIC_FILES=true` → logger antes do `Static` (comportamento atual).
- [x] Boot com `RAILS_SERVE_STATIC_FILES=false` → **sobe sem crash**.

Closes EVO-2012

## Summary by Sourcery

Bug Fixes:
- Prevent boot failures when ActionDispatch::Static is not present in the middleware stack by conditionally inserting the FacebookWebhookLogger.