### PR TITLE
fix(onboarding): guard onboarding redirect against orphan flag (EVO-2013)

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -60,11 +60,12 @@ class DashboardController < ActionController::Base
   def ensure_installation_onboarding
     return unless ::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
 
-    # EVO-2013: se já existe usuário, a instalação não é virgem — a flag ficou órfã
-    # (ex.: admin criado pelo evo-auth-service e sincronizado ao logar, sem passar
-    # pelo onboarding#create do CRM, ou um re-run do seed). Limpa a flag e não
-    # redireciona, evitando o loop de onboarding. (Evo CRM é single-tenant, sem
-    # model Account — o sinal de "instalação já usada" é a existência de User.)
+    # EVO-2013: if a user already exists the installation is not virgin — the flag
+    # went orphan (e.g. the admin was created by evo-auth-service and synced on
+    # login, never passing through the CRM onboarding#create, or a seed re-run).
+    # Clear it and skip the redirect to break the onboarding loop. (Evo CRM is
+    # single-tenant, there is no Account model — an existing User is the signal
+    # for "installation already in use".)
     if User.exists?
       ::Redis::Alfred.delete(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
       return

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -58,7 +58,19 @@ class DashboardController < ActionController::Base
   end
 
   def ensure_installation_onboarding
-    redirect_to '/installation/onboarding' if ::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
+    return unless ::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
+
+    # EVO-2013: se já existe usuário, a instalação não é virgem — a flag ficou órfã
+    # (ex.: admin criado pelo evo-auth-service e sincronizado ao logar, sem passar
+    # pelo onboarding#create do CRM, ou um re-run do seed). Limpa a flag e não
+    # redireciona, evitando o loop de onboarding. (Evo CRM é single-tenant, sem
+    # model Account — o sinal de "instalação já usada" é a existência de User.)
+    if User.exists?
+      ::Redis::Alfred.delete(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
+      return
+    end
+
+    redirect_to '/installation/onboarding'
   end
 
   def render_hc_if_custom_domain

--- a/app/controllers/installation/onboarding_controller.rb
+++ b/app/controllers/installation/onboarding_controller.rb
@@ -37,6 +37,15 @@ class Installation::OnboardingController < ApplicationController
   end
 
   def ensure_installation_onboarding
-    redirect_to '/' unless ::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
+    return redirect_to '/' unless ::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
+
+    # EVO-2013: on API-only deploys (EVOLUTION_API_ONLY_SERVER default true) the
+    # dashboard routes are not drawn, so the dashboard-side guard never runs and an
+    # orphan flag would keep these endpoints open forever. Same rule as there: an
+    # existing User means the installation is not virgin — clear the flag and leave.
+    return unless User.exists?
+
+    ::Redis::Alfred.delete(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)
+    redirect_to '/'
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,11 +4,12 @@ ConfigLoader.new.process
 
 ## Seeds productions
 if Rails.env.production?
-  # Setup Onboarding flow — só marca onboarding pendente em instalação virgem.
-  # EVO-2013: sem a guarda `unless User.exists?`, um re-run do seed sobre uma
-  # instalação já configurada re-seta a flag e prende o usuário no
-  # /installation/onboarding (a flag só é limpa no onboarding#create). Evo CRM é
-  # single-tenant (sem model Account); o sinal de "já usada" é a existência de User.
+  # Setup Onboarding flow — only mark onboarding as pending on a virgin install.
+  # EVO-2013: without the `unless User.exists?` guard a seed re-run on an already
+  # configured installation re-sets the flag and traps users on
+  # /installation/onboarding (the flag is only cleared by onboarding#create).
+  # Evo CRM is single-tenant (no Account model); an existing User is the signal
+  # for "installation already in use".
   Redis::Alfred.set(Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING, true) unless User.exists?
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,8 +4,12 @@ ConfigLoader.new.process
 
 ## Seeds productions
 if Rails.env.production?
-  # Setup Onboarding flow
-  Redis::Alfred.set(Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING, true)
+  # Setup Onboarding flow — só marca onboarding pendente em instalação virgem.
+  # EVO-2013: sem a guarda `unless User.exists?`, um re-run do seed sobre uma
+  # instalação já configurada re-seta a flag e prende o usuário no
+  # /installation/onboarding (a flag só é limpa no onboarding#create). Evo CRM é
+  # single-tenant (sem model Account); o sinal de "já usada" é a existência de User.
+  Redis::Alfred.set(Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING, true) unless User.exists?
 end
 
 ## Seeds for Local Development

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2013: an orphan EVOLUTION_INSTALLATION_ONBOARDING flag (users exist but the
+# flag was never cleared) used to redirect every dashboard access to
+# /installation/onboarding in a loop. The guard clears the flag instead.
+RSpec.describe DashboardController, type: :controller do
+  controller(described_class) do
+    def index
+      head :ok
+    end
+  end
+
+  before { ::Redis::Alfred.delete(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING) }
+  after { ::Redis::Alfred.delete(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING) }
+
+  context 'when the onboarding flag is not set' do
+    it 'serves the dashboard normally' do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when the onboarding flag is set on a virgin installation (no users)' do
+    before { ::Redis::Alfred.set(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING, true) }
+
+    it 'redirects to onboarding and keeps the flag' do
+      get :index
+      expect(response).to redirect_to('/installation/onboarding')
+      expect(::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)).to be_present
+    end
+  end
+
+  context 'when the onboarding flag went orphan (users already exist)' do
+    before do
+      ::Redis::Alfred.set(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING, true)
+      User.create!(name: 'Existing Admin', email: 'existing-admin@evo.test')
+    end
+
+    it 'clears the flag and does not redirect (no onboarding loop)' do
+      get :index
+      expect(response).to have_http_status(:ok)
+      expect(::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)).to be_nil
+    end
+  end
+end

--- a/spec/requests/installation_onboarding_spec.rb
+++ b/spec/requests/installation_onboarding_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2013: these endpoints are drawn unconditionally, so on API-only deploys
+# (where the dashboard-side guard never runs) they are the only place that can
+# clean up an orphan onboarding flag.
+RSpec.describe 'Installation onboarding', type: :request do
+  before { ::Redis::Alfred.delete(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING) }
+  after { ::Redis::Alfred.delete(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING) }
+
+  context 'when the onboarding flag is not set' do
+    it 'redirects GET away from onboarding' do
+      get '/installation/onboarding'
+      expect(response).to redirect_to('/')
+    end
+  end
+
+  context 'when the onboarding flag went orphan (users already exist)' do
+    before do
+      ::Redis::Alfred.set(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING, true)
+      User.create!(name: 'Existing Admin', email: 'existing-admin@evo.test')
+    end
+
+    it 'GET clears the flag and redirects away' do
+      get '/installation/onboarding'
+      expect(response).to redirect_to('/')
+      expect(::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)).to be_nil
+    end
+
+    it 'POST is blocked before reaching account creation' do
+      expect do
+        post '/installation/onboarding', params: { user: { name: 'X', email: 'x@evo.test' } }
+      end.not_to change(User, :count)
+      expect(response).to redirect_to('/')
+      expect(::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)).to be_nil
+    end
+  end
+
+  context 'when the onboarding flag is set on a virgin installation (no users)' do
+    before { ::Redis::Alfred.set(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING, true) }
+
+    it 'keeps the onboarding endpoint open' do
+      get '/installation/onboarding'
+      expect(response).not_to be_redirect
+      expect(::Redis::Alfred.get(::Redis::Alfred::EVOLUTION_INSTALLATION_ONBOARDING)).to be_present
+    rescue ActionView::MissingExactTemplate
+      # Reaching the render step already proves the guard let the request
+      # through — the backend ships no view for it; the SPA drives the flow.
+    end
+  end
+end


### PR DESCRIPTION
## Problema
Numa instalação que **já tem usuário**, o dashboard redireciona todo acesso para `/installation/onboarding` **em loop**: a flag `EVOLUTION_INSTALLATION_ONBOARDING` fica setada e nunca é limpa. Contorno atual: apagar a flag do Redis na mão.

## Causa-raiz
1. `db/seeds.rb`: seta a flag **incondicionalmente** em produção, sem checar se já há usuário.
2. `dashboard_controller#ensure_installation_onboarding`: redireciona sempre que a flag existe — **sem check**.
3. A flag **só** é limpa em `onboarding#finish_onboarding` (apenas no `create`).
4. Com o gerenciamento de usuários no **evo-auth-service**, o admin pode já existir (sincronizado ao logar) sem passar pelo `onboarding#create` do CRM → flag **órfã** → loop.

## Solução (defesa em profundidade)
Evo CRM é **single-tenant** (sem model `Account`); o sinal de "instalação já usada" é a existência de **`User`**.
- **Runtime (`dashboard_controller`):** se a flag existe **e** `User.exists?` → `Redis::Alfred.delete(flag)` e **não** redireciona. Só redireciona se for instalação virgem.
- **Seed (`db/seeds.rb`):** só seta a flag `unless User.exists?`.

## Testes — executados no container (dados reais, `rails runner`)
Cenário virgem simulado com FKs desabilitadas em transação + `ROLLBACK` (não-destrutivo).
- [x] **C1** instalação usada + flag órfã → limpa a flag, **não** redireciona (PASS).
- [x] **C2** instalação virgem → **redireciona**, mantém a flag (PASS).
- [x] **C3** seed com usuário → **não** re-seta a flag (PASS).
- [x] **C2-seed** seed em banco virgem → **seta** a flag (PASS).
- [x] `User.exists?` resolve sem `NameError` (`Account` não existe no fork — critério correto).
- [x] `ruby -c` OK; estado restaurado ao final.

> Fluxo HTTP puro (GET `/` → 302) não exercitado: com `EVOLUTION_API_ONLY_SERVER=true` (EVO-2010) o backend não serve o dashboard. A guarda é a defesa para deploys com `API_ONLY=false`. Lógica validada no nível Rails.

Closes EVO-2013
