### PR TITLE
fix(features): resilient fallback for account default features (EVO-2000)

### DIFF
--- a/app/models/concerns/featurable.rb
+++ b/app/models/concerns/featurable.rb
@@ -62,10 +62,29 @@ module Featurable
   private
 
   def enable_default_features
-    config = InstallationConfig.find_by(name: 'ACCOUNT_LEVEL_FEATURE_DEFAULTS')
-    return true if config.blank?
+    features_to_enabled = account_level_feature_defaults.select { |f| f[:enabled] }.pluck(:name)
+    enable_features(*features_to_enabled) if features_to_enabled.present?
+    true
+  end
 
-    features_to_enabled = config.value.select { |f| f[:enabled] }.pluck(:name)
-    enable_features(*features_to_enabled)
+  # EVO-2000: fonte das features default. Primária é o InstallationConfig
+  # 'ACCOUNT_LEVEL_FEATURE_DEFAULTS' (populado pelo ConfigLoader no seed). Se ele
+  # não existir (seed não rodou/instalação incompleta), cai para o config/features.yml
+  # — a MESMA fonte que o ConfigLoader usa — para a conta nunca nascer sem features.
+  def account_level_feature_defaults
+    config = InstallationConfig.find_by(name: 'ACCOUNT_LEVEL_FEATURE_DEFAULTS')
+    return config.value if config.present?
+
+    default_features_from_file
+  end
+
+  def default_features_from_file
+    path = Rails.root.join('config', 'features.yml')
+    return [] unless File.exist?(path)
+
+    YAML.safe_load_file(path).map(&:with_indifferent_access)
+  rescue StandardError => e
+    Rails.logger.error("[EVO-2000] fallback de features (features.yml) falhou: #{e.message}")
+    []
   end
 end


### PR DESCRIPTION
## Problema
Em instalações novas, `runtime_configs['account'].features` fica **vazio** e o frontend **não exibe** Flow/Jornadas, Campanhas, Segmentos e Pipelines — "faltam menus", sem erro aparente.

## Causa-raiz
`Featurable#enable_default_features` (`before_create`) fazia:
```ruby
config = InstallationConfig.find_by(name: 'ACCOUNT_LEVEL_FEATURE_DEFAULTS')
return true if config.blank?   # <- conta nasce SEM features
```
Se o `InstallationConfig` não foi populado no setup (o `ConfigLoader` roda no seed, mas nem toda instalação o executa), o `before_create` retorna sem habilitar nada.

## Solução
**Fallback resiliente** (defesa em profundidade): quando o `InstallationConfig` está ausente, lê os defaults **direto do `config/features.yml`** — a **mesma fonte** que o `ConfigLoader` usa — via `with_indifferent_access`, para que o código de seleção (`select { enabled }.pluck(:name)`) sirva às duas fontes sem duplicação. Fonte primária continua o `InstallationConfig` quando presente.

> A origem (#1 — seed popular o config via `ConfigLoader`) **já existe** (`db/seeds.rb` → `ConfigLoader.new.process`). Esta PR adiciona o **#2** (fallback no código), que faltava: o critério "com InstallationConfig ausente, o fallback habilita os defaults" não estava satisfeito.

## Testes
- [x] Sintaxe Ruby validada (`ruby -c`).
- [x] Lógica do fallback validada sobre o `features.yml` real: **37/42** features habilitadas por default (inclui `campaigns`, `crm`, `reports`, `labels`, `automations`).
- [ ] Conta criada **com** `InstallationConfig` → habilita a lista do config (comportamento original).
- [ ] Conta criada **sem** `InstallationConfig` → habilita o fallback (nunca vazia).
- [ ] Provisionar do zero → menus (Flow/Campanhas/Pipelines/Segmentos) visíveis.

> Specs completas exigem o container (factory de `Account`); a lógica pura foi validada acima. Os itens `[ ]` são o roteiro de verificação no Docker/homolog.

Closes EVO-2000
