### PR TITLE
fix(db): heal messages.source on databases bitten by version collision (EVO-1911)

### DIFF
--- a/db/migrate/20260705120000_heal_messages_source_after_version_collision.rb
+++ b/db/migrate/20260705120000_heal_messages_source_after_version_collision.rb
@@ -1,0 +1,22 @@
+# Self-heal for environments bitten by the CRM/auth migration version collision
+# (EVO-1911): CRM and auth shared version 20260622120000 in the same
+# schema_migrations table, so databases that migrated auth first recorded the
+# version before CRM's add_source_to_messages ran — Rails then skips it forever,
+# leaving messages.source missing and breaking the Message model at boot
+# ("Undeclared attribute type for enum 'source'").
+#
+# Re-applies the skipped column iff it is absent; no-op on healthy databases.
+# Manual alternative for environments that cannot upgrade yet:
+# scripts/README-migration-guard.md (umbrella repo), "Recovery" section.
+class HealMessagesSourceAfterVersionCollision < ActiveRecord::Migration[7.1]
+  def up
+    return if column_exists?(:messages, :source)
+
+    add_column :messages, :source, :integer, default: 0, null: false
+  end
+
+  def down
+    # No-op: the column is owned by 20260622120000_add_source_to_messages.
+    # Reverting the heal must not drop a column that migration still declares.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_01_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_05_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"


### PR DESCRIPTION
## Summary
- Migration de self-heal `20260705120000_heal_messages_source_after_version_collision.rb`: re-aplica a coluna `messages.source` (integer, default 0, not null) **somente se ausente** — no-op em bancos saudáveis.
- Alvo: ambientes que migraram auth-first enquanto CRM e auth compartilhavam a versão `20260622120000` (EVO-1911). Nesses bancos o `schema_migrations` já contém a versão, então o Rails pula `add_source_to_messages` pra sempre e o model `Message` quebra no boot (`Undeclared attribute type for enum 'source'`). Re-pull das imagens corrigidas da rc6 não conserta — só uma migration nova (esta) roda no próximo upgrade.
- `down` é no-op de propósito: a coluna pertence à `20260622120000_add_source_to_messages`; reverter o heal não pode derrubar uma coluna que aquela migration ainda declara.
- `db/schema.rb`: só bump da version pra `2026_07_05_120000` (a coluna já estava declarada).

## Validation
- `ruby -c` na migration: Syntax OK.
- Guard de colisão: versão `20260705120000` não existe em `evo-auth-service-community/db/migrate` (18 versões, última `20260626130000`); o job `check-migration-collision` do umbrella valida de novo no bump.
- Não executada contra banco vivo nesta PR — a lógica é `column_exists?` + `add_column` idêntico ao da migration original.

## Runbook (quem está quebrado AGORA, sem esperar release)
Ver `scripts/README-migration-guard.md` no umbrella, seção Recovery — fix manual de uma linha via `rails runner`.

## Linked Issue
- EVO-1911