### PR TITLE
fix(whatsapp): guard control/empty-content messages against empty bubbles (EVO-1908)

### DIFF
--- a/app/services/whatsapp/evolution_go_handlers/helpers.rb
+++ b/app/services/whatsapp/evolution_go_handlers/helpers.rb
@@ -354,4 +354,26 @@ module Whatsapp::EvolutionGoHandlers::Helpers
       'unsupported'
     end
   end
+
+  # EVO-1908: parity with EvolutionHandlers::Helpers#ignore_message? — control /
+  # empty-content messages must not produce blank bubbles. `reaction` is skipped
+  # incondicionalmente (não renderizamos bolha só-emoji).
+  def ignore_message?
+    return true if message_type.in?(%w[protocol unsupported context edited reaction])
+    return true if message_content.blank? && !media_attachment?
+
+    false
+  end
+
+  # Disappearing messages wrap the real payload inside `ephemeralMessage.message`.
+  # Without unwrap the outer type falls into `'unsupported'` and the inner content
+  # is lost.
+  def unwrap_ephemeral_message!
+    return unless @evolution_go_message.is_a?(Hash)
+
+    inner = @evolution_go_message[:ephemeralMessage].is_a?(Hash) ? @evolution_go_message[:ephemeralMessage][:message] : nil
+    return unless inner.is_a?(Hash) && inner.any?
+
+    @evolution_go_message = inner
+  end
 end

--- a/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
@@ -8,8 +8,15 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
   private
 
   def handle_message
+    unwrap_ephemeral_message!
+
     if protocol_message?
       handle_revoke_protocol
+      return
+    end
+
+    if ignore_message?
+      Rails.logger.info "Evolution Go API: Ignoring message #{raw_message_id} (type: #{message_type})"
       return
     end
 
@@ -317,6 +324,26 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
     # Media captions
     caption = extract_media_caption
     return caption if caption.present?
+
+    # EVO-1908: parity with EvolutionHandlers::Helpers#message_content — reaction/
+    # location/contacts carry a non-nil renderable string. `reaction` is still
+    # skipped upstream by `ignore_message?` but we return its text for parity.
+    case message_type
+    when 'reaction'
+      return message.dig(:reactionMessage, :text)
+    when 'location'
+      location_msg = message[:locationMessage]
+      return nil unless location_msg
+
+      return "Location: #{location_msg[:degreesLatitude]}, #{location_msg[:degreesLongitude]}"
+    when 'contacts'
+      contact_msg = message[:contactMessage] || message.dig(:contactsArrayMessage, :contacts)&.first
+      return nil unless contact_msg
+
+      return contact_msg[:displayName].presence ||
+             contact_msg[:vcard].to_s.match(/FN:(.+)/i)&.[](1)&.strip ||
+             'Contact'
+    end
 
     # Empty content for media without caption
     return '' if media_message?

--- a/app/services/whatsapp/evolution_handlers/helpers.rb
+++ b/app/services/whatsapp/evolution_handlers/helpers.rb
@@ -142,8 +142,13 @@ module Whatsapp::EvolutionHandlers::Helpers
   end
 
   def ignore_message?
-    # Skip unsupported message types
-    return true if message_type.in?(%w[protocol unsupported])
+    # Skip unsupported message types.
+    # EVO-1908: `reaction` skipped incondicionalmente — reactions carry a
+    # non-blank emoji as content, so relying on the blank-content guard alone
+    # would still surface a solitary bubble containing only the emoji. We do not
+    # yet route reactions to a target-message updater; skipping is the correct
+    # behaviour until that path exists.
+    return true if message_type.in?(%w[protocol unsupported reaction])
 
     # Skip if no content available
     return true if message_content.blank? && !media_attachment?

--- a/spec/services/whatsapp/evolution_go_handlers/messages_upsert_spec.rb
+++ b/spec/services/whatsapp/evolution_go_handlers/messages_upsert_spec.rb
@@ -125,6 +125,163 @@ RSpec.describe Whatsapp::EvolutionGoHandlers::MessagesUpsert do
     end
   end
 
+  # EVO-1908: control / empty-content messages must not produce blank bubbles
+  # (paridade com EvolutionHandlers). Every skipped type below is asserted to
+  # NOT call `create_message` when `handle_message` is exercised, and the
+  # renderable types (reaction/location/contacts) round-trip real content
+  # through `message_content`.
+  describe '#ignore_message?' do
+    {
+      'protocol'    => { protocolMessage: { type: 'REVOKE' } },
+      'unsupported' => { pollCreationMessage: { name: 'Choose' } },
+      'reaction'    => { reactionMessage: { text: '👍', key: { id: 'abc' } } }
+    }.each do |label, msg|
+      it "skips #{label}" do
+        service.instance_variable_set(:@evolution_go_message, msg)
+        expect(service.send(:ignore_message?)).to be(true)
+      end
+    end
+
+    it 'skips reaction removal (empty text)' do
+      service.instance_variable_set(:@evolution_go_message, { reactionMessage: { text: '', key: { id: 'x' } } })
+      expect(service.send(:ignore_message?)).to be(true)
+    end
+
+    it 'does NOT skip location (has renderable content)' do
+      service.instance_variable_set(:@evolution_go_message,
+                                    { locationMessage: { degreesLatitude: -23.5, degreesLongitude: -46.6 } })
+      expect(service.send(:ignore_message?)).to be(false)
+    end
+
+    it 'does NOT skip contacts (has renderable content)' do
+      service.instance_variable_set(:@evolution_go_message,
+                                    { contactMessage: { displayName: 'Alice' } })
+      expect(service.send(:ignore_message?)).to be(false)
+    end
+
+    it 'does NOT skip text' do
+      service.instance_variable_set(:@evolution_go_message, { conversation: 'hi' })
+      expect(service.send(:ignore_message?)).to be(false)
+    end
+
+    it 'does NOT skip media (blank caption still has attachment)' do
+      service.instance_variable_set(:@evolution_go_message, { imageMessage: { mimetype: 'image/jpeg' } })
+      expect(service.send(:ignore_message?)).to be(false)
+    end
+  end
+
+  describe '#message_content (EVO-1908 parity extractors)' do
+    it 'extracts reaction emoji text' do
+      service.instance_variable_set(:@evolution_go_message, { reactionMessage: { text: '❤️' } })
+      expect(service.send(:message_content)).to eq('❤️')
+    end
+
+    it 'renders location as "Location: <lat>, <long>"' do
+      service.instance_variable_set(:@evolution_go_message,
+                                    { locationMessage: { degreesLatitude: -23.55, degreesLongitude: -46.63 } })
+      expect(service.send(:message_content)).to eq('Location: -23.55, -46.63')
+    end
+
+    it 'renders contactMessage displayName' do
+      service.instance_variable_set(:@evolution_go_message, { contactMessage: { displayName: 'Bob' } })
+      expect(service.send(:message_content)).to eq('Bob')
+    end
+
+    it 'falls back to vcard FN when displayName is missing' do
+      vcard = "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Carol Souza\r\nEND:VCARD"
+      service.instance_variable_set(:@evolution_go_message, { contactMessage: { vcard: vcard } })
+      expect(service.send(:message_content)).to eq('Carol Souza')
+    end
+
+    it 'uses first entry of contactsArrayMessage.contacts' do
+      service.instance_variable_set(:@evolution_go_message,
+                                    { contactsArrayMessage: { contacts: [{ displayName: 'Dave' }, { displayName: 'Eve' }] } })
+      expect(service.send(:message_content)).to eq('Dave')
+    end
+
+    it 'falls back to "Contact" when no name is extractable' do
+      service.instance_variable_set(:@evolution_go_message, { contactMessage: { vcard: 'BEGIN:VCARD\nEND:VCARD' } })
+      expect(service.send(:message_content)).to eq('Contact')
+    end
+  end
+
+  describe '#unwrap_ephemeral_message!' do
+    it 'replaces @evolution_go_message with the inner disappearing payload' do
+      inner = { conversation: 'ghost message' }
+      service.instance_variable_set(:@evolution_go_message, { ephemeralMessage: { message: inner } })
+      service.send(:unwrap_ephemeral_message!)
+      expect(service.instance_variable_get(:@evolution_go_message)).to eq(inner)
+    end
+
+    it 'is a no-op when message is not ephemeral' do
+      original = { conversation: 'hi' }
+      service.instance_variable_set(:@evolution_go_message, original)
+      service.send(:unwrap_ephemeral_message!)
+      expect(service.instance_variable_get(:@evolution_go_message)).to eq(original)
+    end
+
+    it 'is a no-op when ephemeralMessage carries no inner payload' do
+      service.instance_variable_set(:@evolution_go_message, { ephemeralMessage: {} })
+      expect { service.send(:unwrap_ephemeral_message!) }.not_to raise_error
+    end
+
+    it 'lets classification see the inner type after unwrap' do
+      service.instance_variable_set(:@evolution_go_message,
+                                    { ephemeralMessage: { message: { conversation: 'ghost' } } })
+      service.send(:unwrap_ephemeral_message!)
+      expect(service.send(:message_type)).to eq('text')
+      expect(service.send(:message_content)).to eq('ghost')
+    end
+  end
+
+  describe '#handle_message (EVO-1908 — no empty bubbles)' do
+    let(:info) { { ID: 'msg-1', IsFromMe: false, Chat: '5511@s.whatsapp.net' } }
+
+    before do
+      # Avoid touching Rails DB: assert we never reach the create path for skipped types.
+      allow(service).to receive(:message_processable?).and_return(true)
+      allow(service).to receive(:set_contact)
+      allow(service).to receive(:set_conversation)
+      allow(service).to receive(:update_conversation_status_if_needed)
+      service.instance_variable_set(:@contact_inbox, double('contact_inbox'))
+    end
+
+    {
+      'reaction'    => { reactionMessage: { text: '👍', key: { id: 'x' } } },
+      'poll'        => { pollCreationMessage: { name: 'p' } },
+      'unsupported' => { messageContextInfo: {} },
+      'edited'      => { editedMessage: { message: { conversation: 'x' } } }
+    }.each do |label, msg|
+      it "does not call create_message for #{label}" do
+        service.instance_variable_set(:@evolution_go_message, msg)
+        expect(service).not_to receive(:create_message)
+        service.send(:handle_message)
+      end
+    end
+
+    it 'unwraps ephemeral text and proceeds to create_message with real content' do
+      inner = { conversation: 'ghost' }
+      service.instance_variable_set(:@evolution_go_message, { ephemeralMessage: { message: inner } })
+      expect(service).to receive(:create_message).with(attach_media: false)
+      service.send(:handle_message)
+      expect(service.instance_variable_get(:@evolution_go_message)).to eq(inner)
+      expect(service.send(:message_content)).to eq('ghost')
+    end
+
+    it 'reaches create_message for location (renderable content)' do
+      service.instance_variable_set(:@evolution_go_message,
+                                    { locationMessage: { degreesLatitude: 1.0, degreesLongitude: 2.0 } })
+      expect(service).to receive(:create_message).with(attach_media: false)
+      service.send(:handle_message)
+    end
+
+    it 'reaches create_message for contacts (renderable content)' do
+      service.instance_variable_set(:@evolution_go_message, { contactMessage: { displayName: 'Alice' } })
+      expect(service).to receive(:create_message).with(attach_media: false)
+      service.send(:handle_message)
+    end
+  end
+
   describe '#audio_voice_note?' do
     it 'returns false without raising when @evolution_go_info is nil' do
       service.instance_variable_set(:@evolution_go_info, nil)

--- a/spec/services/whatsapp/evolution_handlers/helpers_spec.rb
+++ b/spec/services/whatsapp/evolution_handlers/helpers_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+begin
+  require 'rails_helper'
+rescue LoadError
+  RSpec.describe 'Whatsapp::EvolutionHandlers::Helpers' do
+    it 'has spec scaffold ready' do
+      skip 'rails_helper is not available in this workspace snapshot'
+    end
+  end
+end
+
+return unless defined?(Rails)
+
+# EVO-1908: `reactionMessage` must be skipped incondicionalmente in the
+# Evolution API (baileys) handler. Prior to this fix, `message_type` classified
+# it as `'reaction'` and its content extractor returned the emoji itself, so
+# the base incoming service materialised a solitary bubble containing only the
+# reaction emoji.
+RSpec.describe Whatsapp::EvolutionHandlers::Helpers do
+  let(:host_class) do
+    Class.new do
+      include Whatsapp::EvolutionHandlers::Helpers
+
+      def initialize(raw_message)
+        @raw_message = raw_message
+      end
+    end
+  end
+
+  subject(:helper) { host_class.new(raw_message) }
+
+  describe '#ignore_message?' do
+    context 'when the raw payload is a reactionMessage with a non-blank emoji' do
+      let(:raw_message) do
+        {
+          key: { id: 'msg-1', fromMe: false, remoteJid: '55@s.whatsapp.net' },
+          message: { reactionMessage: { text: '👍', key: { id: 'target' } } }
+        }
+      end
+
+      it 'returns true (skip) so no bubble is materialised' do
+        expect(helper.send(:message_type)).to eq('reaction')
+        expect(helper.send(:ignore_message?)).to be(true)
+      end
+    end
+
+    context 'when the raw payload is a reaction removal (empty text)' do
+      let(:raw_message) do
+        {
+          key: { id: 'msg-2', fromMe: false, remoteJid: '55@s.whatsapp.net' },
+          message: { reactionMessage: { text: '', key: { id: 'target' } } }
+        }
+      end
+
+      it 'returns true (skip)' do
+        expect(helper.send(:ignore_message?)).to be(true)
+      end
+    end
+
+    context 'when the raw payload is protocolMessage' do
+      let(:raw_message) do
+        { key: { id: 'x' }, message: { protocolMessage: { type: 'REVOKE' } } }
+      end
+
+      it 'returns true (skip)' do
+        expect(helper.send(:ignore_message?)).to be(true)
+      end
+    end
+
+    context 'when the raw payload is an unsupported type (blank content, non-media)' do
+      let(:raw_message) do
+        { key: { id: 'x' }, message: { messageContextInfo: {} } }
+      end
+
+      it 'returns true (skip)' do
+        expect(helper.send(:ignore_message?)).to be(true)
+      end
+    end
+
+    context 'when the raw payload is a plain text message' do
+      let(:raw_message) do
+        { key: { id: 'x' }, message: { conversation: 'hi' } }
+      end
+
+      it 'returns false (process)' do
+        expect(helper.send(:ignore_message?)).to be(false)
+      end
+    end
+
+    context 'when the raw payload is an image without caption' do
+      let(:raw_message) do
+        { key: { id: 'x' }, message: { imageMessage: { mimetype: 'image/jpeg' } } }
+      end
+
+      it 'returns false (process — media attachment overrides blank content)' do
+        expect(helper.send(:ignore_message?)).to be(false)
+      end
+    end
+
+    context 'when the raw payload is a location (renderable, not skipped)' do
+      let(:raw_message) do
+        { key: { id: 'x' }, message: { locationMessage: { degreesLatitude: 1.0, degreesLongitude: 2.0 } } }
+      end
+
+      it 'returns false (process)' do
+        expect(helper.send(:ignore_message?)).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **evolution_go handler** ganha paridade com Evolution API (baileys) para mensagens de controle / sem conteúdo: adiciona `ignore_message?` (skip `protocol/unsupported/context/edited/reaction` + blank-content-não-media), extração de content para reaction/location/contacts (renderiza conteúdo real), e unwrap de `ephemeralMessage.message` antes da classificação
- **Evolution API handler** ganha `reaction` no skip set incondicional (reactionMessage carrega emoji não-blank; sem esse fix continuava criando bolha solta só-emoji)
- **31 examples novos** (24 evolution_go + 7 Evolution API) cobrindo os 8 tipos de controle/sem-conteúdo do card

Fecha [EVO-1908](https://linear.app/evoai/issue/EVO-1908).

## Test plan

- [x] `bundle exec rspec spec/services/whatsapp/evolution_go_handlers/messages_upsert_spec.rb spec/services/whatsapp/evolution_handlers/helpers_spec.rb` — 31 examples verde local
- [x] Smoke end-to-end via 13 webhook posts sintéticos contra o handler real (sidekiq + `IncomingMessageEvolutionGoService`), cobrindo todos os 11 casos do card + 2 pares (edit-original/edit-new, revoke-original/revoke-protocol). **13/13 pass**, zero bolhas vazias sem attachment produzidas. Extractors novos entregaram `"Location: -23.55052, -46.633308"` e `"João da Silva"` corretamente; ephemeral unwrap preservou conteúdo interno.
- [ ] Smoke opcional com WhatsApp real (fora do escopo dessa PR — validação sintética já cobre o caminho do handler; único gap teórico seria whatsmeow serializando chaves diferentes das assumidas)

> **Nota:** CI da crm-community não roda RSpec — os specs foram validados localmente e via smoke sintético no ambiente docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)