### PR TITLE
fix(oauth): redirect channel callbacks to the frontend under API-only (EVO-2014)

### DIFF
--- a/app/controllers/concerns/frontend_redirectable.rb
+++ b/app/controllers/concerns/frontend_redirectable.rb
@@ -1,0 +1,26 @@
+# Builds absolute URLs into the SPA served by the separate evo-frontend service.
+#
+# The backend runs API-only by default (EVOLUTION_API_ONLY_SERVER=true), so the
+# in-app `app_*` dashboard route helpers are not registered — channel OAuth
+# callbacks that used them raised NoMethodError (HTTP 500). Callbacks must build
+# the frontend URL explicitly and redirect the browser to the frontend host.
+module FrontendRedirectable
+  extend ActiveSupport::Concern
+
+  private
+
+  def frontend_app_url(path, **query)
+    base = ENV.fetch('FRONTEND_URL', 'http://localhost:3000').chomp('/')
+    url = "#{base}#{path}"
+    params = query.compact
+    url = "#{url}?#{params.to_query}" if params.present?
+    url
+  end
+
+  # allow_other_host is required because FRONTEND_URL is a different host than the
+  # backend that receives the provider callback; with load_defaults 7.0,
+  # raise_on_open_redirects is on and a cross-host redirect would otherwise raise.
+  def redirect_to_frontend(path, **query)
+    redirect_to frontend_app_url(path, **query), allow_other_host: true
+  end
+end

--- a/app/controllers/instagram/callbacks_controller.rb
+++ b/app/controllers/instagram/callbacks_controller.rb
@@ -1,6 +1,7 @@
 class Instagram::CallbacksController < ApplicationController
   include InstagramConcern
   include Instagram::IntegrationHelper
+  include FrontendRedirectable
 
   def show
     # Check if Instagram redirected with an error (user canceled authorization)
@@ -29,9 +30,9 @@ class Instagram::CallbacksController < ApplicationController
     inbox, already_exists = find_or_create_inbox
 
     if already_exists
-      redirect_to app_instagram_inbox_settings_url(inbox_id: inbox.id)
+      redirect_to_frontend("/app/settings/inboxes/#{inbox.id}")
     else
-      redirect_to app_instagram_inbox_agents_url(inbox_id: inbox.id)
+      redirect_to_frontend("/app/settings/inboxes/new/#{inbox.id}/agents")
     end
   end
 
@@ -79,7 +80,8 @@ class Instagram::CallbacksController < ApplicationController
   # This ensures consistent error handling across different error scenarios
   # Frontend will handle the error page based on the error_type
   def redirect_to_error_page(error_info)
-    redirect_to app_new_instagram_inbox_url(
+    redirect_to_frontend(
+      '/app/settings/inboxes/new/instagram',
       error_type: error_info['error_type'],
       code: error_info['code'],
       error_message: error_info['error_message']

--- a/app/controllers/oauth_callback_controller.rb
+++ b/app/controllers/oauth_callback_controller.rb
@@ -1,4 +1,6 @@
 class OauthCallbackController < ApplicationController
+  include FrontendRedirectable
+
   # Load EvolutionExceptionTracker (using load to avoid Zeitwerk constant name mismatch)
   load Rails.root.join('lib', 'evolution_exception_tracker.rb').to_s unless defined?(EvolutionExceptionTracker)
 
@@ -21,9 +23,9 @@ class OauthCallbackController < ApplicationController
     inbox, already_exists = find_or_create_inbox
 
     if already_exists
-      redirect_to app_email_inbox_settings_url(inbox_id: inbox.id)
+      redirect_to_frontend("/app/settings/inboxes/#{inbox.id}")
     else
-      redirect_to app_email_inbox_agents_url(inbox_id: inbox.id)
+      redirect_to_frontend("/app/settings/inboxes/new/#{inbox.id}/agents")
     end
   end
 

--- a/app/controllers/slack_uploads_controller.rb
+++ b/app/controllers/slack_uploads_controller.rb
@@ -6,7 +6,8 @@ class SlackUploadsController < ApplicationController
     if @blob
       redirect_to blob_url
     else
-      redirect_to avatar_url
+      # avatar_url points at the frontend host, so cross-host redirect must be allowed
+      redirect_to avatar_url, allow_other_host: true
     end
   end
 

--- a/app/controllers/twitter/callbacks_controller.rb
+++ b/app/controllers/twitter/callbacks_controller.rb
@@ -1,21 +1,22 @@
 class Twitter::CallbacksController < Twitter::BaseController
   include TwitterConcern
+  include FrontendRedirectable
 
   def show
-    return redirect_to twitter_app_redirect_url if permitted_params[:denied]
+    return redirect_to twitter_app_redirect_url, allow_other_host: true if permitted_params[:denied]
 
     @response = ensure_access_token
-    return redirect_to twitter_app_redirect_url if @response.status != '200'
+    return redirect_to twitter_app_redirect_url, allow_other_host: true if @response.status != '200'
 
     ActiveRecord::Base.transaction do
       inbox = create_inbox
       ::Redis::Alfred.delete(permitted_params[:oauth_token])
       ::Twitter::WebhookSubscribeService.new(inbox_id: inbox.id).perform
-      redirect_to app_twitter_inbox_agents_url(inbox_id: inbox.id)
+      redirect_to_frontend("/app/settings/inboxes/new/#{inbox.id}/agents")
     end
   rescue StandardError => e
     EvolutionExceptionTracker.new(e).capture_exception
-    redirect_to twitter_app_redirect_url
+    redirect_to twitter_app_redirect_url, allow_other_host: true
   end
 
   private
@@ -25,7 +26,7 @@ class Twitter::CallbacksController < Twitter::BaseController
   end
 
   def twitter_app_redirect_url
-    app_new_twitter_inbox_url
+    frontend_app_url('/app/settings/inboxes/new/twitter')
   end
 
   def ensure_access_token

--- a/app/controllers/whatsapp/callbacks_controller.rb
+++ b/app/controllers/whatsapp/callbacks_controller.rb
@@ -1,4 +1,6 @@
 class Whatsapp::CallbacksController < ApplicationController
+  include FrontendRedirectable
+
   def show
     Rails.logger.info "WhatsApp callback controller called with params: #{params.inspect}"
     Rails.logger.info "Request URL: #{request.url}"
@@ -22,7 +24,8 @@ class Whatsapp::CallbacksController < ApplicationController
   private
 
   def redirect_to_setup_page
-    redirect_to app_new_whatsapp_inbox_url(
+    redirect_to_frontend(
+      '/app/settings/inboxes/new/whatsapp',
       code: params[:code],
       state: params[:state]
     )
@@ -53,14 +56,11 @@ class Whatsapp::CallbacksController < ApplicationController
   end
 
   def redirect_to_error_page(error_info)
-    redirect_to app_new_whatsapp_inbox_url(
+    redirect_to_frontend(
+      '/app/settings/inboxes/new/whatsapp',
       error_type: error_info['error_type'],
       code: error_info['code'],
       error_message: error_info['error_message']
     )
-  end
-
-  def base_url
-    ENV.fetch('FRONTEND_URL', 'http://localhost:3000')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,11 @@ Rails.application.routes.draw do
     get '/app/settings/inboxes/new/:inbox_id/agents', to: 'dashboard#index', as: 'app_whatsapp_inbox_agents'
     get '/app/settings/inboxes/:inbox_id', to: 'dashboard#index', as: 'app_instagram_inbox_settings'
     get '/app/settings/inboxes/:inbox_id', to: 'dashboard#index', as: 'app_email_inbox_settings'
-
-    resource :slack_uploads, only: [:show]
   end
+
+  ## Slack fetches these avatar/attachment URLs directly (not the SPA), so the route
+  ## must exist even when the backend is API-only.
+  resource :slack_uploads, only: [:show]
 
   get '/api', to: 'api#index'
   namespace :api, defaults: { format: 'json' } do

--- a/spec/requests/api_only_routing_spec.rb
+++ b/spec/requests/api_only_routing_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe 'API-only routing default (EVO-2010)', type: :routing do
     expect(post: '/installation/onboarding').not_to be_routable
   end
 
+  # EVO-2014: slack_uploads was nested under the legacy (non-API-only) branch, so
+  # Slack's avatar/attachment fetches 404'd. It is consumed by Slack, not the SPA,
+  # and must stay registered when the backend is API-only.
+  it 'keeps the slack_uploads route registered when API-only (EVO-2014)' do
+    expect(get: '/slack_uploads').to route_to('slack_uploads#show')
+  end
+
   context 'with EVOLUTION_API_ONLY_SERVER=false (legacy backend-served SPA)' do
     around do |example|
       ENV['EVOLUTION_API_ONLY_SERVER'] = 'false'

--- a/spec/requests/channel_oauth_callbacks_spec.rb
+++ b/spec/requests/channel_oauth_callbacks_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+begin
+  require 'rails_helper'
+rescue LoadError
+  RSpec.describe 'Channel OAuth callbacks' do
+    it 'has spec scaffold ready' do
+      skip 'rails_helper is not available in this workspace snapshot'
+    end
+  end
+end
+
+return unless defined?(Rails)
+
+# EVO-2014: with the backend API-only (EVOLUTION_API_ONLY_SERVER default true),
+# the in-app app_*_inbox route helpers are not registered. Channel OAuth callbacks
+# used them and raised NoMethodError (HTTP 500). They must instead redirect to the
+# frontend host — which also requires allow_other_host under load_defaults 7.0.
+RSpec.describe 'Channel OAuth callbacks redirect to the frontend (EVO-2014)', type: :request do
+  frontend = 'https://app.example.test'
+
+  around do |example|
+    previous = ENV.fetch('FRONTEND_URL', nil)
+    ENV['FRONTEND_URL'] = frontend
+    example.run
+  ensure
+    previous.nil? ? ENV.delete('FRONTEND_URL') : ENV['FRONTEND_URL'] = previous
+  end
+
+  it 'whatsapp callback error path redirects to the frontend instead of 500' do
+    get '/whatsapp/callback', params: { error: 'access_denied', error_description: 'user cancelled' }
+
+    expect(response).to have_http_status(:found)
+    expect(response.location).to start_with("#{frontend}/app/settings/inboxes/new/whatsapp")
+    expect(response.location).to include('error_type=access_denied')
+  end
+
+  it 'instagram callback error path redirects to the frontend instead of 500' do
+    get '/instagram/callback', params: { error: 'access_denied', error_description: 'user cancelled' }
+
+    expect(response).to have_http_status(:found)
+    expect(response.location).to start_with("#{frontend}/app/settings/inboxes/new/instagram")
+    expect(response.location).to include('error_type=access_denied')
+  end
+
+  it 'twitter callback denied path redirects to the frontend instead of 500' do
+    get '/twitter/callback', params: { denied: '1' }
+
+    expect(response).to have_http_status(:found)
+    expect(response.location).to eq("#{frontend}/app/settings/inboxes/new/twitter")
+  end
+end

--- a/spec/requests/channel_oauth_callbacks_spec.rb
+++ b/spec/requests/channel_oauth_callbacks_spec.rb
@@ -49,4 +49,64 @@ RSpec.describe 'Channel OAuth callbacks redirect to the frontend (EVO-2014)', ty
     expect(response).to have_http_status(:found)
     expect(response.location).to eq("#{frontend}/app/settings/inboxes/new/twitter")
   end
+
+  # The happy path is the primary behavior this fix ships: a *successful* channel
+  # connect must land on the frontend inbox routes, not 500 on a missing app_* helper.
+  # Twitter and the email (microsoft/google) callbacks reuse the exact same two
+  # literals asserted here (".../new/:id/agents" for new, ".../:id" for existing),
+  # so covering whatsapp + instagram guards every distinct success target string.
+  describe 'success paths' do
+    it 'whatsapp success redirects to the frontend setup page carrying code and state' do
+      get '/whatsapp/callback', params: { code: 'auth-code', state: 'st-123' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to start_with("#{frontend}/app/settings/inboxes/new/whatsapp")
+      expect(response.location).to include('code=auth-code')
+      expect(response.location).to include('state=st-123')
+    end
+
+    it 'drops blank query params and never double-slashes a trailing-slash FRONTEND_URL' do
+      ENV['FRONTEND_URL'] = "#{frontend}/"
+
+      get '/whatsapp/callback', params: { code: 'auth-code' }
+
+      expect(response.location).to start_with("#{frontend}/app/settings/inboxes/new/whatsapp")
+      expect(response.location).not_to include("#{frontend}//app")
+      expect(response.location).not_to include('state=')
+    end
+
+    it 'instagram success on a brand-new inbox lands on the agents step' do
+      stub_instagram_token_exchange(inbox_id: 7, already_exists: false)
+
+      get '/instagram/callback', params: { code: 'oauth-code' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to eq("#{frontend}/app/settings/inboxes/new/7/agents")
+    end
+
+    it 'instagram success on an existing inbox lands on its settings page' do
+      stub_instagram_token_exchange(inbox_id: 42, already_exists: true)
+
+      get '/instagram/callback', params: { code: 'oauth-code' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to eq("#{frontend}/app/settings/inboxes/42")
+    end
+  end
+
+  # Stub the OAuth token exchange + inbox resolution seams so the example exercises
+  # only the redirect target this fix changed, not Instagram's token/DB machinery.
+  # The OAuth2 client is an opaque external object (no loadable class to verify
+  # against), and a request spec has no handle on the controller instance, so plain
+  # doubles + any_instance are the pragmatic seam here.
+  def stub_instagram_token_exchange(inbox_id:, already_exists:)
+    client = double(auth_code: double(get_token: double(token: 'short-token'))) # rubocop:disable RSpec/VerifiedDoubles
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Instagram::CallbacksController).to receive(:instagram_client).and_return(client)
+    allow_any_instance_of(Instagram::CallbacksController)
+      .to receive(:exchange_for_long_lived_token).and_return('access_token' => 'long-token')
+    allow_any_instance_of(Instagram::CallbacksController)
+      .to receive(:find_or_create_inbox).and_return([instance_double(Inbox, id: inbox_id), already_exists])
+    # rubocop:enable RSpec/AnyInstance
+  end
 end


### PR DESCRIPTION
## Summary
With the backend running API-only (`EVOLUTION_API_ONLY_SERVER` default `true`),
the in-app `app_*_inbox` route helpers are no longer registered. The channel OAuth
callbacks still used them and raised `NoMethodError` (HTTP 500). They now build the
target URL from `FRONTEND_URL` and redirect the browser to the frontend host.

## Changes
- Add a shared `FrontendRedirectable` concern (`frontend_app_url` / `redirect_to_frontend`).
- WhatsApp / Twitter / Instagram / Microsoft+Google (email) callbacks redirect to the
  frontend `/app/settings/inboxes/...` paths with `allow_other_host: true` (required
  for cross-host redirects under `load_defaults 7.0`).
- Move `resource :slack_uploads` out of the non-API-only branch: Slack fetches those
  URLs directly (not the SPA), so it 404'd under API-only. Allow its cross-host avatar
  fallback redirect as well.

## Verification
- Request specs: whatsapp/instagram error and twitter denied callbacks now 302 to the
  frontend instead of 500.
- Routing spec: `slack_uploads` stays registered when API-only.
- Boot green; rubocop clean on changed files.
