### PR TITLE
fix: QR code lowercase keys + newsletter JID support + connection pool

### DIFF
--- a/.github/workflows/fork-build.yml
+++ b/.github/workflows/fork-build.yml
@@ -1,0 +1,107 @@
+name: Fork Build & Publish
+
+on:
+  push:
+    branches: [fix/evolution-go-qr-code-format, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: excarplex/evo-ai-crm-community
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          build-args: |
+            RAILS_ENV=production
+            BUNDLE_WITHOUT=development:test
+            RAILS_SERVE_STATIC_FILES=true
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    name: Merge Manifests & Tag
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve tags
+        id: tags
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          IMAGE="${{ env.IMAGE_NAME }}"
+          SHA_SHORT="${GH_SHA:0:7}"
+          TAGS="${IMAGE}:fix-qr,${IMAGE}:fix-qr-${SHA_SHORT}"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push manifest
+        working-directory: /tmp/digests
+        env:
+          MERGE_TAGS: ${{ steps.tags.outputs.tags }}
+        run: |
+          IFS=',' read -ra TAG_ARRAY <<< "${MERGE_TAGS}"
+          TAG_ARGS=""
+          for tag in "${TAG_ARRAY[@]}"; do
+            TAG_ARGS="${TAG_ARGS} -t ${tag}"
+          done
+          docker buildx imagetools create ${TAG_ARGS} \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)

--- a/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
+++ b/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
@@ -156,16 +156,24 @@ class Api::V1::EvolutionGo::QrcodesController < Api::V1::BaseController
     # }
 
     if parsed_response['data']
+      # Evolution Go returns lowercase keys in some versions and uppercase
+      # in others — check both to stay compatible.
+      qr_code = parsed_response['data']['qrcode'] || parsed_response['data']['Qrcode']
+      qr_code_code = parsed_response['data']['code'] || parsed_response['data']['Code']
+
       {
-        base64: parsed_response['data']['Qrcode'],
-        code: parsed_response['data']['Code'],
+        base64: qr_code,
+        code: qr_code_code,
         connected: false
       }
     else
       # Fallback se estrutura for diferente
+      qr_code = parsed_response['qrcode'] || parsed_response['Qrcode']
+      qr_code_code = parsed_response['code'] || parsed_response['Code']
+
       {
-        base64: parsed_response['Qrcode'],
-        code: parsed_response['Code'],
+        base64: qr_code,
+        code: qr_code_code,
         connected: false
       }
     end

--- a/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
+++ b/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
@@ -19,7 +19,14 @@ class Api::V1::EvolutionGo::QrcodesController < Api::V1::BaseController
       # Get QR code using Evolution Go API
       qrcode_data = get_qrcode_go(@api_url, @instance_token)
 
-      render json: qrcode_data
+      # Wrap in standard response format so frontend can find base64 at
+      # response.base64 or response.data.base64 (both paths supported)
+      render json: {
+        success: true,
+        base64: qrcode_data[:base64],
+        code: qrcode_data[:code],
+        connected: qrcode_data[:connected]
+      }
     rescue StandardError => e
       Rails.logger.error "Evolution Go API: QR code error: #{e.class} - #{e.message}"
       Rails.logger.error e.backtrace.join("\n")

--- a/app/services/whatsapp/evolution_go_handlers/helpers.rb
+++ b/app/services/whatsapp/evolution_go_handlers/helpers.rb
@@ -47,6 +47,14 @@ module Whatsapp::EvolutionGoHandlers::Helpers
     @evolution_go_info&.dig(:IsGroup) == true
   end
 
+  # Newsletter messages come from JIDs like "120363170942886188@newsletter".
+  # They are not regular groups (IsGroup is false) nor individual contacts,
+  # so they need their own detection to avoid the source_id validation failing
+  # on the long numeric newsletter ID.
+  def newsletter_message?
+    conversation_id.to_s.end_with?('@newsletter')
+  end
+
   def raw_message_id
     @evolution_go_info&.dig(:ID)
   end
@@ -75,11 +83,12 @@ module Whatsapp::EvolutionGoHandlers::Helpers
   end
 
   def group_jid
-    conversation_id if group_message?
+    return conversation_id if group_message?
+    return conversation_id if newsletter_message?
   end
 
   def group_subject
-    return nil unless group_message?
+    return nil unless group_message? || newsletter_message?
 
     group_data = @evolution_go_data&.dig(:groupData) || {}
     group_data[:Name].presence || group_data[:Subject].presence || fallback_group_name

--- a/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
@@ -21,7 +21,7 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
   end
 
   def set_contact
-    if group_message?
+    if group_message? || newsletter_message?
       set_group_contact
     else
       set_individual_contact

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,10 +4,15 @@ default: &default
   host: <%= ENV.fetch('POSTGRES_HOST', 'localhost') %>
   port: <%= ENV.fetch('POSTGRES_PORT', '5432') %>
    # ref: https://github.com/mperham/sidekiq/issues/2985#issuecomment-531097962
-  pool: <%= Sidekiq.server? ? ENV.fetch('SIDEKIQ_CONCURRENCY', 10) : ENV.fetch('RAILS_MAX_THREADS', 5) %>
+  # Use higher pool for Sidekiq to avoid ConnectionTimeoutError under load.
+  # Web server (Puma) also needs enough connections for ActionCable + normal requests.
+  pool: <%= Sidekiq.server? ? ENV.fetch('SIDEKIQ_CONCURRENCY', 15) : ENV.fetch('RAILS_MAX_THREADS', 10) %>
+  # How long to wait for a connection from the pool before raising
+  # ConnectionTimeoutError. Default is 5s — bump to 10s to survive spikes.
+  checkout_timeout: <%= ENV.fetch('DB_POOL_CHECKOUT_TIMEOUT', 10) %>
   # frequency in seconds to periodically run the Reaper, which attempts
   # to find and recover connections from dead threads
-  reaping_frequency: <%= ENV.fetch('DB_POOL_REAPING_FREQUENCY', 30) %>
+  reaping_frequency: <%= ENV.fetch('DB_POOL_REAPING_FREQUENCY', 15) %>
   variables:
     # we are setting this value to be close to the racktimeout value. we will iterate and reduce this value going forward
     statement_timeout: <%= ENV["POSTGRES_STATEMENT_TIMEOUT"] || "14s" %>

--- a/lib/regex_helper.rb
+++ b/lib/regex_helper.rb
@@ -20,5 +20,7 @@ module RegexHelper
   #   * legacy: creator phone + creation epoch joined by hyphen,
   #     e.g. "553184455827-1593702061@g.us"
   WHATSAPP_GROUP_JID_REGEX = /\d+(?:-\d+)?@g\.us/
-  WHATSAPP_CHANNEL_REGEX = Regexp.new("\\A(?:\\+?\\d{1,15}|\\+?\\d+@lid|#{WHATSAPP_GROUP_JID_REGEX.source}|[A-Z]{2}\\.[a-zA-Z0-9]+)\\z")
+  # Newsletter JIDs from Evolution Go: "120363170942886188@newsletter"
+  WHATSAPP_NEWSLETTER_JID_REGEX = /\d+@newsletter/
+  WHATSAPP_CHANNEL_REGEX = Regexp.new("\\A(?:\\+?\\d{1,15}|\\+?\\d+@lid|#{WHATSAPP_GROUP_JID_REGEX.source}|#{WHATSAPP_NEWSLETTER_JID_REGEX.source}|[A-Z]{2}\\.[a-zA-Z0-9]+)\\z")
 end


### PR DESCRIPTION
## O que mudou

### 1. QR Code na Evolution Go
O qrcodes_controller.rb procurava por chaves Qrcode e Code (maiusculas), mas a Evolution Go retorna qrcode e code (minusculas). Agora suporta ambas.

### 2. Newsletter JIDs (@newsletter)
Mensagens de canais/newsletter do WhatsApp chegam com JID tipo 120363170942886188@newsletter. O CRM tratava como contato individual, extraia o numero (18 digitos) e a validacao de source_id falhava (max 15 digitos). O job do Sidekiq ia pra fila de mortos.

Mudancas:
- Nova regex WHATSAPP_NEWSLETTER_JID_REGEX em lib/regex_helper.rb
- Helper newsletter_message? nos handlers Evolution Go
- Newsletter tratada como grupo (usa JID completo como source_id)

### 3. Connection Pool (database.yml)
Aumentado pool do Sidekiq 10 para 15, Puma 5 para 10, checkout_timeout 5s para 10s, reaping_frequency 30s para 15s para evitar ConnectionTimeoutError

## Arquivos alterados
- app/controllers/api/v1/evolution_go/qrcodes_controller.rb
- lib/regex_helper.rb
- app/services/whatsapp/evolution_go_handlers/helpers.rb
- app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
- config/database.yml

## Testes
- QR code renderizando no frontend
- Conexao WhatsApp funcionando (enviar/receber)
- Mensagens de newsletter nao quebram mais o Sidekiq