### PR TITLE
fix(pipelines): persist stage_type, serialize pipeline/stage values, filter forms by pipeline

### DIFF
--- a/app/controllers/api/v1/crm_forms_controller.rb
+++ b/app/controllers/api/v1/crm_forms_controller.rb
@@ -24,6 +24,11 @@ class Api::V1::CrmFormsController < Api::V1::BaseController
 
     scope = scope.where(published: ActiveModel::Type::Boolean.new.cast(params[:published])) if params[:published].present?
 
+    # Scope to a pipeline: forms whose DEFAULT destination is this pipeline. Lets the
+    # in-pipeline "Formulários de Captura" modal list only that pipeline's forms.
+    # (A form's routing_rules can still route some submissions elsewhere; not filtered.)
+    scope = scope.where(default_pipeline_id: params[:pipeline_id]) if params[:pipeline_id].present?
+
     page = params[:page].presence || 1
     per_page = params[:pageSize].presence || params[:per_page].presence || 20
     @crm_forms = scope.page(page).per(per_page)

--- a/app/models/pipeline_stage.rb
+++ b/app/models/pipeline_stage.rb
@@ -26,6 +26,12 @@ class PipelineStage < ApplicationRecord
   has_many :stage_movements_from, class_name: 'StageMovement', foreign_key: 'from_stage_id', dependent: :destroy, inverse_of: :from_stage
   has_many :stage_movements_to, class_name: 'StageMovement', foreign_key: 'to_stage_id', dependent: :destroy, inverse_of: :to_stage
 
+  # stage_type is an integer column (default 0). Without this enum the frontend's
+  # string values ("active"/"completed"/"cancelled") were coerced via String#to_i to 0,
+  # so a stage saved as "completed"/"cancelled" always silently reverted to "active".
+  # The enum maps the strings to/from the integers so save + serialize round-trip.
+  enum :stage_type, { active: 0, completed: 1, cancelled: 2 }, prefix: :stage
+
   validates :name, presence: true
   validates :position, presence: true, uniqueness: { scope: :pipeline_id }
   validates :color, format: { with: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, message: :invalid_hex_color }

--- a/app/serializers/pipeline_serializer.rb
+++ b/app/serializers/pipeline_serializer.rb
@@ -96,6 +96,21 @@ module PipelineSerializer
       end
     end
 
+    # Pipeline-level services_info (Valor Total do funil). The list screen and the
+    # board header both read services_info.total_value / formatted_total per pipeline;
+    # without this block the frontend always shows R$ 0,00. Mirrors the per-item
+    # services_info shape (PipelineItemSerializer) but aggregated over the whole
+    # pipeline via Pipeline#total_value. Preloaded pipeline_items keep this N+1-free.
+    if include_services_info
+      total_value = pipeline.total_value
+      result[:services_info] = {
+        total_value: total_value,
+        currency: 'BRL',
+        formatted_total: format('%.2f', total_value).tr('.', ','),
+        has_services: total_value.positive?
+      }
+    end
+
     result
   end
 

--- a/app/serializers/pipeline_stage_serializer.rb
+++ b/app/serializers/pipeline_stage_serializer.rb
@@ -31,7 +31,13 @@ module PipelineStageSerializer
       updated_at: pipeline_stage.updated_at&.iso8601
     }
 
-    result[:item_count] = pipeline_stage.item_count if include_item_count
+    if include_item_count
+      result[:item_count] = pipeline_stage.item_count
+      # Per-stage services total (same services_total_value the pipeline/board sum on).
+      # Lets the list surface value-per-stage (e.g. the "Ganhos"/completed-stage value)
+      # without loading every item into the list payload.
+      result[:total_value] = pipeline_stage.pipeline_items.sum(&:services_total_value)
+    end
 
     result
   end


### PR DESCRIPTION
## O que
Três correções de backend do CRM community, todas ligadas ao redesign de Pipelines:

- **`stage_type` nunca persistia.** `PipelineStage.stage_type` é coluna `integer` sem `enum`, então as strings do front (`active`/`completed`/`cancelled`) viravam `String#to_i == 0` e toda etapa salva como *completed/cancelled* voltava silenciosamente pra *active*. Adicionado o `enum` pra o save + serialize fazerem round-trip.
- **`services_info` do pipeline nunca era serializado.** A lista/board mostrava sempre R$ 0,00 no Valor Total. Adicionado o bloco `services_info` (total_value/formatted_total) no `PipelineSerializer` quando `include_services_info`.
- **Valor por etapa.** `PipelineStageSerializer` agora retorna `total_value` por etapa junto do `item_count` (pra lista mostrar Ganhos/valor por etapa).
- **Filtro de forms por pipeline.** `CrmFormsController#index` aceita `pipeline_id` (via `default_pipeline_id`) pro modal de Formulários de Captura dentro do pipeline.

## Por que
Bugs genuínos do community (não enterprise) — corrigidos na fonte conforme a regra do monorepo.

## Verificação
Provado via API: PATCH stage_type=completed persiste; add serviço R$1500 → lista retorna formatted_total. `ruby -c` OK nos 4 arquivos.

## Summary by Sourcery

Fix CRM pipeline stage type persistence and enhance pipeline/stage value serialization and form filtering.

New Features:
- Expose pipeline-level total services value and formatted total via services_info in pipeline serialization.
- Include per-stage total services value alongside item count in pipeline stage serialization.
- Support filtering CRM forms by default_pipeline_id to show forms associated with a specific pipeline.

Bug Fixes:
- Ensure pipeline stage_type is correctly persisted by defining an enum mapping for active, completed, and cancelled stages.