### PR TITLE
test(migrations): paridade PAR de version (anti-colisão CRM×auth) — EVO-2090

### DIFF
--- a/.github/workflows/migration-version-parity.yml
+++ b/.github/workflows/migration-version-parity.yml
@@ -1,0 +1,43 @@
+name: Migration version parity
+
+# EVO-2090: CRM and evo-auth-service-community share ONE `schema_migrations` table
+# (same database). A reused version makes Rails skip the second app's migration ->
+# missing DDL -> boot crash (messages.source, EVO-1911). Each app owns a disjoint
+# slice of the version space so collisions are impossible by construction:
+#   * CRM (this repo) -> EVEN versions
+#   * auth            -> ODD  versions
+# This job FAILS the PR if a migration created under the convention (version >=
+# CUTOFF) is ODD. Older migrations are grandfathered. Runs without Rails/DB — it
+# only scans db/migrate filenames — so it is fast and cannot be skipped by the
+# (partial) RSpec CI. Mirrored in the auth repo (ODD) and backstopped by the
+# monorepo guard (evolution-foundation/evo-crm-community).
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check migration version parity (CRM = EVEN)
+        run: |
+          set -euo pipefail
+          cutoff=20260713000000
+          bad="$(ls db/migrate 2>/dev/null | grep -oE '^[0-9]{14}' \
+                 | awk -v c="$cutoff" '$1>=c { if (substr($0,14,1)%2==1) print $0 }')"
+          if [ -n "$bad" ]; then
+            echo "::error::EVO-2090: CRM owns EVEN migration versions (auth owns ODD)."
+            echo "The following are ODD and >= $cutoff, so they can collide with an auth migration in the shared schema_migrations table:"
+            echo "$bad" | sed 's/^/  /'
+            echo "Fix: bump the migration timestamp by 1 second so its version is even."
+            exit 1
+          fi
+          echo "OK: no ODD migration >= $cutoff — CRM parity respected."

--- a/.github/workflows/migration-version-parity.yml
+++ b/.github/workflows/migration-version-parity.yml
@@ -31,8 +31,11 @@ jobs:
         run: |
           set -euo pipefail
           cutoff=20260713000000
+          # `|| true`: grep exits 1 when db/migrate has no 14-digit file, which
+          # under `pipefail` would abort the step with a confusing failure instead
+          # of the intended "no versions" pass.
           bad="$(ls db/migrate 2>/dev/null | grep -oE '^[0-9]{14}' \
-                 | awk -v c="$cutoff" '$1>=c { if (substr($0,14,1)%2==1) print $0 }')"
+                 | awk -v c="$cutoff" '$1>=c { if (substr($0,14,1)%2==1) print $0 }' || true)"
           if [ -n "$bad" ]; then
             echo "::error::EVO-2090: CRM owns EVEN migration versions (auth owns ODD)."
             echo "The following are ODD and >= $cutoff, so they can collide with an auth migration in the shared schema_migrations table:"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,3 +86,20 @@ Thanks for helping make Evo CRM Backend better!
 ---
 
 © 2026 Evolution Foundation
+
+## Database migrations — version parity (EVO-2090)
+
+This service shares a single `schema_migrations` table with
+`evo-auth-service-community` (both apps point at the same database). If the two
+ever create a migration with the same 14-digit version, Rails records it once
+and **skips** the other app's migration forever → missing DDL → boot crash.
+
+To make collisions impossible by construction, each app owns a **disjoint slice
+of the version space by parity**:
+
+- **CRM (this repo): EVEN versions** — timestamps ending in `0/2/4/6/8`
+- **auth: ODD versions** — timestamps ending in `1/3/5/7/9`
+
+When you generate a migration, bump the timestamp by 1 second if needed so its
+version is **even**. Enforced by `spec/migration_version_parity_spec.rb`
+(migrations created before the convention are grandfathered by a cutoff date).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,12 +94,30 @@ This service shares a single `schema_migrations` table with
 ever create a migration with the same 14-digit version, Rails records it once
 and **skips** the other app's migration forever → missing DDL → boot crash.
 
-To make collisions impossible by construction, each app owns a **disjoint slice
-of the version space by parity**:
+To make collisions impossible by construction for **new** migrations, each app
+owns a **disjoint slice of the version space by parity**:
 
 - **CRM (this repo): EVEN versions** — timestamps ending in `0/2/4/6/8`
 - **auth: ODD versions** — timestamps ending in `1/3/5/7/9`
 
 When you generate a migration, bump the timestamp by 1 second if needed so its
-version is **even**. Enforced by `spec/migration_version_parity_spec.rb`
-(migrations created before the convention are grandfathered by a cutoff date).
+version is **even**.
+
+**Enforcement:** the real gate is the `.github/workflows/migration-version-parity.yml`
+workflow (`parity` job) — a lightweight filename scan that runs on every PR
+without Rails/DB, since the RSpec suite is not run in full on PRs. The companion
+`spec/migration_version_parity_spec.rb` documents the same rule for local runs.
+For either to actually **block** a merge, its check must be marked *required* in
+this repo's branch-protection settings.
+
+**Scope of the guarantee:** parity only makes *new* (≥ cutoff) migrations
+collision-free. Migrations predating the convention are grandfathered and may sit
+in the other app's parity slice; the monorepo backstop
+(`evo-crm-community`) catches any *exact* residual collision, but only when its
+pinned submodule commits are bumped — after both PRs have already merged. Never
+hand-pick an old timestamp for a new migration.
+
+**Why not isolate `schema_migrations` per service?** That would require a backfill
+on existing customer databases (a freshly-created table would re-run every
+migration, breaking non-idempotent ones and the login boot). Rejected as too
+risky; parity achieves the same guarantee with zero database change.

--- a/spec/migration_version_parity_spec.rb
+++ b/spec/migration_version_parity_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2090 — collision-free migration versions.
+#
+# evo-ai-crm-community and evo-auth-service-community run as SEPARATE apps but
+# point at the SAME database, sharing ONE `schema_migrations` table. If both ever
+# create a migration with the same version (14-digit timestamp), Rails records it
+# once and SKIPS the second app's migration forever -> missing DDL -> boot crash
+# (this is what broke `messages.source`, EVO-1911).
+#
+# To make a collision IMPOSSIBLE BY CONSTRUCTION -- no shared-table split, no
+# separate database, no cross-repo CI -- each app owns a DISJOINT slice of the
+# version space by PARITY:
+#
+#   * CRM (this repo) -> EVEN versions  (...0, ...2, ...4, ...6, ...8)
+#   * auth            -> ODD  versions  (...1, ...3, ...5, ...7, ...9)
+#
+# even and odd are disjoint, so the two apps can never pick the same version.
+# Each repo enforces its OWN parity locally (this spec), catching a bad migration
+# in the PR that introduces it -- no access to the other repo required.
+#
+# Migrations created before this convention are grandfathered via CUTOFF.
+RSpec.describe 'Migration version parity (EVO-2090)' do
+  # The convention takes effect from this timestamp. A migration whose version is
+  # >= CUTOFF must be EVEN; anything older predates the rule and is exempt.
+  let(:cutoff) { 20_260_713_000_000 }
+
+  def migration_versions
+    Dir[Rails.root.join('db/migrate/*.rb')]
+      .map { |path| File.basename(path)[/\A\d{14}/]&.to_i }
+      .compact
+  end
+
+  it 'finds migrations (guards against a broken glob / wrong path)' do
+    expect(migration_versions).not_to be_empty
+  end
+
+  # CRM owns EVEN versions; auth owns ODD. Any ODD version at/after the cutoff can
+  # collide with an auth migration in the shared schema_migrations table.
+  it 'every migration created under the convention (version >= CUTOFF) uses an EVEN version' do
+    offenders = migration_versions.select { |version| version >= cutoff && version.odd? }
+
+    expect(offenders).to be_empty, <<~MSG
+      Migration version collision guard (EVO-2090): this repo (CRM) owns EVEN
+      migration versions; auth owns ODD. The versions below are ODD and >= the
+      convention cutoff (#{cutoff}), so they can collide with an auth migration in
+      the shared `schema_migrations` table:
+
+        #{offenders.sort.join("\n        ")}
+
+      Fix: bump the migration timestamp by 1 second so its version becomes even.
+    MSG
+  end
+
+  it 'the rule is active — an odd version at/after the cutoff would be flagged' do
+    # Sanity: proves the predicate actually rejects odd versions in-range, so a
+    # green suite means the real check above is meaningful (not vacuously true).
+    odd_in_range = [cutoff + 1, cutoff + 3]
+    expect(odd_in_range.select { |version| version >= cutoff && version.odd? }).to eq(odd_in_range)
+    expect(cutoff).to be_even
+  end
+end


### PR DESCRIPTION
## Contexto
CRM e auth compartilham **uma** tabela `schema_migrations` (mesmo banco). Uma version repetida entre os dois faz o Rails **pular** a migration de um → DDL ausente → boot quebra (`messages.source`, EVO-1911).

## Solução (sem banco novo, sem tabela nova, sem cross-repo)
Cada app dono de uma fatia **disjunta** do espaço de versions por **paridade**:
- **CRM (este repo): PAR** (`...0/2/4/6/8`)
- **auth: ÍMPAR** (`...1/3/5/7/9`)

`par ∩ ímpar = ∅` → **colisão impossível por construção**. Cada repo valida a **si mesmo** no próprio CI — pega a migration ruim no PR que a introduz, sem acessar o outro repo, sem PAT, sem mexer em banco.

## O que entra
- `spec/migration_version_parity_spec.rb` — falha se qualquer migration com version ≥ cutoff (`20260713000000`) for **ímpar**. Migrations anteriores são **grandfathered**. Inclui guard do glob + sanity de que a regra está ativa.
- `CONTRIBUTING.md` — documenta a regra par/ímpar.

## Testes
Roda na suíte RSpec existente (`bundle exec rspec spec/migration_version_parity_spec.rb`). Validado que as migrations atuais **não violam** (todas < cutoff). *(Não executei RSpec localmente — sem Ruby aqui; roda no CI.)*

Par (auth ímpar) casa com a remediação da colisão (`20260622120000 → 20260622120001`). Complementa o guard do monorepo (evo-crm-community#159). Refs **EVO-2090**.