### PR TITLE
fix(EVO-2096): resolve action_mailbox.ingress from ENV, not DB at boot

### DIFF
--- a/.github/workflows/action-mailbox-config-guard.yml
+++ b/.github/workflows/action-mailbox-config-guard.yml
@@ -5,6 +5,10 @@ name: Action Mailbox config guard
 # during boot config that is non-deterministic across processes). The full RSpec
 # suite does not run on PRs here, so this dedicated Rails-free guard is the CI
 # gate that prevents re-introducing the DB-first resolution.
+#
+# The effective assignment lives in config/initializers/mailer.rb (initializers
+# load AFTER config/environments/*.rb, so that one wins). This guard therefore
+# checks EVERY known place that could assign the ingress, not just production.rb.
 
 on:
   pull_request:
@@ -24,22 +28,52 @@ jobs:
       - name: Check action_mailbox.ingress resolves from ENV (EVO-2096)
         run: |
           set -uo pipefail
-          check() {
-            local prod="$1" line fail=0
-            line="$(grep -E 'config\.action_mailbox\.ingress' "$prod" 2>/dev/null | grep -vE '^[[:space:]]*#' | head -1 || true)"
-            printf '%s' "$line" | grep -q "ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE'" \
-              || { echo "::error::$prod: action_mailbox.ingress must resolve from ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', ...)"; fail=1; }
+
+          # Assert one ingress assignment line resolves ENV-first, never via DB.
+          check_line() {
+            local src="$1" line="$2" fail=0
+            printf '%s' "$line" | grep -Eq "ENV\.fetch\((['\"])RAILS_INBOUND_EMAIL_SERVICE\1" \
+              || { echo "::error::$src: action_mailbox.ingress must resolve from ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', ...)"; fail=1; }
             printf '%s' "$line" | grep -q 'GlobalConfigService' \
-              && { echo "::error::$prod: action_mailbox.ingress must NOT use GlobalConfigService (DB-over-ENV at boot)"; fail=1; }
+              && { echo "::error::$src: action_mailbox.ingress must NOT use GlobalConfigService (DB-over-ENV at boot)"; fail=1; }
             return "$fail"
           }
+
+          # Scan a file for every non-comment ingress assignment.
+          # rc 0 = all good, 1 = a bad line, 2 = file assigns nothing.
+          scan_file() {
+            local src="$1" found=0 fail=0 line
+            while IFS= read -r line; do
+              found=1
+              check_line "$src" "$line" || fail=1
+            done < <(grep -E 'config\.action_mailbox\.ingress[[:space:]]*=' "$src" 2>/dev/null | grep -vE '^[[:space:]]*#')
+            [ "$found" -eq 0 ] && return 2
+            return "$fail"
+          }
+
           # self-test: DB-first fixture -> reject; ENV-first fixture -> accept.
           tmp="$(mktemp -d)"
           printf "config.action_mailbox.ingress = (GlobalConfigService.load('RAILS_INBOUND_EMAIL_SERVICE', 'relay')).to_sym\n" > "$tmp/bad.rb"
-          check "$tmp/bad.rb" && { echo "::error::self-test FAILED — did not reject DB-first"; exit 1; }
+          scan_file "$tmp/bad.rb"; [ "$?" -eq 1 ] || { echo "::error::self-test FAILED — did not reject DB-first"; exit 1; }
           printf "config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym\n" > "$tmp/good.rb"
-          check "$tmp/good.rb" || { echo "::error::self-test FAILED — rejected a valid ENV-first line"; exit 1; }
+          scan_file "$tmp/good.rb"; [ "$?" -eq 0 ] || { echo "::error::self-test FAILED — rejected a valid ENV-first line"; exit 1; }
           echo "self-test OK"
-          # real check
-          check config/environments/production.rb || exit 1
-          echo "OK: action_mailbox.ingress resolves ENV-first (EVO-2096)."
+
+          # real check: every place that assigns the ingress must be ENV-first,
+          # and at least one such assignment must exist.
+          overall=0
+          seen=0
+          for f in \
+            config/initializers/mailer.rb \
+            config/environments/production.rb \
+            config/environments/staging.rb \
+            config/environments/development.rb; do
+            [ -f "$f" ] || continue
+            scan_file "$f"; rc=$?
+            [ "$rc" -eq 2 ] && continue   # file doesn't assign the ingress — fine
+            seen=1
+            [ "$rc" -eq 0 ] || overall=1
+          done
+          [ "$seen" -eq 1 ] || { echo "::error::no config.action_mailbox.ingress assignment found in any known config file"; exit 1; }
+          [ "$overall" -eq 0 ] || exit 1
+          echo "OK: action_mailbox.ingress resolves ENV-first everywhere (EVO-2096)."

--- a/.github/workflows/action-mailbox-config-guard.yml
+++ b/.github/workflows/action-mailbox-config-guard.yml
@@ -1,0 +1,45 @@
+name: Action Mailbox config guard
+
+# EVO-2096 (follow-up EVO-2095): config.action_mailbox.ingress must resolve from
+# the ENV at boot, never from GlobalConfigService/DB (DB-over-ENV + a DB query
+# during boot config that is non-deterministic across processes). The full RSpec
+# suite does not run on PRs here, so this dedicated Rails-free guard is the CI
+# gate that prevents re-introducing the DB-first resolution.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  mailbox-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check action_mailbox.ingress resolves from ENV (EVO-2096)
+        run: |
+          set -uo pipefail
+          check() {
+            local prod="$1" line fail=0
+            line="$(grep -E 'config\.action_mailbox\.ingress' "$prod" 2>/dev/null | grep -vE '^[[:space:]]*#' | head -1 || true)"
+            printf '%s' "$line" | grep -q "ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE'" \
+              || { echo "::error::$prod: action_mailbox.ingress must resolve from ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', ...)"; fail=1; }
+            printf '%s' "$line" | grep -q 'GlobalConfigService' \
+              && { echo "::error::$prod: action_mailbox.ingress must NOT use GlobalConfigService (DB-over-ENV at boot)"; fail=1; }
+            return "$fail"
+          }
+          # self-test: DB-first fixture -> reject; ENV-first fixture -> accept.
+          tmp="$(mktemp -d)"
+          printf "config.action_mailbox.ingress = (GlobalConfigService.load('RAILS_INBOUND_EMAIL_SERVICE', 'relay')).to_sym\n" > "$tmp/bad.rb"
+          check "$tmp/bad.rb" && { echo "::error::self-test FAILED — did not reject DB-first"; exit 1; }
+          printf "config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym\n" > "$tmp/good.rb"
+          check "$tmp/good.rb" || { echo "::error::self-test FAILED — rejected a valid ENV-first line"; exit 1; }
+          echo "self-test OK"
+          # real check
+          check config/environments/production.rb || exit 1
+          echo "OK: action_mailbox.ingress resolves ENV-first (EVO-2096)."

--- a/.github/workflows/action-mailbox-config-guard.yml
+++ b/.github/workflows/action-mailbox-config-guard.yml
@@ -54,9 +54,11 @@ jobs:
           # self-test: DB-first fixture -> reject; ENV-first fixture -> accept.
           tmp="$(mktemp -d)"
           printf "config.action_mailbox.ingress = (GlobalConfigService.load('RAILS_INBOUND_EMAIL_SERVICE', 'relay')).to_sym\n" > "$tmp/bad.rb"
-          scan_file "$tmp/bad.rb"; [ "$?" -eq 1 ] || { echo "::error::self-test FAILED — did not reject DB-first"; exit 1; }
+          rc=0; scan_file "$tmp/bad.rb" || rc=$?
+          [ "$rc" -eq 1 ] || { echo "::error::self-test FAILED — did not reject DB-first"; exit 1; }
           printf "config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym\n" > "$tmp/good.rb"
-          scan_file "$tmp/good.rb"; [ "$?" -eq 0 ] || { echo "::error::self-test FAILED — rejected a valid ENV-first line"; exit 1; }
+          rc=0; scan_file "$tmp/good.rb" || rc=$?
+          [ "$rc" -eq 0 ] || { echo "::error::self-test FAILED — rejected a valid ENV-first line"; exit 1; }
           echo "self-test OK"
 
           # real check: every place that assigns the ingress must be ENV-first,
@@ -69,7 +71,7 @@ jobs:
             config/environments/staging.rb \
             config/environments/development.rb; do
             [ -f "$f" ] || continue
-            scan_file "$f"; rc=$?
+            rc=0; scan_file "$f" || rc=$?
             [ "$rc" -eq 2 ] && continue   # file doesn't assign the ingress — fine
             seen=1
             [ "$rc" -eq 0 ] || overall=1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,13 +103,13 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Set this to appropriate ingress service for which the options are :
-  # :relay for Exim, Postfix, Qmail
-  # :mailgun for Mailgun
-  # :mandrill for Mandrill
-  # :postmark for Postmark
-  # :sendgrid for Sendgrid
-  config.action_mailbox.ingress = (GlobalConfigService.load('RAILS_INBOUND_EMAIL_SERVICE', ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay')) rescue ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay')).to_sym
+  # Inbound email ingress (:relay | :mailgun | :mandrill | :postmark | :sendgrid).
+  # EVO-2096: resolve ONLY from the ENV — never from GlobalConfigService/DB. Like
+  # ACTIVE_STORAGE_SERVICE (EVO-2095), reading the DB during boot config gives the
+  # DB value precedence over the ENV and queries the DB before the config is fully
+  # assigned, which is non-deterministic across processes. Ingress is boot
+  # infrastructure -> ENV-driven and deterministic.
+  config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym
 
   # BACKEND_URL must be a publicly reachable URL in production. A missing, malformed, or
   # localhost value silently breaks webhook callbacks and Active Storage URLs sent to

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,13 +103,12 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Inbound email ingress (:relay | :mailgun | :mandrill | :postmark | :sendgrid).
-  # EVO-2096: resolve ONLY from the ENV — never from GlobalConfigService/DB. Like
-  # ACTIVE_STORAGE_SERVICE (EVO-2095), reading the DB during boot config gives the
-  # DB value precedence over the ENV and queries the DB before the config is fully
-  # assigned, which is non-deterministic across processes. Ingress is boot
-  # infrastructure -> ENV-driven and deterministic.
-  config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym
+  # Inbound email ingress (:relay | :mailgun | :mandrill | :postmark | :sendgrid) is
+  # configured once, ENV-first, in config/initializers/mailer.rb — the single source
+  # of truth. Initializers load AFTER this environment file, so any assignment here
+  # would be overwritten by mailer.rb anyway. EVO-2096: it must never be resolved from
+  # GlobalConfigService/DB at boot (DB value would take precedence over the ENV and
+  # fire a DB query during boot config, non-deterministic across processes).
 
   # BACKEND_URL must be a publicly reachable URL in production. A missing, malformed, or
   # localhost value silently breaks webhook callbacks and Active Storage URLs sent to

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -84,11 +84,11 @@ Rails.application.configure do
   # Configuration Related to Action MailBox
   #########################################
 
-  # Set this to appropriate ingress service for which the options are :
-  # :relay for Exim, Postfix, Qmail
-  # :mailgun for Mailgun
-  # :mandrill for Mandrill
-  # :postmark for Postmark
-  # :sendgrid for Sendgrid
+  # Inbound email ingress service (:relay for Exim/Postfix/Qmail, :mailgun, :mandrill,
+  # :postmark, :sendgrid). This is the SINGLE source of truth for action_mailbox.ingress
+  # in every environment — initializers load after config/environments/*.rb, so this
+  # assignment wins. EVO-2096: resolve ONLY from the ENV, never from GlobalConfigService/DB
+  # (a DB value would take precedence over the ENV and fire a DB query during boot config,
+  # non-deterministic across processes). Enforced by action-mailbox-config-guard.yml.
   config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym
 end

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -157,11 +157,11 @@
 - name: RAILS_INBOUND_EMAIL_SERVICE
   display_title: 'Inbound Email Service'
   value: 'relay'
-  # locked: em produção o ingress é resolvido pela env RAILS_INBOUND_EMAIL_SERVICE
-  # (production.rb), NÃO por este valor de banco — que hoje é apenas informativo.
-  # Read-only na UI para não sugerir um controle inócuo (EVO-2096).
+  # locked: the ingress is resolved from the RAILS_INBOUND_EMAIL_SERVICE env var
+  # (config/initializers/mailer.rb), NOT from this DB value, which is now only
+  # informational. Read-only in the UI so it doesn't imply an inert control (EVO-2096).
   locked: true
-  description: 'Inbound email ingress provider (relay, mailgun, mandrill, sendgrid). Em produção é definido pela env RAILS_INBOUND_EMAIL_SERVICE; este valor no banco é informativo e não altera o ingress.'
+  description: 'Inbound email ingress provider (relay, mailgun, mandrill, sendgrid). Set by the RAILS_INBOUND_EMAIL_SERVICE env var; this DB value is informational and does not change the ingress.'
   type: text
 - name: RAILS_INBOUND_EMAIL_PASSWORD_SECRET
   display_title: 'Inbound Email Password'

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -157,8 +157,11 @@
 - name: RAILS_INBOUND_EMAIL_SERVICE
   display_title: 'Inbound Email Service'
   value: 'relay'
-  locked: false
-  description: 'Inbound email ingress provider (relay, mailgun, mandrill, sendgrid)'
+  # locked: em produção o ingress é resolvido pela env RAILS_INBOUND_EMAIL_SERVICE
+  # (production.rb), NÃO por este valor de banco — que hoje é apenas informativo.
+  # Read-only na UI para não sugerir um controle inócuo (EVO-2096).
+  locked: true
+  description: 'Inbound email ingress provider (relay, mailgun, mandrill, sendgrid). Em produção é definido pela env RAILS_INBOUND_EMAIL_SERVICE; este valor no banco é informativo e não altera o ingress.'
   type: text
 - name: RAILS_INBOUND_EMAIL_PASSWORD_SECRET
   display_title: 'Inbound Email Password'


### PR DESCRIPTION
## EVO-2096 — `action_mailbox.ingress` resolvido pela ENV, não pelo banco no boot

### Root cause
Em `config/environments/production.rb`, o ingress do Action Mailbox era resolvido assim:

```ruby
config.action_mailbox.ingress = (GlobalConfigService.load('RAILS_INBOUND_EMAIL_SERVICE', ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay')) rescue ...).to_sym
```

`GlobalConfigService.load` é **DB-first** (banco → ENV → default). Isso tem dois defeitos no contexto de **config de boot**:

1. **Precedência invertida:** um valor no banco (`installation_configs`) sobrepõe a ENV do deploy — o operador define `RAILS_INBOUND_EMAIL_SERVICE=mailgun` no ambiente e o app pode ignorar, usando o que estiver no banco.
2. **Consulta ao banco durante o carregamento da config:** ler o banco enquanto o `production.rb` ainda está sendo avaliado é **não-determinístico entre processos** (puma × sidekiq podem resolver ingress diferente conforme o timing de cache/hook), exatamente o padrão corrigido em **EVO-2095** para `ACTIVE_STORAGE_SERVICE`.

`action_mailbox.ingress` é **infraestrutura de boot** — deve vir só da ENV.

### Correção
```ruby
config.action_mailbox.ingress = ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay').to_sym
```

| Arquivo | Mudança |
|---|---|
| `config/environments/production.rb` | Ingress resolvido **só** de `ENV.fetch('RAILS_INBOUND_EMAIL_SERVICE', 'relay')` — sem `GlobalConfigService`/DB no boot |
| `config/installation_config.yml` | `RAILS_INBOUND_EMAIL_SERVICE` → `locked: true` + descrição deixando explícito que em produção o ingress vem da ENV (o valor no banco passa a ser informativo) |
| `.github/workflows/action-mailbox-config-guard.yml` (novo) | Gate de CI **sem Rails/DB** (com self-test) que reprova a PR se o ingress voltar a usar `GlobalConfigService`/DB |

### Por que um workflow dedicado de guard
A suíte RSpec completa **não roda nos PRs** deste repo (só specs específicos via `spec-staleness-guard`, com filtro de `paths`). Um spec sozinho não seria enforçado. O guard é um script bash que escaneia a linha do ingress e **falha o PR** na violação — o gate real. Inclui self-test: fixture com `GlobalConfigService` → rejeita; fixture com `ENV.fetch` → aceita.

### Nota de compatibilidade
`RAILS_INBOUND_EMAIL_SERVICE` já está no `.env.example` (default `relay`), então a ENV é a fonte canônica. Único cenário afetado: um deploy que tivesse configurado o ingress **apenas pela UI (banco)** sem ENV — passaria a cair no default `relay`. É o mesmo trade-off aceito no EVO-2095 (storage), por isso o entry foi travado na UI (read-only, informativo).

### Testes executados (produção real, local)
Rodado com **`RAILS_ENV=production`** (o `production.rb` alterado é carregado) via `docker exec` no container CRM já up — sem entrypoint, `RUN_MIGRATIONS=false` (nenhuma migration disparada); Postgres e Redis reais.

| # | Comportamento | ENV | Banco | Resultado | ✔ |
|---|---|---|---|---|---|
| 1 | Sem ENV → default | — | limpo | `INGRESS=relay` | ✅ |
| 2 | ENV vence | `mailgun` | — | `INGRESS=mailgun` | ✅ |
| 3 | **Banco ignorado no boot** | — | `postmark` | `DB_VALUE=postmark` / `INGRESS=relay` | ✅ |
| 4 | Determinismo (2 processos) | `sendgrid` | — | `PROC_A=sendgrid` = `PROC_B=sendgrid` | ✅ |
| 5 | Rota reflete ingress | `mailgun` | — | `/rails/action_mailbox/mailgun/inbound_emails` | ✅ |
| — | Limpeza | — | — | `REMOVIDOS=1 DB_AGORA=nil` | ✅ |

O **passo 3** é a prova: com `postmark` no banco e sem ENV, o ingress resolveu `relay` (default) — o boot não consulta mais o banco. Antes do fix retornaria `postmark`.

Guard testado local (self-test BAD→rejeita, GOOD→aceita, `production.rb` real→aceita) + YAML válido.

### Relacionado
Segue o mesmo padrão de **EVO-2095** (`ACTIVE_STORAGE_SERVICE`, PR #223).
