### PR TITLE
fix(evo-flow): answer 503 on a missing config and default to evo-flow's real port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -271,8 +271,9 @@ USE_OPTIMIZED_CONVERSATION_FINDER=false
 EVOAI_CRM_API_TOKEN=
 
 # EvoFlow Integration (event tracking → evo-flow)
-# Base URL INCLUDING the /api/v1 prefix
-EVO_FLOW_API_URL=http://evo-flow:3000/api/v1
+# Base URL INCLUDING the /api/v1 prefix. Port 3334 is what evo-flow listens on
+# (see its own .env.example); 3000 is only its fallback when PORT is unset.
+EVO_FLOW_API_URL=http://evo-flow:3334/api/v1
 # Shared service-to-service key; MUST equal evo-flow's AUTH_APIKEY_INTEGRATION_LOCAL (no default)
 AUTH_APIKEY_INTEGRATION_LOCAL=
 # In production the client refuses to send the key over plain http. Accepts

--- a/app/controllers/api/v1/evo_flow/segments_controller.rb
+++ b/app/controllers/api/v1/evo_flow/segments_controller.rb
@@ -15,6 +15,13 @@ class Api::V1::EvoFlow::SegmentsController < Api::V1::BaseController
     recompute_all: 'segments.recompute'
   })
 
+  # An unusable evo-flow config (no shared key, missing scheme, cleartext in
+  # production) raises while the client is being CONSTRUCTED — before any request
+  # leaves the process — so the per-action `rescue EvoFlow::HTTPError` below never
+  # sees it. Unhandled, it surfaced as an opaque 500 INTERNAL_ERROR, which reads as
+  # a bug in Segments instead of a deployment that never wired evo-flow up.
+  rescue_from EvoFlow::ConfigurationError, with: :handle_evo_flow_misconfiguration
+
   # Bound the opaque definition we forward to evo-flow (it is passed through with
   # to_unsafe_h, so without a cap a client could amplify an arbitrarily
   # large/deep payload against evo-flow).
@@ -153,5 +160,17 @@ class Api::V1::EvoFlow::SegmentsController < Api::V1::BaseController
   def handle_evo_flow_error(error)
     body = error.response&.parsed_response || { message: error.message }
     render json: { errors: body }, status: (error.code || :bad_gateway)
+  end
+
+  # 503, not 500: nothing is broken, the integration was never configured on this
+  # deployment. The operator-facing detail (which setting is missing) goes to the
+  # log; the client gets a stable code it can branch on.
+  def handle_evo_flow_misconfiguration(error)
+    Rails.logger.error("evo-flow integration is not configured: #{error.message}")
+    error_response(
+      ApiErrorCodes::SERVICE_UNAVAILABLE,
+      'Segments are unavailable: the evo-flow integration is not configured on this deployment',
+      status: :service_unavailable
+    )
   end
 end

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -23,7 +23,11 @@ module EvoFlow
   class Client
     include HTTParty
 
-    DEFAULT_API_URL = 'http://evo-flow:3000/api/v1'.freeze
+    # 3334 is the port evo-flow ships with (its own .env.example and every compose
+    # in the family set PORT=3334). Its code falls back to 3000 only when PORT is
+    # unset, which no deployment of ours does — defaulting to 3000 here just means
+    # a silent timeout against a port nothing listens on.
+    DEFAULT_API_URL = 'http://evo-flow:3334/api/v1'.freeze
     REDACTED_4XX = '[redacted: 4xx body]'.freeze
     MAX_LOGGED_BODY = 500
     VALID_SCHEMES = %w[http https].freeze

--- a/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
@@ -297,4 +297,30 @@ RSpec.describe Api::V1::EvoFlow::SegmentsController, type: :controller do
       expect(response.parsed_body).to eq('errors' => error_body)
     end
   end
+
+  # A deployment that never wired evo-flow up (no shared key, no URL) raises
+  # EvoFlow::ConfigurationError while the client is being CONSTRUCTED — before any
+  # request is issued — so the per-action `rescue EvoFlow::HTTPError` never sees it.
+  # It used to escape as an opaque 500 INTERNAL_ERROR, which reads as a bug in
+  # Segments rather than a missing setting.
+  describe 'evo-flow is not configured' do
+    before do
+      allow(EvoFlow::Client).to receive(:new)
+        .and_raise(EvoFlow::ConfigurationError, 'AUTH_APIKEY_INTEGRATION_LOCAL is not set')
+    end
+
+    it 'answers 503 SERVICE_UNAVAILABLE on #index instead of a 500' do
+      get :index
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body.dig('error', 'code')).to eq('SERVICE_UNAVAILABLE')
+    end
+
+    it 'answers 503 on a write action too (#create)' do
+      post :create, params: { name: 'VIPs', definition: definition }
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body.dig('error', 'code')).to eq('SERVICE_UNAVAILABLE')
+    end
+  end
 end

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -8,6 +8,26 @@ RSpec.describe EvoFlow::Client do
   let(:track_url) { "#{api_url}/events/track" }
   let(:payload) { { event: 'contact.created', contactId: '42' } }
 
+  describe 'DEFAULT_API_URL' do
+    # evo-flow listens on 3334 (its own .env.example, and every compose in the
+    # family sets PORT=3334). Defaulting to 3000 here pointed the client at a port
+    # nothing listens on, so a deployment that omitted EVO_FLOW_API_URL got a
+    # silent timeout instead of working.
+    it 'targets evo-flow on port 3334 when EVO_FLOW_API_URL is unset' do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch)
+        .with('EVO_FLOW_API_URL', described_class::DEFAULT_API_URL)
+        .and_return(described_class::DEFAULT_API_URL)
+
+      stub = stub_request(:get, 'http://evo-flow:3334/api/v1/segments')
+             .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      described_class.new(api_key: api_key).get('/segments')
+
+      expect(stub).to have_been_requested
+    end
+  end
+
   describe '#post' do
     it 'POSTs to the full /api/v1 URL with auth + json headers (AC1)' do
       stub = stub_request(:post, track_url)


### PR DESCRIPTION
Complementa [evo-crm-community#163](https://github.com/evolution-foundation/evo-crm-community/pull/163), que declara o evo-flow no stack de deploy. Esta PR trata o lado do CRM: os dois pontos que fizeram o mesmo bug ser difícil de diagnosticar.

## 1. Misconfig virava 500 opaco

`EvoFlow::ConfigurationError` é levantada na **construção** do client (`client.rb:99`) — antes de qualquer request sair do processo. O `rescue EvoFlow::HTTPError` de cada action nunca a via, então ela escapava para o `RequestExceptionHandler` e virava:

```json
{"success":false,"error":{"code":"INTERNAL_ERROR","message":"An unexpected error occurred"}}
```

Isso lê como *bug na feature de Segments*, quando na verdade é *deployment sem o evo-flow configurado*. Foi exatamente o que aconteceu no staging: horas gastas procurando bug de código onde faltava uma variável de ambiente.

Agora um `rescue_from` responde **503 `SERVICE_UNAVAILABLE`** com mensagem acionável, e loga qual setting está faltando. 503 e não 500 porque nada está quebrado — a integração nunca foi configurada naquele deployment. Vale para todas as actions (leitura e escrita), já que todas passam pelo mesmo `client`.

## 2. Porta default errada

`DEFAULT_API_URL` apontava para **3000**. O evo-flow escuta em **3334** — é o que está no `.env.example` do próprio evo-flow e o que todo compose da família seta via `PORT`. O 3000 é apenas o fallback do código dele (`main.ts:473`, `process.env.PORT ?? 3000`), que nenhum deployment nosso usa.

Resultado: quem subisse o CRM sem setar `EVO_FLOW_API_URL` explicitamente batia numa porta onde ninguém escuta — timeout silencioso. O `.env.example` do CRM carregava o mesmo 3000 e propagava a armadilha.

## Testes

Adicionados (o harness já stubava `EvoFlow::Client`, então a costura estava pronta):

- `segments_controller_spec.rb`: `EvoFlow::Client.new` levantando `ConfigurationError` → 503 + code `SERVICE_UNAVAILABLE`, em leitura (`#index`) e escrita (`#create`).
- `client_spec.rb`: com `EVO_FLOW_API_URL` ausente, o client bate em `http://evo-flow:3334/api/v1` (WebMock prova a requisição real, não só o valor da constante).

```
51 examples, 0 failures
```

**Nota sobre o ambiente de teste:** rodando com o `.env` de dev carregado, `client_spec.rb:281` ("refuses cleartext http without an explicit opt-out") falha — o `.env` seta `EVO_FLOW_ALLOW_INSECURE=true`, que vaza para o `RAILS_ENV=test` e faz o client aceitar cleartext. Confirmei que essa falha **também ocorre em `develop` sem nenhuma mudança minha** (mesma linha, mesmo erro); com a variável neutralizada, a suíte fica verde. Não é regressão desta PR, mas é uma armadilha de quem rodar a suíte localmente.

## Summary by Sourcery

Handle evo-flow misconfiguration more gracefully and align the default evo-flow client URL with the actual service port.

Bug Fixes:
- Return a 503 SERVICE_UNAVAILABLE error with a stable code when evo-flow configuration is missing or invalid instead of an opaque 500 error.
- Update the evo-flow client default API URL to use port 3334 so deployments without EVO_FLOW_API_URL connect to the correct service instead of timing out on an unused port.

Tests:
- Add controller specs ensuring EvoFlow::ConfigurationError on client construction yields a 503 SERVICE_UNAVAILABLE for both read and write segment actions.
- Add client specs verifying that, when EVO_FLOW_API_URL is unset, the evo-flow client targets http://evo-flow:3334/api/v1.