### PR TITLE
fix(whatsapp): reseta provider_connection ao reconectar (EVO-2140)

### DIFF
--- a/app/jobs/webhooks/whatsapp_events_job.rb
+++ b/app/jobs/webhooks/whatsapp_events_job.rb
@@ -655,7 +655,7 @@ class Webhooks::WhatsappEventsJob < ApplicationJob
       return false
     end
 
-    channel.reauthorized! # limpa a flag presa no Redis (mesmo metodo do hotfix de campo)
+    channel.mark_connected! # clear the stuck Redis flag AND reset provider_connection to 'open'
     true
   rescue StandardError => e
     Rails.logger.error "EVO-1967: channel reconciliation failed for channel #{channel&.id}: #{e.message}"

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -112,6 +112,16 @@ class Channel::Whatsapp < ApplicationRecord
     save!(validate: false)
   end
 
+  # Realigns both "connected" views — the reauthorization flag (Redis) and the
+  # provider_connection snapshot (JSONB) — back to connected. Every reconnect
+  # signal must call this; otherwise provider_connection stays stuck on a stale
+  # 'close'/'logged_out' after a silent reconnect and the composer/banner (which
+  # read it) keep showing the channel as disconnected.
+  def mark_connected!
+    reauthorized! if reauthorization_required?
+    update_provider_connection!({ 'connection' => 'open', 'error' => nil })
+  end
+
   def provider_connection_data
     data = { connection: provider_connection['connection'] }
     if Current.user&.role == 'administrator'

--- a/app/services/whatsapp/incoming_message_evolution_service.rb
+++ b/app/services/whatsapp/incoming_message_evolution_service.rb
@@ -103,12 +103,11 @@ class Whatsapp::IncomingMessageEvolutionService < Whatsapp::IncomingMessageBaseS
   def handle_connection_open(profile_picture_url)
     Rails.logger.info "Evolution API: Connection opened successfully for instance #{processed_params[:instance]}"
 
-    # Clear any reauthorization flags from previous disconnections
+    # Reconnected: realign both connection views to 'open'. Previously this only
+    # cleared the reauthorization flag, leaving provider_connection stuck on the
+    # last 'close'/'logged_out' — which kept the composer/banner disconnected.
     channel = inbox.channel
-    if channel.reauthorization_required?
-      Rails.logger.info "Evolution API: Clearing reauthorization flag for channel #{channel.id}"
-      channel.reauthorized!
-    end
+    channel.mark_connected!
 
     # Update inbox avatar if profile picture URL is present
     return unless profile_picture_url.present?

--- a/spec/jobs/webhooks/whatsapp_events_job_spec.rb
+++ b/spec/jobs/webhooks/whatsapp_events_job_spec.rb
@@ -178,15 +178,15 @@ RSpec.describe Webhooks::WhatsappEventsJob, type: :job do
       allow(job).to receive(:set_reconcile_cooldown!)
     end
 
-    it 'reauthorizes and returns true when Evolution reports open' do
+    it 'marks the channel connected and returns true when Evolution reports open' do
       allow(job).to receive(:evolution_connection_state).and_return('open')
-      expect(evo_channel).to receive(:reauthorized!)
+      expect(evo_channel).to receive(:mark_connected!)
       expect(job.send(:reconcile_channel_state!, evo_channel, { instance: 'vendedor-2' })).to be(true)
     end
 
-    it 'does NOT reauthorize (and arms cooldown) when Evolution reports a closed state' do
+    it 'does NOT mark connected (and arms cooldown) when Evolution reports a closed state' do
       allow(job).to receive(:evolution_connection_state).and_return('close')
-      expect(evo_channel).not_to receive(:reauthorized!)
+      expect(evo_channel).not_to receive(:mark_connected!)
       expect(job).to receive(:set_reconcile_cooldown!).with(evo_channel)
       expect(job.send(:reconcile_channel_state!, evo_channel, {})).to be(false)
     end

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -72,4 +72,26 @@ RSpec.describe Channel::Whatsapp, type: :model do
       end
     end
   end
+
+  describe '#mark_connected!' do
+    it 'clears the reauthorization flag and resets provider_connection to open' do
+      channel = described_class.new(provider: 'evolution')
+      allow(channel).to receive(:reauthorization_required?).and_return(true)
+
+      expect(channel).to receive(:reauthorized!)
+      expect(channel).to receive(:update_provider_connection!).with({ 'connection' => 'open', 'error' => nil })
+
+      channel.mark_connected!
+    end
+
+    it 'leaves the reauthorization flag alone when none is set' do
+      channel = described_class.new(provider: 'evolution')
+      allow(channel).to receive(:reauthorization_required?).and_return(false)
+
+      expect(channel).not_to receive(:reauthorized!)
+      expect(channel).to receive(:update_provider_connection!).with({ 'connection' => 'open', 'error' => nil })
+
+      channel.mark_connected!
+    end
+  end
 end

--- a/spec/services/whatsapp/incoming_message_evolution_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_evolution_service_spec.rb
@@ -97,4 +97,19 @@ RSpec.describe Whatsapp::IncomingMessageEvolutionService do
       service.send(:handle_connection_close, '440')
     end
   end
+
+  describe '#handle_connection_open (reconnect resets provider_connection)' do
+    let(:channel) { instance_double(Channel::Whatsapp, id: 1) }
+    let(:inbox) { instance_double(Inbox, channel: channel) }
+    let(:service) { described_class.new(inbox: inbox, params: { instance: 'vendedor-2' }) }
+
+    before do
+      allow(service).to receive(:processed_params).and_return({ instance: 'vendedor-2' })
+    end
+
+    it 'marks the channel connected on state=open (clears reauth flag + resets provider_connection)' do
+      expect(channel).to receive(:mark_connected!)
+      service.send(:handle_connection_open, nil)
+    end
+  end
 end


### PR DESCRIPTION
## Problema

Em staging, a conversa mostra o banner **"Instance has been logged out"** e o campo de resposta fica **bloqueado**, mesmo com o número conectado de verdade (as mensagens de entrada chegam normalmente no CRM).

## Causa raiz

`provider_connection` é um *latch de mão única*. O estado "conectado" vive em dois lugares — a flag `reauthorization_required` (Redis) e o snapshot `provider_connection` (JSONB). Todo caminho de desconexão atualiza os dois, mas os de reconexão só limpavam a flag e **nunca resetavam o `provider_connection` para `open`**:

- `incoming_message_evolution_service.rb#handle_connection_open` (evento `connection.update state=open`)
- `whatsapp_events_job.rb#reconcile_channel_state!` (self-heal do EVO-1967)

Depois de uma reconexão silenciosa o campo ficava preso em `logged_out`. O front lê esse campo (`ChatArea.tsx`) → banner + `isDisabled` no composer.

## Correção

Método único `Channel::Whatsapp#mark_connected!` que limpa a flag de reauthorization **e** reseta `provider_connection` para `{connection: 'open', error: nil}`, chamado nos dois pontos de reconexão. Backstop: se um evento `open` se perder, o self-heal conserta no próximo inbound.

## Fora de escopo

A "IA não responde" **não** é causada por isto — o fluxo de IA no backend não lê `provider_connection` e o envio de saída não tem gate de conexão. Investigado separadamente (credencial/instância velha no outbound vs. dispatch do bot).

## Testes

`bundle exec rspec` nos arquivos afetados + specs vizinhos de estado de conexão: **54 exemplos, 0 falhas**. Cobertura nova para `mark_connected!` (model), regressão do `handle_connection_open` (service) e atualização do reconcile (job).

Relacionado: EVO-1967 · Card: EVO-2140

## Summary by Sourcery

Ensure WhatsApp Evolution reconnections consistently realign channel connection state so conversations no longer appear logged out after a silent reconnect.

Bug Fixes:
- Reset the WhatsApp channel provider_connection snapshot to open on reconnection to avoid the UI staying stuck in a logged-out state.

Enhancements:
- Introduce Channel::Whatsapp#mark_connected! to unify reconnection behavior across services and jobs that handle Evolution connection reopen events.

Tests:
- Add and update specs for Channel::Whatsapp#mark_connected!, incoming_message_evolution_service connection handling, and whatsapp_events_job reconciliation logic to cover the new reconnection flow.