### PR TITLE
fix(evo-flow): extrai ConfigurationError p/ arquivo próprio (boot crash no eager_load)

### DIFF
--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -1,6 +1,12 @@
 module EvoFlow
   # Raised on any non-2xx evo-flow response, an unparseable body, or a network
   # failure. Mirrors Crm::Hubspot::Api::BaseClient::ApiError (code + response).
+  #
+  # ConfigurationError was moved to its own file (configuration_error.rb) so
+  # Zeitwerk can autoload it by name: SegmentsController rescues it at class-body
+  # level, which resolves during eager-load before this file would define it.
+  # HTTPError stays here — it is only referenced inside method bodies (call-time),
+  # never at eager-load.
   class HTTPError < StandardError
     attr_reader :code, :response
 
@@ -10,12 +16,6 @@ module EvoFlow
       super(message)
     end
   end
-
-  # Raised at construction time for an unusable configuration (missing key,
-  # invalid scheme, or cleartext transport in production). Fails fast instead
-  # of emitting a request that is guaranteed to 401 or that leaks the shared
-  # key over cleartext.
-  class ConfigurationError < StandardError; end
 
   # Instance-based (DI-friendly) authenticated HTTP client for evo-flow.
   # Pattern mirrors app/services/crm/hubspot/api/base_client.rb (HTTParty +

--- a/app/services/evo_flow/configuration_error.rb
+++ b/app/services/evo_flow/configuration_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module EvoFlow
+  # Raised at construction time for an unusable configuration (missing key,
+  # invalid scheme, or cleartext transport in production). Fails fast instead
+  # of emitting a request that is guaranteed to 401 or that leaks the shared
+  # key over cleartext.
+  #
+  # Lives in its own file (not inside client.rb) so Zeitwerk can autoload it by
+  # name: SegmentsController rescues it at class-body level, which resolves
+  # during eager-load before client.rb would otherwise define it.
+  class ConfigurationError < StandardError; end
+end


### PR DESCRIPTION
## Problema

Todo build fresco de produção a partir do `develop` **morre no boot**:

```
app/controllers/api/v1/evo_flow/segments_controller.rb: uninitialized constant EvoFlow::ConfigurationError (NameError)
```

O PR #227 adicionou `rescue_from EvoFlow::ConfigurationError` no `SegmentsController` — no **corpo da classe**, que resolve no `eager_load` de produção. Mas `ConfigurationError` está **co-alocado dentro do `client.rb`**, então o Zeitwerk não a autoloada por esse nome: quando o controller é eager-loaded antes do `client.rb`, a constante não existe → `NameError`, o processo não sobe.

Passou batido porque em dev/test **não há `eager_load`** (a referência só resolveria em runtime) e o **CI do community não roda rspec nem um smoke de boot**. Um container `:develop` antigo (anterior ao #227) segue de pé; qualquer imagem nova do develop quebra.

## Correção

Move `EvoFlow::ConfigurationError` para o seu próprio arquivo `app/services/evo_flow/configuration_error.rb` (nome idêntico → autoloadable pelo Zeitwerk). `HTTPError` permanece no `client.rb` — só é referenciado dentro de métodos (call-time), nunca no eager-load.

Sem mudança de referência em nenhum lugar (mesma constante `EvoFlow::ConfigurationError`).

## Verificação

- `Rails.application.eager_load!` → **OK** (antes: `NameError`).
- `bundle exec rails zeitwerk:check` → **"All is good!"**.
- Specs de `evo_flow` (`client_spec`, `segments_controller_spec`) sem nova falha.

Não mexe no teste da porta default (3000→3334) — tratado à parte.

## Summary by Sourcery

Enhancements:
- Move EvoFlow::ConfigurationError from client.rb into app/services/evo_flow/configuration_error.rb while keeping the constant name and behavior unchanged.