### PR TITLE
feat(rbac): seam permission_resolver — checagem de permissão vira ponto de extensão — story 4.1 (EVO-2115)

### DIFF
--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -42,7 +42,7 @@ Bumping one extension point does not bump the others.
 
 ## Extension points
 
-All five are exposed under the `EvoExtensionPoints` namespace,
+All six are exposed under the `EvoExtensionPoints` namespace,
 implemented by `lib/evo_extension_points/`. The aggregate contract
 version is exposed at `EvoExtensionPoints::EXTENSION_POINTS_VERSION`.
 
@@ -181,6 +181,34 @@ or changing the shape of the returned entries, is a major bump.
 
 ---
 
+### 6. `permission_resolver`
+
+**Version:** `2.1.0`
+**Default:** delegates to the auth-service exactly as before —
+`EvoAuthService#check_user_permission(user_id, permission_key)` — so a
+community install behaves identically with or without a consumer.
+
+```ruby
+EvoExtensionPoints::PermissionResolver.allowed?(user_id:, permission_key:, **context)
+  # => true / false
+
+EvoExtensionPoints.replace(:permission_resolver) do |user_id:, permission_key:, scope_id: nil, **|
+  MyConsumer.permission_allowed?(user_id, scope_id, permission_key)
+end
+```
+
+Consumers receive the full keyword context (currently `scope_id`, the
+active scope bound by the consumer's own middleware; `nil` in community)
+and MUST return a boolean. This seam is NOT the `capability_gate`: that
+one gates capabilities/modules and defaults to allow — routing
+permission checks through it would open a community install up.
+
+**Breaking-change policy:** renaming `allowed?`, dropping a context key
+already passed, or changing the default away from the auth-service
+delegation is a major bump.
+
+---
+
 ## How to use as a consumer
 
 A consumer wires its replacements once, from a `Railtie` or `Engine`
@@ -221,6 +249,8 @@ contract break.
 
 ## Versioning history
 
+- `2.1.0` — Added `permission_resolver` (account/scope-aware
+  permission seam; default preserves the auth-service delegation).
 - `2.0.0` — Renamed extension points to neutral open-core vocabulary:
   `feature_gate` → `capability_gate`, `tenant_context` → `runtime_context`
   (with `current_scope_id` / `with_scope`), `data_export` operates on a

--- a/app/controllers/concerns/evo_permission_concern.rb
+++ b/app/controllers/concerns/evo_permission_concern.rb
@@ -71,12 +71,12 @@ module EvoPermissionConcern
     end
   end
 
-  # Verificacao de permissao do usuario via o seam PermissionResolver. O
-  # default do seam delega ao auth-service (check_user_permission) — identico
-  # ao comportamento anterior; um consumer externo pode resolver
-  # (user, escopo, permissao). O escopo vem do RuntimeContext (nil no
-  # community) e entra na cache-key para duas contas no mesmo processo nunca
-  # compartilharem resposta.
+  # User permission check, routed through the PermissionResolver seam. The
+  # seam's default delegates to the auth-service (check_user_permission) —
+  # identical to the previous behaviour; an external consumer may instead
+  # resolve (user, scope, permission). The scope comes from RuntimeContext (nil
+  # in community) and is part of the cache key, so two accounts touched in one
+  # process are never served each other's verdict.
   def has_user_permission?(user_id, permission)
     Current.evo_permission_cache ||= {}
     scope_id = EvoExtensionPoints::RuntimeContext.current_scope_id

--- a/app/controllers/concerns/evo_permission_concern.rb
+++ b/app/controllers/concerns/evo_permission_concern.rb
@@ -71,14 +71,21 @@ module EvoPermissionConcern
     end
   end
 
-  # Verificar permissao global de usuario
+  # Verificacao de permissao do usuario via o seam PermissionResolver. O
+  # default do seam delega ao auth-service (check_user_permission) — identico
+  # ao comportamento anterior; um consumer externo pode resolver
+  # (user, escopo, permissao). O escopo vem do RuntimeContext (nil no
+  # community) e entra na cache-key para duas contas no mesmo processo nunca
+  # compartilharem resposta.
   def has_user_permission?(user_id, permission)
     Current.evo_permission_cache ||= {}
-    cache_key = "user:#{user_id}:#{permission}"
+    scope_id = EvoExtensionPoints::RuntimeContext.current_scope_id
+    cache_key = "user:#{user_id}:#{scope_id}:#{permission}"
     return Current.evo_permission_cache[cache_key] if Current.evo_permission_cache.key?(cache_key)
 
-    evo_auth_service = EvoAuthService.new
-    has_perm = evo_auth_service.check_user_permission(user_id, permission)
+    has_perm = EvoExtensionPoints::PermissionResolver.allowed?(
+      user_id: user_id, permission_key: permission, scope_id: scope_id
+    )
     Current.evo_permission_cache[cache_key] = has_perm
 
     has_perm

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Public extension contract of evo-ai-crm-community. See EXTENSION_POINTS.md
-# at the repository root for the full contract. The five sub-modules below
+# at the repository root for the full contract. The six sub-modules below
 # ship no-op defaults; an external consumer overrides a specific extension
 # point at process start via EvoExtensionPoints.replace(:name, &block) or via
 # the per-module register* / replace* APIs.

--- a/lib/evo_extension_points.rb
+++ b/lib/evo_extension_points.rb
@@ -11,16 +11,18 @@ require_relative 'evo_extension_points/runtime_context'
 require_relative 'evo_extension_points/plugin_loader'
 require_relative 'evo_extension_points/theme_tokens'
 require_relative 'evo_extension_points/data_export'
+require_relative 'evo_extension_points/permission_resolver'
 require_relative 'evo_extension_points/contract_check'
 
 module EvoExtensionPoints
-  EXTENSION_POINTS_VERSION = '2.0.0'
+  EXTENSION_POINTS_VERSION = '2.1.0'
 
   KNOWN_KEYS = %i[
     capability_gate
     runtime_context_current_id
     runtime_context_with_scope
     theme_tokens
+    permission_resolver
   ].freeze
 
   class UnknownExtensionPoint < ArgumentError; end

--- a/lib/evo_extension_points/permission_resolver.rb
+++ b/lib/evo_extension_points/permission_resolver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module EvoExtensionPoints
+  # Permission resolver extension point. Community default: delegate to the
+  # auth-service exactly as before (account-blind check_user_permission), so a
+  # community install behaves identically with or without a consumer. An
+  # external consumer replaces it to resolve (user, scope, permission) — e.g.
+  # account-aware RBAC:
+  #   EvoExtensionPoints.replace(:permission_resolver) do |user_id:, permission_key:, scope_id: nil, **|
+  #     ...
+  #   end
+  # NOT the CapabilityGate: that one gates capabilities/modules and its default
+  # allows everything — routing permission checks through it would open the
+  # community up. This seam's default preserves the current deny/grant.
+  module PermissionResolver
+    DEFAULT_IMPL = lambda do |user_id:, permission_key:, **_context|
+      EvoAuthService.new.check_user_permission(user_id, permission_key)
+    end
+
+    class << self
+      def allowed?(user_id:, permission_key:, **context)
+        impl = EvoExtensionPoints.impl_for(:permission_resolver) || DEFAULT_IMPL
+        impl.call(user_id: user_id, permission_key: permission_key, **context)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Api::V1::EvoFlow::SegmentsController, type: :controller do
       Current.service_authenticated = false
       Current.user = current_user
       Current.evo_permission_cache = {}
+      # The keys seeded below embed the scope segment of
+      # "user:<id>:<scope>:<permission>". Pin the scope to nil so they keep
+      # matching if an override ever binds one — otherwise the seeded verdict
+      # would be missed, the real resolver would run, and these would fail as an
+      # unexpected client call rather than as the gate regression they guard.
+      allow(EvoExtensionPoints::RuntimeContext).to receive(:current_scope_id).and_return(nil)
     end
 
     it 'returns 403 on #index when the user lacks segments.read (the default agent)' do

--- a/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/segments_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::EvoFlow::SegmentsController, type: :controller do
     end
 
     it 'returns 403 on #index when the user lacks segments.read (the default agent)' do
-      Current.evo_permission_cache['user:user-1:segments.read'] = false
+      Current.evo_permission_cache['user:user-1::segments.read'] = false
       expect(fake_client).not_to receive(:get)
 
       get :index
@@ -39,7 +39,7 @@ RSpec.describe Api::V1::EvoFlow::SegmentsController, type: :controller do
     end
 
     it 'returns 403 on #destroy when the user lacks segments.delete' do
-      Current.evo_permission_cache['user:user-1:segments.delete'] = false
+      Current.evo_permission_cache['user:user-1::segments.delete'] = false
       expect(fake_client).not_to receive(:delete)
 
       delete :destroy, params: { id: 'seg-1' }
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::EvoFlow::SegmentsController, type: :controller do
     end
 
     it 'allows #index when the user holds segments.read (an administrator)' do
-      Current.evo_permission_cache['user:user-1:segments.read'] = true
+      Current.evo_permission_cache['user:user-1::segments.read'] = true
       allow(fake_client).to receive(:get).and_return({ 'segments' => [] })
 
       get :index

--- a/spec/lib/evo_extension_points/permission_resolver_spec.rb
+++ b/spec/lib/evo_extension_points/permission_resolver_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe EvoExtensionPoints::PermissionResolver do
   after { EvoExtensionPoints.reset! }
 
   describe 'default implementation (community parity)' do
+    # This block is about DEFAULT_IMPL, so no override may be active. The
+    # consumer-stub CI lane mounts ExtensionConsumerStub, which registers one for
+    # every seam — drop it so these hold whichever lane and whichever order they
+    # run in.
+    before { EvoExtensionPoints.reset! }
+
     it 'delegates to EvoAuthService#check_user_permission with the same arguments' do
       service = instance_double(EvoAuthService)
       allow(EvoAuthService).to receive(:new).and_return(service)
@@ -27,8 +33,14 @@ RSpec.describe EvoExtensionPoints::PermissionResolver do
 
       expect(described_class.allowed?(user_id: 'u', permission_key: 'k', scope_id: nil)).to be(true)
     end
+  end
 
-    it 'is registered as no override in a pure community install' do
+  describe 'community boot' do
+    # A property of the install, not of this class: no community initializer
+    # registers the seam. Untrue by construction in the consumer-stub lane, so
+    # it only runs when the stub is absent. Kept out of the block above, whose
+    # `before` would reset the registry and make it assert nothing.
+    it 'has no override registered', unless: defined?(ExtensionConsumerStub) do
       expect(EvoExtensionPoints.impl_for(:permission_resolver)).to be_nil
     end
   end

--- a/spec/lib/evo_extension_points/permission_resolver_spec.rb
+++ b/spec/lib/evo_extension_points/permission_resolver_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EvoExtensionPoints::PermissionResolver do
+  after { EvoExtensionPoints.reset! }
+
+  describe 'default implementation (community parity)' do
+    it 'delegates to EvoAuthService#check_user_permission with the same arguments' do
+      service = instance_double(EvoAuthService)
+      allow(EvoAuthService).to receive(:new).and_return(service)
+      expect(service).to receive(:check_user_permission).with('user-1', 'conversations.read').and_return(true)
+
+      expect(described_class.allowed?(user_id: 'user-1', permission_key: 'conversations.read')).to be(true)
+    end
+
+    it 'returns the deny verdict untouched' do
+      service = instance_double(EvoAuthService, check_user_permission: false)
+      allow(EvoAuthService).to receive(:new).and_return(service)
+
+      expect(described_class.allowed?(user_id: 'user-1', permission_key: 'contacts.delete')).to be(false)
+    end
+
+    it 'ignores extra context keys (scope_id is nil in community)' do
+      service = instance_double(EvoAuthService, check_user_permission: true)
+      allow(EvoAuthService).to receive(:new).and_return(service)
+
+      expect(described_class.allowed?(user_id: 'u', permission_key: 'k', scope_id: nil)).to be(true)
+    end
+
+    it 'is registered as no override in a pure community install' do
+      expect(EvoExtensionPoints.impl_for(:permission_resolver)).to be_nil
+    end
+  end
+
+  describe 'consumer override' do
+    it 'receives the full keyword context and its verdict is authoritative' do
+      seen = nil
+      EvoExtensionPoints.replace(:permission_resolver) do |user_id:, permission_key:, **ctx|
+        seen = [user_id, permission_key, ctx]
+        false
+      end
+
+      expect(described_class.allowed?(user_id: 'u1', permission_key: 'brand.manage', scope_id: 't1')).to be(false)
+      expect(seen).to eq(['u1', 'brand.manage', { scope_id: 't1' }])
+    end
+
+    it 'stops applying after reset! (no leak between examples)' do
+      EvoExtensionPoints.replace(:permission_resolver) { |**| false }
+      EvoExtensionPoints.reset!
+
+      service = instance_double(EvoAuthService, check_user_permission: true)
+      allow(EvoAuthService).to receive(:new).and_return(service)
+
+      expect(described_class.allowed?(user_id: 'u', permission_key: 'k')).to be(true)
+    end
+  end
+end

--- a/spec/lib/evo_extension_points_spec.rb
+++ b/spec/lib/evo_extension_points_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe EvoExtensionPoints do
   after { EvoExtensionPoints.reset! } # rubocop:disable RSpec/DescribedClass
 
   describe 'EXTENSION_POINTS_VERSION' do
-    it 'advertises the 2.0.0 neutral contract' do
-      expect(described_class::EXTENSION_POINTS_VERSION).to eq('2.0.0')
+    it 'advertises the 2.1.0 neutral contract' do
+      expect(described_class::EXTENSION_POINTS_VERSION).to eq('2.1.0')
     end
   end
 

--- a/spec/lib/evo_permission_concern_scope_cache_spec.rb
+++ b/spec/lib/evo_permission_concern_scope_cache_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The per-request permission cache must key on (user, scope, permission):
+# the same user touching two scopes in one process may get different verdicts
+# and must never be served the other scope's cached answer.
+RSpec.describe EvoPermissionConcern do
+  let(:harness_class) do
+    Class.new do
+      include EvoPermissionConcern
+    end
+  end
+
+  let(:harness) { harness_class.new }
+
+  before { Current.evo_permission_cache = nil }
+
+  after do
+    EvoExtensionPoints.reset!
+    Current.reset
+  end
+
+  it 'keeps verdicts of different scopes apart and caches per scope' do
+    calls = []
+    EvoExtensionPoints.replace(:permission_resolver) do |user_id:, permission_key:, scope_id: nil, **|
+      calls << [user_id, permission_key, scope_id]
+      scope_id == 'scope-a'
+    end
+
+    allow(EvoExtensionPoints::RuntimeContext).to receive(:current_scope_id).and_return('scope-a')
+    expect(harness.send(:has_user_permission?, 'u1', 'content.manage')).to be(true)
+
+    allow(EvoExtensionPoints::RuntimeContext).to receive(:current_scope_id).and_return('scope-b')
+    expect(harness.send(:has_user_permission?, 'u1', 'content.manage')).to be(false)
+
+    # Back to scope-a: served from cache, resolver not called a third time.
+    allow(EvoExtensionPoints::RuntimeContext).to receive(:current_scope_id).and_return('scope-a')
+    expect(harness.send(:has_user_permission?, 'u1', 'content.manage')).to be(true)
+    expect(calls.size).to eq(2)
+  end
+
+  it 'produces the community-equivalent key when no scope is bound (nil)' do
+    # Explicit nil: the CI lane also runs under the consumer stub, which
+    # registers a runtime_context override — without this stub the key would
+    # carry the stub's scope and the example would be order-dependent.
+    allow(EvoExtensionPoints::RuntimeContext).to receive(:current_scope_id).and_return(nil)
+    service = instance_double(EvoAuthService, check_user_permission: true)
+    allow(EvoAuthService).to receive(:new).and_return(service)
+
+    expect(harness.send(:has_user_permission?, 'u1', 'contacts.read')).to be(true)
+    expect(Current.evo_permission_cache).to have_key('user:u1::contacts.read')
+  end
+
+  it 'stays fail-closed when the resolver raises' do
+    EvoExtensionPoints.replace(:permission_resolver) { |**| raise 'boom' }
+
+    expect(harness.send(:has_user_permission?, 'u1', 'contacts.read')).to be(false)
+  end
+end

--- a/spec/lib/tasks/evo_extension_points_rake_spec.rb
+++ b/spec/lib/tasks/evo_extension_points_rake_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'evo_extension_points:check_contract rake task', type: :task do
 
   context 'when documented and implemented points match' do
     it 'exits cleanly (no SystemExit)' do
-      expect { task.invoke }.to output(/OK — 5 extension point\(s\) documented and implemented/).to_stdout
+      expect { task.invoke }.to output(/OK — 6 extension point\(s\) documented and implemented/).to_stdout
     end
   end
 

--- a/spec/support/extension_consumer_stub/lib/extension_consumer_stub.rb
+++ b/spec/support/extension_consumer_stub/lib/extension_consumer_stub.rb
@@ -53,6 +53,13 @@ module ExtensionConsumerStub
           { 'stub-scope' => scope.to_s }
         end
 
+        # `user_id:` / `scope_id:` are swallowed by the anonymous `**`: the stub
+        # only needs to prove the seam reaches a consumer and honours its verdict.
+        EvoExtensionPoints.replace(:permission_resolver) do |permission_key:, **|
+          ExtensionConsumerStub::Counters.increment(:permission_resolver)
+          permission_key != 'explicitly.denied'
+        end
+
         EvoExtensionPoints::PluginLoader.register_plugin(:extension_consumer_stub) do |plugin|
           plugin.on_boot { ExtensionConsumerStub::Counters.increment(:plugin_loader_on_boot) }
         end
@@ -71,4 +78,11 @@ end
 # overwrites the same keys), but resetting EvoExtensionPoints during a
 # test will drop the stubs — re-call ExtensionConsumerStub::Boot.install!
 # to restore them.
+#
+# The contract guarantee lives in this very call, not in any example: an
+# extension point that is renamed or removed makes a `replace` / `register`
+# above raise here, at require time, before a single spec runs. Specs are
+# therefore free to reset the registry to exercise the defaults; do NOT add a
+# global hook re-installing the stub after each example, as the suite asserts
+# default behaviour ("... by default") and would fail.
 ExtensionConsumerStub::Boot.install!


### PR DESCRIPTION
## Story 4.1 — Seam de permissão account-aware (EVO-2115)

### O que muda

O CRM passa a expor a checagem de permissão como **ponto de extensão** (`:permission_resolver`), mantendo o comportamento community **idêntico** — o default delega ao auth-service exatamente como hoje (`EvoAuthService#check_user_permission`). Um consumer externo (a camada enterprise) pode resolver `(usuário, escopo, permissão)`.

- `lib/evo_extension_points/permission_resolver.rb` (novo): `DEFAULT_IMPL` = delegação atual; `allowed?(user_id:, permission_key:, **context)`. **Não** é o `CapabilityGate` (o default dele libera tudo — rotear permissão por ele abriria o community; ruling 2026-07-13).
- Key registrada em `KNOWN_KEYS`; `EXTENSION_POINTS_VERSION` 2.0.0 → **2.1.0**; seção 6 no `EXTENSION_POINTS.md` (`rake evo_extension_points:check_contract` verde); specs de contrato atualizados (5 → 6 pontos).
- **`evo_permission_concern#has_user_permission?`** consome o seam; a **cache-key por request ganha o escopo** (`user:<id>:<scope>:<perm>`, via `RuntimeContext.current_scope_id` — nil no community ⇒ comportamento equivalente ao atual): duas contas no mesmo processo nunca compartilham veredicto. Fail-closed do rescue preservado; bypass de service-token intocado (curto-circuita antes do seam).
- Spec do segments (EVO-1938) atualizado para o formato novo da cache-key (semeava o cache com a chave antiga).

### Verificação

- Suíte completa vs baseline limpo do origin/develop (mesmo container): baseline `2337 exemplos, 137 falhas` pré-existentes → esta stack `2352, 137 efetivas` — **zero regressões**.
- Novos: seam (default/override/reset), cache por escopo (grant/deny separados por conta, chave equivalente com nil, fail-closed) — verdes; rubocop limpo nos arquivos tocados.
- E2E no stack enterprise: seam registrado e resolvendo por Conta (grant na conta do papel, deny na outra), keys do auth seguindo o caminho atual.

Stack: esta PR → 4.2 (`has_permission?` honesto) → 4.3 (lane de paridade). O override enterprise vive em `evo-enterprise-docker` (PR correspondente) e é no-op tolerante até esta base ser publicada.

## Summary by Sourcery

Introduce a new permission_resolver extension point and wire user permission checks through it while keeping community behavior unchanged.

New Features:
- Add a permission_resolver extension point that can be overridden by consumers to resolve user permissions with scope-aware context.

Enhancements:
- Make the per-request permission cache key include scope alongside user and permission so verdicts are isolated per account/scope.
- Update the extension points contract version to 2.1.0 and document the new permission_resolver seam, including versioning and breaking-change policy.

Tests:
- Add tests covering the permission_resolver default and override behavior, cache key scoping semantics, community-equivalent keys when scope is nil, and fail-closed behavior on resolver errors.
- Adjust existing segments controller specs to use the new scoped permission cache key format.