### PR TITLE
fix(rbac): User#has_permission? honesto via seam — fim do stub true — story 4.2 (EVO-2116)

### DIFF
--- a/app/models/concerns/user_attribute_helpers.rb
+++ b/app/models/concerns/user_attribute_helpers.rb
@@ -35,8 +35,22 @@ module UserAttributeHelpers
     administrator? ? 'administrator' : 'agent'
   end
 
-  def has_permission?(_permission)
-    true
+  # Real permission check via the PermissionResolver seam (community default:
+  # auth-service; a consumer may resolve per scope). Shares the per-request
+  # cache namespace with EvoPermissionConcern so a verdict is fetched once per
+  # (user, scope, permission). Fail-closed on errors.
+  def has_permission?(permission)
+    scope_id = EvoExtensionPoints::RuntimeContext.current_scope_id
+    cache = (Current.evo_permission_cache ||= {})
+    cache_key = "user:#{id}:#{scope_id}:#{permission}"
+    return cache[cache_key] if cache.key?(cache_key)
+
+    cache[cache_key] = EvoExtensionPoints::PermissionResolver.allowed?(
+      user_id: id, permission_key: permission.to_s, scope_id: scope_id
+    )
+  rescue StandardError => e
+    Rails.logger.error "Error checking permission #{permission} for user #{id}: #{e.message}"
+    false
   end
 
   # Used internally for Evolution in Evolution

--- a/app/policies/inbox_policy.rb
+++ b/app/policies/inbox_policy.rb
@@ -25,7 +25,7 @@ class InboxPolicy < ApplicationPolicy
     return true if @user.is_a?(AgentBot)
 
     # Admins or users granted `conversations.read_all` (resolved into Current by
-    # EvoAuthConcern — the CRM `has_permission?` is a no-op stub) can view any inbox.
+    # EvoAuthConcern) can view any inbox.
     return true if @user&.administrator? || Current.evo_can_read_all_inboxes
 
     # Restricted users can only view their assigned inboxes; a user with no

--- a/app/policies/installation_config_policy.rb
+++ b/app/policies/installation_config_policy.rb
@@ -1,7 +1,10 @@
 class InstallationConfigPolicy < ApplicationPolicy
-  # In single-tenant mode, has_permission? always returns true for all authenticated users.
-  # Effective access control is: authenticate_request! (must be logged in) + administrator? (SuperAdmin type).
-  # The has_permission? call future-proofs for multi-tenant permission granularity.
+  # This policy is the ONLY gate on Api::V1::Admin::BaseController (/api/v1/admin/*)
+  # — that controller declares no require_permissions of its own.
+  # While has_permission? was stubbed to `true`, manage? admitted ANY
+  # authenticated user; since story 4.2 it resolves for real, so access is
+  # administrator? (super_admin/account_owner/administrator/admin) or an
+  # explicit installation_configs.manage grant.
   def manage?
     @user&.administrator? || @user&.has_permission?('installation_configs.manage')
   end

--- a/spec/models/concerns/user_attribute_helpers_permission_spec.rb
+++ b/spec/models/concerns/user_attribute_helpers_permission_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# User#has_permission? stopped being an unconditional `true` (story RBAC 4.2):
+# it now resolves through the PermissionResolver seam, which re-arms every
+# Pundit policy built on `administrator? || has_permission?(...)`.
+RSpec.describe UserAttributeHelpers, type: :model do
+  # Sem FactoryBot no repo: has_permission? só consulta #id — um User em
+  # memória com uuid basta (o mirror não exige persistência para isto).
+  let(:user) { User.new(id: SecureRandom.uuid) }
+
+  after do
+    EvoExtensionPoints.reset!
+    Current.reset
+  end
+
+  describe '#has_permission?' do
+    it 'grants when the resolver grants' do
+      EvoExtensionPoints.replace(:permission_resolver) do |permission_key:, **|
+        permission_key == 'conversations.read'
+      end
+
+      expect(user.has_permission?('conversations.read')).to be(true)
+    end
+
+    it 'denies when the resolver denies (no more unconditional true)' do
+      EvoExtensionPoints.replace(:permission_resolver) { |**| false }
+
+      expect(user.has_permission?('conversations.delete')).to be(false)
+    end
+
+    it 'delegates to the auth-service by default with the user id' do
+      service = instance_double(EvoAuthService)
+      allow(EvoAuthService).to receive(:new).and_return(service)
+      expect(service).to receive(:check_user_permission).with(user.id, 'contacts.read').and_return(true)
+
+      expect(user.has_permission?('contacts.read')).to be(true)
+    end
+
+    it 'reuses the per-request cache across repeated checks' do
+      calls = 0
+      EvoExtensionPoints.replace(:permission_resolver) do |**|
+        calls += 1
+        true
+      end
+
+      2.times { expect(user.has_permission?('contacts.read')).to be(true) }
+      expect(calls).to eq(1)
+    end
+
+    it 'stays fail-closed when the resolver raises' do
+      EvoExtensionPoints.replace(:permission_resolver) { |**| raise 'boom' }
+
+      expect(user.has_permission?('contacts.read')).to be(false)
+    end
+
+    it 're-arms the Pundit policies built on it' do
+      EvoExtensionPoints.replace(:permission_resolver) { |**| false }
+      agent = User.new(id: SecureRandom.uuid)
+      allow(agent).to receive(:administrator?).and_return(false)
+
+      expect(ConversationPolicy.new(agent, nil).index?).to be(false)
+    end
+  end
+end

--- a/spec/models/concerns/user_attribute_helpers_permission_spec.rb
+++ b/spec/models/concerns/user_attribute_helpers_permission_spec.rb
@@ -60,7 +60,20 @@ RSpec.describe UserAttributeHelpers, type: :model do
       agent = User.new(id: SecureRandom.uuid)
       allow(agent).to receive(:administrator?).and_return(false)
 
-      expect(ConversationPolicy.new(agent, nil).index?).to be(false)
+      # ApplicationPolicy takes a user_context HASH, not a User — passing the
+      # user directly leaves @user nil, so `&.` short-circuits to nil and the
+      # policy never reaches has_permission?, proving nothing.
+      expect(ConversationPolicy.new({ user: agent }, nil).index?).to be(false)
+    end
+
+    it 'grants the same policy once the resolver holds the key' do
+      EvoExtensionPoints.replace(:permission_resolver) do |permission_key:, **|
+        permission_key == 'conversations.read'
+      end
+      agent = User.new(id: SecureRandom.uuid)
+      allow(agent).to receive(:administrator?).and_return(false)
+
+      expect(ConversationPolicy.new({ user: agent }, nil).index?).to be(true)
     end
   end
 end


### PR DESCRIPTION
## Story 4.2 (parte CRM) — User#has_permission? honesto (EVO-2116)

> Empilhada sobre a PR #231 (4.1) — mergear em ordem; o GitHub retargeta a base.

### Root cause

`User#has_permission?` era `def has_permission?(_permission) = true` — **toda** Pundit policy do padrão `administrator? || has_permission?(key)` estava neutralizada (o "não pode" era teatro do front, FR25).

### O que muda

O método resolve pelo seam da 4.1 (default: auth-service), compartilhando o cache por request do concern (`user:<id>:<scope>:<perm>` — um veredicto por permissão/escopo/request) e fail-closed em erro.

### ⚠️ Mudança de comportamento real (decisão de produto — destacar na revisão)

Com as policies reativadas, call sites vivos mudam para o role `agent` (seed atual só tem `inboxes.read`):
- `inbox_members_controller` (add/update/remove colaborador) e `inboxes_controller#{message_templates,whatsapp_*}` passam a **negar** para agent — antes o stub liberava.
Direção compatível com EVO-1938 (o gate deixa de morar só no front), mas é mudança visível: se o produto quiser agent gerindo colaboradores, é ajuste de SEED (conceder `inboxes.manage`/equivalente), não reverter este fix. Policies restantes (csat/crm_forms/oauth/pipeline/team_member/template) não têm call site vivo hoje.

### Verificação

- Specs novos: grant/deny via seam, default auth-service com o id certo, cache único por (user, escopo, permissão), fail-closed, reativação provada (`ConversationPolicy` nega sem a key).
- Suíte completa: coberta pela validação da stack (zero regressões vs baseline — detalhe na PR #231).

## Summary by Sourcery

Replace the stubbed user permission check with a real resolver-backed implementation that reactivates RBAC policies and enforces permissions consistently.

New Features:
- Introduce a scope-aware, cache-backed permission check on User via the PermissionResolver extension point.

Enhancements:
- Share a per-request permission verdict cache across User helpers and EvoPermissionConcern and default to fail-closed on permission resolution errors.

Tests:
- Add model specs covering permission grant/deny behavior, auth-service delegation, cache reuse, error handling, and Pundit policy reactivation.