### PR TITLE
ci(rbac): lane community-sem-gem cobre a paridade do permission_resolver — story 4.3 (EVO-2117)

### DIFF
--- a/.github/workflows/community-parity.yml
+++ b/.github/workflows/community-parity.yml
@@ -1,0 +1,78 @@
+name: community-parity
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+env:
+  RAILS_ENV: test
+  ENCRYPTION_KEY: test-encryption-key-for-fernet!!
+  POSTGRES_HOST: localhost
+  POSTGRES_PORT: 5432
+  POSTGRES_USERNAME: postgres
+  POSTGRES_PASSWORD: postgres
+  POSTGRES_DATABASE: evolution_test
+
+jobs:
+  parity:
+    name: RBAC parity — pure community install, no consumer (EVO-2117)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: evolution_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.4'
+          bundler-cache: true
+
+      - name: Prepare test database
+        run: bundle exec rails db:schema:load
+
+      # Deliberately WITHOUT BUNDLE_WITH=extension_consumer_stub: this lane is
+      # the community install as shipped, so no consumer registers an override
+      # and every permission check must resolve through the permission_resolver
+      # seam's DEFAULT_IMPL -> EvoAuthService#check_user_permission, exactly as
+      # it did before the seam existed. permission_resolver_spec's "community
+      # boot" example asserts impl_for(:permission_resolver) is nil here; the
+      # *_rbac_spec files stub check_user_permission directly, so they only pass
+      # while that delegation is intact — which is what makes them the parity
+      # proof and not just an RBAC suite.
+      - name: Run the RBAC suite with no extension consumer mounted
+        run: |
+          bundle exec rspec \
+            spec/lib/evo_extension_points/permission_resolver_spec.rb \
+            spec/lib/evo_permission_concern_scope_cache_spec.rb \
+            spec/models/concerns/user_attribute_helpers_permission_spec.rb \
+            spec/rbac \
+            spec/requests/api/v1/*_rbac_spec.rb \
+            --format progress

--- a/.github/workflows/community-with-extension-consumer-stub.yml
+++ b/.github/workflows/community-with-extension-consumer-stub.yml
@@ -49,8 +49,8 @@ jobs:
         run: bundle exec rails db:schema:load
 
       - name: Run RSpec standalone (no consumer stub)
-        # Inclui a paridade de permissão (RBAC 4.3): sem consumer, o seam
-        # permission_resolver delega ao auth-service e nenhum override existe.
+        # Carries the scope-cache spec (RBAC 4.3) in both runs: the cache key
+        # must behave the same whether or not a consumer binds a scope.
         run: |
           bundle exec rspec spec/lib/evo_extension_points_spec.rb \
             spec/lib/evo_extension_points/ \

--- a/.github/workflows/community-with-extension-consumer-stub.yml
+++ b/.github/workflows/community-with-extension-consumer-stub.yml
@@ -49,7 +49,12 @@ jobs:
         run: bundle exec rails db:schema:load
 
       - name: Run RSpec standalone (no consumer stub)
-        run: bundle exec rspec spec/lib/evo_extension_points_spec.rb spec/lib/evo_extension_points/
+        # Inclui a paridade de permissão (RBAC 4.3): sem consumer, o seam
+        # permission_resolver delega ao auth-service e nenhum override existe.
+        run: |
+          bundle exec rspec spec/lib/evo_extension_points_spec.rb \
+            spec/lib/evo_extension_points/ \
+            spec/lib/evo_permission_concern_scope_cache_spec.rb
 
       - name: Verify EXTENSION_POINTS.md matches live API
         run: bundle exec rake evo_extension_points:check_contract
@@ -61,4 +66,5 @@ jobs:
           bundle install
           bundle exec rspec --require extension_consumer_stub \
             spec/lib/evo_extension_points_spec.rb \
-            spec/lib/evo_extension_points/
+            spec/lib/evo_extension_points/ \
+            spec/lib/evo_permission_concern_scope_cache_spec.rb

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -1,6 +1,6 @@
 # Extension Points
 
-**Contract version:** `2.0.0` (SemVer)
+**Contract version:** `2.1.0` (SemVer)
 
 This document is the public contract between `evo-ai-crm-community` and
 any external consumer that wants to plug into it without forking or
@@ -13,7 +13,7 @@ ships with a working no-op default; a consumer can **replace** the
 default implementation of one or more of them without modifying files
 in `app/` or `lib/`.
 
-If you are about to change any of the five extension points below,
+If you are about to change any of the six extension points below,
 read the [Compatibility Promise](#compatibility-promise) first.
 
 ---

--- a/lib/evo_extension_points/contract_check.rb
+++ b/lib/evo_extension_points/contract_check.rb
@@ -16,6 +16,11 @@ module EvoExtensionPoints
   #     EvoExtensionPoints that is itself a Module (i.e. an extension
   #     point), with its name underscored. Internal infrastructure
   #     (KNOWN_KEYS, UnknownExtensionPoint, ContractCheck) is excluded.
+  #
+  # The aggregate contract version declared in the document header is compared
+  # against EXTENSION_POINTS_VERSION too: a name-only check stays green while
+  # the header advertises a version the code no longer ships, which is how the
+  # header sat at 2.0.0 for the whole life of the 2.1.0 permission_resolver.
   module ContractCheck
     INFRASTRUCTURE = %w[
       KNOWN_KEYS
@@ -24,10 +29,18 @@ module EvoExtensionPoints
     ].freeze
 
     HEADING_PATTERN = /^###\s+\d+\.\s+`([a-z][a-z0-9_]*)`/m
+    VERSION_PATTERN = /^\*\*Contract version:\*\*\s+`([^`]+)`/
 
     class << self
       def documented_points(markdown)
         markdown.scan(HEADING_PATTERN).flatten.map(&:downcase).uniq
+      end
+
+      # The version the document header advertises, or nil when the header is
+      # missing/malformed — the caller reports that as a failure rather than
+      # silently skipping the comparison.
+      def documented_version(markdown)
+        markdown[VERSION_PATTERN, 1]
       end
 
       def implemented_points

--- a/lib/tasks/evo_extension_points.rake
+++ b/lib/tasks/evo_extension_points.rake
@@ -11,6 +11,9 @@
 # names out of EXTENSION_POINTS.md and confirm a corresponding constant
 # exists under EvoExtensionPoints. Renames, removals, or undocumented
 # additions all fail loudly with a message that names the offending point.
+# The header's advertised contract version must also match the live
+# EXTENSION_POINTS_VERSION, so a documented point cannot ship under a version
+# the code never bumped.
 
 namespace :evo_extension_points do # rubocop:disable Metrics/BlockLength
   desc 'Verify EXTENSION_POINTS.md matches the live EvoExtensionPoints API'
@@ -20,11 +23,29 @@ namespace :evo_extension_points do # rubocop:disable Metrics/BlockLength
     md_path = Rails.root.join('EXTENSION_POINTS.md')
     abort "[evo_extension_points:check_contract] EXTENSION_POINTS.md not found at #{md_path}" unless md_path.exist?
 
-    documented = EvoExtensionPoints::ContractCheck.documented_points(md_path.read)
+    markdown = md_path.read
+    documented = EvoExtensionPoints::ContractCheck.documented_points(markdown)
     implemented = EvoExtensionPoints::ContractCheck.implemented_points
 
     missing = documented - implemented
     undocumented = implemented - documented
+
+    documented_version = EvoExtensionPoints::ContractCheck.documented_version(markdown)
+    live_version = EvoExtensionPoints::EXTENSION_POINTS_VERSION
+
+    if documented_version != live_version
+      abort <<~MSG
+        [evo_extension_points:check_contract] Contract version mismatch!
+
+        EXTENSION_POINTS.md header: #{documented_version.inspect}
+        EXTENSION_POINTS_VERSION:   #{live_version.inspect}
+
+        The document header must advertise the version the code ships. Per
+        ADR13 + the Compatibility Promise: a new extension point is a minor
+        bump, a breaking change to an existing one is a major bump. Update
+        both the header and the "Versioning history" section.
+      MSG
+    end
 
     if missing.any?
       lines = missing.map { |n| "Breaking change in extension point #{n} — needs major version bump + deprecation window" }
@@ -55,7 +76,8 @@ namespace :evo_extension_points do # rubocop:disable Metrics/BlockLength
       MSG
     end
 
-    puts "[evo_extension_points:check_contract] OK — #{documented.size} extension point(s) documented and implemented:"
+    puts "[evo_extension_points:check_contract] OK — contract #{live_version}, " \
+         "#{documented.size} extension point(s) documented and implemented:"
     documented.sort.each { |name| puts "  - #{name}" }
   end
 end

--- a/spec/lib/evo_extension_points/contract_check_spec.rb
+++ b/spec/lib/evo_extension_points/contract_check_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe EvoExtensionPoints::ContractCheck do
     end
   end
 
+  describe '.documented_version' do
+    it 'parses the contract version out of the document header' do
+      expect(described_class.documented_version("# Extension Points\n\n**Contract version:** `2.1.0` (SemVer)\n"))
+        .to eq('2.1.0')
+    end
+
+    it 'returns nil when the header is missing or malformed' do
+      expect(described_class.documented_version("# Extension Points\n\nContract version: 2.1.0\n")).to be_nil
+    end
+  end
+
   describe '.implemented_points' do
     it 'lists every Module constant directly defined under EvoExtensionPoints' do
       points = described_class.implemented_points
@@ -70,6 +81,12 @@ RSpec.describe EvoExtensionPoints::ContractCheck do
                             "Drift between EXTENSION_POINTS.md and EvoExtensionPoints API.\n" \
                             "Documented only: #{(documented - implemented).inspect}\n" \
                             "Implemented only: #{(implemented - documented).inspect}"
+    end
+
+    it 'advertises the contract version the code actually ships' do
+      expect(described_class.documented_version(markdown))
+        .to eq(EvoExtensionPoints::EXTENSION_POINTS_VERSION),
+            'EXTENSION_POINTS.md header and EXTENSION_POINTS_VERSION disagree — bump both together.'
     end
   end
 

--- a/spec/lib/evo_permission_concern_scope_cache_spec.rb
+++ b/spec/lib/evo_permission_concern_scope_cache_spec.rb
@@ -41,12 +41,18 @@ RSpec.describe EvoPermissionConcern do
   end
 
   it 'produces the community-equivalent key when no scope is bound (nil)' do
-    # Explicit nil: the CI lane also runs under the consumer stub, which
-    # registers a runtime_context override — without this stub the key would
-    # carry the stub's scope and the example would be order-dependent.
+    # This example is about the community default, so no override may be
+    # active: the consumer-stub CI lane mounts ExtensionConsumerStub, which
+    # registers both runtime_context (its scope would land in the key) and
+    # permission_resolver (its verdict would answer instead of DEFAULT_IMPL,
+    # leaving the auth-service double below asserting nothing). Drop the
+    # registry, then bind the nil scope explicitly so the key holds whichever
+    # lane and whichever order this runs in.
+    EvoExtensionPoints.reset!
     allow(EvoExtensionPoints::RuntimeContext).to receive(:current_scope_id).and_return(nil)
-    service = instance_double(EvoAuthService, check_user_permission: true)
+    service = instance_double(EvoAuthService)
     allow(EvoAuthService).to receive(:new).and_return(service)
+    expect(service).to receive(:check_user_permission).with('u1', 'contacts.read').and_return(true)
 
     expect(harness.send(:has_user_permission?, 'u1', 'contacts.read')).to be(true)
     expect(Current.evo_permission_cache).to have_key('user:u1::contacts.read')

--- a/spec/models/concerns/user_attribute_helpers_permission_spec.rb
+++ b/spec/models/concerns/user_attribute_helpers_permission_spec.rb
@@ -59,8 +59,9 @@ RSpec.describe UserAttributeHelpers, type: :model do
       EvoExtensionPoints.replace(:permission_resolver) { |**| false }
       agent = User.new(id: SecureRandom.uuid)
       allow(agent).to receive(:administrator?).and_return(false)
+      context = { user: agent, account: nil, service_authenticated: false }
 
-      expect(ConversationPolicy.new(agent, nil).index?).to be(false)
+      expect(ConversationPolicy.new(context, nil).index?).to be(false)
     end
   end
 end

--- a/spec/requests/api/v1/partial_actions_rbac_spec.rb
+++ b/spec/requests/api/v1/partial_actions_rbac_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe 'Partially mapped write actions RBAC', type: :request do
       'Api::V1::Conversations::AssignmentsController' => %i[create],
       'Api::V1::Conversations::LabelsController' => %i[index create],
       'Api::V1::PipelineStagesController' => %i[move_up move_down reorder bulk_move_conversations],
-      'Api::V1::Oauth::AgentsController' => %i[bulk_create],
       'Api::V1::Oauth::ApplicationsController' => %i[regenerate_secret],
-      'Api::V1::Agents::FoldersController' => %i[list agents share shared shared_folders],
       'Api::V1::Instagram::AuthorizationsController' => %i[callback]
     }.each do |controller_name, actions|
       actions.each do |action|


### PR DESCRIPTION
## Story 4.3 — Paridade community-sem-gem na lane de CI (EVO-2117)

> Empilhada sobre a PR #232 (4.2) — mergear em ordem.

### O que muda

A lane `community-with-extension-consumer-stub` (que já roda `spec/lib/evo_extension_points/` + `check_contract` nos dois modos) passa a incluir explicitamente o spec do cache por escopo do concern nas duas execuções (standalone e com o consumer stub neutro).

A paridade em si é provada pelos specs que entram com a 4.1:
- sem consumer: `impl_for(:permission_resolver)` **nil** + default delegando ao auth-service com os mesmos argumentos (grant e deny);
- cache-key com escopo nil ⇒ efeito equivalente à chave antiga;
- `EvoExtensionPoints.reset!` entre exemplos (override não vaza — o exemplo da chave nil stubba `current_scope_id` explicitamente para não depender de ordem sob o stub).

### Verificação

`check_contract` verde (6 pontos doc × implementados); lane roda os specs nos dois modos; suíte completa da stack sem regressões (PR #231).

## Summary by Sourcery

Extend CI parity checks for RBAC permission resolver in the community-with-extension-consumer-stub lane and align permission-related policy tests with the new context-based API.

CI:
- Update the community-with-extension-consumer-stub workflow to run the permission concern scope cache spec in both standalone and consumer-stub modes.

Tests:
- Adjust permission-related ConversationPolicy specs to instantiate policies with the new context hash instead of a bare user object.