### PR TITLE
feat: add Evolution Go health monitors with cross-instance alerts

### DIFF
--- a/app/controllers/api/v1/evolution_go/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution_go/authorizations_controller.rb
@@ -121,9 +121,10 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
       provider_connection = nil
       if @inbox
         channel = @inbox.channel
-        is_connected = instance_data['connected'] == true
+        connection_status = normalized_connection_status(instance_data['connected'])
+        is_connected = connection_status.nil? ? channel.provider_connection['connection'] == 'open' : connection_status
 
-        if is_connected
+        if connection_status == true
           Rails.logger.info "Evolution Go API: Instance #{@instance_uuid} is connected, updating channel status"
 
           # Clear reauthorization flag if set
@@ -147,7 +148,7 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
               # Don't raise - profile picture update is not critical
             end
           end
-        else
+        elsif connection_status == false
           Rails.logger.info "Evolution Go API: Instance #{@instance_uuid} is disconnected, updating channel status"
 
           # Update provider_connection to close
@@ -157,9 +158,11 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
         end
       end
 
-      # Convert Evolution Go format to frontend-expected format
-      # Frontend expects: { data: { instance: { state: 'open' } } }
-      is_connected = instance_data['connected'] == true
+      # Convert Evolution Go format to frontend-expected format. Preserve the
+      # event-driven snapshot when a partial polling response has no status.
+      connection_status = normalized_connection_status(instance_data['connected'])
+      current_connection = @inbox&.channel&.provider_connection&.dig('connection')
+      is_connected = connection_status.nil? ? current_connection == 'open' : connection_status
       state = is_connected ? 'open' : 'close'
 
       render json: {
@@ -239,6 +242,16 @@ class Api::V1::EvolutionGo::AuthorizationsController < Api::V1::BaseController
   end
 
   private
+
+  # Evolution Go versions have returned this field as booleans, strings and,
+  # during transient/partial responses, not at all. A read-only browser poll
+  # must not turn an unknown response into a persisted disconnect.
+  def normalized_connection_status(value)
+    return true if value == true || value == 1 || value.to_s.casecmp('true').zero?
+    return false if value == false || value == 0 || value.to_s.casecmp('false').zero?
+
+    nil
+  end
 
   def set_instance_params
     # Parâmetros vêm dentro de authorization ou como query params

--- a/app/controllers/api/v1/evolution_go/health_monitors_controller.rb
+++ b/app/controllers/api/v1/evolution_go/health_monitors_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::EvolutionGo::HealthMonitorsController < Api::V1::BaseController
   end
 
   def test
-    EvolutionGo::HealthMonitorJob.perform_later(@monitor)
+    EvolutionGo::HealthMonitorJob.perform_later(@monitor.id)
     render json: { success: true, message: 'Health check queued' }, status: :accepted
   end
 

--- a/app/controllers/api/v1/evolution_go/health_monitors_controller.rb
+++ b/app/controllers/api/v1/evolution_go/health_monitors_controller.rb
@@ -1,0 +1,61 @@
+class Api::V1::EvolutionGo::HealthMonitorsController < Api::V1::BaseController
+  require_permissions({
+    index: 'inboxes.read',
+    create: 'inboxes.update',
+    update: 'inboxes.update',
+    destroy: 'inboxes.update',
+    test: 'inboxes.update'
+  })
+
+  before_action :set_monitor, only: [:update, :destroy, :test]
+
+  def index
+    render json: { success: true, data: EvolutionGoHealthMonitor.order(created_at: :desc).map { |monitor| serialize(monitor) } }
+  end
+
+  def create
+    monitor = EvolutionGoHealthMonitor.create!(monitor_params)
+    render json: { success: true, data: serialize(monitor) }, status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+  end
+
+  def update
+    @monitor.update!(monitor_params)
+    render json: { success: true, data: serialize(@monitor) }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+  end
+
+  def destroy
+    @monitor.destroy!
+    head :no_content
+  end
+
+  def test
+    EvolutionGo::HealthMonitorJob.perform_later(@monitor)
+    render json: { success: true, message: 'Health check queued' }, status: :accepted
+  end
+
+  private
+
+  def set_monitor
+    @monitor = EvolutionGoHealthMonitor.find(params[:id])
+  end
+
+  def monitor_params
+    params.require(:health_monitor).permit(
+      :observed_channel_id, :notification_channel_id, :recipient_number,
+      :enabled, :failure_threshold, :recovery_threshold, :cooldown_minutes
+    )
+  end
+
+  def serialize(monitor)
+    monitor.as_json(
+      only: [:id, :observed_channel_id, :notification_channel_id, :recipient_number, :enabled,
+             :failure_threshold, :recovery_threshold, :cooldown_minutes, :last_state,
+             :consecutive_failures, :consecutive_successes, :last_checked_at, :last_alerted_at,
+             :last_error, :created_at, :updated_at]
+    )
+  end
+end

--- a/app/jobs/evolution_go/health_monitor_job.rb
+++ b/app/jobs/evolution_go/health_monitor_job.rb
@@ -1,0 +1,12 @@
+class EvolutionGo::HealthMonitorJob < MutexApplicationJob
+  queue_as :scheduled_jobs
+
+  def perform(monitor_id)
+    monitor = EvolutionGoHealthMonitor.find(monitor_id)
+    with_lock("evolution-go-health-monitor:#{monitor_id}") do
+      EvolutionGo::HealthMonitorService.new(monitor).perform
+    end
+  rescue ActiveRecord::RecordNotFound
+    # Monitor was deleted between enqueue and perform; safe to skip.
+  end
+end

--- a/app/jobs/evolution_go/health_monitor_scheduler_job.rb
+++ b/app/jobs/evolution_go/health_monitor_scheduler_job.rb
@@ -1,0 +1,9 @@
+class EvolutionGo::HealthMonitorSchedulerJob < ApplicationJob
+  queue_as :scheduled_jobs
+
+  def perform
+    EvolutionGoHealthMonitor.enabled.pluck(:id).each do |monitor_id|
+      EvolutionGo::HealthMonitorJob.perform_later(monitor_id)
+    end
+  end
+end

--- a/app/models/evolution_go_health_monitor.rb
+++ b/app/models/evolution_go_health_monitor.rb
@@ -1,0 +1,21 @@
+class EvolutionGoHealthMonitor < ApplicationRecord
+  STATES = %w[unknown healthy degraded].freeze
+
+  belongs_to :observed_channel, class_name: 'Channel::Whatsapp'
+  belongs_to :notification_channel, class_name: 'Channel::Whatsapp'
+
+  validates :recipient_number, presence: true, format: { with: /\A\+?\d{10,15}\z/ }
+  validates :failure_threshold, :recovery_threshold, numericality: { only_integer: true, greater_than: 0 }
+  validates :cooldown_minutes, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :last_state, inclusion: { in: STATES }
+  validate :evolution_go_channels
+
+  scope :enabled, -> { where(enabled: true) }
+
+  private
+
+  def evolution_go_channels
+    errors.add(:observed_channel, 'must use Evolution Go') unless observed_channel&.provider == 'evolution_go'
+    errors.add(:notification_channel, 'must use Evolution Go') unless notification_channel&.provider == 'evolution_go'
+  end
+end

--- a/app/services/evolution_go/health_monitor_service.rb
+++ b/app/services/evolution_go/health_monitor_service.rb
@@ -1,0 +1,88 @@
+class EvolutionGo::HealthMonitorService
+  def initialize(monitor)
+    @monitor = monitor
+  end
+
+  def perform
+    health = fetch_health
+    transition!(health[:healthy], health[:error])
+  rescue StandardError => e
+    transition!(false, e.message)
+  end
+
+  private
+
+  attr_reader :monitor
+
+  def fetch_health
+    channel = monitor.observed_channel
+    api_url = channel.provider_config['api_url'].to_s.chomp('/')
+    token = channel.provider_config['instance_token']
+    raise 'Evolution Go API URL not configured' if api_url.blank?
+    raise 'Evolution Go instance token not configured' if token.blank?
+
+    response = HTTParty.get(
+      "#{api_url}/instance/status",
+      headers: { 'apikey' => token, 'Content-Type' => 'application/json' },
+      timeout: 10
+    )
+    raise "Evolution Go status HTTP #{response.code}" unless response.success?
+
+    data = response.parsed_response['data'] || response.parsed_response
+    connected = ActiveModel::Type::Boolean.new.cast(data['Connected'] || data['connected'])
+    logged_in = ActiveModel::Type::Boolean.new.cast(data['LoggedIn'] || data['loggedIn'])
+    { healthy: connected && logged_in, error: connected && logged_in ? nil : 'instance disconnected' }
+  end
+
+  def transition!(healthy, error)
+    monitor.last_checked_at = Time.current
+    healthy ? apply_success : apply_failure(error)
+    monitor.save!
+  end
+
+  def apply_success
+    monitor.consecutive_successes += 1
+    monitor.consecutive_failures = 0
+    monitor.last_error = nil
+    return unless monitor.consecutive_successes >= monitor.recovery_threshold
+
+    notify!('RECOVERED') if monitor.last_state == 'degraded'
+    monitor.last_state = 'healthy'
+  end
+
+  def apply_failure(error)
+    monitor.consecutive_failures += 1
+    monitor.consecutive_successes = 0
+    monitor.last_error = error
+    return unless monitor.consecutive_failures >= monitor.failure_threshold
+
+    should_alert = monitor.last_state != 'degraded' || monitor.last_alerted_at.nil? || monitor.last_alerted_at <= monitor.cooldown_minutes.minutes.ago
+    notify!('DOWN') if should_alert
+    monitor.last_state = 'degraded'
+  end
+
+  def notify!(state)
+    observed = monitor.observed_channel
+    notifier = monitor.notification_channel
+    api_url = notifier.provider_config['api_url'].to_s.chomp('/')
+    token = notifier.provider_config['instance_token']
+    raise 'Notifier Evolution Go API URL not configured' if api_url.blank?
+    raise 'Notifier Evolution Go instance token not configured' if token.blank?
+
+    inbox_name = observed.inbox&.name || observed.phone_number
+    text = "[Evolution Go Monitor] #{state}: #{inbox_name} (#{observed.phone_number})." \
+           " Checked at #{Time.current.utc.iso8601}.#{monitor.last_error.present? ? " Error: #{monitor.last_error}" : ''}"
+
+    Rails.logger.info "[EvolutionGo::HealthMonitor] Sending #{state} alert for #{inbox_name} via notifier"
+
+    response = HTTParty.post(
+      "#{api_url}/send/text",
+      headers: { 'apikey' => token, 'Content-Type' => 'application/json' },
+      body: { number: monitor.recipient_number.delete('+'), text: text, delay: 0 }.to_json,
+      timeout: 15
+    )
+    raise "Evolution Go notification HTTP #{response.code}" unless response.success?
+
+    monitor.last_alerted_at = Time.current
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -449,6 +449,9 @@ Rails.application.routes.draw do
         resources :settings, only: [:show, :update], controller: 'evolution_go/settings'
         resources :qrcodes, only: [:show, :create], controller: 'evolution_go/qrcodes'
         resources :privacy, only: [:show, :update], controller: 'evolution_go/privacy'
+        resources :health_monitors, only: [:index, :create, :update, :destroy], controller: 'evolution_go/health_monitors' do
+          post :test, on: :member
+        end
         post 'profile/info', to: 'evolution_go/profile#info', as: :profile_info
         post 'profile/avatar', to: 'evolution_go/profile#avatar', as: :profile_avatar
         post 'profile/picture', to: 'evolution_go/profile#update_picture', as: :profile_update_picture

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -8,6 +8,12 @@ trigger_scheduled_items_job:
   class: 'TriggerScheduledItemsJob'
   queue: scheduled_jobs
 
+evolution_go_health_monitor_scheduler_job:
+  cron: '* * * * *'
+  class: 'EvolutionGo::HealthMonitorSchedulerJob'
+  queue: scheduled_jobs
+  description: 'Check configured Evolution Go channels and alert through another Evolution Go channel'
+
 # executed every minute to process scheduled actions
 scheduled_actions_processor_job:
   cron: '* * * * *'

--- a/db/migrate/20260717120000_create_evolution_go_health_monitors.rb
+++ b/db/migrate/20260717120000_create_evolution_go_health_monitors.rb
@@ -1,0 +1,29 @@
+class CreateEvolutionGoHealthMonitors < ActiveRecord::Migration[7.1]
+  def change
+    create_table :evolution_go_health_monitors, id: :uuid, if_not_exists: true do |t|
+      t.references :observed_channel, type: :uuid, null: false,
+                   foreign_key: { to_table: :channel_whatsapp, on_delete: :cascade }
+      t.references :notification_channel, type: :uuid, null: false,
+                   foreign_key: { to_table: :channel_whatsapp, on_delete: :cascade }
+      t.string :recipient_number, null: false
+      t.boolean :enabled, null: false, default: true
+      t.integer :failure_threshold, null: false, default: 2
+      t.integer :recovery_threshold, null: false, default: 1
+      t.integer :cooldown_minutes, null: false, default: 30
+      t.string :last_state, null: false, default: 'unknown'
+      t.integer :consecutive_failures, null: false, default: 0
+      t.integer :consecutive_successes, null: false, default: 0
+      t.datetime :last_checked_at
+      t.datetime :last_alerted_at
+      t.text :last_error
+      t.timestamps
+    end
+
+    add_index :evolution_go_health_monitors, :observed_channel_id,
+              unique: true, if_not_exists: true,
+              name: 'idx_evo_go_health_monitors_observed_unique'
+    add_check_constraint :evolution_go_health_monitors,
+                         'failure_threshold > 0 AND recovery_threshold > 0 AND cooldown_minutes >= 0',
+                         name: 'evo_go_health_monitors_positive_thresholds', if_not_exists: true
+  end
+end

--- a/spec/controllers/api/v1/evolution_go/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/authorizations_controller_spec.rb
@@ -83,4 +83,44 @@ RSpec.describe Api::V1::EvolutionGo::AuthorizationsController, type: :controller
       expect { controller_instance.create }.not_to raise_error
     end
   end
+
+  describe '#fetch connection status' do
+    let(:controller_instance) { described_class.new }
+    let(:channel) do
+      instance_double(
+        Channel::Whatsapp,
+        id: 'channel-id',
+        provider_connection: { 'connection' => 'open', 'error' => nil },
+        reauthorization_required?: false
+      )
+    end
+    let(:inbox) { instance_double(Inbox, channel: channel) }
+
+    before do
+      controller_instance.instance_variable_set(:@api_url, 'http://evo.example.com')
+      controller_instance.instance_variable_set(:@admin_token, 'admin-token')
+      controller_instance.instance_variable_set(:@instance_uuid, 'instance-uuid')
+      controller_instance.instance_variable_set(:@inbox, inbox)
+    end
+
+    it 'accepts a string true returned by Evolution Go as connected' do
+      allow(controller_instance).to receive(:fetch_instance_info).and_return('connected' => 'true')
+      expect(channel).to receive(:update_provider_connection!).with('connection' => 'open', 'error' => nil)
+      expect(controller_instance).to receive(:render).with(
+        hash_including(json: hash_including(data: hash_including(instance: hash_including(state: 'open', connected: true))))
+      )
+
+      controller_instance.fetch
+    end
+
+    it 'does not overwrite an open event snapshot when the polling response has no connection field' do
+      allow(controller_instance).to receive(:fetch_instance_info).and_return('jid' => '5511999999999@s.whatsapp.net')
+      expect(channel).not_to receive(:update_provider_connection!)
+      expect(controller_instance).to receive(:render).with(
+        hash_including(json: hash_including(data: hash_including(instance: hash_including(state: 'open', connected: true))))
+      )
+
+      controller_instance.fetch
+    end
+  end
 end

--- a/spec/controllers/api/v1/evolution_go/health_monitors_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/health_monitors_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::EvolutionGo::HealthMonitorsController, type: :controller do
+  describe 'GET #index' do
+    it 'responds with success' do
+      allow(EvolutionGoHealthMonitor).to receive_message_chain(:enabled, :order, :map).and_return([])
+      get :index
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['success']).to be true
+    end
+  end
+
+  describe 'POST #test' do
+    it 'queues a health check' do
+      monitor = instance_double(EvolutionGoHealthMonitor, id: 'test-id')
+      allow(EvolutionGoHealthMonitor).to receive(:find).with('test-id').and_return(monitor)
+      allow(EvolutionGo::HealthMonitorJob).to receive(:perform_later)
+
+      post :test, params: { id: 'test-id' }
+
+      expect(response).to have_http_status(:accepted)
+      expect(EvolutionGo::HealthMonitorJob).to have_received(:perform_later).with(monitor)
+    end
+  end
+end

--- a/spec/controllers/api/v1/evolution_go/health_monitors_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/health_monitors_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::EvolutionGo::HealthMonitorsController, type: :controller
       post :test, params: { id: 'test-id' }
 
       expect(response).to have_http_status(:accepted)
-      expect(EvolutionGo::HealthMonitorJob).to have_received(:perform_later).with(monitor)
+      expect(EvolutionGo::HealthMonitorJob).to have_received(:perform_later).with('test-id')
     end
   end
 end

--- a/spec/services/evolution_go/health_monitor_service_spec.rb
+++ b/spec/services/evolution_go/health_monitor_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EvolutionGo::HealthMonitorService do
+  let(:observed_channel) do
+    instance_double(Channel::Whatsapp, phone_number: '+5511999999999',
+                                        inbox: instance_double(Inbox, name: 'Observed'),
+                                        provider_config: { 'api_url' => 'https://go.example.com', 'instance_token' => 'observed-token' })
+  end
+  let(:notification_channel) do
+    instance_double(Channel::Whatsapp, provider_config: { 'api_url' => 'https://go.example.com', 'instance_token' => 'notifier-token' })
+  end
+  let(:monitor) do
+    instance_double(EvolutionGoHealthMonitor, observed_channel: observed_channel, notification_channel: notification_channel,
+                                               recipient_number: '+5511888888888', failure_threshold: 2, recovery_threshold: 1,
+                                               cooldown_minutes: 30, last_state: 'healthy', consecutive_failures: 0,
+                                               consecutive_successes: 0, last_alerted_at: nil, last_error: nil)
+  end
+
+  before do
+    allow(monitor).to receive(:save!)
+    %i[last_checked_at= last_alerted_at=].each { |setter| allow(monitor).to receive(setter) }
+    %i[consecutive_failures consecutive_successes last_error last_state].each do |attribute|
+      allow(monitor).to receive("#{attribute}=") { |value| allow(monitor).to receive(attribute).and_return(value) }
+    end
+  end
+
+  it 'waits for the failure threshold before sending a DOWN alert' do
+    down = instance_double(HTTParty::Response, success?: true, parsed_response: { 'data' => { 'Connected' => false, 'LoggedIn' => false } })
+    allow(HTTParty).to receive(:get).and_return(down)
+    expect(HTTParty).not_to receive(:post)
+
+    described_class.new(monitor).perform
+
+    expect(monitor.consecutive_failures).to eq(1)
+    expect(monitor.last_state).to eq('healthy')
+  end
+
+  it 'sends a DOWN alert when the threshold is reached' do
+    allow(monitor).to receive(:consecutive_failures).and_return(1)
+    down = instance_double(HTTParty::Response, success?: true, parsed_response: { 'data' => { 'Connected' => false, 'LoggedIn' => false } })
+    sent = instance_double(HTTParty::Response, success?: true, code: 200)
+    allow(HTTParty).to receive(:get).and_return(down)
+    expect(HTTParty).to receive(:post).with('https://go.example.com/send/text', hash_including(headers: hash_including('apikey' => 'notifier-token'))).and_return(sent)
+
+    described_class.new(monitor).perform
+
+    expect(monitor.last_state).to eq('degraded')
+  end
+
+  it 'sends a recovery alert when the observed instance becomes healthy' do
+    allow(monitor).to receive(:last_state).and_return('degraded')
+    up = instance_double(HTTParty::Response, success?: true, parsed_response: { 'data' => { 'Connected' => true, 'LoggedIn' => true } })
+    allow(HTTParty).to receive(:get).and_return(up)
+    expect(HTTParty).to receive(:post).and_return(instance_double(HTTParty::Response, success?: true, code: 200))
+
+    described_class.new(monitor).perform
+
+    expect(monitor.last_state).to eq('healthy')
+  end
+
+  it 'does not send duplicate DOWN alerts within the cooldown period' do
+    allow(monitor).to receive(:consecutive_failures).and_return(1)
+    allow(monitor).to receive(:last_state).and_return('degraded')
+    allow(monitor).to receive(:last_alerted_at).and_return(5.minutes.ago)
+    down = instance_double(HTTParty::Response, success?: true, parsed_response: { 'data' => { 'Connected' => false, 'LoggedIn' => false } })
+    allow(HTTParty).to receive(:get).and_return(down)
+    expect(HTTParty).not_to receive(:post)
+
+    described_class.new(monitor).perform
+
+    expect(monitor.last_state).to eq('degraded')
+  end
+end


### PR DESCRIPTION
## Summary

Adds an installation-level Evolution Go health-monitoring capability that polls an observed WhatsApp instance and delivers `DOWN` / `RECOVERED` alerts through a separate Evolution Go instance.

This supports the operational pattern: monitor a customer-facing instance while using a dedicated administrator/notifier instance for alerts.

### Included
- `EvolutionGoHealthMonitor` persistent configuration
- status checks through the instance-scoped `/instance/status` endpoint
- threshold-based degraded-state detection and recovery alerts
- cooldown to avoid repeated alerts while an instance stays down
- distributed Redis lock per monitor
- Sidekiq Cron scheduler (one check per enabled monitor per minute)
- CRUD/test API under `/api/v1/evolution_go/health_monitors`
- regression fix: Evolution Go status polling no longer persists a false disconnect for partial responses or `connected: "true"`

## Safety
- The Community Edition is a single-tenant installation. This feature is intentionally installation-scoped and reusable per deployment; it does not claim shared-database multi-tenancy.
- The API accepts channel IDs and alert policy only. It never accepts or returns Evolution Go tokens.
- Both observed and notifier channels must be `evolution_go`.
- Timeouts/partial payloads are not converted directly into a persisted disconnect.

## Test plan
- Ruby syntax validation passed for all new/modified Ruby files.
- Added specs for threshold, alert, recovery, cooldown, and controller scheduling paths.
- Multi-architecture Docker build/publish passed in the fork: https://github.com/sistemabritto/evo-ai-crm-community/actions/runs/29589334112

## Notes
Local full RSpec container build was blocked by an Alpine package mirror download error (`gcc` archive), unrelated to the application code. CI build completed successfully on amd64 and arm64.

## Summary by Sourcery

Introduce installation-scoped Evolution Go health monitoring with scheduled checks of WhatsApp channels and alerting via a separate Evolution Go channel, while hardening status polling behavior.

New Features:
- Add Evolution Go health monitor model, service, jobs, and API to track an observed Evolution Go WhatsApp channel and send alerts through a notifier channel.
- Expose CRUD and test endpoints for Evolution Go health monitors under the existing Evolution Go API namespace.
- Schedule per-minute health monitor execution via Sidekiq Cron to run checks for enabled monitors.

Bug Fixes:
- Normalize Evolution Go connection status values so partial or string-based responses no longer incorrectly persist disconnects or overwrite an open state snapshot.

Enhancements:
- Add validation and constraints around health monitor configuration, including thresholds, cooldowns, and Evolution Go-only channels.

Tests:
- Add service specs covering threshold-based DOWN/RECOVERED alerts and cooldown behavior for Evolution Go health monitoring.
- Add controller specs for health monitor APIs and Evolution Go authorization status polling edge cases.