### PR TITLE
refactor(rbac): forward scope_id from the seam to auth-service (EVO-2156)

### DIFF
--- a/app/services/evo_auth_service.rb
+++ b/app/services/evo_auth_service.rb
@@ -95,35 +95,19 @@ class EvoAuthService
     token ? { 'X-Service-Token' => token } : {}
   end
 
-  # Check account-scoped permission for user
-  def check_account_permission(user_id, _identifier = nil, permission_key)
-    # Use new standard: /api/v1/users/:id/check_permission with account-id header
-    response = instrument_remote_call(
-      'check_account_permission',
-      user_id: user_id
-    ) do
-      post_request("/api/v1/users/#{user_id}/check_permission",
-                   { permission_key: permission_key },
-                   service_auth_headers)
-    end
+  # Server-to-server permission check. Optional `scope_id` scopes the resolution
+  # to a single Account: without it, the auth resolves across the union of the
+  # user's roles (community/single-tenant behaviour, byte-for-byte compatible);
+  # with it, the auth-enterprise overlay filters derived roles to the current
+  # scope so an agency_owner in Account A does not carry those verbs into
+  # Account B (EVO-2156 / AC1, AC2).
+  def check_user_permission(user_id, permission_key, scope_id: nil)
+    payload = { permission_key: permission_key }
+    payload[:scope_id] = scope_id if scope_id.present?
 
-    data = response['data'] || {}
-    if data&.dig('has_permission')
-      true
-    else
-      Rails.logger.error "Failed to check account permission: #{response&.dig('error') || 'Unknown error'}"
-      false
-    end
-  rescue StandardError => e
-    Rails.logger.error "Error checking account permission: #{e.message}"
-    false
-  end
-
-  # Check global user permission
-  def check_user_permission(user_id, permission_key)
     response = instrument_remote_call('check_user_permission', user_id: user_id) do
       post_request("/api/v1/users/#{user_id}/check_permission",
-                   { permission_key: permission_key },
+                   payload,
                    service_auth_headers)
     end
 

--- a/lib/evo_extension_points/permission_resolver.rb
+++ b/lib/evo_extension_points/permission_resolver.rb
@@ -13,8 +13,19 @@ module EvoExtensionPoints
   # allows everything — routing permission checks through it would open the
   # community up. This seam's default preserves the current deny/grant.
   module PermissionResolver
-    DEFAULT_IMPL = lambda do |user_id:, permission_key:, **_context|
-      EvoAuthService.new.check_user_permission(user_id, permission_key)
+    # The seam call site (evo_permission_concern#has_user_permission?) already
+    # passes scope_id from RuntimeContext. Forward it so the auth-enterprise
+    # overlay can filter derived roles by scope (EVO-2156 / AC1). Bifurcated on
+    # scope_id.present? so the call arity in community (scope_id nil) stays
+    # identical to the pre-EVO-2156 signature — AC2 (byte-for-byte parity) plus
+    # a guard against surprising every existing spec that stubs the two-arg form.
+    DEFAULT_IMPL = lambda do |user_id:, permission_key:, scope_id: nil, **_context|
+      service = EvoAuthService.new
+      if scope_id.present?
+        service.check_user_permission(user_id, permission_key, scope_id: scope_id)
+      else
+        service.check_user_permission(user_id, permission_key)
+      end
     end
 
     class << self

--- a/spec/lib/evo_extension_points/permission_resolver_spec.rb
+++ b/spec/lib/evo_extension_points/permission_resolver_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EvoExtensionPoints::PermissionResolver do
     # run in.
     before { EvoExtensionPoints.reset! }
 
-    it 'delegates to EvoAuthService#check_user_permission with the same arguments' do
+    it 'delegates to EvoAuthService#check_user_permission with the pre-EVO-2156 two-arg form when scope_id is absent' do
       service = instance_double(EvoAuthService)
       allow(EvoAuthService).to receive(:new).and_return(service)
       expect(service).to receive(:check_user_permission).with('user-1', 'conversations.read').and_return(true)
@@ -27,9 +27,21 @@ RSpec.describe EvoExtensionPoints::PermissionResolver do
       expect(described_class.allowed?(user_id: 'user-1', permission_key: 'contacts.delete')).to be(false)
     end
 
-    it 'ignores extra context keys (scope_id is nil in community)' do
-      service = instance_double(EvoAuthService, check_user_permission: true)
+    it 'forwards scope_id when the call site provides one (EVO-2156 / AC1)' do
+      service = instance_double(EvoAuthService)
       allow(EvoAuthService).to receive(:new).and_return(service)
+      expect(service).to receive(:check_user_permission)
+        .with('u1', 'conversations.delete', scope_id: 'tenant-B').and_return(false)
+
+      expect(
+        described_class.allowed?(user_id: 'u1', permission_key: 'conversations.delete', scope_id: 'tenant-B')
+      ).to be(false)
+    end
+
+    it 'omits scope_id from the downstream call when explicitly nil (parity guard, AC2)' do
+      service = instance_double(EvoAuthService)
+      allow(EvoAuthService).to receive(:new).and_return(service)
+      expect(service).to receive(:check_user_permission).with('u', 'k').and_return(true)
 
       expect(described_class.allowed?(user_id: 'u', permission_key: 'k', scope_id: nil)).to be(true)
     end

--- a/spec/services/evo_auth_service_spec.rb
+++ b/spec/services/evo_auth_service_spec.rb
@@ -130,4 +130,59 @@ RSpec.describe EvoAuthService do
       end.to raise_error(EvoAuthService::AuthenticationError, 'Authentication service unavailable')
     end
   end
+
+  # EVO-2156 / AC2: without scope_id the payload is byte-for-byte identical to
+  # what community/self-hosted sent before this story (single-tenant parity).
+  # With scope_id, the auth-enterprise overlay filters derived roles by scope.
+  describe '#check_user_permission' do
+    let(:check_endpoint) { "#{base_url}/api/v1/users/user-1/check_permission" }
+
+    before { ENV['EVOAI_CRM_API_TOKEN'] = 'svc-token' }
+    after  { ENV.delete('EVOAI_CRM_API_TOKEN') }
+
+    it 'sends a payload without scope_id when none is provided (AC2)' do
+      stub_request(:post, check_endpoint)
+        .with(
+          headers: { 'X-Service-Token' => 'svc-token' },
+          body: { permission_key: 'conversations.read' }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: { data: { has_permission: true } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.check_user_permission('user-1', 'conversations.read')).to be(true)
+    end
+
+    it 'includes scope_id in the payload when present (AC1)' do
+      stub_request(:post, check_endpoint)
+        .with(
+          headers: { 'X-Service-Token' => 'svc-token' },
+          body: { permission_key: 'conversations.delete', scope_id: 'tenant-B' }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: { data: { has_permission: false } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.check_user_permission('user-1', 'conversations.delete', scope_id: 'tenant-B')).to be(false)
+    end
+
+    it 'omits scope_id from the payload when explicitly nil (parity guard)' do
+      stub_request(:post, check_endpoint)
+        .with(
+          headers: { 'X-Service-Token' => 'svc-token' },
+          body: { permission_key: 'contacts.read' }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: { data: { has_permission: true } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.check_user_permission('user-1', 'contacts.read', scope_id: nil)).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Community-side wiring for [EVO-2156](https://linear.app/evoai/issue/EVO-2156) (RBAC 4.5 — scope-aware permission resolution). The seam call site (EvoPermissionConcern) already carries `scope_id` from RuntimeContext; the default impl was dropping it before hitting the wire.

- `EvoAuthService#check_user_permission` accepts optional `scope_id:` kwarg; omitted from POST body when nil so the payload stays **byte-for-byte identical** to the pre-EVO-2156 self-hosted/community behaviour (AC2).
- Remove vestigial `EvoAuthService#check_account_permission` (no call sites in crm-community / auth / crm-enterprise; PM decision on the issue).
- `PermissionResolver::DEFAULT_IMPL` bifurcates on `scope_id.present?` so the downstream call arity in the community path (nil scope) stays the two-arg form the existing test suite stubs.

The auth-enterprise overlay (separate PR in `evo-enterprise-docker`) consumes this to filter derived roles by tenant. Community with no scope stays flat (FR26 / `no-enterprise-guard`).

## Test plan

- [x] `spec/services/evo_auth_service_spec.rb` — new `#check_user_permission` describe covering: no scope_id → payload without it (AC2), with scope_id → included, explicit nil → excluded (parity guard)
- [x] `spec/lib/evo_extension_points/permission_resolver_spec.rb` — DEFAULT_IMPL delegation with/without scope_id
- [x] `spec/lib/evo_permission_concern_scope_cache_spec.rb` — unchanged behaviour verified (stub signature preserved)
- [x] Smoke test end-to-end inside built enterprise stack: 11/11 assertions passed against real Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Forward scope-aware permission context from the community seam into EvoAuthService while preserving existing single-tenant behaviour when no scope is provided.

New Features:
- Allow EvoAuthService#check_user_permission to accept an optional scope_id for scoped permission resolution.

Enhancements:
- Update the default PermissionResolver implementation to conditionally pass scope_id to EvoAuthService, keeping the legacy two-argument form when scope_id is absent.
- Remove the unused EvoAuthService#check_account_permission endpoint-facing method.

Tests:
- Add specs ensuring check_user_permission payloads include scope_id when present and are byte-for-byte identical to previous behaviour when scope_id is nil or omitted.
- Extend PermissionResolver specs to cover delegation with and without scope_id, including explicit nil parity guards.