### PR TITLE
feat: list a user's permissions from the auth-service

### DIFF
--- a/app/services/evo_auth_service.rb
+++ b/app/services/evo_auth_service.rb
@@ -96,11 +96,10 @@ class EvoAuthService
   end
 
   # Server-to-server permission check. Optional `scope_id` scopes the resolution
-  # to a single Account: without it, the auth resolves across the union of the
-  # user's roles (community/single-tenant behaviour, byte-for-byte compatible);
-  # with it, the auth-enterprise overlay filters derived roles to the current
-  # scope so an agency_owner in Account A does not carry those verbs into
-  # Account B (EVO-2156 / AC1, AC2).
+  # to a single account: without it, the auth resolves across the union of the
+  # user's roles (single-tenant behaviour, byte-for-byte compatible); with it,
+  # an auth that supports per-account scoping filters the resolution to that
+  # account, and one that doesn't simply ignores the parameter.
   def check_user_permission(user_id, permission_key, scope_id: nil)
     payload = { permission_key: permission_key }
     payload[:scope_id] = scope_id if scope_id.present?
@@ -121,6 +120,29 @@ class EvoAuthService
   rescue StandardError => e
     Rails.logger.error "Error checking user permission: #{e.message}"
     false
+  end
+
+  # Lists the caller's own permission keys from the auth-service
+  # (GET /api/v1/permissions). The call authenticates AS the user via their
+  # bearer token — the auth resolves `current_user.permissions`, so no user id
+  # is passed. Optional `scope_id` narrows the resolution to a single account:
+  # an auth that supports per-account scoping filters to that account; an auth
+  # that doesn't ignores the parameter and returns the global list, so the
+  # method is behaviour-flat when unscoped. Fail-soft: any error yields [].
+  def list_user_permissions(bearer_token, scope_id: nil)
+    endpoint = '/api/v1/permissions'
+    endpoint += "?scope_id=#{URI.encode_www_form_component(scope_id.to_s)}" if scope_id.present?
+    headers = bearer_token.present? ? { 'Authorization' => bearer_token } : {}
+
+    response = instrument_remote_call('list_user_permissions', scope_id: scope_id) do
+      get_request(endpoint, headers)
+    end
+
+    data = response['data'] || {}
+    Array(data['permissions'])
+  rescue StandardError => e
+    Rails.logger.error "Error listing user permissions: #{e.message}"
+    []
   end
 
   # Get user role

--- a/spec/services/evo_auth_service_spec.rb
+++ b/spec/services/evo_auth_service_spec.rb
@@ -131,9 +131,9 @@ RSpec.describe EvoAuthService do
     end
   end
 
-  # EVO-2156 / AC2: without scope_id the payload is byte-for-byte identical to
-  # what community/self-hosted sent before this story (single-tenant parity).
-  # With scope_id, the auth-enterprise overlay filters derived roles by scope.
+  # Without scope_id the payload is byte-for-byte identical to the single-tenant
+  # behaviour (parity). With scope_id, an auth that supports per-account scoping
+  # filters the resolution to that account; a plain auth ignores the parameter.
   describe '#check_user_permission' do
     let(:check_endpoint) { "#{base_url}/api/v1/users/user-1/check_permission" }
 
@@ -183,6 +183,42 @@ RSpec.describe EvoAuthService do
         )
 
       expect(service.check_user_permission('user-1', 'contacts.read', scope_id: nil)).to be(true)
+    end
+  end
+
+  describe '#list_user_permissions' do
+    let(:list_endpoint) { "#{base_url}/api/v1/permissions" }
+    let(:bearer) { 'Bearer user-token' }
+
+    it 'lists the permissions using the caller bearer, unscoped' do
+      stub_request(:get, list_endpoint)
+        .with(headers: { 'Authorization' => bearer })
+        .to_return(
+          status: 200,
+          body: { data: { permissions: %w[conversations.read contacts.read] } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.list_user_permissions(bearer)).to eq(%w[conversations.read contacts.read])
+    end
+
+    it 'appends scope_id to the query string when present' do
+      stub_request(:get, "#{list_endpoint}?scope_id=tenant-B")
+        .with(headers: { 'Authorization' => bearer })
+        .to_return(
+          status: 200,
+          body: { data: { permissions: ['conversations.read'] } }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      expect(service.list_user_permissions(bearer, scope_id: 'tenant-B')).to eq(['conversations.read'])
+    end
+
+    it 'fails soft to [] on an error response' do
+      stub_request(:get, list_endpoint)
+        .to_return(status: 500, body: 'boom')
+
+      expect(service.list_user_permissions(bearer)).to eq([])
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds `EvoAuthService#list_user_permissions(bearer_token, scope_id:)` — a read counterpart to the existing `check_user_permission`. It performs `GET /api/v1/permissions` authenticating **as the caller** (forwarding their bearer), so the auth-service resolves `current_user.permissions`; no user id is passed.

- Optional `scope_id` narrows the resolution to a single account when the auth supports per-account scoping; an auth that doesn't simply ignores the parameter and returns the global list (behaviour-flat when unscoped).
- Reuses the service's existing HTTP plumbing (`get_request` + persistent client). `apply_headers` already honours an explicit `Authorization` header, so the caller's bearer is not shadowed by `Current`.
- Fail-soft: any error yields `[]`.

Also tidies two stale inline comments in this file to keep them implementation-neutral.

## Security

- Authenticates as the caller (their own bearer) — lists only the caller's own permissions, no privilege escalation.
- `scope_id` is URL-encoded via `URI.encode_www_form_component`.

## Test plan

- `bundle exec rspec spec/services/evo_auth_service_spec.rb` → 13 examples, 0 failures (3 new for `list_user_permissions`: unscoped, scoped query string, fail-soft on error).

## Changed Files

- `app/services/evo_auth_service.rb`
- `spec/services/evo_auth_service_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support in EvoAuthService for listing a caller’s own permissions from the auth service using their bearer token, with optional account scoping and fail-soft behavior.

New Features:
- Introduce EvoAuthService#list_user_permissions to retrieve the current caller’s permission keys from the auth-service, optionally scoped to a specific account.

Enhancements:
- Clarify inline documentation around scope_id handling for server-to-server permission checks.

Tests:
- Add specs covering list_user_permissions for unscoped calls, scoped query string handling, and graceful fallback to an empty list on error responses.