### PR TITLE
fix(EVO-2179): forward incoming attachments to the bot_runtime

### DIFF
--- a/app/services/bot_runtime/delegation_service.rb
+++ b/app/services/bot_runtime/delegation_service.rb
@@ -41,24 +41,54 @@ module BotRuntime
     # @message here is rebuilt from the webhook payload (an unpersisted Message.new
     # with only the id set — see AgentBotListener#create_message_from_payload), so
     # @message.attachments is an empty in-memory collection. Reload the persisted
-    # record to read the real ActiveStorage attachments and their download_url
-    # (a proxy URL on BACKEND_URL, reachable by the Go service).
+    # record — blobs preloaded, this runs on every incoming delegation — to read
+    # the real ActiveStorage attachments. Ordered so a multi-media message always
+    # produces the file parts in the order the contact sent them.
     def build_attachments
-      persisted = @conversation.messages.find_by(id: @message.id)
+      persisted = @conversation.messages
+                               .includes(attachments: { file_attachment: :blob })
+                               .find_by(id: @message.id)
       return [] if persisted.nil?
 
-      persisted.attachments.filter_map do |att|
-        next unless att.file.attached? && att.with_attached_file?
-
-        {
-          url: att.download_url,
-          content_type: att.file.content_type,
-          file_type: att.file_type
-        }
-      end
+      persisted.attachments
+               .sort_by { |att| [att.created_at, att.id.to_s] }
+               .filter_map { |att| attachment_payload(att) }
     rescue StandardError => e
-      Rails.logger.error("[BotRuntime::DelegationService] build_attachments failed: #{e.message}")
+      log_attachment_failure('build_attachments', e)
       []
+    end
+
+    # The bot_runtime fetches this URL server-side, so it is an outbound media URL
+    # like the ones handed to Evolution API / Evolution Go — not a browser URL.
+    # BlobUrlOptions.outbound_media_url honors ACTIVE_STORAGE_URL (the host a
+    # sibling container can reach; BACKEND_URL is browser-facing and is not
+    # required to resolve inside the network) and signs the link with a 15-minute
+    # TTL instead of the permanent signed id of Attachment#download_url. The TTL
+    # covers the debounce window (seconds) plus the SendEventJob retries.
+    #
+    # Rescued per attachment: one broken record (a NULL file_type makes
+    # with_attached_file? raise) must not drop the media of the whole message.
+    def attachment_payload(att)
+      return if att.file_type.blank?
+      return unless att.file.attached? && att.with_attached_file?
+
+      blob = att.file.blob
+      {
+        url: BlobUrlOptions.outbound_media_url(blob),
+        content_type: blob.content_type,
+        file_type: att.file_type
+      }
+    rescue StandardError => e
+      log_attachment_failure("attachment #{att.id}", e)
+      nil
+    end
+
+    def log_attachment_failure(context, error)
+      Rails.logger.error(
+        "[BotRuntime::DelegationService] #{context} failed " \
+        "(message=#{@message.id} conversation=#{@conversation.display_id}): " \
+        "#{error.class}: #{error.message}"
+      )
     end
 
     def build_bot_config

--- a/app/services/bot_runtime/delegation_service.rb
+++ b/app/services/bot_runtime/delegation_service.rb
@@ -25,12 +25,40 @@ module BotRuntime
         contact_id: stable_contact_id,
         message_id: @message.id.to_s,
         message_content: @message.content.to_s,
+        attachments: build_attachments,
         api_key: @agent_bot.api_key.to_s,
         outgoing_url: @agent_bot.outgoing_url.to_s,
         bot_config: build_bot_config,
         postback_url: build_postback_url,
         metadata: build_metadata
       }
+    end
+
+    # EVO-2179: forward incoming media (image/audio/…) so the bot_runtime can pass
+    # it to the AI processor as A2A file parts. Without this a media-only message
+    # reaches the AI empty ("No content to process") — the agent never sees it.
+    #
+    # @message here is rebuilt from the webhook payload (an unpersisted Message.new
+    # with only the id set — see AgentBotListener#create_message_from_payload), so
+    # @message.attachments is an empty in-memory collection. Reload the persisted
+    # record to read the real ActiveStorage attachments and their download_url
+    # (a proxy URL on BACKEND_URL, reachable by the Go service).
+    def build_attachments
+      persisted = @conversation.messages.find_by(id: @message.id)
+      return [] if persisted.nil?
+
+      persisted.attachments.filter_map do |att|
+        next unless att.file.attached? && att.with_attached_file?
+
+        {
+          url: att.download_url,
+          content_type: att.file.content_type,
+          file_type: att.file_type
+        }
+      end
+    rescue StandardError => e
+      Rails.logger.error("[BotRuntime::DelegationService] build_attachments failed: #{e.message}")
+      []
     end
 
     def build_bot_config

--- a/spec/services/bot_runtime/delegation_service_spec.rb
+++ b/spec/services/bot_runtime/delegation_service_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2179: BotRuntime::DelegationService must forward incoming media attachments to
+# the bot_runtime. The @message it receives is an unpersisted Message.new (only id),
+# so build_attachments reloads the persisted record via the conversation and maps its
+# ActiveStorage media attachments to {url, content_type, file_type}.
+RSpec.describe BotRuntime::DelegationService do
+  subject(:service) { described_class.new(agent_bot, message, conversation) }
+
+  let(:agent_bot) { double('agent_bot') }
+  let(:message) { double('message', id: 42) }
+  let(:messages_relation) { double('messages_relation') }
+  let(:conversation) { double('conversation', messages: messages_relation) }
+
+  def attachment(file_type:, attached: true, with_attached: true, content_type: 'image/png',
+                 url: 'https://crm.example.com/rails/active_storage/blobs/proxy/photo.png')
+    file = double('file', attached?: attached, content_type: content_type)
+    double('attachment', file: file, with_attached_file?: with_attached, download_url: url, file_type: file_type)
+  end
+
+  def stub_persisted_with(attachments)
+    persisted = double('persisted_message', attachments: attachments)
+    allow(messages_relation).to receive(:find_by).with(id: 42).and_return(persisted)
+  end
+
+  describe '#build_attachments' do
+    it 'reloads the persisted message and maps media attachments' do
+      stub_persisted_with([attachment(file_type: 'image')])
+
+      expect(service.send(:build_attachments)).to eq(
+        [{
+          url: 'https://crm.example.com/rails/active_storage/blobs/proxy/photo.png',
+          content_type: 'image/png',
+          file_type: 'image'
+        }]
+      )
+    end
+
+    it 'maps multiple media attachments (image + audio)' do
+      atts = [
+        attachment(file_type: 'image', content_type: 'image/jpeg', url: 'https://c/img.jpg'),
+        attachment(file_type: 'audio', content_type: 'audio/ogg', url: 'https://c/a.ogg')
+      ]
+      stub_persisted_with(atts)
+
+      result = service.send(:build_attachments)
+      expect(result.map { |a| a[:file_type] }).to eq(%w[image audio])
+      expect(result.map { |a| a[:content_type] }).to eq(['image/jpeg', 'audio/ogg'])
+    end
+
+    it 'returns [] when the persisted message is not found' do
+      allow(messages_relation).to receive(:find_by).with(id: 42).and_return(nil)
+      expect(service.send(:build_attachments)).to eq([])
+    end
+
+    it 'skips attachments whose file is not attached' do
+      stub_persisted_with([attachment(file_type: 'image', attached: false)])
+      expect(service.send(:build_attachments)).to eq([])
+    end
+
+    it 'skips non-media attachments (e.g. location)' do
+      stub_persisted_with([attachment(file_type: 'location', with_attached: false)])
+      expect(service.send(:build_attachments)).to eq([])
+    end
+
+    it 'never raises: logs and returns [] on error' do
+      allow(messages_relation).to receive(:find_by).and_raise(StandardError.new('boom'))
+      allow(Rails.logger).to receive(:error)
+
+      expect(service.send(:build_attachments)).to eq([])
+      expect(Rails.logger).to have_received(:error).with(/build_attachments failed/)
+    end
+  end
+end

--- a/spec/services/bot_runtime/delegation_service_spec.rb
+++ b/spec/services/bot_runtime/delegation_service_spec.rb
@@ -6,22 +6,56 @@ require 'rails_helper'
 # the bot_runtime. The @message it receives is an unpersisted Message.new (only id),
 # so build_attachments reloads the persisted record via the conversation and maps its
 # ActiveStorage media attachments to {url, content_type, file_type}.
+#
+# The collaborators are verifying doubles on purpose: the whole point of this spec is
+# the mapping, so it must fail if the Attachment/Blob API it maps from drifts.
 RSpec.describe BotRuntime::DelegationService do
   subject(:service) { described_class.new(agent_bot, message, conversation) }
 
-  let(:agent_bot) { double('agent_bot') }
-  let(:message) { double('message', id: 42) }
-  let(:messages_relation) { double('messages_relation') }
-  let(:conversation) { double('conversation', messages: messages_relation) }
+  let(:agent_bot) do
+    instance_double(AgentBot, id: 'bot-1', name: 'Agente', api_key: 'api-key',
+                              outgoing_url: 'https://agent.example/webhook', debounce_time: 5,
+                              message_signature: '', text_segmentation_enabled: false,
+                              text_segmentation_limit: 300, text_segmentation_min_size: 50,
+                              delay_per_character: 50)
+  end
+  let(:message) { instance_double(Message, id: 42, content: 'olha a foto') }
+  let(:messages_relation) { instance_double(ActiveRecord::Relation) }
+  let(:labels) { instance_double(ActiveRecord::Relation, pluck: ['vip']) }
+  let(:contact) do
+    instance_double(Contact, id: 'contact-1', name: 'Ana', email: 'ana@example.com',
+                             phone_number: '+5511999999999', identifier: nil, type: 'person',
+                             contact_type: 'lead', blocked: false, location: 'SP', country_code: 'BR',
+                             additional_attributes: {}, custom_attributes: {}, labels: labels)
+  end
+  let(:inbox) { instance_double(Inbox, id: 'inbox-1', name: 'WhatsApp') }
+  let(:conversation) do
+    instance_double(Conversation, id: 'conv-1', display_id: 7, contact_id: 'contact-1',
+                                  contact: contact, inbox: inbox, messages: messages_relation)
+  end
 
-  def attachment(file_type:, attached: true, with_attached: true, content_type: 'image/png',
-                 url: 'https://crm.example.com/rails/active_storage/blobs/proxy/photo.png')
-    file = double('file', attached?: attached, content_type: content_type)
-    double('attachment', file: file, with_attached_file?: with_attached, download_url: url, file_type: file_type)
+  before do
+    # The service preloads the blobs (no N+1 on the delegation hot path).
+    allow(messages_relation).to receive(:includes).with(attachments: { file_attachment: :blob }).and_return(messages_relation)
+  end
+
+  # ActiveStorage::Attached::One delegates #blob to the attachment record through
+  # method_missing, so a verifying double cannot stand in for it — the file wrapper
+  # is the only plain double here.
+  def attachment(file_type:, **opts)
+    url = opts.fetch(:url, 'https://crm.example.com/rails/active_storage/blobs/proxy/photo.png')
+    blob = instance_double(ActiveStorage::Blob, content_type: opts.fetch(:content_type, 'image/png'))
+    file = double('ActiveStorage::Attached::One', attached?: opts.fetch(:attached, true), blob: blob)
+    # Outbound media URL (ACTIVE_STORAGE_URL host + 15min TTL), not the permanent
+    # browser-facing Attachment#download_url — the bot_runtime fetches it server-side.
+    allow(BlobUrlOptions).to receive(:outbound_media_url).with(blob).and_return(url)
+    instance_double(Attachment, file: file, with_attached_file?: opts.fetch(:with_attached, true),
+                                file_type: file_type, id: opts.fetch(:id, 'att-1'),
+                                created_at: opts.fetch(:created_at, Time.zone.local(2026, 7, 20, 12, 0, 0)))
   end
 
   def stub_persisted_with(attachments)
-    persisted = double('persisted_message', attachments: attachments)
+    persisted = instance_double(Message, attachments: attachments)
     allow(messages_relation).to receive(:find_by).with(id: 42).and_return(persisted)
   end
 
@@ -38,12 +72,12 @@ RSpec.describe BotRuntime::DelegationService do
       )
     end
 
-    it 'maps multiple media attachments (image + audio)' do
-      atts = [
-        attachment(file_type: 'image', content_type: 'image/jpeg', url: 'https://c/img.jpg'),
-        attachment(file_type: 'audio', content_type: 'audio/ogg', url: 'https://c/a.ogg')
-      ]
-      stub_persisted_with(atts)
+    it 'maps multiple media attachments in the order the contact sent them' do
+      image = attachment(file_type: 'image', content_type: 'image/jpeg', url: 'https://c/img.jpg',
+                         created_at: Time.zone.local(2026, 7, 20, 12, 0, 0), id: 'att-img')
+      audio = attachment(file_type: 'audio', content_type: 'audio/ogg', url: 'https://c/a.ogg',
+                         created_at: Time.zone.local(2026, 7, 20, 12, 0, 1), id: 'att-audio')
+      stub_persisted_with([audio, image]) # DB order is not guaranteed
 
       result = service.send(:build_attachments)
       expect(result.map { |a| a[:file_type] }).to eq(%w[image audio])
@@ -65,12 +99,56 @@ RSpec.describe BotRuntime::DelegationService do
       expect(service.send(:build_attachments)).to eq([])
     end
 
+    it 'skips attachments with no file_type instead of blowing up' do
+      stub_persisted_with([attachment(file_type: nil)])
+      expect(service.send(:build_attachments)).to eq([])
+    end
+
+    it 'keeps the healthy attachments when one of them raises' do
+      broken = instance_double(Attachment, file_type: 'image', id: 'att-boom',
+                                           created_at: Time.zone.local(2026, 7, 20, 12, 0, 0))
+      allow(broken).to receive(:file).and_raise(StandardError, 'blob vanished')
+      good = attachment(file_type: 'audio', content_type: 'audio/ogg', url: 'https://c/a.ogg',
+                        created_at: Time.zone.local(2026, 7, 20, 12, 0, 1), id: 'att-audio')
+      stub_persisted_with([broken, good])
+      allow(Rails.logger).to receive(:error)
+
+      result = service.send(:build_attachments)
+
+      expect(result.map { |a| a[:file_type] }).to eq(%w[audio])
+      expect(Rails.logger).to have_received(:error).with(/attachment att-boom failed .*message=42/)
+    end
+
     it 'never raises: logs and returns [] on error' do
       allow(messages_relation).to receive(:find_by).and_raise(StandardError.new('boom'))
       allow(Rails.logger).to receive(:error)
 
       expect(service.send(:build_attachments)).to eq([])
       expect(Rails.logger).to have_received(:error).with(/build_attachments failed/)
+    end
+  end
+
+  describe '#build_message_event' do
+    before { allow(BotRuntime::Config).to receive(:postback_base_url).and_return('https://crm.example.com') }
+
+    # The wire contract with the Go service: MessageEvent.Attachments is bound from
+    # the snake_case "attachments" key (evo-bot-runtime pkg/pipeline/model/pipeline.go).
+    it 'ships the mapped attachments under the :attachments key' do
+      stub_persisted_with([attachment(file_type: 'image', url: 'https://crm.example.com/img.png')])
+
+      event = service.send(:build_message_event)
+
+      expect(event[:attachments]).to eq(
+        [{ url: 'https://crm.example.com/img.png', content_type: 'image/png', file_type: 'image' }]
+      )
+      expect(event.keys).to include(:agent_bot_id, :conversation_id, :contact_id, :message_id, :message_content,
+                                    :attachments, :api_key, :outgoing_url, :bot_config, :postback_url, :metadata)
+    end
+
+    it 'sends an empty list when the message has no attachments' do
+      stub_persisted_with([])
+
+      expect(service.send(:build_message_event)[:attachments]).to eq([])
     end
   end
 end


### PR DESCRIPTION
## EVO-2179 — CRM: `DelegationService` envia os anexos ao bot_runtime

Sub-issue de **EVO-2178** (agente não processa mídia). Primeiro elo: o CRM precisa **colocar a mídia no evento**.

### Root cause
`BotRuntime::DelegationService#build_message_event` enviava só `message_content` (texto). E o `@message` que ele recebe é um **`Message.new` não-persistido** (só `id`, reconstruído do payload em `AgentBotListener#create_message_from_payload`) → `@message.attachments` é uma coleção vazia. Ler `@message.attachments` direto (como o hotfix propunha) retornaria `[]`.

### Correção
- `attachments: build_attachments` no evento (o hash já vira JSON no `BotRuntime::Client`).
- `build_attachments` **recarrega a mensagem persistida** (`@conversation.messages.find_by(id: @message.id)`) e mapeia os anexos de mídia (`image/audio/video/file` via `Attachment#with_attached_file?` + `file.attached?`) para `{ url: download_url, content_type:, file_type: }`. `download_url` é a URL proxy no `BACKEND_URL`, alcançável pelo serviço Go. `rescue` → `[]` (mídia nunca bloqueia a delegação de texto).

### Testes (`spec/services/bot_runtime/delegation_service_spec.rb`, novo)
recarrega + mapeia mídia · múltiplos (imagem+áudio) · mensagem não encontrada → `[]` · `file` não-attached → pulado · não-mídia (location) → pulado · nunca levanta (loga + `[]`). **6 examples, 0 failures** (rodado no container CRM). CI do CRM não roda suíte cheia nos PRs.

### Ponta-a-ponta
+ **EVO-2180** (bot_runtime encaminha como A2A file part, PR #5) + **EVO-2181** (processor deixa a imagem chegar ao modelo, PR #44).

## Summary by Sourcery

Forward media attachments from CRM messages to the bot runtime by enriching delegation events with attachment metadata and ensuring robust handling when attachments cannot be loaded.

New Features:
- Include attachments metadata in delegated message events so the bot_runtime can receive and process incoming media (images, audio, etc.).

Enhancements:
- Add a resilient attachment-building routine that reloads the persisted message, filters valid media attachments, and logs errors while falling back to an empty attachment list.

Tests:
- Add unit tests for BotRuntime::DelegationService#build_attachments covering media mapping, multiple attachments, missing messages, skipped non-media or unattached files, and error handling.