### PR TITLE
feat(EVO-2187): CI guard so a new FK can't silently break contact deletion

### DIFF
--- a/.github/fk-deletion-allowlist.txt
+++ b/.github/fk-deletion-allowlist.txt
@@ -1,0 +1,17 @@
+# EVO-2187 — reviewed child tables that have a FK to conversations/contacts/messages
+# WITHOUT ON DELETE CASCADE, and are confirmed to NOT break contact/conversation
+# deletion (either cleaned up in Api::V1::ContactsController#cleanup_contact_dependent_records
+# or removed by a dependent: :destroy association).
+#
+# One table name per line. The cascade-deletion guard fails the PR when a NEW
+# non-cascade FK to those parents appears that is NOT listed here — forcing a
+# conscious decision (add on_delete: :cascade / dependent: :destroy, or add it here
+# AFTER making cleanup cover it). This is the systemic guard behind EVO-2186
+# (macro_executions was the 422 that slipped through).
+#
+# Blank lines and lines starting with # are ignored.
+
+facebook_comment_moderations   # cleanup: conversation.facebook_comment_moderations.destroy_all
+macro_executions               # cleanup: MacroExecution.where(conversation_id:).destroy_all (EVO-2186)
+pipeline_items                 # cleanup: destroy_all per conversation + where(contact_id:)
+contact_companies              # Contact has_many :contact_companies, dependent: :destroy

--- a/.github/fk-deletion-allowlist.txt
+++ b/.github/fk-deletion-allowlist.txt
@@ -1,17 +1,28 @@
-# EVO-2187 — reviewed child tables that have a FK to conversations/contacts/messages
-# WITHOUT ON DELETE CASCADE, and are confirmed to NOT break contact/conversation
-# deletion (either cleaned up in Api::V1::ContactsController#cleanup_contact_dependent_records
-# or removed by a dependent: :destroy association).
+# EVO-2187 — reviewed (child_table, parent_table) foreign keys into the
+# contact/conversation/inbox delete chain that have NO ON DELETE CASCADE, and are
+# confirmed to not break the delete because something removes the child first.
 #
-# One table name per line. The cascade-deletion guard fails the PR when a NEW
-# non-cascade FK to those parents appears that is NOT listed here — forcing a
-# conscious decision (add on_delete: :cascade / dependent: :destroy, or add it here
-# AFTER making cleanup cover it). This is the systemic guard behind EVO-2186
-# (macro_executions was the 422 that slipped through).
+# DECISION (card AC #1): both. Prefer on_delete: :cascade or a synchronous
+# dependent: :destroy on new tables — the allowlist is the fallback for FKs already
+# handled by a hand-written cleanup, not the default answer.
 #
-# Blank lines and lines starting with # are ignored.
+# Format: "<child_table> <parent_table>   # how it is handled". The pair matters:
+# allowlisting pipeline_items for its FK to contacts must NOT silently cover a future
+# pipeline_items -> messages FK. Blank lines and lines starting with # are ignored.
+#
+# The guard fails the PR when a non-cascade FK into the chain is missing here, AND
+# when an entry here has no matching cleanup code — a stale line cannot vouch for a
+# destroy_all somebody deleted. Beware dependent: :destroy_async: it enqueues a job
+# instead of deleting in the same transaction, so it does NOT satisfy the FK.
+#
+# This is the systemic guard behind EVO-2186 (macro_executions was the 422 that
+# slipped through, in both the contact and the conversation delete paths).
 
-facebook_comment_moderations   # cleanup: conversation.facebook_comment_moderations.destroy_all
-macro_executions               # cleanup: MacroExecution.where(conversation_id:).destroy_all (EVO-2186)
-pipeline_items                 # cleanup: destroy_all per conversation + where(contact_id:)
-contact_companies              # Contact has_many :contact_companies, dependent: :destroy
+facebook_comment_moderations conversations   # cleanup: conversation.facebook_comment_moderations.destroy_all (both paths)
+facebook_comment_moderations messages        # same rows, removed with the conversation before its messages go
+macro_executions conversations               # cleanup: MacroExecution.where(conversation_id:).destroy_all (EVO-2186, both paths)
+pipeline_items conversations                 # cleanup: conversation.pipeline_items.destroy_all (both paths)
+pipeline_items contacts                      # cleanup: PipelineItem.where(contact_id:).destroy_all
+contact_companies contacts                   # Contact has_many :contact_companies, dependent: :destroy
+pipeline_tasks pipeline_items                # PipelineItem has_many :tasks, class_name: 'PipelineTask', dependent: :destroy
+stage_movements pipeline_items               # PipelineItem has_many :stage_movements, dependent: :destroy

--- a/.github/scripts/check-cascade-deletion-coverage.sh
+++ b/.github/scripts/check-cascade-deletion-coverage.sh
@@ -2,43 +2,214 @@
 #
 # EVO-2187 — cascade-deletion coverage guard.
 #
-# Deleting a contact/conversation destroys the conversation, which fails with a
-# PG::ForeignKeyViolation -> HTTP 422 (OPERATION_NOT_ALLOWED) whenever a table has a
-# FK to conversations/contacts/messages that is neither ON DELETE CASCADE nor cleaned
-# up before the destroy. macro_executions was exactly this (EVO-2186).
+# Deleting a contact (Api::V1::ContactsController#cleanup_contact_dependent_records)
+# or a conversation/inbox (DeleteObjectJob#cleanup_conversation_dependencies!) destroys
+# a chain of rows. A table with a FK into that chain that is neither ON DELETE CASCADE
+# nor removed before the parent goes away raises PG::ForeignKeyViolation — 422 on the
+# contact path, 500 on the job path. macro_executions was exactly this (EVO-2186).
 #
-# This guard fails the build when a NEW non-cascade FK to those parents appears that
-# is not in the reviewed allowlist, forcing a conscious decision. Rails-free.
+# Both cleanups are hand-maintained lists, so the next such FK reintroduces the bug
+# silently. This guard fails the build when a non-cascade FK into the chain is not in
+# the reviewed allowlist, forcing a conscious decision. Rails-free.
 #
-# Usage: check-cascade-deletion-coverage.sh [schema.rb] [allowlist.txt]
+# It scans BOTH db/schema.rb and db/migrate/: this repo sets
+# dump_schema_after_migration = false, so a PR can add a FK-bearing migration without
+# regenerating the dump (that is how macro_executions landed in PR #84 — the FK only
+# reached db/schema.rb five days later, in an unrelated commit).
+#
+# Usage: check-cascade-deletion-coverage.sh [schema.rb] [allowlist.txt] [db/migrate|-] [evidence_root|-]
+#   Pass "-" for the migrate dir / evidence root to skip that scan (used by the self-tests).
 set -uo pipefail
 
 SCHEMA="${1:-db/schema.rb}"
 ALLOWLIST="${2:-.github/fk-deletion-allowlist.txt}"
-PARENTS='conversations|contacts|messages'
+MIGRATE_DIR="${3:-db/migrate}"
+EVIDENCE_ROOT="${4:-.}"
 
-# Allowlisted child tables = first token of each non-comment, non-blank line.
-allow=""
-if [ -f "$ALLOWLIST" ]; then
-  allow="$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | awk '{print $1}')"
-fi
-in_allow() { printf '%s\n' "$allow" | grep -qxF "$1"; }
+# Tables destroyed while deleting a contact/conversation/inbox. A non-cascade FK into
+# any of them breaks the delete unless something removes the child first.
+PARENTS="conversations contacts messages pipeline_items contact_inboxes notes \
+csat_survey_responses mentions conversation_participants reporting_events"
+
+# Files that are allowed to be the "something removes the child first".
+EVIDENCE_CLEANUPS="app/controllers/api/v1/contacts_controller.rb app/jobs/delete_object_job.rb"
+EVIDENCE_MODELS="app/models"
 
 fail=0
-found_any=0
-while IFS= read -r line; do
-  found_any=1
-  # Cascade FKs are handled by the DB — nothing to clean up.
-  printf '%s' "$line" | grep -q 'on_delete: :cascade' && continue
-  child="$(printf '%s' "$line" | sed -E 's/.*add_foreign_key "([^"]+)", "[^"]+".*/\1/')"
-  if ! in_allow "$child"; then
-    echo "::error::FK '${child}' -> conversations/contacts/messages has no ON DELETE CASCADE and is not in ${ALLOWLIST}. Deleting a contact/conversation will 422 (OPERATION_NOT_ALLOWED) unless handled. Fix: add on_delete: :cascade or dependent: :destroy, OR add '${child}' to the allowlist AFTER making cleanup_contact_dependent_records remove it (EVO-2187)."
-    fail=1
-  fi
-done < <(grep -E "add_foreign_key \"[^\"]+\", \"(${PARENTS})\"" "$SCHEMA" 2>/dev/null)
+err() { echo "::error::$*"; fail=1; }
 
-if [ "$found_any" -eq 0 ]; then
-  echo "::warning::no add_foreign_key to conversations/contacts/messages found in ${SCHEMA} — check the path."
+is_parent() {
+  case " $PARENTS " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+# "conversation" -> "conversations". Only used to test membership in PARENTS, so the
+# naive rule is safe: a name it pluralizes wrong simply is not a parent.
+pluralize() { case "$1" in *s) printf '%s' "$1" ;; *) printf '%ss' "$1" ;; esac; }
+
+# ---------------------------------------------------------------------------
+# 1. Collect (child, parent, cascade) triples from db/schema.rb.
+# ---------------------------------------------------------------------------
+if [ ! -f "$SCHEMA" ]; then
+  echo "::error::schema file '${SCHEMA}' not found — the guard cannot verify anything. Fix the path (EVO-2187)."
+  exit 1
 fi
-[ "$fail" -eq 0 ] && echo "OK: every FK to conversations/contacts/messages is cascade or allowlisted (EVO-2187)."
+
+pairs=""
+schema_fk_lines=0
+while IFS= read -r line; do
+  schema_fk_lines=$((schema_fk_lines + 1))
+  child="$(printf '%s' "$line" | sed -E 's/.*add_foreign_key "([^"]+)", "([^"]+)".*/\1/')"
+  parent="$(printf '%s' "$line" | sed -E 's/.*add_foreign_key "([^"]+)", "([^"]+)".*/\2/')"
+  cascade=no
+  printf '%s' "$line" | grep -q 'on_delete: :cascade' && cascade=yes
+  pairs="${pairs}${child} ${parent} ${cascade} ${SCHEMA}
+"
+done < <(grep -E '^[[:space:]]*add_foreign_key "[^"]+", "[^"]+"' "$SCHEMA")
+
+# A dump with no foreign keys at all means the format changed (structure.sql), the
+# path is wrong, or the file is truncated. Passing green there is how a guard rots.
+if [ "$schema_fk_lines" -eq 0 ]; then
+  echo "::error::no add_foreign_key found in '${SCHEMA}'. Either the path is wrong or the schema format changed — the guard would pass vacuously, so it fails instead (EVO-2187)."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Collect the same triples from db/migrate/. Most migrations here declare FKs as
+#    `t.references :conversation, foreign_key: true`, which never appears as
+#    add_foreign_key, so scanning only the dump misses them.
+# ---------------------------------------------------------------------------
+if [ "$MIGRATE_DIR" != "-" ] && [ -d "$MIGRATE_DIR" ]; then
+  # Tables a later migration dropped or renamed away. Their historical FKs are dead
+  # weight — without this, `add_contact_to_pipeline_conversations` reports a table
+  # that `rename_table :pipeline_conversations, :pipeline_items` removed in 2025.
+  dead="$(grep -rhoE '(drop_table|rename_table)[( ]+[:"][a-z0-9_]+' "$MIGRATE_DIR"/*.rb 2>/dev/null \
+          | sed -E 's/.*[:"]//' | sort -u)"
+  is_dead() { printf '%s\n' "$dead" | grep -qxF "$1"; }
+
+  mig_pairs="$(awk '
+    function emit(child, ref, cascade) {
+      gsub(/[^a-z0-9_]/, "", ref); if (ref == "" || child == "") return
+      print child " " ref " " cascade " " FILENAME
+    }
+    # create_table :foo / create_table "foo" opens a block; t.references inside it
+    # belongs to that table.
+    /create_table[( ]+[:"][a-z0-9_]+/ {
+      t = $0; sub(/.*create_table[( ]+[:"]/, "", t); sub(/[^a-z0-9_].*/, "", t); cur = t
+    }
+    /^[[:space:]]*end[[:space:]]*$/ { cur = "" }
+    # t.references :conversation, foreign_key: true  (also t.belongs_to)
+    /[[:space:]]t\.(references|belongs_to)[[:space:]]+:[a-z0-9_]+/ {
+      if (cur == "" || $0 !~ /foreign_key/) next
+      r = $0; sub(/.*t\.(references|belongs_to)[[:space:]]+:/, "", r); sub(/[^a-z0-9_].*/, "", r)
+      if ($0 ~ /to_table:[[:space:]]*[:"]/) { r = $0; sub(/.*to_table:[[:space:]]*[:"]/, "", r); sub(/[^a-z0-9_].*/, "", r) }
+      emit(cur, r, ($0 ~ /on_delete:[[:space:]]*:cascade/) ? "yes" : "no")
+    }
+    # add_reference :sla_reports, :conversation, foreign_key: true
+    /add_reference[( ]+[:"][a-z0-9_]+/ {
+      if ($0 !~ /foreign_key/) next
+      c = $0; sub(/.*add_reference[( ]+[:"]/, "", c); sub(/[^a-z0-9_].*/, "", c)
+      r = $0; sub(/.*add_reference[( ]+[:"][a-z0-9_]+[^:"]*[:"]/, "", r); sub(/[^a-z0-9_].*/, "", r)
+      if ($0 ~ /to_table:[[:space:]]*[:"]/) { r = $0; sub(/.*to_table:[[:space:]]*[:"]/, "", r); sub(/[^a-z0-9_].*/, "", r) }
+      emit(c, r, ($0 ~ /on_delete:[[:space:]]*:cascade/) ? "yes" : "no")
+    }
+    # add_foreign_key :sla_reports, :conversations (symbol form, absent from the dump)
+    /add_foreign_key[( ]+[:"][a-z0-9_]+/ {
+      c = $0; sub(/.*add_foreign_key[( ]+[:"]/, "", c); sub(/[^a-z0-9_].*/, "", c)
+      r = $0; sub(/.*add_foreign_key[( ]+[:"][a-z0-9_]+[^:"]*[:"]/, "", r); sub(/[^a-z0-9_].*/, "", r)
+      emit(c, r, ($0 ~ /on_delete:[[:space:]]*:cascade/) ? "yes" : "no")
+    }
+  ' "$MIGRATE_DIR"/*.rb 2>/dev/null)"
+
+  while IFS=' ' read -r child ref cascade src; do
+    [ -z "${child:-}" ] && continue
+    is_dead "$child" && continue
+    pairs="${pairs}${child} $(pluralize "$ref") ${cascade} ${src}
+"
+  done <<< "$mig_pairs"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Load the reviewed allowlist: "<child_table> <parent_table>" per line.
+#    Keyed on the PAIR, not the child alone — allowlisting pipeline_items for its FK
+#    to contacts must not silently cover a future pipeline_items -> messages FK.
+# ---------------------------------------------------------------------------
+allow=""
+if [ -f "$ALLOWLIST" ]; then
+  allow="$(sed 's/\r$//' "$ALLOWLIST" | grep -vE '^[[:space:]]*(#|$)' | awk 'NF>=2 { print $1 " " $2 }')"
+  bad_fmt="$(sed 's/\r$//' "$ALLOWLIST" | grep -vE '^[[:space:]]*(#|$)' | awk 'NF<2 { print $1 }')"
+  if [ -n "$bad_fmt" ]; then
+    err "allowlist '${ALLOWLIST}' has entries without a parent table: $(printf '%s' "$bad_fmt" | tr '\n' ' '). Format is '<child_table> <parent_table>   # how it is handled' (EVO-2187)."
+  fi
+fi
+in_allow() { printf '%s\n' "$allow" | grep -qxF "$1 $2"; }
+
+# ---------------------------------------------------------------------------
+# 4. Evidence: an allowlist entry must correspond to real cleanup code. The EVO-2186
+#    failure mode was a MISSING destroy_all, and a plain text file cannot notice that
+#    someone deleted the line.
+#
+#    Accepted evidence for table `foo_bars`:
+#      - `foo_bars` or `FooBars?` on a non-comment line of a cleanup method, or
+#      - a `dependent: :destroy` association in app/models mentioning it.
+#    `dependent: :destroy_async` is explicitly NOT evidence: it enqueues a job instead
+#    of deleting in the same transaction, so the FK still blocks the parent destroy.
+#    That distinction matters here — this codebase uses :destroy_async far more than
+#    :destroy, so "I added a dependent:" is not by itself a fix.
+# ---------------------------------------------------------------------------
+camelize() { printf '%s' "$1" | awk -F_ '{ s=""; for (i=1;i<=NF;i++) s = s toupper(substr($i,1,1)) substr($i,2); print s }'; }
+singularize() { case "$1" in *s) printf '%s' "${1%s}" ;; *) printf '%s' "$1" ;; esac; }
+
+evidence_enabled=yes
+if [ "$EVIDENCE_ROOT" = "-" ]; then
+  evidence_enabled=no
+else
+  for f in $EVIDENCE_CLEANUPS; do
+    if [ ! -f "${EVIDENCE_ROOT}/${f}" ]; then
+      echo "::error::cleanup source '${EVIDENCE_ROOT}/${f}' not found — the allowlist cannot be verified. Update EVIDENCE_CLEANUPS in this script if the method moved (EVO-2187)."
+      exit 1
+    fi
+  done
+fi
+
+has_cleanup_evidence() {
+  local table="$1" re f
+  # `macro_executions` matches the table name or the class (MacroExecution) the
+  # cleanup calls. Singularize before camelizing, then let the plural be optional.
+  re="(${table}|$(camelize "$(singularize "$table")")s?)([^A-Za-z0-9_]|$)"
+  # Cleanup methods: any non-comment mention counts (destroy_all, delete_all, ...).
+  for f in $EVIDENCE_CLEANUPS; do
+    grep -vE '^[[:space:]]*#' "${EVIDENCE_ROOT}/${f}" | grep -qE "$re" && return 0
+  done
+  # Associations: synchronous dependent: :destroy only — never :destroy_async.
+  grep -rhE "dependent:[[:space:]]*:destroy([^_]|$)" "${EVIDENCE_ROOT}/${EVIDENCE_MODELS}" 2>/dev/null \
+    | grep -qE "$re" && return 0
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# 5. Verdict.
+# ---------------------------------------------------------------------------
+checked=0
+seen=""
+while IFS=' ' read -r child parent cascade src; do
+  [ -z "${child:-}" ] && continue
+  is_parent "$parent" || continue
+  [ "$cascade" = "yes" ] && continue          # the DB handles it
+  case " $seen " in *" ${child}>${parent} "*) continue ;; esac
+  seen="${seen}${child}>${parent} "
+  checked=$((checked + 1))
+
+  if ! in_allow "$child" "$parent"; then
+    err "FK '${child}' -> '${parent}' (${src}) has no ON DELETE CASCADE and is not in ${ALLOWLIST}. Deleting a contact/conversation/inbox will fail with PG::ForeignKeyViolation (422 on the contact path, 500 on the job path) unless something removes '${child}' first. Fix: add on_delete: :cascade, OR a synchronous 'dependent: :destroy' association (NOT :destroy_async — it enqueues a job and does not delete in the same transaction), OR add '${child} ${parent}' to the allowlist AFTER covering it in cleanup_contact_dependent_records AND DeleteObjectJob#cleanup_conversation_dependencies! (EVO-2187)."
+    continue
+  fi
+
+  if [ "$evidence_enabled" = yes ] && ! has_cleanup_evidence "$child"; then
+    err "'${child}' is allowlisted for '${parent}' but no cleanup covers it: it is not referenced in ${EVIDENCE_CLEANUPS// /, } and has no synchronous 'dependent: :destroy' in ${EVIDENCE_MODELS}/. Either the cleanup line was removed, or it is only handled by :destroy_async, which does NOT prevent the FK violation. Restore the cleanup or drop the allowlist entry (EVO-2187)."
+  fi
+done <<< "$pairs"
+
+if [ "$fail" -eq 0 ]; then
+  echo "OK: ${checked} non-cascade FK(s) into the contact/conversation delete chain, all allowlisted with real cleanup coverage (EVO-2187)."
+fi
 exit "$fail"

--- a/.github/scripts/check-cascade-deletion-coverage.sh
+++ b/.github/scripts/check-cascade-deletion-coverage.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# EVO-2187 — cascade-deletion coverage guard.
+#
+# Deleting a contact/conversation destroys the conversation, which fails with a
+# PG::ForeignKeyViolation -> HTTP 422 (OPERATION_NOT_ALLOWED) whenever a table has a
+# FK to conversations/contacts/messages that is neither ON DELETE CASCADE nor cleaned
+# up before the destroy. macro_executions was exactly this (EVO-2186).
+#
+# This guard fails the build when a NEW non-cascade FK to those parents appears that
+# is not in the reviewed allowlist, forcing a conscious decision. Rails-free.
+#
+# Usage: check-cascade-deletion-coverage.sh [schema.rb] [allowlist.txt]
+set -uo pipefail
+
+SCHEMA="${1:-db/schema.rb}"
+ALLOWLIST="${2:-.github/fk-deletion-allowlist.txt}"
+PARENTS='conversations|contacts|messages'
+
+# Allowlisted child tables = first token of each non-comment, non-blank line.
+allow=""
+if [ -f "$ALLOWLIST" ]; then
+  allow="$(grep -vE '^[[:space:]]*(#|$)' "$ALLOWLIST" | awk '{print $1}')"
+fi
+in_allow() { printf '%s\n' "$allow" | grep -qxF "$1"; }
+
+fail=0
+found_any=0
+while IFS= read -r line; do
+  found_any=1
+  # Cascade FKs are handled by the DB — nothing to clean up.
+  printf '%s' "$line" | grep -q 'on_delete: :cascade' && continue
+  child="$(printf '%s' "$line" | sed -E 's/.*add_foreign_key "([^"]+)", "[^"]+".*/\1/')"
+  if ! in_allow "$child"; then
+    echo "::error::FK '${child}' -> conversations/contacts/messages has no ON DELETE CASCADE and is not in ${ALLOWLIST}. Deleting a contact/conversation will 422 (OPERATION_NOT_ALLOWED) unless handled. Fix: add on_delete: :cascade or dependent: :destroy, OR add '${child}' to the allowlist AFTER making cleanup_contact_dependent_records remove it (EVO-2187)."
+    fail=1
+  fi
+done < <(grep -E "add_foreign_key \"[^\"]+\", \"(${PARENTS})\"" "$SCHEMA" 2>/dev/null)
+
+if [ "$found_any" -eq 0 ]; then
+  echo "::warning::no add_foreign_key to conversations/contacts/messages found in ${SCHEMA} — check the path."
+fi
+[ "$fail" -eq 0 ] && echo "OK: every FK to conversations/contacts/messages is cascade or allowlisted (EVO-2187)."
+exit "$fail"

--- a/.github/workflows/cascade-deletion-guard.yml
+++ b/.github/workflows/cascade-deletion-guard.yml
@@ -1,20 +1,22 @@
 name: Cascade deletion guard
 
-# EVO-2187: fail the PR when a new table gets a FK to conversations/contacts/messages
-# without ON DELETE CASCADE and without being handled in the contact-deletion cleanup
+# EVO-2187: fail the PR when a new table gets a FK into the contact/conversation/inbox
+# delete chain without ON DELETE CASCADE and without being handled by a cleanup
 # (tracked in .github/fk-deletion-allowlist.txt). This is the systemic guard behind
-# EVO-2186 (macro_executions was the FK that slipped through and caused a 422 on
-# contact deletion). The full RSpec suite does not run on PRs here, so this Rails-free
-# guard is the CI gate.
+# EVO-2186 (macro_executions was the FK that slipped through, breaking both the
+# contact-delete path with a 422 and the DeleteObjectJob path with a 500). The full
+# RSpec suite does not run on PRs here, so this Rails-free guard is the CI gate.
+#
+# Deliberately UNCONDITIONAL — no `paths:` filter, like every other guard in this repo.
+# This repo sets dump_schema_after_migration = false, so a PR can add a FK-bearing
+# migration WITHOUT touching db/schema.rb: that is exactly how macro_executions landed
+# in PR #84, whose FK only reached the dump five days later in an unrelated commit. A
+# path filter would have skipped the guard on the one PR it existed to catch, and a
+# skipped required check reports green.
 
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - 'db/schema.rb'
-      - '.github/fk-deletion-allowlist.txt'
-      - '.github/scripts/check-cascade-deletion-coverage.sh'
-      - '.github/workflows/cascade-deletion-guard.yml'
   push:
     branches: [main, develop]
 
@@ -27,32 +29,92 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: FK to conversations/contacts/messages must be cascade or allowlisted (EVO-2187)
+      - name: Self-test the guard (fixtures)
         run: |
           set -uo pipefail
-          guard=.github/scripts/check-cascade-deletion-coverage.sh
-          chmod +x "$guard"
-
+          g=.github/scripts/check-cascade-deletion-coverage.sh
           tmp="$(mktemp -d)"
-
-          # self-test 1: a new non-cascade FK, empty allowlist -> must FAIL.
-          printf 'add_foreign_key "new_table", "conversations"\n' > "$tmp/bad_schema.rb"
+          mkdir -p "$tmp/mig" "$tmp/app/controllers/api/v1" "$tmp/app/jobs" "$tmp/app/models"
           : > "$tmp/empty_allow.txt"
-          if bash "$guard" "$tmp/bad_schema.rb" "$tmp/empty_allow.txt" >/dev/null 2>&1; then
-            echo "::error::self-test FAILED — did not reject an unhandled non-cascade FK"; exit 1
-          fi
 
-          # self-test 2: same FK but ON DELETE CASCADE -> must PASS.
+          expect_fail() { local what="$1"; shift
+            if bash "$g" "$@" >/dev/null 2>&1; then
+              echo "::error::self-test FAILED — $what should have been rejected"; exit 1
+            fi; }
+          expect_pass() { local what="$1"; shift
+            bash "$g" "$@" >/dev/null 2>&1 \
+              || { echo "::error::self-test FAILED — $what should have been accepted"; exit 1; }; }
+
+          # A schema whose only FK is irrelevant, so fixtures below are not accidentally
+          # rejected by the "dump has no foreign keys at all" check.
+          printf 'add_foreign_key "widgets", "users"\n' > "$tmp/inert_schema.rb"
+
+          # 1. new non-cascade FK, empty allowlist -> reject.
+          printf 'add_foreign_key "new_table", "conversations"\n' > "$tmp/bad_schema.rb"
+          expect_fail "an unhandled non-cascade FK" "$tmp/bad_schema.rb" "$tmp/empty_allow.txt" - -
+
+          # 2. same FK with ON DELETE CASCADE -> accept.
           printf 'add_foreign_key "new_table", "conversations", on_delete: :cascade\n' > "$tmp/cascade_schema.rb"
-          bash "$guard" "$tmp/cascade_schema.rb" "$tmp/empty_allow.txt" >/dev/null 2>&1 \
-            || { echo "::error::self-test FAILED — rejected a cascade FK"; exit 1; }
+          expect_pass "a cascade FK" "$tmp/cascade_schema.rb" "$tmp/empty_allow.txt" - -
 
-          # self-test 3: non-cascade FK but allowlisted -> must PASS.
-          printf 'new_table   # handled in cleanup\n' > "$tmp/allow.txt"
-          bash "$guard" "$tmp/bad_schema.rb" "$tmp/allow.txt" >/dev/null 2>&1 \
-            || { echo "::error::self-test FAILED — rejected an allowlisted FK"; exit 1; }
+          # 3. non-cascade FK, allowlisted as a (child, parent) pair -> accept.
+          printf 'new_table conversations   # handled in cleanup\n' > "$tmp/allow.txt"
+          expect_pass "an allowlisted FK" "$tmp/bad_schema.rb" "$tmp/allow.txt" - -
 
-          echo "self-test OK"
+          # 4. a missing / FK-less dump must FAIL, never pass vacuously. Same reasoning
+          #    as the role-STI guard: a check that green-lights an unreadable input rots.
+          : > "$tmp/empty_schema.rb"
+          expect_fail "a nonexistent schema path" "$tmp/nope.rb" "$tmp/allow.txt" - -
+          expect_fail "a schema with no foreign keys" "$tmp/empty_schema.rb" "$tmp/allow.txt" - -
 
-          # real check against the committed schema + allowlist.
-          bash "$guard" db/schema.rb .github/fk-deletion-allowlist.txt
+          # 5. FK declared ONLY in a migration, as t.references — the dominant idiom here
+          #    and the form macro_executions used. Scanning just the dump misses it.
+          cat > "$tmp/mig/20260101000000_create_sla_reports.rb" <<'RUBY'
+          class CreateSlaReports < ActiveRecord::Migration[7.1]
+            def change
+              create_table :sla_reports, id: :uuid do |t|
+                t.references :conversation, type: :uuid, null: false, foreign_key: true
+                t.timestamps
+              end
+            end
+          end
+          RUBY
+          expect_fail "a FK added by a migration without a schema dump" \
+            "$tmp/inert_schema.rb" "$tmp/allow.txt" "$tmp/mig" -
+
+          # 6. the allowlist is keyed on the PAIR: clearing pipeline_items for contacts
+          #    must not silently clear a brand-new pipeline_items -> messages FK.
+          printf 'add_foreign_key "pipeline_items", "messages"\n' > "$tmp/pair_schema.rb"
+          printf 'pipeline_items contacts   # cleared for a different parent\n' > "$tmp/pair_allow.txt"
+          expect_fail "a FK to a parent the child was not cleared for" \
+            "$tmp/pair_schema.rb" "$tmp/pair_allow.txt" - -
+
+          # 7. an allowlist entry must be backed by real cleanup code. A stale line cannot
+          #    vouch for a destroy_all someone deleted — that was the EVO-2186 failure mode.
+          printf 'add_foreign_key "ghost_tables", "conversations"\n' > "$tmp/ghost_schema.rb"
+          printf 'ghost_tables conversations   # claims to be handled\n' > "$tmp/ghost_allow.txt"
+          printf 'class ContactsController; end\n' > "$tmp/app/controllers/api/v1/contacts_controller.rb"
+          printf 'class DeleteObjectJob; end\n' > "$tmp/app/jobs/delete_object_job.rb"
+          expect_fail "an allowlist entry with no cleanup behind it" \
+            "$tmp/ghost_schema.rb" "$tmp/ghost_allow.txt" - "$tmp"
+
+          # 8. dependent: :destroy_async is NOT a fix — it enqueues a job instead of
+          #    deleting in the same transaction, so the FK still blocks the parent.
+          #    This repo uses :destroy_async more than :destroy, so the trap is live.
+          printf 'has_many :ghost_tables, dependent: :destroy_async\n' > "$tmp/app/models/conversation.rb"
+          expect_fail "cleanup claimed via dependent: :destroy_async" \
+            "$tmp/ghost_schema.rb" "$tmp/ghost_allow.txt" - "$tmp"
+
+          # 9. ...while the synchronous form IS accepted.
+          printf 'has_many :ghost_tables, dependent: :destroy\n' > "$tmp/app/models/conversation.rb"
+          expect_pass "cleanup via a synchronous dependent: :destroy" \
+            "$tmp/ghost_schema.rb" "$tmp/ghost_allow.txt" - "$tmp"
+
+          # 10. a commented-out FK is not a FK.
+          printf 'add_foreign_key "widgets", "users"\n# add_foreign_key "new_table", "conversations"\n' > "$tmp/comment_schema.rb"
+          expect_pass "a commented-out FK line" "$tmp/comment_schema.rb" "$tmp/empty_allow.txt" - -
+
+          echo "self-test OK (10 cases)"
+
+      - name: FK into the contact/conversation delete chain must be cascade or allowlisted (EVO-2187)
+        run: bash .github/scripts/check-cascade-deletion-coverage.sh

--- a/.github/workflows/cascade-deletion-guard.yml
+++ b/.github/workflows/cascade-deletion-guard.yml
@@ -1,0 +1,58 @@
+name: Cascade deletion guard
+
+# EVO-2187: fail the PR when a new table gets a FK to conversations/contacts/messages
+# without ON DELETE CASCADE and without being handled in the contact-deletion cleanup
+# (tracked in .github/fk-deletion-allowlist.txt). This is the systemic guard behind
+# EVO-2186 (macro_executions was the FK that slipped through and caused a 422 on
+# contact deletion). The full RSpec suite does not run on PRs here, so this Rails-free
+# guard is the CI gate.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'db/schema.rb'
+      - '.github/fk-deletion-allowlist.txt'
+      - '.github/scripts/check-cascade-deletion-coverage.sh'
+      - '.github/workflows/cascade-deletion-guard.yml'
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  cascade-deletion-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: FK to conversations/contacts/messages must be cascade or allowlisted (EVO-2187)
+        run: |
+          set -uo pipefail
+          guard=.github/scripts/check-cascade-deletion-coverage.sh
+          chmod +x "$guard"
+
+          tmp="$(mktemp -d)"
+
+          # self-test 1: a new non-cascade FK, empty allowlist -> must FAIL.
+          printf 'add_foreign_key "new_table", "conversations"\n' > "$tmp/bad_schema.rb"
+          : > "$tmp/empty_allow.txt"
+          if bash "$guard" "$tmp/bad_schema.rb" "$tmp/empty_allow.txt" >/dev/null 2>&1; then
+            echo "::error::self-test FAILED — did not reject an unhandled non-cascade FK"; exit 1
+          fi
+
+          # self-test 2: same FK but ON DELETE CASCADE -> must PASS.
+          printf 'add_foreign_key "new_table", "conversations", on_delete: :cascade\n' > "$tmp/cascade_schema.rb"
+          bash "$guard" "$tmp/cascade_schema.rb" "$tmp/empty_allow.txt" >/dev/null 2>&1 \
+            || { echo "::error::self-test FAILED — rejected a cascade FK"; exit 1; }
+
+          # self-test 3: non-cascade FK but allowlisted -> must PASS.
+          printf 'new_table   # handled in cleanup\n' > "$tmp/allow.txt"
+          bash "$guard" "$tmp/bad_schema.rb" "$tmp/allow.txt" >/dev/null 2>&1 \
+            || { echo "::error::self-test FAILED — rejected an allowlisted FK"; exit 1; }
+
+          echo "self-test OK"
+
+          # real check against the committed schema + allowlist.
+          bash "$guard" db/schema.rb .github/fk-deletion-allowlist.txt


### PR DESCRIPTION
## EVO-2187 — guard de CI: nova FK não pode quebrar silenciosamente o delete de contato

> Hardening / follow-up do **EVO-2186** (`macro_executions`). **Não há bug ativo hoje** — este PR é preventivo.

### Problema (estrutural)
Excluir contato/conversa retorna **422 `OPERATION_NOT_ALLOWED`** sempre que uma tabela tem FK para `conversations`/`contacts`/`messages` que **não** é `ON DELETE CASCADE` **nem** é limpa antes do `destroy!`. Foi exatamente o `macro_executions`. A limpeza (`cleanup_contact_dependent_records`) é uma **allowlist manual** → a próxima FK desse tipo reintroduz o 422 sem ninguém perceber.

### Auditoria (estado atual, pós-EVO-2186)
Todas as FKs para esses pais já estão cobertas: `facebook_comment_moderations`/`pipeline_items`/`macro_executions` (cleanup), `contact_companies` (`dependent: :destroy`), `scheduled_actions` (`on_delete: :cascade`). **Nenhum 422 ativo.**

### Solução (guard Rails-free, estilo dos outros)
Falha o PR quando uma **nova** FK não-cascade para esses pais aparece e **não** está na allowlist revisada — forçando uma decisão consciente.
- `.github/fk-deletion-allowlist.txt` — o conjunto revisado (com como cada um é tratado).
- `.github/scripts/check-cascade-deletion-coverage.sh` — a checagem (cascade é pulado; não-cascade tem que estar na allowlist).
- `.github/workflows/cascade-deletion-guard.yml` — roda com self-test (não tratado→falha; cascade→passa; allowlisted→passa) + o schema real.

### Verificação local
Schema real + allowlist → **passa**. FK nova não tratada (ex.: `sla_reports`) → **pega** com mensagem clara. Self-test verde. YAML válido.

cc @guilherme.gomes — de olho no padrão do guard (allowlist + self-test), no mesmo estilo dos guards de storage/role-STI/mailbox.

## Summary by Sourcery

Add a CI guard to ensure new foreign keys to conversations/contacts/messages do not silently break contact deletion by requiring cascade or explicit cleanup coverage.

Enhancements:
- Add a script and allowlist file to enforce that foreign keys to conversations/contacts/messages are either ON DELETE CASCADE or explicitly handled in contact-deletion cleanup.

CI:
- Introduce a GitHub Actions workflow that runs a cascade-deletion coverage check on schema changes and validates its behavior via self-tests.