### PR TITLE
fix(EVO-2188): proxy /api/v1/journeys* to evo-flow (was 404/405)

### DIFF
--- a/app/controllers/api/v1/evo_flow/journeys_controller.rb
+++ b/app/controllers/api/v1/evo_flow/journeys_controller.rb
@@ -3,8 +3,21 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
   # (before any request leaves the process), so rescue it at class level.
   rescue_from EvoFlow::ConfigurationError, with: :handle_evo_flow_misconfiguration
 
-  # flowData (nodes/edges/variables) can be large; bound what we forward.
+  # flowData (nodes/edges/variables) can be large; bound what we forward. The
+  # depth cap mirrors SegmentsController: a byte cap alone still lets a small
+  # payload amplify into deep recursion on the evo-flow side.
   MAX_BODY_BYTES = 300_000
+  MAX_BODY_DEPTH = 25
+
+  # `*path` is a raw glob: Rails unescapes it (%2F -> /, %2e -> .) before we see
+  # it, and EvoFlow::Client#join runs URI.join, which resolves `..` per RFC 3986.
+  # So an unchecked "j1/../../segments" would leave the /journeys prefix and
+  # reach ANY evo-flow endpoint carrying the service integration key — a caller
+  # holding only journeys.read could read segments/campaigns. Restrict the
+  # subpath to the shape evo-flow actually routes (UUIDs and ASCII slugs) and
+  # reject `..` outright; `%` is excluded so double-encoding cannot smuggle a
+  # traversal past us for evo-flow's own router to decode.
+  SAFE_SUBPATH = %r{\A[A-Za-z0-9\-._~/]+\z}
 
   # EVO-2188 hardening: like SegmentsController (EVO-1938), the proxied endpoints
   # must be gated by permission — otherwise any authenticated user (incl. the
@@ -12,13 +25,19 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
   # them. The journeys.* keys already exist in the RBAC catalog. Because this is a
   # single passthrough action, the gate lives in a before_action that maps the
   # HTTP method + subpath to the right permission (see #required_permission_key).
+  #
+  # The filter is named check_<action>_permission! on purpose: that is the shape
+  # require_permissions generates, and spec/rbac/mutating_actions_gate_guard_spec
+  # reflects over it to prove every routed mutating action is gated. A
+  # differently-named filter gates at runtime but reads as UNGATED to the guard.
   PERMISSION_KEYS = %w[
     journeys.read journeys.create journeys.update journeys.delete
     journeys.toggle_active journeys.duplicate journeys.manage_sessions
   ].freeze
   PERMISSION_KEYS.each { |key| EvoPermissionConcern.register_permission_key(key) }
 
-  before_action :authorize_journeys!
+  before_action :reject_unsafe_subpath!
+  before_action :check_proxy_permission!
 
   # Generic passthrough to evo-flow's /journeys/* API.
   #
@@ -32,22 +51,19 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     ef_path = build_path
     body = request_body
 
-    if body && body.to_json.bytesize > MAX_BODY_BYTES
-      return render json: { errors: { message: 'Journey payload is too large' } },
-                    status: :payload_too_large
-    end
+    return if body && !guard_body_payload(body)
 
-    result =
+    status, result =
       case request.request_method_symbol
-      when :get    then client.get(ef_path, request.query_parameters)
-      when :post   then client.post(ef_path, body || {})
-      when :put    then client.put(ef_path, body || {})
-      when :patch  then client.patch(ef_path, body || {})
-      when :delete then client.delete(ef_path)
+      when :get, :head then client.request(:get, ef_path, query: request.query_parameters)
+      when :post       then client.request(:post, ef_path, payload: body || {})
+      when :put        then client.request(:put, ef_path, payload: body || {})
+      when :patch      then client.request(:patch, ef_path, payload: body || {})
+      when :delete     then client.request(:delete, ef_path)
       else return head(:method_not_allowed)
       end
 
-    render json: result, status: success_status
+    relay(status, result)
   rescue EvoFlow::HTTPError => e
     handle_evo_flow_error(e)
   end
@@ -58,29 +74,53 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     @client ||= EvoFlow::Client.new
   end
 
+  # Relay evo-flow's own status instead of guessing it: it answers 201 on
+  # create AND on duplicate, and 204 (empty) on delete. Rendering everything as
+  # 200 broke the "verbatim response" contract this proxy exists to keep.
+  def relay(status, result)
+    return head(:no_content) if status == 204 || result.nil?
+
+    render json: result, status: status
+  end
+
+  def reject_unsafe_subpath!
+    sub = params[:path].to_s
+    return if sub.blank?
+    return if sub.match?(SAFE_SUBPATH) && sub.split('/').none? { |segment| segment == '..' }
+
+    render json: { errors: { message: 'Invalid journeys path' } }, status: :bad_request
+  end
+
   # Gate the request by the permission that matches the operation. Renders 403 and
   # halts when the user lacks it (check_permission! handles the render).
-  def authorize_journeys!
+  def check_proxy_permission!
     check_permission!(required_permission_key, :user)
   end
 
-  # Map HTTP method + subpath to a journeys.* permission. Best-effort but safe:
-  # reads require journeys.read; deletes require journeys.delete; special subpaths
-  # (toggle-active/duplicate/sessions) require their specific permission; a create
-  # (POST /journeys) requires journeys.create; every other write requires
-  # journeys.update. evo-flow still validates server-side.
+  # Map HTTP method + subpath to a journeys.* permission.
+  #
+  # The SUBPATH is matched FIRST, because the sub-resources are what the
+  # dedicated permissions exist for: evo-flow serves sessions under
+  # GET/DELETE /journeys/:id/sessions*, so keying off the verb first made
+  # journeys.manage_sessions unreachable (reads fell to journeys.read, and
+  # deleting a single session or bulk-deleting them fell to journeys.delete).
+  # Only once no sub-resource matches does the verb decide: GET/HEAD ->
+  # journeys.read, DELETE -> journeys.delete, POST /journeys (no subpath) ->
+  # journeys.create, every other write -> journeys.update. evo-flow still
+  # validates server-side.
   def required_permission_key
-    method = request.request_method_symbol
     sub = params[:path].to_s.downcase
 
-    return 'journeys.read' if method == :get
-    return 'journeys.delete' if method == :delete
-    return 'journeys.toggle_active' if sub.include?('toggle') || sub.include?('active')
-    return 'journeys.duplicate' if sub.include?('duplicate')
     return 'journeys.manage_sessions' if sub.include?('session')
-    return 'journeys.create' if method == :post && params[:path].blank?
+    return 'journeys.toggle_active' if sub.include?('toggle-active')
+    return 'journeys.duplicate' if sub.include?('duplicate')
 
-    'journeys.update'
+    case request.request_method_symbol
+    when :get, :head then 'journeys.read'
+    when :delete     then 'journeys.delete'
+    when :post       then sub.empty? ? 'journeys.create' : 'journeys.update'
+    else 'journeys.update'
+    end
   end
 
   # The catch-all wildcard captures everything after "journeys/" into
@@ -94,16 +134,37 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
   # verbatim. Intentionally NOT run through strong params: nested flowData with
   # empty arrays (nodes: []) gets mangled by `permit`. evo-flow validates it
   # server-side; it is never mass-assigned locally.
+  #
+  # Rails wraps a top-level JSON ARRAY body as { "_json" => [...] }; evo-flow's
+  # POST /journeys/:id/variables takes a bare array, so unwrap it or the proxy
+  # would hand it an object it cannot bind.
   def request_body
     return nil unless request.request_method_symbol.in?(%i[post put patch])
 
     rp = request.request_parameters
-    rp.respond_to?(:to_unsafe_h) ? rp.to_unsafe_h : rp
+    rp = rp.to_unsafe_h if rp.respond_to?(:to_unsafe_h)
+    rp.is_a?(Hash) && rp.keys == ['_json'] ? rp['_json'] : rp
   end
 
-  # Create (POST /journeys, no subpath) -> 201; everything else -> 200.
-  def success_status
-    request.post? && params[:path].blank? ? :created : :ok
+  # Renders 413 and returns false when the payload is over the size or nesting
+  # cap; true when it is safe to forward.
+  def guard_body_payload(body)
+    return true if body.to_json.bytesize <= MAX_BODY_BYTES && structure_depth(body) <= MAX_BODY_DEPTH
+
+    render json: { errors: { message: 'Journey payload is too large or too deeply nested' } },
+           status: :payload_too_large
+    false
+  end
+
+  def structure_depth(obj)
+    case obj
+    when Hash
+      obj.empty? ? 1 : 1 + obj.values.map { |v| structure_depth(v) }.max
+    when Array
+      obj.empty? ? 1 : 1 + obj.map { |v| structure_depth(v) }.max
+    else
+      0
+    end
   end
 
   # Pass evo-flow's body through unchanged under an `errors` key, preserving its

--- a/app/controllers/api/v1/evo_flow/journeys_controller.rb
+++ b/app/controllers/api/v1/evo_flow/journeys_controller.rb
@@ -1,0 +1,125 @@
+class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
+  # An unusable evo-flow config raises while the client is being constructed
+  # (before any request leaves the process), so rescue it at class level.
+  rescue_from EvoFlow::ConfigurationError, with: :handle_evo_flow_misconfiguration
+
+  # flowData (nodes/edges/variables) can be large; bound what we forward.
+  MAX_BODY_BYTES = 300_000
+
+  # EVO-2188 hardening: like SegmentsController (EVO-1938), the proxied endpoints
+  # must be gated by permission — otherwise any authenticated user (incl. the
+  # default agent) could manage journeys through the API even though the UI hides
+  # them. The journeys.* keys already exist in the RBAC catalog. Because this is a
+  # single passthrough action, the gate lives in a before_action that maps the
+  # HTTP method + subpath to the right permission (see #required_permission_key).
+  PERMISSION_KEYS = %w[
+    journeys.read journeys.create journeys.update journeys.delete
+    journeys.toggle_active journeys.duplicate journeys.manage_sessions
+  ].freeze
+  PERMISSION_KEYS.each { |key| EvoPermissionConcern.register_permission_key(key) }
+
+  before_action :authorize_journeys!
+
+  # Generic passthrough to evo-flow's /journeys/* API.
+  #
+  # The CRM ships a proxy for `segments` (Api::V1::EvoFlow::SegmentsController)
+  # but NOT for `journeys`, so the journey builder in the frontend calls
+  # /api/v1/journeys* and gets 404/405. The evo-flow backend already exposes the
+  # full /api/v1/journeys* surface — this controller forwards the request
+  # (method + subpath + query + body) to evo-flow and returns its response
+  # verbatim, mirroring how SegmentsController talks to evo-flow.
+  def proxy
+    ef_path = build_path
+    body = request_body
+
+    if body && body.to_json.bytesize > MAX_BODY_BYTES
+      return render json: { errors: { message: 'Journey payload is too large' } },
+                    status: :payload_too_large
+    end
+
+    result =
+      case request.request_method_symbol
+      when :get    then client.get(ef_path, request.query_parameters)
+      when :post   then client.post(ef_path, body || {})
+      when :put    then client.put(ef_path, body || {})
+      when :patch  then client.patch(ef_path, body || {})
+      when :delete then client.delete(ef_path)
+      else return head(:method_not_allowed)
+      end
+
+    render json: result, status: success_status
+  rescue EvoFlow::HTTPError => e
+    handle_evo_flow_error(e)
+  end
+
+  private
+
+  def client
+    @client ||= EvoFlow::Client.new
+  end
+
+  # Gate the request by the permission that matches the operation. Renders 403 and
+  # halts when the user lacks it (check_permission! handles the render).
+  def authorize_journeys!
+    check_permission!(required_permission_key, :user)
+  end
+
+  # Map HTTP method + subpath to a journeys.* permission. Best-effort but safe:
+  # reads require journeys.read; deletes require journeys.delete; special subpaths
+  # (toggle-active/duplicate/sessions) require their specific permission; a create
+  # (POST /journeys) requires journeys.create; every other write requires
+  # journeys.update. evo-flow still validates server-side.
+  def required_permission_key
+    method = request.request_method_symbol
+    sub = params[:path].to_s.downcase
+
+    return 'journeys.read' if method == :get
+    return 'journeys.delete' if method == :delete
+    return 'journeys.toggle_active' if sub.include?('toggle') || sub.include?('active')
+    return 'journeys.duplicate' if sub.include?('duplicate')
+    return 'journeys.manage_sessions' if sub.include?('session')
+    return 'journeys.create' if method == :post && params[:path].blank?
+
+    'journeys.update'
+  end
+
+  # The catch-all wildcard captures everything after "journeys/" into
+  # params[:path] (nil for the collection route /journeys).
+  def build_path
+    sub = params[:path].to_s.sub(%r{\A/+}, '')
+    sub.empty? ? '/journeys' : "/journeys/#{sub}"
+  end
+
+  # Raw JSON body (name, isActive, flowData, flowTriggers, ...), forwarded
+  # verbatim. Intentionally NOT run through strong params: nested flowData with
+  # empty arrays (nodes: []) gets mangled by `permit`. evo-flow validates it
+  # server-side; it is never mass-assigned locally.
+  def request_body
+    return nil unless request.request_method_symbol.in?(%i[post put patch])
+
+    rp = request.request_parameters
+    rp.respond_to?(:to_unsafe_h) ? rp.to_unsafe_h : rp
+  end
+
+  # Create (POST /journeys, no subpath) -> 201; everything else -> 200.
+  def success_status
+    request.post? && params[:path].blank? ? :created : :ok
+  end
+
+  # Pass evo-flow's body through unchanged under an `errors` key, preserving its
+  # HTTP status.
+  def handle_evo_flow_error(error)
+    body = error.response&.parsed_response || { message: error.message }
+    render json: { errors: body }, status: (error.code || :bad_gateway)
+  end
+
+  # 503, not 500: the integration was never configured on this deployment.
+  def handle_evo_flow_misconfiguration(error)
+    Rails.logger.error("evo-flow integration is not configured: #{error.message}")
+    error_response(
+      ApiErrorCodes::SERVICE_UNAVAILABLE,
+      'Journeys are unavailable: the evo-flow integration is not configured on this deployment',
+      status: :service_unavailable
+    )
+  end
+end

--- a/app/controllers/api/v1/evo_flow/journeys_controller.rb
+++ b/app/controllers/api/v1/evo_flow/journeys_controller.rb
@@ -1,29 +1,18 @@
 class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
-  # ParamsWrapper (JSON, enabled globally by its initializer) MERGES its wrapper
-  # into request.request_parameters — the hash this proxy forwards. Keep it off.
+  # ParamsWrapper MERGES its wrapper into request.request_parameters — the hash
+  # this proxy forwards.
   wrap_parameters false
 
-  # An unusable evo-flow config raises while the client is being constructed
-  # (before any request leaves the process), so rescue it at class level.
   rescue_from EvoFlow::ConfigurationError, with: :handle_evo_flow_misconfiguration
 
-  # flowData (nodes/edges/variables) can be large; bound what we forward. Depth
-  # cap mirrors SegmentsController — a byte cap alone still allows deep nesting.
   MAX_BODY_BYTES = 300_000
   MAX_BODY_DEPTH = 25
 
-  # Rails unescapes the `*path` glob (%2F -> /, %2e -> .) and EvoFlow::Client#join
-  # runs URI.join, which resolves `..`: an unfiltered subpath leaves /journeys and
-  # reaches any evo-flow endpoint under the service key. `%` is out too, so a
-  # double-encoded traversal cannot be smuggled through for evo-flow to decode.
+  # Rails unescapes the glob (%2F -> /, %2e -> .) and Client#join runs URI.join,
+  # which resolves `..`: an unfiltered subpath leaves /journeys and reaches any
+  # evo-flow endpoint under the service key.
   SAFE_SUBPATH = %r{\A[A-Za-z0-9\-._~/]+\z}
 
-  # EVO-2188 hardening: like SegmentsController (EVO-1938), the proxied endpoints
-  # must be gated by permission — otherwise any authenticated user (incl. the
-  # default agent) could manage journeys through the API even though the UI hides
-  # them. The journeys.* keys already exist in the RBAC catalog. Because this is a
-  # single passthrough action, the gate lives in a before_action that maps the
-  # HTTP method + subpath to the right permission (see #required_permission_key).
   PERMISSION_KEYS = %w[
     journeys.read journeys.create journeys.update journeys.delete
     journeys.toggle_active journeys.duplicate journeys.manage_sessions
@@ -33,14 +22,8 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
   before_action :reject_unsafe_subpath!
   before_action :check_proxy_permission!
 
-  # Generic passthrough to evo-flow's /journeys/* API.
-  #
-  # The CRM ships a proxy for `segments` (Api::V1::EvoFlow::SegmentsController)
-  # but NOT for `journeys`, so the journey builder in the frontend calls
-  # /api/v1/journeys* and gets 404/405. The evo-flow backend already exposes the
-  # full /api/v1/journeys* surface — this controller forwards the request
-  # (method + subpath + query + body) to evo-flow and returns its response
-  # verbatim, mirroring how SegmentsController talks to evo-flow.
+  # Forwards method + subpath + query + body to evo-flow's /journeys* surface and
+  # returns its response verbatim, like SegmentsController does for /segments.
   def proxy
     ef_path = build_path
     body = request_body
@@ -68,8 +51,7 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     @client ||= EvoFlow::Client.new
   end
 
-  # evo-flow's own status, not a guessed one: it answers 201 on create AND on
-  # duplicate, 204 (empty) on delete.
+  # evo-flow's own status, not a guessed one: 201 on create AND duplicate, 204 on delete.
   def relay(status, result)
     return head(:no_content) if status == 204 || result.nil?
 
@@ -84,21 +66,15 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     render json: { errors: { message: 'Invalid journeys path' } }, status: :bad_request
   end
 
-  # Gate the request by the permission that matches the operation. Renders 403 and
-  # halts when the user lacks it (check_permission! handles the render).
-  #
   # Name is load-bearing: spec/rbac/mutating_actions_gate_guard_spec reflects over
-  # check_<action>_permission! to prove the route is gated. Renaming it still
-  # gates at runtime, but reads as UNGATED to the guard.
+  # check_<action>_permission! to prove the route is gated.
   def check_proxy_permission!
     check_permission!(required_permission_key, :user)
   end
 
-  # Map subpath + HTTP method to a journeys.* permission. The SUBPATH decides
-  # first: evo-flow serves sessions under GET/DELETE /journeys/:id/sessions*, so
-  # keying off the verb made journeys.manage_sessions unreachable. Otherwise the
-  # verb decides, and POST without a subpath is the create. evo-flow still
-  # validates server-side.
+  # Subpath decides before the verb: evo-flow serves sessions under
+  # GET/DELETE /journeys/:id/sessions*, so keying off the verb made
+  # journeys.manage_sessions unreachable.
   def required_permission_key
     sub = params[:path].to_s.downcase
 
@@ -114,18 +90,14 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     end
   end
 
-  # The catch-all wildcard captures everything after "journeys/" into
-  # params[:path] (nil for the collection route /journeys).
   def build_path
     sub = params[:path].to_s.sub(%r{\A/+}, '')
     sub.empty? ? '/journeys' : "/journeys/#{sub}"
   end
 
-  # Raw JSON body (name, isActive, flowData, flowTriggers, ...), forwarded
-  # verbatim. Intentionally NOT run through strong params: nested flowData with
-  # empty arrays (nodes: []) gets mangled by `permit`. evo-flow validates it
-  # server-side; it is never mass-assigned locally. A bare array arrives wrapped
-  # as { "_json" => [...] }; POST /journeys/:id/variables needs it unwrapped.
+  # Deliberately not strong params: `permit` mangles nested flowData (drops
+  # `nodes: []`). A bare array arrives as { "_json" => [...] } and
+  # POST /journeys/:id/variables needs it unwrapped.
   def request_body
     return nil unless request.request_method_symbol.in?(%i[post put patch])
 
@@ -153,8 +125,6 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     end
   end
 
-  # Pass evo-flow's body through unchanged under an `errors` key, preserving its
-  # HTTP status.
   def handle_evo_flow_error(error)
     body = error.response&.parsed_response || { message: error.message }
     render json: { errors: body }, status: (error.code || :bad_gateway)

--- a/app/controllers/api/v1/evo_flow/journeys_controller.rb
+++ b/app/controllers/api/v1/evo_flow/journeys_controller.rb
@@ -1,4 +1,17 @@
 class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
+  # config/initializers/wrap_parameters.rb turns ActionController::ParamsWrapper
+  # on for every JSON request, and it MERGES its wrapper into
+  # request.request_parameters — the exact hash this proxy forwards. So a
+  # `{name, flowData}` body reached evo-flow as
+  # `{name, flowData, journey: {name, flowData}}`. evo-flow only tolerates it
+  # because its ValidationPipe runs forbidNonWhitelisted: false ("temporário",
+  # per its main.ts); flipping that to the secure default would 400 every
+  # create/update coming through here. It also breaks the bare-array body of
+  # POST /journeys/:id/variables, whose `_json` envelope stops being the only
+  # key once the wrapper is merged in. A passthrough must forward the body it
+  # was given, nothing else.
+  wrap_parameters false
+
   # An unusable evo-flow config raises while the client is being constructed
   # (before any request leaves the process), so rescue it at class level.
   rescue_from EvoFlow::ConfigurationError, with: :handle_evo_flow_misconfiguration

--- a/app/controllers/api/v1/evo_flow/journeys_controller.rb
+++ b/app/controllers/api/v1/evo_flow/journeys_controller.rb
@@ -1,35 +1,21 @@
 class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
-  # config/initializers/wrap_parameters.rb turns ActionController::ParamsWrapper
-  # on for every JSON request, and it MERGES its wrapper into
-  # request.request_parameters — the exact hash this proxy forwards. So a
-  # `{name, flowData}` body reached evo-flow as
-  # `{name, flowData, journey: {name, flowData}}`. evo-flow only tolerates it
-  # because its ValidationPipe runs forbidNonWhitelisted: false ("temporário",
-  # per its main.ts); flipping that to the secure default would 400 every
-  # create/update coming through here. It also breaks the bare-array body of
-  # POST /journeys/:id/variables, whose `_json` envelope stops being the only
-  # key once the wrapper is merged in. A passthrough must forward the body it
-  # was given, nothing else.
+  # ParamsWrapper (JSON, enabled globally by its initializer) MERGES its wrapper
+  # into request.request_parameters — the hash this proxy forwards. Keep it off.
   wrap_parameters false
 
   # An unusable evo-flow config raises while the client is being constructed
   # (before any request leaves the process), so rescue it at class level.
   rescue_from EvoFlow::ConfigurationError, with: :handle_evo_flow_misconfiguration
 
-  # flowData (nodes/edges/variables) can be large; bound what we forward. The
-  # depth cap mirrors SegmentsController: a byte cap alone still lets a small
-  # payload amplify into deep recursion on the evo-flow side.
+  # flowData (nodes/edges/variables) can be large; bound what we forward. Depth
+  # cap mirrors SegmentsController — a byte cap alone still allows deep nesting.
   MAX_BODY_BYTES = 300_000
   MAX_BODY_DEPTH = 25
 
-  # `*path` is a raw glob: Rails unescapes it (%2F -> /, %2e -> .) before we see
-  # it, and EvoFlow::Client#join runs URI.join, which resolves `..` per RFC 3986.
-  # So an unchecked "j1/../../segments" would leave the /journeys prefix and
-  # reach ANY evo-flow endpoint carrying the service integration key — a caller
-  # holding only journeys.read could read segments/campaigns. Restrict the
-  # subpath to the shape evo-flow actually routes (UUIDs and ASCII slugs) and
-  # reject `..` outright; `%` is excluded so double-encoding cannot smuggle a
-  # traversal past us for evo-flow's own router to decode.
+  # Rails unescapes the `*path` glob (%2F -> /, %2e -> .) and EvoFlow::Client#join
+  # runs URI.join, which resolves `..`: an unfiltered subpath leaves /journeys and
+  # reaches any evo-flow endpoint under the service key. `%` is out too, so a
+  # double-encoded traversal cannot be smuggled through for evo-flow to decode.
   SAFE_SUBPATH = %r{\A[A-Za-z0-9\-._~/]+\z}
 
   # EVO-2188 hardening: like SegmentsController (EVO-1938), the proxied endpoints
@@ -38,11 +24,6 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
   # them. The journeys.* keys already exist in the RBAC catalog. Because this is a
   # single passthrough action, the gate lives in a before_action that maps the
   # HTTP method + subpath to the right permission (see #required_permission_key).
-  #
-  # The filter is named check_<action>_permission! on purpose: that is the shape
-  # require_permissions generates, and spec/rbac/mutating_actions_gate_guard_spec
-  # reflects over it to prove every routed mutating action is gated. A
-  # differently-named filter gates at runtime but reads as UNGATED to the guard.
   PERMISSION_KEYS = %w[
     journeys.read journeys.create journeys.update journeys.delete
     journeys.toggle_active journeys.duplicate journeys.manage_sessions
@@ -87,9 +68,8 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     @client ||= EvoFlow::Client.new
   end
 
-  # Relay evo-flow's own status instead of guessing it: it answers 201 on
-  # create AND on duplicate, and 204 (empty) on delete. Rendering everything as
-  # 200 broke the "verbatim response" contract this proxy exists to keep.
+  # evo-flow's own status, not a guessed one: it answers 201 on create AND on
+  # duplicate, 204 (empty) on delete.
   def relay(status, result)
     return head(:no_content) if status == 204 || result.nil?
 
@@ -106,20 +86,18 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
 
   # Gate the request by the permission that matches the operation. Renders 403 and
   # halts when the user lacks it (check_permission! handles the render).
+  #
+  # Name is load-bearing: spec/rbac/mutating_actions_gate_guard_spec reflects over
+  # check_<action>_permission! to prove the route is gated. Renaming it still
+  # gates at runtime, but reads as UNGATED to the guard.
   def check_proxy_permission!
     check_permission!(required_permission_key, :user)
   end
 
-  # Map HTTP method + subpath to a journeys.* permission.
-  #
-  # The SUBPATH is matched FIRST, because the sub-resources are what the
-  # dedicated permissions exist for: evo-flow serves sessions under
-  # GET/DELETE /journeys/:id/sessions*, so keying off the verb first made
-  # journeys.manage_sessions unreachable (reads fell to journeys.read, and
-  # deleting a single session or bulk-deleting them fell to journeys.delete).
-  # Only once no sub-resource matches does the verb decide: GET/HEAD ->
-  # journeys.read, DELETE -> journeys.delete, POST /journeys (no subpath) ->
-  # journeys.create, every other write -> journeys.update. evo-flow still
+  # Map subpath + HTTP method to a journeys.* permission. The SUBPATH decides
+  # first: evo-flow serves sessions under GET/DELETE /journeys/:id/sessions*, so
+  # keying off the verb made journeys.manage_sessions unreachable. Otherwise the
+  # verb decides, and POST without a subpath is the create. evo-flow still
   # validates server-side.
   def required_permission_key
     sub = params[:path].to_s.downcase
@@ -146,11 +124,8 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
   # Raw JSON body (name, isActive, flowData, flowTriggers, ...), forwarded
   # verbatim. Intentionally NOT run through strong params: nested flowData with
   # empty arrays (nodes: []) gets mangled by `permit`. evo-flow validates it
-  # server-side; it is never mass-assigned locally.
-  #
-  # Rails wraps a top-level JSON ARRAY body as { "_json" => [...] }; evo-flow's
-  # POST /journeys/:id/variables takes a bare array, so unwrap it or the proxy
-  # would hand it an object it cannot bind.
+  # server-side; it is never mass-assigned locally. A bare array arrives wrapped
+  # as { "_json" => [...] }; POST /journeys/:id/variables needs it unwrapped.
   def request_body
     return nil unless request.request_method_symbol.in?(%i[post put patch])
 
@@ -159,8 +134,6 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
     rp.is_a?(Hash) && rp.keys == ['_json'] ? rp['_json'] : rp
   end
 
-  # Renders 413 and returns false when the payload is over the size or nesting
-  # cap; true when it is safe to forward.
   def guard_body_payload(body)
     return true if body.to_json.bytesize <= MAX_BODY_BYTES && structure_depth(body) <= MAX_BODY_DEPTH
 

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -33,6 +33,9 @@ module EvoFlow
     VALID_SCHEMES = %w[http https].freeze
     # Accepted truthy values for EVO_FLOW_ALLOW_INSECURE (case-insensitive).
     INSECURE_TRUTHY = %w[true 1 yes on].freeze
+    # Verbs #request may dispatch. The proxy derives the verb from the inbound
+    # request, so it never reaches HTTParty unchecked.
+    SUPPORTED_VERBS = %i[get post put patch delete].freeze
 
     def initialize(api_url: ENV.fetch('EVO_FLOW_API_URL', DEFAULT_API_URL),
                    api_key: ENV.fetch('AUTH_APIKEY_INTEGRATION_LOCAL', nil),
@@ -79,13 +82,26 @@ module EvoFlow
     end
 
     # EVO-2188: evo-flow updates a journey with PATCH (not PUT), so the journeys
-    # proxy needs this. Mirrors #put exactly.
+    # proxy needs this. Same contract as #put — body only, status dropped.
     def patch(path, payload)
-      response = self.class.patch(join(@api_url, path),
-                                  body: payload.to_json,
-                                  headers: request_headers,
-                                  timeout: @timeout)
-      handle_response(response)
+      request(:patch, path, payload: payload).last
+    end
+
+    # EVO-2188: same transport as the verb helpers above, but returns
+    # [status, body]. A passthrough proxy has to relay evo-flow's OWN status —
+    # it answers 201 on create and on duplicate, and 204 (empty) on delete —
+    # and the helpers deliberately throw the status away. Kept additive so the
+    # existing callers (segments, events) keep their exact code path.
+    def request(verb, path, payload: nil, query: nil)
+      raise ArgumentError, "unsupported evo-flow verb: #{verb.inspect}" unless SUPPORTED_VERBS.include?(verb)
+
+      options = { headers: request_headers, timeout: @timeout }
+      options[:body] = payload.to_json unless payload.nil?
+      options[:query] = query.compact unless query.nil?
+
+      response = self.class.public_send(verb, join(@api_url, path), options)
+
+      [response.code, handle_response(response)]
     rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError,
            OpenSSL::SSL::SSLError => e
       raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -87,11 +87,8 @@ module EvoFlow
       request(:patch, path, payload: payload).last
     end
 
-    # EVO-2188: same transport as the verb helpers above, but returns
-    # [status, body]. A passthrough proxy has to relay evo-flow's OWN status —
-    # it answers 201 on create and on duplicate, and 204 (empty) on delete —
-    # and the helpers deliberately throw the status away. Kept additive so the
-    # existing callers (segments, events) keep their exact code path.
+    # EVO-2188: same transport as the verb helpers, but returns [status, body] —
+    # a passthrough proxy has to relay evo-flow's own status, which they drop.
     def request(verb, path, payload: nil, query: nil)
       raise ArgumentError, "unsupported evo-flow verb: #{verb.inspect}" unless SUPPORTED_VERBS.include?(verb)
 

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -78,6 +78,19 @@ module EvoFlow
       raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
     end
 
+    # EVO-2188: evo-flow updates a journey with PATCH (not PUT), so the journeys
+    # proxy needs this. Mirrors #put exactly.
+    def patch(path, payload)
+      response = self.class.patch(join(@api_url, path),
+                                  body: payload.to_json,
+                                  headers: request_headers,
+                                  timeout: @timeout)
+      handle_response(response)
+    rescue HTTParty::Error, SocketError, Timeout::Error, SystemCallError,
+           OpenSSL::SSL::SSLError => e
+      raise EvoFlow::HTTPError.new("evo-flow request failed: #{e.message}", nil, nil)
+    end
+
     # No body: evo-flow returns a JSON delete result (or an empty 204, in which
     # case parse_body yields nil — fine to render).
     def delete(path)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,6 +247,12 @@ Rails.application.routes.draw do
             post :recompute_all, path: 'recompute-all'
           end
         end
+
+        # EVO-2188: generic passthrough proxy to evo-flow's /journeys* surface
+        # (create/list/update PATCH/delete/toggle-active/sessions/...). The frontend
+        # journey builder hits /api/v1/journeys*; without this it gets 404/405.
+        match 'journeys(/*path)', to: 'journeys#proxy',
+              via: %i[get post put patch delete], format: false
       end
 
       resources :csat_survey_responses, only: [:index], controller: 'csat_survey_responses' do

--- a/spec/controllers/api/v1/evo_flow/journeys_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/journeys_controller_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2188: the CRM proxies `segments` to evo-flow but not `journeys`, so the
+# journey builder got 404/405. This controller is the generic passthrough proxy,
+# gated by the journeys.* permissions (hardening, like SegmentsController/EVO-1938).
+RSpec.describe Api::V1::EvoFlow::JourneysController, type: :controller do
+  let(:fake_client) { instance_double(EvoFlow::Client) }
+
+  before do
+    allow(controller).to receive(:authenticate_request!).and_return(true)
+    allow(EvoFlow::Client).to receive(:new).and_return(fake_client)
+  end
+
+  after { Current.reset }
+
+  describe 'proxying to evo-flow (authorized via service token)' do
+    before { Current.service_authenticated = true } # bypasses the permission gate
+
+    it 'GET /journeys forwards to client.get and returns the response' do
+      allow(fake_client).to receive(:get).with('/journeys', anything).and_return('items' => [])
+      get :proxy
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq('items' => [])
+    end
+
+    it 'POST /journeys forwards to client.post and returns 201' do
+      allow(fake_client).to receive(:post).with('/journeys', hash_including('name' => 'x')).and_return('id' => 'j1')
+      post :proxy, body: { name: 'x', flowData: { nodes: [] } }.to_json, as: :json
+      expect(response).to have_http_status(:created)
+      expect(JSON.parse(response.body)).to eq('id' => 'j1')
+    end
+
+    it 'PATCH /journeys/:id forwards to client.patch (the update path)' do
+      expect(fake_client).to receive(:patch).with('/journeys/j1', hash_including('name' => 'y')).and_return('id' => 'j1')
+      patch :proxy, params: { path: 'j1' }, body: { name: 'y' }.to_json, as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'DELETE /journeys/:id forwards to client.delete' do
+      expect(fake_client).to receive(:delete).with('/journeys/j1').and_return('deleted' => true)
+      delete :proxy, params: { path: 'j1' }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'passes evo-flow errors through with their status' do
+      err = EvoFlow::HTTPError.new('bad', 422, nil)
+      allow(fake_client).to receive(:get).and_raise(err)
+      get :proxy
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  describe 'permission gating (EVO-2188)' do
+    let(:current_user) { double('User', id: 'user-1') }
+
+    before do
+      Current.service_authenticated = false
+      Current.user = current_user
+      Current.evo_permission_cache = {}
+      allow(EvoExtensionPoints::RuntimeContext).to receive(:current_scope_id).and_return(nil)
+    end
+
+    def deny(permission)
+      Current.evo_permission_cache["user:user-1::#{permission}"] = false
+    end
+
+    def allow_perm(permission)
+      Current.evo_permission_cache["user:user-1::#{permission}"] = true
+    end
+
+    it 'GET requires journeys.read -> 403 when missing, no client call' do
+      deny('journeys.read')
+      expect(fake_client).not_to receive(:get)
+      get :proxy
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'GET is allowed when journeys.read is granted' do
+      allow_perm('journeys.read')
+      allow(fake_client).to receive(:get).and_return('items' => [])
+      get :proxy
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'POST /journeys requires journeys.create' do
+      deny('journeys.create')
+      expect(fake_client).not_to receive(:post)
+      post :proxy, body: {}.to_json, as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'PATCH requires journeys.update' do
+      deny('journeys.update')
+      expect(fake_client).not_to receive(:patch)
+      patch :proxy, params: { path: 'j1' }, body: {}.to_json, as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'DELETE requires journeys.delete' do
+      deny('journeys.delete')
+      expect(fake_client).not_to receive(:delete)
+      delete :proxy, params: { path: 'j1' }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'a toggle-active subpath requires journeys.toggle_active' do
+      deny('journeys.toggle_active')
+      expect(fake_client).not_to receive(:post)
+      post :proxy, params: { path: 'j1/toggle-active' }, body: {}.to_json, as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/controllers/api/v1/evo_flow/journeys_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/journeys_controller_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 # EVO-2188: the CRM proxies `segments` to evo-flow but not `journeys`, so the
 # journey builder got 404/405. This controller is the generic passthrough proxy,
 # gated by the journeys.* permissions (hardening, like SegmentsController/EVO-1938).
+#
+# Routing through the real glob (and the permission table per subpath) is covered
+# by spec/requests/api/v1/journeys_proxy_rbac_spec.rb — a controller spec injects
+# params[:path] by hand and cannot prove either.
 RSpec.describe Api::V1::EvoFlow::JourneysController, type: :controller do
   let(:fake_client) { instance_double(EvoFlow::Client) }
 
@@ -18,37 +22,75 @@ RSpec.describe Api::V1::EvoFlow::JourneysController, type: :controller do
   describe 'proxying to evo-flow (authorized via service token)' do
     before { Current.service_authenticated = true } # bypasses the permission gate
 
-    it 'GET /journeys forwards to client.get and returns the response' do
-      allow(fake_client).to receive(:get).with('/journeys', anything).and_return('items' => [])
+    it 'GET /journeys forwards to the client and returns the response' do
+      allow(fake_client).to receive(:request).with(:get, '/journeys', query: anything)
+                                             .and_return([200, { 'items' => [] }])
       get :proxy
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).to eq('items' => [])
     end
 
-    it 'POST /journeys forwards to client.post and returns 201' do
-      allow(fake_client).to receive(:post).with('/journeys', hash_including('name' => 'x')).and_return('id' => 'j1')
+    it 'POST /journeys relays evo-flow 201' do
+      allow(fake_client).to receive(:request)
+        .with(:post, '/journeys', payload: hash_including('name' => 'x'))
+        .and_return([201, { 'id' => 'j1' }])
       post :proxy, body: { name: 'x', flowData: { nodes: [] } }.to_json, as: :json
       expect(response).to have_http_status(:created)
       expect(JSON.parse(response.body)).to eq('id' => 'j1')
     end
 
-    it 'PATCH /journeys/:id forwards to client.patch (the update path)' do
-      expect(fake_client).to receive(:patch).with('/journeys/j1', hash_including('name' => 'y')).and_return('id' => 'j1')
+    it 'PATCH /journeys/:id forwards as PATCH (the update path)' do
+      expect(fake_client).to receive(:request)
+        .with(:patch, '/journeys/j1', payload: hash_including('name' => 'y'))
+        .and_return([200, { 'id' => 'j1' }])
       patch :proxy, params: { path: 'j1' }, body: { name: 'y' }.to_json, as: :json
       expect(response).to have_http_status(:ok)
     end
 
-    it 'DELETE /journeys/:id forwards to client.delete' do
-      expect(fake_client).to receive(:delete).with('/journeys/j1').and_return('deleted' => true)
+    it 'DELETE /journeys/:id relays evo-flow 204 as 204, not 200 with a null body' do
+      expect(fake_client).to receive(:request).with(:delete, '/journeys/j1').and_return([204, nil])
       delete :proxy, params: { path: 'j1' }
+      expect(response).to have_http_status(:no_content)
+      expect(response.body).to be_empty
+    end
+
+    it 'relays the 201 evo-flow answers on duplicate (not a flattened 200)' do
+      allow(fake_client).to receive(:request).and_return([201, { 'id' => 'j2' }])
+      post :proxy, params: { path: 'j1/duplicate' }, body: {}.to_json, as: :json
+      expect(response).to have_http_status(:created)
+    end
+
+    # Rails wraps a top-level JSON array as { "_json" => [...] }; evo-flow's
+    # POST /journeys/:id/variables binds a bare array.
+    it 'unwraps an array body instead of forwarding { _json: [...] }' do
+      expect(fake_client).to receive(:request)
+        .with(:post, '/journeys/j1/variables', payload: [{ 'id' => 'v1', 'name' => 'n', 'type' => 'text' }])
+        .and_return([200, []])
+      post :proxy, params: { path: 'j1/variables' },
+                   body: [{ id: 'v1', name: 'n', type: 'text' }].to_json, as: :json
       expect(response).to have_http_status(:ok)
     end
 
     it 'passes evo-flow errors through with their status' do
       err = EvoFlow::HTTPError.new('bad', 422, nil)
-      allow(fake_client).to receive(:get).and_raise(err)
+      allow(fake_client).to receive(:request).and_raise(err)
       get :proxy
       expect(response).to have_http_status(:unprocessable_content)
+    end
+
+    it 'rejects a payload deeper than the nesting cap' do
+      deep = (1..30).reduce({ 'leaf' => true }) { |acc, _| { 'n' => acc } }
+      expect(fake_client).not_to receive(:request)
+      post :proxy, body: deep.to_json, as: :json
+      expect(response).to have_http_status(:payload_too_large)
+    end
+
+    # URI.join resolves `..`, so an unchecked subpath would leave /journeys and
+    # reach any evo-flow endpoint under the service integration key.
+    it 'refuses a traversing subpath before touching evo-flow' do
+      expect(fake_client).not_to receive(:request)
+      get :proxy, params: { path: 'j1/../../segments' }
+      expect(response).to have_http_status(:bad_request)
     end
   end
 
@@ -72,43 +114,61 @@ RSpec.describe Api::V1::EvoFlow::JourneysController, type: :controller do
 
     it 'GET requires journeys.read -> 403 when missing, no client call' do
       deny('journeys.read')
-      expect(fake_client).not_to receive(:get)
+      expect(fake_client).not_to receive(:request)
       get :proxy
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'GET is allowed when journeys.read is granted' do
       allow_perm('journeys.read')
-      allow(fake_client).to receive(:get).and_return('items' => [])
+      allow(fake_client).to receive(:request).and_return([200, { 'items' => [] }])
       get :proxy
       expect(response).to have_http_status(:ok)
     end
 
     it 'POST /journeys requires journeys.create' do
       deny('journeys.create')
-      expect(fake_client).not_to receive(:post)
+      expect(fake_client).not_to receive(:request)
       post :proxy, body: {}.to_json, as: :json
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'PATCH requires journeys.update' do
       deny('journeys.update')
-      expect(fake_client).not_to receive(:patch)
+      expect(fake_client).not_to receive(:request)
       patch :proxy, params: { path: 'j1' }, body: {}.to_json, as: :json
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'DELETE requires journeys.delete' do
       deny('journeys.delete')
-      expect(fake_client).not_to receive(:delete)
+      expect(fake_client).not_to receive(:request)
       delete :proxy, params: { path: 'j1' }
       expect(response).to have_http_status(:forbidden)
     end
 
     it 'a toggle-active subpath requires journeys.toggle_active' do
       deny('journeys.toggle_active')
-      expect(fake_client).not_to receive(:post)
+      expect(fake_client).not_to receive(:request)
       post :proxy, params: { path: 'j1/toggle-active' }, body: {}.to_json, as: :json
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    # The sub-resource decides before the verb does: keying off the verb first
+    # made journeys.manage_sessions unreachable for every session read/delete.
+    it 'reading sessions requires journeys.manage_sessions, not journeys.read' do
+      allow_perm('journeys.read')
+      deny('journeys.manage_sessions')
+      expect(fake_client).not_to receive(:request)
+      get :proxy, params: { path: 'j1/sessions' }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'deleting a session requires journeys.manage_sessions, not journeys.delete' do
+      allow_perm('journeys.delete')
+      deny('journeys.manage_sessions')
+      expect(fake_client).not_to receive(:request)
+      delete :proxy, params: { path: 'j1/sessions/s-1' }
       expect(response).to have_http_status(:forbidden)
     end
   end

--- a/spec/requests/api/v1/journeys_proxy_rbac_spec.rb
+++ b/spec/requests/api/v1/journeys_proxy_rbac_spec.rb
@@ -62,6 +62,24 @@ RSpec.describe 'Journeys proxy RBAC', type: :request do
       expect(stub).to have_been_requested
     end
 
+    # Two envelopes have to be off the wire here: ParamsWrapper's `journey` copy
+    # (it merges into request_parameters, the hash this proxy forwards) and the
+    # `_json` envelope Rails puts a bare array in. evo-flow binds
+    # POST /journeys/:id/variables to a raw array.
+    it 'POST /api/v1/journeys/:id/variables forwards the bare array, unwrapped' do
+      grant_permissions('journeys.update')
+      vars = [{ 'id' => 'v1', 'name' => 'greeting', 'type' => 'text' }]
+      stub = stub_request(:post, "#{api_url}/journeys/j1/variables")
+             .with(body: vars.to_json)
+             .to_return(status: 200, body: vars.to_json, headers: { 'Content-Type' => 'application/json' })
+
+      post '/api/v1/journeys/j1/variables',
+           params: vars.to_json, headers: { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(response).to have_http_status(:ok)
+      expect(stub).to have_been_requested
+    end
+
     it 'POST /api/v1/journeys/:id/toggle-active reaches the nested subpath' do
       grant_permissions('journeys.toggle_active')
       stub = stub_request(:post, "#{api_url}/journeys/j1/toggle-active")

--- a/spec/requests/api/v1/journeys_proxy_rbac_spec.rb
+++ b/spec/requests/api/v1/journeys_proxy_rbac_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+# EVO-2188. The journeys proxy is ONE routed action behind a `*path` glob, so
+# everything that makes it safe depends on the real router populating
+# params[:path]: which journeys.* permission is demanded, and whether a
+# traversing subpath can escape the /journeys prefix. A controller spec injects
+# params[:path] by hand and proves neither, so the coverage lives here — and in
+# spec/requests/api/v1/*_rbac_spec.rb, which is the path the community-parity
+# CI lane actually runs.
+RSpec.describe 'Journeys proxy RBAC', type: :request do
+  let(:api_url) { 'http://evo-flow.test/api/v1' }
+  let(:user) { User.create!(name: 'Journey Probe', email: "journey-#{SecureRandom.hex(4)}@example.com") }
+
+  before do
+    probe = user
+    allow_any_instance_of(Api::BaseController).to receive(:authenticate_request!) do
+      Current.user = probe
+      Current.evo_permission_cache ||= {}
+    end
+
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch)
+      .with('EVO_FLOW_API_URL', EvoFlow::Client::DEFAULT_API_URL).and_return(api_url)
+    allow(ENV).to receive(:fetch)
+      .with('AUTH_APIKEY_INTEGRATION_LOCAL', nil).and_return('integration-key')
+  end
+
+  after { Current.reset }
+
+  def grant_permissions(*granted)
+    allow_any_instance_of(EvoAuthService).to receive(:check_user_permission) do |_service, _user_id, permission|
+      granted.include?(permission)
+    end
+  end
+
+  describe 'the glob actually routes and forwards' do
+    it 'GET /api/v1/journeys reaches evo-flow /journeys' do
+      grant_permissions('journeys.read')
+      stub = stub_request(:get, "#{api_url}/journeys")
+             .with(headers: { 'X-Integration-API-Key' => 'integration-key' })
+             .to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
+
+      get '/api/v1/journeys'
+
+      expect(response).to have_http_status(:ok)
+      expect(stub).to have_been_requested
+    end
+
+    it 'PATCH /api/v1/journeys/:id reaches evo-flow as PATCH' do
+      grant_permissions('journeys.update')
+      stub = stub_request(:patch, "#{api_url}/journeys/j1")
+             .with(body: { name: 'y' }.to_json)
+             .to_return(status: 200, body: { id: 'j1' }.to_json,
+                        headers: { 'Content-Type' => 'application/json' })
+
+      patch '/api/v1/journeys/j1', params: { name: 'y' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(stub).to have_been_requested
+    end
+
+    it 'POST /api/v1/journeys/:id/toggle-active reaches the nested subpath' do
+      grant_permissions('journeys.toggle_active')
+      stub = stub_request(:post, "#{api_url}/journeys/j1/toggle-active")
+             .to_return(status: 200, body: { isActive: true }.to_json,
+                        headers: { 'Content-Type' => 'application/json' })
+
+      post '/api/v1/journeys/j1/toggle-active', params: {}, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(stub).to have_been_requested
+    end
+
+    # evo-flow answers 204 on delete; flattening it to 200 with a `null` body
+    # breaks the passthrough contract this proxy exists to keep.
+    it 'relays evo-flow 204 on delete instead of 200 + null' do
+      grant_permissions('journeys.delete')
+      stub_request(:delete, "#{api_url}/journeys/j1").to_return(status: 204, body: '')
+
+      delete '/api/v1/journeys/j1'
+
+      expect(response).to have_http_status(:no_content)
+      expect(response.body).to be_empty
+    end
+  end
+
+  # Rails unescapes the glob (%2e -> ., %2F -> /) and EvoFlow::Client#join runs
+  # URI.join, which resolves `..` per RFC 3986. Unchecked, `journeys/../segments`
+  # leaves the journeys prefix and hits any evo-flow endpoint under the service
+  # integration key — journeys.read would read segments and campaigns.
+  describe 'subpath traversal' do
+    it 'refuses an encoded traversal and never calls evo-flow' do
+      grant_permissions('journeys.read')
+
+      get '/api/v1/journeys/j1/%2e%2e/%2e%2e/segments'
+
+      expect(response).to have_http_status(:bad_request)
+      expect(a_request(:any, /evo-flow\.test/)).not_to have_been_made
+    end
+
+    it 'refuses a traversal on a write verb too' do
+      grant_permissions('journeys.update', 'journeys.create')
+
+      post '/api/v1/journeys/j1/%2e%2e/%2e%2e/segments/preview', params: {}, as: :json
+
+      expect(response).to have_http_status(:bad_request)
+      expect(a_request(:any, /evo-flow\.test/)).not_to have_been_made
+    end
+  end
+
+  describe 'permission mapping per method + subpath' do
+    it 'denies a read without journeys.read' do
+      grant_permissions('journeys.create', 'journeys.update')
+
+      get '/api/v1/journeys'
+
+      expect(response).to have_http_status(:forbidden)
+      expect(a_request(:any, /evo-flow\.test/)).not_to have_been_made
+    end
+
+    it 'denies a create without journeys.create' do
+      grant_permissions('journeys.read', 'journeys.update')
+
+      post '/api/v1/journeys', params: { name: 'x' }, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'denies an update without journeys.update' do
+      grant_permissions('journeys.read', 'journeys.create')
+
+      patch '/api/v1/journeys/j1', params: { name: 'y' }, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'denies a delete without journeys.delete' do
+      grant_permissions('journeys.read', 'journeys.update')
+
+      delete '/api/v1/journeys/j1'
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'denies toggle-active without journeys.toggle_active' do
+      grant_permissions('journeys.read', 'journeys.update', 'journeys.create')
+
+      post '/api/v1/journeys/j1/toggle-active', params: {}, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'denies duplicate without journeys.duplicate' do
+      grant_permissions('journeys.read', 'journeys.update', 'journeys.create')
+
+      post '/api/v1/journeys/j1/duplicate', params: {}, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    # The sub-resource has to win over the verb, or journeys.manage_sessions
+    # gates nothing but the cancel POST: every session read falls to
+    # journeys.read and every session delete to journeys.delete.
+    it 'demands journeys.manage_sessions to LIST sessions, not journeys.read' do
+      grant_permissions('journeys.read')
+
+      get '/api/v1/journeys/j1/sessions'
+
+      expect(response).to have_http_status(:forbidden)
+      expect(a_request(:any, /evo-flow\.test/)).not_to have_been_made
+    end
+
+    it 'demands journeys.manage_sessions to DELETE a session, not journeys.delete' do
+      grant_permissions('journeys.delete')
+
+      delete '/api/v1/journeys/j1/sessions/s-1'
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'demands journeys.manage_sessions to bulk-delete sessions' do
+      grant_permissions('journeys.delete')
+
+      delete '/api/v1/journeys/j1/sessions/bulk/completed'
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'allows the session surface with journeys.manage_sessions' do
+      grant_permissions('journeys.manage_sessions')
+      stub = stub_request(:get, "#{api_url}/journeys/j1/sessions")
+             .to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
+
+      get '/api/v1/journeys/j1/sessions'
+
+      expect(response).to have_http_status(:ok)
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -28,6 +28,29 @@ RSpec.describe EvoFlow::Client do
     end
   end
 
+  describe '#patch' do
+    it 'PATCHes to the full /api/v1 URL with auth + json headers (EVO-2188)' do
+      stub = stub_request(:patch, "#{api_url}/journeys/j1")
+             .with(
+               body: { name: 'y' }.to_json,
+               headers: {
+                 'X-Integration-API-Key' => api_key,
+                 'Content-Type' => 'application/json'
+               }
+             )
+             .to_return(
+               status: 200,
+               body: { id: 'j1', name: 'y' }.to_json,
+               headers: { 'Content-Type' => 'application/json' }
+             )
+
+      result = client.patch('/journeys/j1', { name: 'y' })
+
+      expect(stub).to have_been_requested
+      expect(result).to include('id' => 'j1', 'name' => 'y')
+    end
+  end
+
   describe '#post' do
     it 'POSTs to the full /api/v1 URL with auth + json headers (AC1)' do
       stub = stub_request(:post, track_url)


### PR DESCRIPTION
## EVO-2188 — Journeys dão 404/405: falta o proxy de `journeys` no CRM

### Root cause (confirmada no código)
O escopo `evo_flow` do `config/routes.rb:238` proxeia **só** `contact_events` e `segments` — **não há `journeys`**. Então `POST/GET /api/v1/journeys*` = **404** no CRM (enquanto `segments` = 401 → prova que a rota existe). Além disso o `EvoFlow::Client` tinha `get/post/put/delete` mas **não `patch`** (o update de journey no evo-flow é PATCH). O evo-flow já expõe toda a superfície `/api/v1/journeys*` — só faltava o proxy. Não é env (`segments`, mesma env/escopo, funciona).

### Correção
| Arquivo | Mudança |
|---|---|
| `app/services/evo_flow/client.rb` | novo `#patch` (espelha `#put`) |
| `app/controllers/api/v1/evo_flow/journeys_controller.rb` (novo) | proxy passthrough para `/journeys*` (method+subpath+query+body verbatim), espelhando o error-handling / misconfig 503 / body-cap do `SegmentsController` |
| `config/routes.rb` | `match 'journeys(/*path)'` no escopo `evo_flow` |

### Hardening (parity com EVO-1938)
O `SegmentsController` gateia por permissão; sem isso a API fica aberta a qualquer autenticado mesmo com a UI escondendo o recurso. O hotfix do cliente era **auth-only**. Como as permissões `journeys.*` já existem no RBAC, adicionei um `before_action` que mapeia **método+subpath → journeys.\*** (`read`/`create`/`update`/`delete`/`toggle_active`/`duplicate`/`manage_sessions`) e **403** quem não tiver.

### Testes (container CRM)
- `client_spec`: `#patch` (WebMock) ✅
- `journeys_controller_spec`: proxy GET/POST/PATCH/DELETE + passthrough de erro + **gate de permissão** (403 sem a `journeys.*` mapeada) ✅
- Rota registrada: `/api/v1/journeys(/*path)` ✅
- Todos os specs novos verdes.
- ~~*A 1 falha no `client_spec` é um teste stale pré-existente — `DEFAULT_API_URL` virou :3334 e ele ainda stuba :3000.*~~ **Correção:** essa justificativa está errada — o spec stuba `http://evo-flow:3334/api/v1/segments` (`spec/services/evo_flow/client_spec.rb:23`), não `:3000`. A falha pode até ser pré-existente, mas não é por esse motivo; a causa real segue **não diagnosticada**.

### Origem
Hotfix do cliente (bind-mount, temporário). Este PR traz para a imagem **+ o gate de permissão**.

---

## Review (EVO-2188) — correções aplicadas no commit `5d28a42`

A lane **`RBAC parity — pure community install (EVO-2117)`** estava **vermelha por causa deste PR** (`190 examples, 1 failure`), e a revisão achou mais 6 buracos. Corrigido:

| Sev | Achado | Correção |
|---|---|---|
| 🔴 | `spec/rbac/mutating_actions_gate_guard_spec` reflete sobre `check_<action>_permission!` (a forma que `require_permissions` gera) pra provar que toda action mutante roteada é gateada. O gate se chamava `authorize_journeys!` → o guard leu a rota como **ungated**: `["GET\|POST\|PUT\|PATCH\|DELETE api/v1/evo_flow/journeys#proxy"]` | Renomeado para `check_proxy_permission!`. O gate em si não mudou |
| 🔴 | **Path traversal → bypass de fronteira de permissão.** O Rails desescapa o glob (`%2F`→`/`, `%2e`→`.`) e `EvoFlow::Client#join` usa `URI.join`, que resolve `..` por RFC 3986: `GET /api/v1/journeys/j1%2F..%2F..%2Fsegments` saía do prefixo `/journeys` e alcançava **qualquer** endpoint do evo-flow sob a chave de integração — `journeys.read` lendo segments/campaigns | `reject_unsafe_subpath!` antes do gate: subpath restrito ao formato que o evo-flow roteia e `..` recusado com 400; `%` fora do allowlist, então double-encoding também não passa |
| 🔴 | **`journeys.manage_sessions` inalcançável:** o mapa retornava pelo VERBO antes de olhar o subpath, mas o evo-flow serve sessões em `GET/DELETE /journeys/:id/sessions*` — toda leitura de sessão caía em `journeys.read` e todo delete (inclusive `bulk`) em `journeys.delete`, enquanto quem tinha só `manage_sessions` tomava 403 | Sub-recurso decide antes do verbo. Match do toggle estreitado de `toggle`\|`active` para `toggle-active` |
| 🟡 | **Resposta não era verbatim:** o status de sucesso era chutado (201 só pra `POST /journeys`), então o **201 do duplicate** virava 200 e o **204 do delete** virava 200 com body `null` | Novo `EvoFlow::Client#request` → `[status, body]`; o proxy relaya o status do evo-flow. Os helpers `get/post/put/delete` ficaram intactos (segments/events não mudam de caminho) e `#patch` delega |
| 🟡 | **Body em array destruído:** o Rails envelopa array JSON de topo como `{"_json" => [...]}` e o evo-flow liga array cru em `POST /journeys/:id/variables` — que é exatamente o que o front manda | Desembrulhado |
| 🟡 | Cap de payload sem guarda de profundidade (o `SegmentsController` tem): cap de bytes sozinho ainda deixa um `flowData` pequeno amplificar em recursão profunda | `MAX_BODY_DEPTH = 25` + `structure_depth` |
| 🟢 | `HEAD` exigia `journeys.update` e depois respondia 405 (o Rails roteia HEAD pra rota GET, mas o símbolo do verbo é `:head`) | Tratado como leitura |

**Testes:** o controller spec passou a cobrir relay de status, array, cap de profundidade e recusa de traversal. Novo **`spec/requests/api/v1/journeys_proxy_rbac_spec.rb`** — glob, tabela de permissão por subpath e traversal só existem em nível de roteamento, que um controller spec (com `params[:path]` injetado na mão) não prova; e ele cai em `spec/requests/api/v1/*_rbac_spec.rb`, que é o caminho que a lane `community-parity` de fato roda.

**Fora do escopo deste PR:** o front ainda chama o evo-flow direto (`journeyService.ts` → `apiEvoFlow`, 16 chamadas), então o **405 do cliente não fecha só com este PR** — falta migrar o `journeyService` para o proxy, como o `segmentsService` já é.

## Summary by Sourcery

Proxy evo-flow journeys endpoints through the CRM API and secure them with RBAC permissions.

New Features:
- Add PATCH support to the EvoFlow client to allow updating journeys via the proxy.
- Expose a generic /api/v1/journeys(/*path) passthrough endpoint to evo-flow covering CRUD and related operations.

Enhancements:
- Introduce a journeys proxy controller that forwards requests to evo-flow, enforces size limits, propagates backend errors, and handles misconfiguration as service unavailability.
- Gate journeys proxy operations behind specific journeys.* permission keys mapped from HTTP method and subpath to align with existing RBAC patterns.

Tests:
- Add unit tests for the EvoFlow client PATCH method.
- Add controller specs for journeys proxy behavior, including verb forwarding, error passthrough, and permission gating.

