### PR TITLE
fix(EVO-2179): skip the media reload on text, and test the contract it relies on

### DIFF
--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -528,9 +528,8 @@ class AgentBotListener < BaseListener
     return unless conversation
 
     message = create_message_from_payload(payload, conversation)
-    # Message#webhook_data only sets :attachments when the persisted record has
-    # them, so this tells the service whether reloading the message is worth a
-    # query at all.
+    # webhook_data only sets :attachments when the record has them, so this saves
+    # the service a query on text-only messages.
     BotRuntime::DelegationService.new(
       agent_bot, message, conversation, has_attachments: payload[:attachments].present?
     ).delegate

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -528,7 +528,12 @@ class AgentBotListener < BaseListener
     return unless conversation
 
     message = create_message_from_payload(payload, conversation)
-    BotRuntime::DelegationService.new(agent_bot, message, conversation).delegate
+    # Message#webhook_data only sets :attachments when the persisted record has
+    # them, so this tells the service whether reloading the message is worth a
+    # query at all.
+    BotRuntime::DelegationService.new(
+      agent_bot, message, conversation, has_attachments: payload[:attachments].present?
+    ).delegate
 
     Rails.logger.info "[BotRuntime] Delegated message to Bot Runtime: " \
                       "conversation=#{conversation.display_id} bot=#{agent_bot.name}"

--- a/app/services/bot_runtime/delegation_service.rb
+++ b/app/services/bot_runtime/delegation_service.rb
@@ -2,18 +2,13 @@
 
 module BotRuntime
   class DelegationService
-    # Preload path for the media reload. A constant rather than an inline hash so
-    # the spec can walk it against the real reflections: if an association is
-    # renamed, build_attachments rescues the resulting error and returns [], which
-    # looks exactly like "the customer sent no media" — the bug EVO-2179 fixed,
-    # silently back, with a green mocked spec.
+    # A constant so the spec can walk it against the real reflections: a renamed
+    # association makes build_attachments rescue to [], indistinguishable from "no
+    # media sent".
     ATTACHMENT_PRELOAD = { attachments: { file_attachment: :blob } }.freeze
 
-    # has_attachments comes from the webhook payload, which Message#webhook_data
-    # populates only when the persisted record actually has attachments. It exists
-    # to keep build_attachments from querying on every text message — see there.
-    # Defaults to true so a caller that does not pass it keeps the safe behaviour
-    # (look, and find nothing) rather than silently skipping media.
+    # has_attachments defaults to true so a caller that omits it still looks for
+    # media instead of silently skipping it.
     def initialize(agent_bot, message, conversation, has_attachments: true)
       @agent_bot = agent_bot
       @message = message
@@ -51,21 +46,14 @@ module BotRuntime
     # it to the AI processor as A2A file parts. Without this a media-only message
     # reaches the AI empty ("No content to process") — the agent never sees it.
     #
-    # @message here is rebuilt from the webhook payload (an unpersisted Message.new
-    # with only the id set — see AgentBotListener#create_message_from_payload), so
-    # @message.attachments is an empty in-memory collection. Reload the persisted
-    # record, blobs preloaded, to read the real ActiveStorage attachments.
+    # @message is an unpersisted Message.new with only the id set (see
+    # AgentBotListener#create_message_from_payload), so its attachments are empty —
+    # hence the reload. Gated on the payload, or every text message pays two queries
+    # for a result that is always [].
     #
-    # Every inbound message on a bot conversation reaches this method, and the vast
-    # majority carry no media at all, so the reload is gated on the payload having
-    # announced attachments — otherwise plain text pays two queries per event on the
-    # delegation hot path for a result that is always [].
-    #
-    # Ordered by created_at so media from different messages in one debounce window
-    # keeps its sequence. Attachments of a *single* message are inserted in one
-    # transaction and routinely share a timestamp; the id is only a stable
-    # tie-break, not send order (it is a random UUID). That is fine here because the
-    # inbound handlers create one attachment per message.
+    # created_at orders media across a debounce window; the id is only a tie-break,
+    # not send order (random UUID), which is fine as the inbound handlers create one
+    # attachment per message.
     def build_attachments
       return [] unless @has_attachments
 

--- a/app/services/bot_runtime/delegation_service.rb
+++ b/app/services/bot_runtime/delegation_service.rb
@@ -2,10 +2,23 @@
 
 module BotRuntime
   class DelegationService
-    def initialize(agent_bot, message, conversation)
+    # Preload path for the media reload. A constant rather than an inline hash so
+    # the spec can walk it against the real reflections: if an association is
+    # renamed, build_attachments rescues the resulting error and returns [], which
+    # looks exactly like "the customer sent no media" — the bug EVO-2179 fixed,
+    # silently back, with a green mocked spec.
+    ATTACHMENT_PRELOAD = { attachments: { file_attachment: :blob } }.freeze
+
+    # has_attachments comes from the webhook payload, which Message#webhook_data
+    # populates only when the persisted record actually has attachments. It exists
+    # to keep build_attachments from querying on every text message — see there.
+    # Defaults to true so a caller that does not pass it keeps the safe behaviour
+    # (look, and find nothing) rather than silently skipping media.
+    def initialize(agent_bot, message, conversation, has_attachments: true)
       @agent_bot = agent_bot
       @message = message
       @conversation = conversation
+      @has_attachments = has_attachments
     end
 
     def delegate
@@ -41,12 +54,23 @@ module BotRuntime
     # @message here is rebuilt from the webhook payload (an unpersisted Message.new
     # with only the id set — see AgentBotListener#create_message_from_payload), so
     # @message.attachments is an empty in-memory collection. Reload the persisted
-    # record — blobs preloaded, this runs on every incoming delegation — to read
-    # the real ActiveStorage attachments. Ordered so a multi-media message always
-    # produces the file parts in the order the contact sent them.
+    # record, blobs preloaded, to read the real ActiveStorage attachments.
+    #
+    # Every inbound message on a bot conversation reaches this method, and the vast
+    # majority carry no media at all, so the reload is gated on the payload having
+    # announced attachments — otherwise plain text pays two queries per event on the
+    # delegation hot path for a result that is always [].
+    #
+    # Ordered by created_at so media from different messages in one debounce window
+    # keeps its sequence. Attachments of a *single* message are inserted in one
+    # transaction and routinely share a timestamp; the id is only a stable
+    # tie-break, not send order (it is a random UUID). That is fine here because the
+    # inbound handlers create one attachment per message.
     def build_attachments
+      return [] unless @has_attachments
+
       persisted = @conversation.messages
-                               .includes(attachments: { file_attachment: :blob })
+                               .includes(ATTACHMENT_PRELOAD)
                                .find_by(id: @message.id)
       return [] if persisted.nil?
 

--- a/spec/services/bot_runtime/delegation_service_spec.rb
+++ b/spec/services/bot_runtime/delegation_service_spec.rb
@@ -59,17 +59,11 @@ RSpec.describe BotRuntime::DelegationService do
     allow(messages_relation).to receive(:find_by).with(id: 42).and_return(persisted)
   end
 
-  # Everything below this point is a double, which is the right shape for the
-  # mapping but blind to the two things that would actually break the feature in
-  # production: a preload path that no longer resolves, and a URL builder that no
-  # longer exists. Both fail the same silent way — build_attachments rescues,
-  # returns [], and the agent goes back to never seeing the image. These examples
-  # check them against the real classes, and still need no database.
+  # The rest of this file is doubles, so a preload path or URL helper that stopped
+  # resolving would go unnoticed: build_attachments rescues to [] and the agent
+  # just stops seeing images. These check them against the real classes, no DB.
   describe 'contract with the models it reads through' do
     it 'preloads a path that every model in it actually declares' do
-      # Walks the preload hash the way ActiveRecord does: each key is an
-      # association on the current model, each value is the path to follow from
-      # the model it points at.
       walk = lambda do |owner, spec|
         next if owner.nil?
 

--- a/spec/services/bot_runtime/delegation_service_spec.rb
+++ b/spec/services/bot_runtime/delegation_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe BotRuntime::DelegationService do
 
   before do
     # The service preloads the blobs (no N+1 on the delegation hot path).
-    allow(messages_relation).to receive(:includes).with(attachments: { file_attachment: :blob }).and_return(messages_relation)
+    allow(messages_relation).to receive(:includes).with(described_class::ATTACHMENT_PRELOAD).and_return(messages_relation)
   end
 
   # ActiveStorage::Attached::One delegates #blob to the attachment record through
@@ -57,6 +57,44 @@ RSpec.describe BotRuntime::DelegationService do
   def stub_persisted_with(attachments)
     persisted = instance_double(Message, attachments: attachments)
     allow(messages_relation).to receive(:find_by).with(id: 42).and_return(persisted)
+  end
+
+  # Everything below this point is a double, which is the right shape for the
+  # mapping but blind to the two things that would actually break the feature in
+  # production: a preload path that no longer resolves, and a URL builder that no
+  # longer exists. Both fail the same silent way — build_attachments rescues,
+  # returns [], and the agent goes back to never seeing the image. These examples
+  # check them against the real classes, and still need no database.
+  describe 'contract with the models it reads through' do
+    it 'preloads a path that every model in it actually declares' do
+      # Walks the preload hash the way ActiveRecord does: each key is an
+      # association on the current model, each value is the path to follow from
+      # the model it points at.
+      walk = lambda do |owner, spec|
+        next if owner.nil?
+
+        case spec
+        when Symbol
+          reflection = owner.reflect_on_association(spec)
+          expect(reflection).not_to(
+            be_nil, "#{owner}.#{spec} no longer exists — build_attachments would rescue to [] on every media message"
+          )
+          reflection&.klass
+        when Hash
+          spec.each { |association, nested| walk.call(walk.call(owner, association), nested) }
+        end
+      end
+
+      walk.call(Message, described_class::ATTACHMENT_PRELOAD)
+    end
+
+    it 'reads the attachment fields it maps from' do
+      expect(Attachment.new).to respond_to(:file, :file_type, :with_attached_file?)
+    end
+
+    it 'builds the outbound URL through the same helper the WhatsApp providers use' do
+      expect(BlobUrlOptions).to respond_to(:outbound_media_url)
+    end
   end
 
   describe '#build_attachments' do
@@ -117,6 +155,13 @@ RSpec.describe BotRuntime::DelegationService do
 
       expect(result.map { |a| a[:file_type] }).to eq(%w[audio])
       expect(Rails.logger).to have_received(:error).with(/attachment att-boom failed .*message=42/)
+    end
+
+    it 'does not query at all when the payload announced no attachments' do
+      service = described_class.new(agent_bot, message, conversation, has_attachments: false)
+      expect(messages_relation).not_to receive(:includes)
+
+      expect(service.send(:build_attachments)).to eq([])
     end
 
     it 'never raises: logs and returns [] on error' do


### PR DESCRIPTION
Review follow-up to **EVO-2179** (PR #237, already merged). Findings from the EVO-2178 review of the merged media path.

## Skip the media reload on text messages

`build_attachments` reloaded the persisted message on **every** inbound delegation, media or not, so a plain text message paid two queries on the hot path for a result that is always `[]`. `Message#webhook_data` only sets `:attachments` when the record has them, so the listener now passes that through and the reload is skipped when there is nothing to reload. The keyword defaults to `true`, so any caller that does not pass it keeps looking rather than silently dropping media.

## Test the contract the mapping relies on

The spec was entirely doubles — the right shape for the mapping, but blind to the two things that would actually break this in production: the preload path and the URL helper. Both fail the same silent way — `build_attachments` rescues, returns `[]`, and the agent stops seeing images, exactly the bug EVO-2179 fixed, with the spec still green.

- The preload path is now the `ATTACHMENT_PRELOAD` constant, and the spec **walks it against the real reflections** (`Message → Attachment → ActiveStorage::Attachment → Blob`); a renamed association fails the example.
- The attachment fields and `BlobUrlOptions.outbound_media_url` are checked against the real classes.
- Still no database involved.

## Also in this PR

- Corrects the ordering comment: attachments of one message are inserted in the same transaction and routinely share `created_at`, so the id tie-break is a random UUID, not send order. Harmless today (the inbound handlers create one attachment per message) but the comment claimed otherwise.

## Verification

Syntax-checked (`ruby -c`) on the three files; the preload walker's logic was validated in isolation (healthy path clean, renamed association → `"Attachment.file_attachment missing"`). **RSpec was not run** — it needs the Rails app + database, which I did not bring up.

Part of EVO-2178 · follow-up to EVO-2179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize bot delegation media handling by avoiding unnecessary reloads for text-only messages and tightening the contract between the delegation service and underlying models.

Bug Fixes:
- Skip media reload queries for inbound messages whose payload declares no attachments, preventing redundant database lookups on text-only messages.

Enhancements:
- Extract the attachment preload path into a constant used by both implementation and tests to guard against association or preload regressions.
- Add contract-style specs that validate the delegation service’s preload path, attachment interface, and outbound media URL helper against real model APIs.
- Clarify documentation around attachment ordering semantics for multi-message debounce windows.

Tests:
- Extend delegation service specs to cover the no-attachments path and to verify preload associations, attachment fields, and media URL helpers align with real models.