### PR TITLE
feat(crm): make pipeline archiving informed and preserve capture-form attribution (EVO-2200)

### DIFF
--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     stats: 'pipelines.read',
     by_contact: 'pipelines.read',
     by_conversation: 'pipelines.read',
-    dependents: 'pipelines.read'
+    dependents: 'pipelines.update'
   })
 
   before_action :fetch_pipeline, only: [:show, :update, :destroy, :archive, :set_as_default, :dependents]
@@ -133,12 +133,15 @@ class Api::V1::PipelinesController < Api::V1::BaseController
   # covered today — automations and journeys are separate cards (EVO-2199), so the
   # payload names what it inspected instead of implying the list is exhaustive.
   def dependents
-    forms = CrmForm.where(default_pipeline_id: @pipeline.id).order(:name)
+    scope = forms_targeting_pipeline
 
     success_response(
       data: {
         inspected: ['crm_forms'],
-        crm_forms: forms.map { |f| { id: f.id, name: f.name, title: f.title, published: f.published } }
+        count: scope.count,
+        published_count: scope.where(published: true).count,
+        names_redacted: !may_read_forms?,
+        crm_forms: may_read_forms? ? serialize_dependent_forms(scope.limit(DEPENDENTS_LIMIT)) : []
       },
       message: 'Pipeline dependents retrieved successfully'
     )
@@ -311,6 +314,39 @@ class Api::V1::PipelinesController < Api::V1::BaseController
       'No updatable attributes were provided',
       status: :unprocessable_entity
     )
+  end
+
+  DEPENDENTS_LIMIT = 50
+
+  # A form reaches a pipeline through its default destination OR through a routing rule
+  # that overrides it (CrmForm#resolve_destination). Matching only the default would let
+  # the dialog report "nothing depends on this" while rule-routed leads keep arriving.
+  def forms_targeting_pipeline
+    CrmForm.where(default_pipeline_id: @pipeline.id)
+           .or(CrmForm.where('routing_rules @> ?', [{ pipeline_id: @pipeline.id }].to_json))
+           .order(:name)
+  end
+
+  def serialize_dependent_forms(forms)
+    forms.map do |form|
+      {
+        id: form.id,
+        name: form.name,
+        title: form.title,
+        published: form.published,
+        via: form.default_pipeline_id == @pipeline.id ? 'default' : 'routing_rule'
+      }
+    end
+  end
+
+  # Form names belong to the crm_forms resource. Someone allowed to archive a pipeline is
+  # not automatically allowed to enumerate forms, so the counts are shared and the names
+  # are withheld when the caller lacks that grant.
+  def may_read_forms?
+    return @may_read_forms if defined?(@may_read_forms)
+
+    @may_read_forms = Current.service_authenticated == true ||
+                      has_user_permission?(Current.user&.id, 'crm_forms.read')
   end
 
   def include_inactive?

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -15,7 +15,8 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     dependents: 'pipelines.update'
   })
 
-  before_action :fetch_pipeline, only: [:show, :update, :destroy, :archive, :set_as_default, :dependents]
+  before_action :fetch_pipeline, only: [:show, :update, :destroy, :archive, :set_as_default]
+  before_action :fetch_pipeline_lean, only: [:dependents]
   before_action :reject_update_without_permitted_attributes, only: [:update]
   before_action :fetch_pipeline_for_stats, only: [:stats], if: -> { params[:id].present? }
   before_action :validate_pipeline_limit, only: [:create]
@@ -266,6 +267,13 @@ class Api::V1::PipelinesController < Api::V1::BaseController
                             }
                           )
                           .find(params[:id])
+  end
+
+  # dependents only needs the pipeline row to key the crm_forms lookup, so it skips the
+  # heavy item/conversation/message eager-load that fetch_pipeline does for show-style
+  # actions — loading that whole graph to answer a confirmation dialog is wasted work.
+  def fetch_pipeline_lean
+    @pipeline = Pipeline.find(params[:id])
   end
 
   def fetch_pipeline_for_stats

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -11,10 +11,11 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     set_as_default: 'pipelines.update',
     stats: 'pipelines.read',
     by_contact: 'pipelines.read',
-    by_conversation: 'pipelines.read'
+    by_conversation: 'pipelines.read',
+    dependents: 'pipelines.read'
   })
 
-  before_action :fetch_pipeline, only: [:show, :update, :destroy, :archive, :set_as_default]
+  before_action :fetch_pipeline, only: [:show, :update, :destroy, :archive, :set_as_default, :dependents]
   before_action :reject_update_without_permitted_attributes, only: [:update]
   before_action :fetch_pipeline_for_stats, only: [:stats], if: -> { params[:id].present? }
   before_action :validate_pipeline_limit, only: [:create]
@@ -124,6 +125,22 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     success_response(
       data: { id: @pipeline.id },
       message: 'Pipeline deleted successfully'
+    )
+  end
+
+  # What would keep running against this pipeline after it is archived. Answers the
+  # confirmation dialog, so archiving stops being a blind action. Only capture forms are
+  # covered today — automations and journeys are separate cards (EVO-2199), so the
+  # payload names what it inspected instead of implying the list is exhaustive.
+  def dependents
+    forms = CrmForm.where(default_pipeline_id: @pipeline.id).order(:name)
+
+    success_response(
+      data: {
+        inspected: ['crm_forms'],
+        crm_forms: forms.map { |f| { id: f.id, name: f.name, title: f.title, published: f.published } }
+      },
+      message: 'Pipeline dependents retrieved successfully'
     )
   end
 

--- a/app/services/public/leads/creation_service.rb
+++ b/app/services/public/leads/creation_service.rb
@@ -7,21 +7,7 @@ class Public::Leads::CreationService
   end
 
   def perform
-    ActiveRecord::Base.transaction do
-      validate_required_params!
-      validate_pipeline_and_stage!
-
-      @contact = find_or_create_contact
-      @pipeline_item = create_pipeline_item
-
-      publish_events
-
-      {
-        success: true,
-        contact: @contact,
-        pipeline_item: @pipeline_item
-      }
-    end
+    ActiveRecord::Base.transaction { create_lead! }
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error "Public Leads API: Validation error - #{e.message}"
     { success: false, error: e.record.errors.full_messages.join(', '), errors: e.record.errors.full_messages }
@@ -32,6 +18,19 @@ class Public::Leads::CreationService
   end
 
   private
+
+  def create_lead!
+    validate_required_params!
+    validate_pipeline_and_stage!
+
+    @contact = find_or_create_contact
+    stamp_capture_form_on_contact
+    @pipeline_item = create_pipeline_item
+
+    publish_events
+
+    { success: true, contact: @contact, pipeline_item: @pipeline_item }
+  end
 
   def validate_required_params!
     # Validate contact required fields
@@ -57,9 +56,38 @@ class Public::Leads::CreationService
     raise StandardError, @errors.join(', ') if @errors.any?
   end
 
+  CAPTURE_FORMS_ATTRIBUTE = 'capture_form_slugs'
+
+  # The capture proceeds on an archived pipeline: the lead stays visible in the form's
+  # Leads tab, which does not filter by is_active, and the contact is a normal contact.
+  # Logged so the proceed is observable — see EVO-2200 for the decision.
+  def log_archived_destination
+    return if @pipeline.is_active
+
+    Rails.logger.warn(
+      "Public Leads API: capturing into archived pipeline #{@pipeline.id} (#{@pipeline.name})"
+    )
+  end
+
+  # form_slug lives only in the pipeline item's custom_fields, and deleting a kanban card
+  # is a hard delete — that would erase the form attribution for good. Mirroring it on the
+  # contact keeps the link alive. Stored as a list: the same person may fill several forms.
+  def stamp_capture_form_on_contact
+    slug = metadata_params[:form_slug].presence || metadata_params['form_slug'].presence
+    return if slug.blank?
+
+    current = Array(@contact.custom_attributes&.dig(CAPTURE_FORMS_ATTRIBUTE))
+    return if current.include?(slug)
+
+    attributes = @contact.custom_attributes || {}
+    @contact.update!(custom_attributes: attributes.merge(CAPTURE_FORMS_ATTRIBUTE => current + [slug]))
+  end
+
   def validate_pipeline_and_stage!
     @pipeline = Pipeline.find_by(id: deal_params[:pipeline_id])
     raise StandardError, 'Pipeline not found' unless @pipeline
+
+    log_archived_destination
 
     # Validate stage belongs to pipeline
     @pipeline_stage = @pipeline.pipeline_stages.find_by(id: deal_params[:stage_id])

--- a/app/services/public/leads/creation_service.rb
+++ b/app/services/public/leads/creation_service.rb
@@ -22,6 +22,7 @@ class Public::Leads::CreationService
   def create_lead!
     validate_required_params!
     validate_pipeline_and_stage!
+    log_archived_destination
 
     @contact = find_or_create_contact
     stamp_capture_form_on_contact
@@ -86,8 +87,6 @@ class Public::Leads::CreationService
   def validate_pipeline_and_stage!
     @pipeline = Pipeline.find_by(id: deal_params[:pipeline_id])
     raise StandardError, 'Pipeline not found' unless @pipeline
-
-    log_archived_destination
 
     # Validate stage belongs to pipeline
     @pipeline_stage = @pipeline.pipeline_stages.find_by(id: deal_params[:stage_id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -579,6 +579,7 @@ Rails.application.routes.draw do
           patch :archive
           patch :set_as_default
           get :stats
+          get :dependents
         end
         resources :pipeline_stages, except: [:new, :edit], controller: 'pipeline_stages' do
           member do

--- a/spec/requests/api/v1/pipeline_dependents_spec.rb
+++ b/spec/requests/api/v1/pipeline_dependents_spec.rb
@@ -55,6 +55,45 @@ RSpec.describe 'Pipeline dependents', type: :request do
     expect(listed.first['published']).to be(true)
   end
 
+  # A routing rule overrides the form's default destination, so matching only the default
+  # would report "nothing depends on this" while rule-routed leads keep arriving.
+  it 'lists a form that reaches this pipeline through a routing rule' do
+    other = Pipeline.create!(name: "Other #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: user)
+    other.pipeline_stages.create!(name: 'New', position: 1)
+    form = build_form(other)
+    form.update!(routing_rules: [{ 'field' => 'plan', 'equals' => 'gold', 'pipeline_id' => pipeline.id }])
+
+    get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
+
+    listed = json_response['data']['crm_forms']
+    expect(listed.map { |f| f['id'] }).to eq([form.id])
+    expect(listed.first['via']).to eq('routing_rule')
+  end
+
+  it 'counts only published forms separately from the full list' do
+    build_form(pipeline)
+    build_form(pipeline).update!(published: false)
+
+    get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
+
+    expect(json_response['data']['count']).to eq(2)
+    expect(json_response['data']['published_count']).to eq(1)
+  end
+
+  it 'withholds form names from a caller without crm_forms.read' do
+    build_form(pipeline)
+    allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?) do |_, _, key|
+      key != 'crm_forms.read'
+    end
+
+    get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response['data']['count']).to eq(1)
+    expect(json_response['data']['crm_forms']).to eq([])
+    expect(json_response['data']['names_redacted']).to be(true)
+  end
+
   it 'does not list forms pointing at a different pipeline' do
     other = Pipeline.create!(name: "Other #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: user)
     other.pipeline_stages.create!(name: 'New', position: 1)

--- a/spec/requests/api/v1/pipeline_dependents_spec.rb
+++ b/spec/requests/api/v1/pipeline_dependents_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2200: archiving a pipeline was a blind action. This endpoint answers what would keep
+# running against it, so the confirmation dialog can name the capture forms that feed it.
+RSpec.describe 'Pipeline dependents', type: :request do
+  let(:user) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
+  let(:pipeline) { Pipeline.create!(name: "Sales #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: user) }
+  let!(:stage) { pipeline.pipeline_stages.create!(name: 'New', position: 1) }
+
+  before do
+    probe = user
+    allow_any_instance_of(Api::BaseController).to receive(:authenticate_request!) do
+      Current.user = probe
+      Current.evo_permission_cache ||= {}
+    end
+    allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?).and_return(true)
+  end
+
+  after { Current.reset }
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  def build_form(destination)
+    CrmForm.create!(
+      name: "Form #{SecureRandom.hex(4)}",
+      default_pipeline: destination,
+      default_stage: destination.pipeline_stages.first,
+      published: true,
+      fields: [
+        { 'key' => 'full_name', 'label' => 'Name', 'type' => 'text', 'required' => true, 'maps_to' => 'name' },
+        { 'key' => 'email', 'label' => 'Email', 'type' => 'email', 'required' => true, 'maps_to' => 'email' }
+      ]
+    )
+  end
+
+  it 'returns an empty list when nothing depends on the pipeline' do
+    get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response['data']['crm_forms']).to eq([])
+  end
+
+  it 'lists the capture forms whose destination is this pipeline' do
+    form = build_form(pipeline)
+
+    get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
+
+    expect(response).to have_http_status(:ok)
+    listed = json_response['data']['crm_forms']
+    expect(listed.map { |f| f['id'] }).to eq([form.id])
+    expect(listed.first['published']).to be(true)
+  end
+
+  it 'does not list forms pointing at a different pipeline' do
+    other = Pipeline.create!(name: "Other #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: user)
+    other.pipeline_stages.create!(name: 'New', position: 1)
+    build_form(other)
+
+    get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
+
+    expect(json_response['data']['crm_forms']).to eq([])
+  end
+
+  # The dialog must not imply it checked automations or journeys — those are separate cards.
+  it 'declares which dependency kinds were inspected' do
+    get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
+
+    expect(json_response['data']['inspected']).to eq(['crm_forms'])
+  end
+end

--- a/spec/requests/api/v1/pipeline_dependents_spec.rb
+++ b/spec/requests/api/v1/pipeline_dependents_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Pipeline dependents', type: :request do
     other = Pipeline.create!(name: "Other #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: user)
     other.pipeline_stages.create!(name: 'New', position: 1)
     form = build_form(other)
-    form.update!(routing_rules: [{ 'field' => 'plan', 'equals' => 'gold', 'pipeline_id' => pipeline.id }])
+    form.update!(routing_rules: [{ 'field' => 'plan', 'op' => 'equals', 'value' => 'gold', 'pipeline_id' => pipeline.id }])
 
     get "/api/v1/pipelines/#{pipeline.id}/dependents", as: :json
 

--- a/spec/services/public/leads/creation_service_spec.rb
+++ b/spec/services/public/leads/creation_service_spec.rb
@@ -45,4 +45,97 @@ RSpec.describe Public::Leads::CreationService do
       expect(existing.custom_attributes['segment']).to eq('enterprise')
     end
   end
+
+  # EVO-2200: form_slug lives only in the pipeline item's custom_fields, and deleting a
+  # kanban card is a hard delete — the form attribution would be lost with it. Mirroring
+  # it on the contact keeps the link, and it is a list because one person may fill several.
+  describe 'capture form attribution on the contact' do
+    let(:email) { "lead-#{SecureRandom.hex(4)}@example.com" }
+
+    # A contact cannot hold two active items in the SAME pipeline (pre-existing rule:
+    # "Contact already has an active journey in this pipeline"), so a second capture for
+    # the same person necessarily lands in another pipeline.
+    let(:other_pipeline) do
+      p = Pipeline.create!(name: "Support #{SecureRandom.hex(4)}", pipeline_type: 'support', created_by: user)
+      p.pipeline_stages.create!(name: 'New', position: 1)
+      p
+    end
+
+    def perform_with_form(slug, contact_email, destination: pipeline)
+      described_class.new(lead_params: {
+        contact: { name: 'Ada', email: contact_email },
+        deal: { pipeline_id: destination.id, stage_id: destination.pipeline_stages.first.id },
+        metadata: { form_slug: slug, lead_source: 'crm_form' }
+      }).perform
+    end
+
+    it 'stamps the originating form on the contact' do
+      result = perform_with_form('contact-us', email)
+
+      expect(result[:success]).to be(true)
+      expect(result[:contact].reload.custom_attributes['capture_form_slugs']).to eq(['contact-us'])
+    end
+
+    it 'accumulates every form the same person filled' do
+      perform_with_form('contact-us', email)
+      result = perform_with_form('newsletter', email, destination: other_pipeline)
+
+      expect(result[:success]).to be(true)
+      expect(result[:contact].reload.custom_attributes['capture_form_slugs'])
+        .to eq(%w[contact-us newsletter])
+    end
+
+    it 'does not duplicate a form the contact already came through' do
+      perform_with_form('contact-us', email)
+      result = perform_with_form('contact-us', email, destination: other_pipeline)
+
+      expect(result[:success]).to be(true)
+      expect(result[:contact].reload.custom_attributes['capture_form_slugs']).to eq(['contact-us'])
+    end
+
+    it 'leaves the contact untouched when the capture carries no form' do
+      result = perform(contact: { name: 'Ada', email: email })
+
+      expect(result[:contact].reload.custom_attributes).not_to have_key('capture_form_slugs')
+    end
+
+    it 'survives deletion of the pipeline item, unlike the item custom_fields' do
+      result = perform_with_form('contact-us', email)
+      result[:pipeline_item].destroy!
+
+      expect(result[:contact].reload.custom_attributes['capture_form_slugs']).to eq(['contact-us'])
+    end
+  end
+
+  describe 'archived destination pipeline' do
+    let(:email) { "lead-#{SecureRandom.hex(4)}@example.com" }
+
+    # Declined C1/C2/C3 on EVO-2200: capture proceeds, because the form's Leads tab does
+    # not filter is_active and the record stays visible and recoverable.
+    it 'still captures the lead' do
+      pipeline.update!(is_active: false)
+
+      result = perform(contact: { name: 'Ada', email: email })
+
+      expect(result[:success]).to be(true)
+      expect(result[:pipeline_item]).to be_present
+    end
+
+    it 'logs the archived destination so the proceed is observable' do
+      pipeline.update!(is_active: false)
+      allow(Rails.logger).to receive(:warn)
+
+      perform(contact: { name: 'Ada', email: email })
+
+      expect(Rails.logger).to have_received(:warn).with(/archived pipeline #{pipeline.id}/)
+    end
+
+    it 'stays quiet while the pipeline is active' do
+      allow(Rails.logger).to receive(:warn)
+
+      perform(contact: { name: 'Ada', email: email })
+
+      expect(Rails.logger).not_to have_received(:warn).with(/archived pipeline/)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Card was re-scoped mid-flight — see the decision comment on EVO-2200. The original proposal (reject capture into an archived pipeline) was declined: rejecting discards the visitor's data, and skipping the pipeline item would break the form's Leads tab, which does not filter `is_active` and shows the lead today. **Runtime capture behaviour is unchanged.** What was missing is prevention.

- `GET /pipelines/:id/dependents` answers what still feeds a pipeline, so the archive confirmation can name it. The payload declares which dependency kinds were inspected — automations and journeys are separate children of EVO-2199, and a dialog implying it checked them would be worse than no dialog.
- The lookup covers both the form's default destination **and** routing rules that override it (`CrmForm#resolve_destination`). Matching only `default_pipeline_id` would report an all-clear while rule-routed leads kept arriving. Uses the existing GIN index on `routing_rules`.
- Capture into an archived pipeline is logged, so the proceed is observable.
- The originating form is mirrored on the contact as `capture_form_slugs` (a list — one person may fill several forms).

### Why the contact stamp matters

`form_slug` lived only in the pipeline item's `custom_fields`, and `DELETE /api/v1/pipeline_items/:id` is a hard delete with no soft-delete on the model. Deleting a kanban card destroyed the form attribution permanently — on a healthy, active pipeline. This stops that from the point forward, and is the prerequisite for the contact-based read (separate card).

## Security

- `dependents` is gated on `pipelines.update`, the operation it serves — not on read.
- Form names belong to the `crm_forms` resource, so they are withheld when the caller lacks `crm_forms.read`; only counts are shared (`names_redacted`).
- No new user input reaches a query; the JSONB match is parameterised.
- The list is capped at 50; counts remain exact.

## Test plan

- `bundle exec rspec spec/services/public spec/requests/public spec/requests/api/v1/pipeline_dependents_spec.rb spec/requests/api/v1/pipelines_activation_spec.rb spec/models/crm_form_spec.rb` — 64 examples, 0 failures
- `bundle exec rubocop app/services/public/leads/creation_service.rb app/controllers/api/v1/pipelines_controller.rb` — 53 offenses, identical to the baseline on `develop`; no new cop
- `ruby -c` on every touched file — Syntax OK
- Manual smoke against a live install: capture with the pipeline active and archived, deactivation dialog listing a real form, and attribution surviving deletion of the kanban card

## Deferred

`stamp_capture_form_on_contact` does a read-modify-write without a lock. Two simultaneous submissions by the same person through different forms could drop one slug. Serialising a contact on an anonymous public endpoint carries its own risk, and the scenario requires the same email hitting two forms at the same instant — recorded rather than fixed.

## Changed Files

- `app/controllers/api/v1/pipelines_controller.rb`
- `app/services/public/leads/creation_service.rb`
- `config/routes.rb`
- `spec/requests/api/v1/pipeline_dependents_spec.rb` (new)
- `spec/services/public/leads/creation_service_spec.rb`

## Related PRs

- Frontend: https://github.com/evolution-foundation/evo-ai-frontend-community/pull/264 — merge this one first, it depends on the `dependents` endpoint.

## Linked Issue

- EVO-2200 — https://linear.app/evoai/issue/EVO-2200

## Summary by Sourcery

Add backend support to surface CRM forms that depend on a pipeline before archiving it and to persist capture-form attribution on contacts while keeping lead capture into archived pipelines observable but unchanged.

New Features:
- Expose a pipelines dependents endpoint that reports CRM forms targeting a given pipeline, including counts and limited form metadata when permitted.
- Persist capture form slugs on contacts when leads are created so attribution survives pipeline item deletion.

Enhancements:
- Log captures into archived pipelines to make continued intake into inactive pipelines observable without blocking it.

Tests:
- Add request specs for the pipeline dependents endpoint and extend public leads creation service specs to cover contact form attribution, archived pipeline logging, and related behaviors.