### PR TITLE
feat(crm): stop stage automations from running on archived pipelines (EVO-2201)

### DIFF
--- a/app/jobs/pipelines/stage_inactivity_check_scheduler_job.rb
+++ b/app/jobs/pipelines/stage_inactivity_check_scheduler_job.rb
@@ -16,16 +16,20 @@ class Pipelines::StageInactivityCheckSchedulerJob < ApplicationJob
     candidates = PipelineItem.where(pipeline_stage_id: stage_ids, completed_at: nil)
     # Archived pipelines stop acting on their own (EVO-2201). Filtered here so an archived
     # board does not enqueue a job per item every minute; the service guards it too, since
-    # this is an optimisation and not the authority.
+    # this is an optimisation and not the authority. Resolved through the stage
+    # (pipeline_stage -> pipeline) — the same source the service guard reads — so the filter
+    # and the authority read the same pipeline and cannot disagree on a drifted row.
     #
     # Counted on the archived side only — this runs every minute and that side is empty in
     # the normal case, so the common path pays for one narrow count instead of two wide ones.
-    skipped = candidates.joins(:pipeline).where(pipelines: { is_active: false }).count
+    skipped = candidates.joins(pipeline_stage: :pipeline).where(pipelines: { is_active: false }).count
     summary = "[StageInactivityScheduler] #{stage_ids.size} stages with inactivity rules"
-    summary += ", #{skipped} items skipped in archived pipelines" if skipped.positive?
+    summary += ", #{skipped} item#{'s' if skipped != 1} skipped in archived pipelines" if skipped.positive?
     Rails.logger.info(summary)
 
-    candidates.joins(:pipeline).where(pipelines: { is_active: true }).find_each(batch_size: 100) do |item|
+    candidates.joins(pipeline_stage: :pipeline)
+              .where(pipelines: { is_active: true })
+              .find_each(batch_size: 100) do |item|
       Pipelines::ProcessStageInactivityActionsJob.perform_later(item.id)
     end
   end

--- a/app/jobs/pipelines/stage_inactivity_check_scheduler_job.rb
+++ b/app/jobs/pipelines/stage_inactivity_check_scheduler_job.rb
@@ -13,12 +13,19 @@ class Pipelines::StageInactivityCheckSchedulerJob < ApplicationJob
     stage_ids = PipelineStage.where(HAS_INACTIVITY_RULE, CONTAINMENT).pluck(:id)
     return if stage_ids.empty?
 
-    Rails.logger.info "[StageInactivityScheduler] #{stage_ids.size} stages with inactivity rules"
+    candidates = PipelineItem.where(pipeline_stage_id: stage_ids, completed_at: nil)
+    # Archived pipelines stop acting on their own (EVO-2201). Filtered here so an archived
+    # board does not enqueue a job per item every minute; the service guards it too, since
+    # this is an optimisation and not the authority.
+    live = candidates.joins(:pipeline).where(pipelines: { is_active: true })
 
-    PipelineItem
-      .where(pipeline_stage_id: stage_ids, completed_at: nil)
-      .find_each(batch_size: 100) do |item|
-        Pipelines::ProcessStageInactivityActionsJob.perform_later(item.id)
-      end
+    Rails.logger.info(
+      "[StageInactivityScheduler] #{stage_ids.size} stages with inactivity rules, " \
+      "#{candidates.count - live.count} items skipped in archived pipelines"
+    )
+
+    live.find_each(batch_size: 100) do |item|
+      Pipelines::ProcessStageInactivityActionsJob.perform_later(item.id)
+    end
   end
 end

--- a/app/jobs/pipelines/stage_inactivity_check_scheduler_job.rb
+++ b/app/jobs/pipelines/stage_inactivity_check_scheduler_job.rb
@@ -17,14 +17,15 @@ class Pipelines::StageInactivityCheckSchedulerJob < ApplicationJob
     # Archived pipelines stop acting on their own (EVO-2201). Filtered here so an archived
     # board does not enqueue a job per item every minute; the service guards it too, since
     # this is an optimisation and not the authority.
-    live = candidates.joins(:pipeline).where(pipelines: { is_active: true })
+    #
+    # Counted on the archived side only — this runs every minute and that side is empty in
+    # the normal case, so the common path pays for one narrow count instead of two wide ones.
+    skipped = candidates.joins(:pipeline).where(pipelines: { is_active: false }).count
+    summary = "[StageInactivityScheduler] #{stage_ids.size} stages with inactivity rules"
+    summary += ", #{skipped} items skipped in archived pipelines" if skipped.positive?
+    Rails.logger.info(summary)
 
-    Rails.logger.info(
-      "[StageInactivityScheduler] #{stage_ids.size} stages with inactivity rules, " \
-      "#{candidates.count - live.count} items skipped in archived pipelines"
-    )
-
-    live.find_each(batch_size: 100) do |item|
+    candidates.joins(:pipeline).where(pipelines: { is_active: true }).find_each(batch_size: 100) do |item|
       Pipelines::ProcessStageInactivityActionsJob.perform_later(item.id)
     end
   end

--- a/app/services/pipelines/stage_automation_service.rb
+++ b/app/services/pipelines/stage_automation_service.rb
@@ -19,7 +19,7 @@ class Pipelines::StageAutomationService
   def perform
     Current.executed_by = :stage_automation
     @conversation.pipeline_items.includes(pipeline_stage: :pipeline).each do |pipeline_item|
-      next if skip_archived_pipeline?(pipeline_item)
+      next if log_and_skip_archived_pipeline(pipeline_item)
 
       evaluate_stage_rules(pipeline_item)
     end
@@ -47,11 +47,11 @@ class Pipelines::StageAutomationService
   # customer, and the operator can no longer even see the board. Evaluated per item, not
   # per conversation: a conversation may sit in several pipelines, and one archived among
   # them must not silence the active ones.
-  def skip_archived_pipeline?(pipeline_item)
+  def log_and_skip_archived_pipeline(pipeline_item)
     pipeline = pipeline_item.pipeline_stage.pipeline
     return false if pipeline.nil? || pipeline.is_active
 
-    Rails.logger.info(
+    Rails.logger.warn(
       "[StageAutomation] conv=#{@conversation.id} item=#{pipeline_item.id} skipped: " \
       "pipeline #{pipeline.id} is archived (is_active=false)"
     )

--- a/app/services/pipelines/stage_automation_service.rb
+++ b/app/services/pipelines/stage_automation_service.rb
@@ -19,6 +19,8 @@ class Pipelines::StageAutomationService
   def perform
     Current.executed_by = :stage_automation
     @conversation.pipeline_items.includes(pipeline_stage: :pipeline).each do |pipeline_item|
+      next if skip_archived_pipeline?(pipeline_item)
+
       evaluate_stage_rules(pipeline_item)
     end
   ensure
@@ -39,6 +41,21 @@ class Pipelines::StageAutomationService
 
       execute_action(rule, pipeline_item)
     end
+  end
+
+  # An archived pipeline must stop acting on its own — its rules can send messages to the
+  # customer, and the operator can no longer even see the board. Evaluated per item, not
+  # per conversation: a conversation may sit in several pipelines, and one archived among
+  # them must not silence the active ones.
+  def skip_archived_pipeline?(pipeline_item)
+    pipeline = pipeline_item.pipeline_stage.pipeline
+    return false if pipeline.nil? || pipeline.is_active
+
+    Rails.logger.info(
+      "[StageAutomation] conv=#{@conversation.id} item=#{pipeline_item.id} skipped: " \
+      "pipeline #{pipeline.id} is archived (is_active=false)"
+    )
+    true
   end
 
   def rule_matches?(rule)
@@ -137,6 +154,15 @@ class Pipelines::StageAutomationService
     target_pipeline = Pipeline.find_by(id: target_pipeline_id)
     unless target_pipeline
       Rails.logger.warn "[StageAutomation] move_to_pipeline aborted: target pipeline #{target_pipeline_id} not found"
+      return
+    end
+
+    # Refusing the move leaves the conversation where it is, visible. Allowing it would
+    # push the conversation into a board the operator archived and can no longer see.
+    unless target_pipeline.is_active
+      Rails.logger.warn(
+        "[StageAutomation] move_to_pipeline aborted: target pipeline #{target_pipeline_id} is archived"
+      )
       return
     end
 

--- a/app/services/pipelines/stage_inactivity_actions_service.rb
+++ b/app/services/pipelines/stage_inactivity_actions_service.rb
@@ -29,9 +29,10 @@ class Pipelines::StageInactivityActionsService
   def eligible?
     return false if @pipeline_item.completed_at.present?
     return false if @pipeline_item.pipeline_stage.nil?
+    return false unless inactivity_rules.any?
     return false if log_and_skip_archived_pipeline
 
-    inactivity_rules.any?
+    true
   end
 
   # This path is time-based: nobody is watching when it fires. An archived pipeline that

--- a/app/services/pipelines/stage_inactivity_actions_service.rb
+++ b/app/services/pipelines/stage_inactivity_actions_service.rb
@@ -29,8 +29,24 @@ class Pipelines::StageInactivityActionsService
   def eligible?
     return false if @pipeline_item.completed_at.present?
     return false if @pipeline_item.pipeline_stage.nil?
+    return false if archived_pipeline?
 
     inactivity_rules.any?
+  end
+
+  # This path is time-based: nobody is watching when it fires. An archived pipeline that
+  # keeps its inactivity rules running would send messages from a board the operator turned
+  # off. The scheduler already filters these out, so reaching here means another caller
+  # enqueued the job — worth a line (EVO-2201).
+  def archived_pipeline?
+    pipeline = @pipeline_item.pipeline
+    return false if pipeline.nil? || pipeline.is_active
+
+    Rails.logger.info(
+      "[StageInactivity] item=#{@pipeline_item.id} skipped: " \
+      "pipeline #{pipeline.id} is archived (is_active=false)"
+    )
+    true
   end
 
   def inactivity_rules

--- a/app/services/pipelines/stage_inactivity_actions_service.rb
+++ b/app/services/pipelines/stage_inactivity_actions_service.rb
@@ -29,7 +29,7 @@ class Pipelines::StageInactivityActionsService
   def eligible?
     return false if @pipeline_item.completed_at.present?
     return false if @pipeline_item.pipeline_stage.nil?
-    return false if archived_pipeline?
+    return false if log_and_skip_archived_pipeline
 
     inactivity_rules.any?
   end
@@ -38,11 +38,15 @@ class Pipelines::StageInactivityActionsService
   # keeps its inactivity rules running would send messages from a board the operator turned
   # off. The scheduler already filters these out, so reaching here means another caller
   # enqueued the job — worth a line (EVO-2201).
-  def archived_pipeline?
-    pipeline = @pipeline_item.pipeline
+  #
+  # Resolved through the stage, not through pipeline_item.pipeline: the row carries both
+  # pipeline_id and pipeline_stage_id with no constraint tying them together, and the event
+  # path reads the same way. One source, so the two paths cannot disagree.
+  def log_and_skip_archived_pipeline
+    pipeline = @pipeline_item.pipeline_stage.pipeline
     return false if pipeline.nil? || pipeline.is_active
 
-    Rails.logger.info(
+    Rails.logger.warn(
       "[StageInactivity] item=#{@pipeline_item.id} skipped: " \
       "pipeline #{pipeline.id} is archived (is_active=false)"
     )

--- a/spec/jobs/pipelines/stage_inactivity_check_scheduler_job_spec.rb
+++ b/spec/jobs/pipelines/stage_inactivity_check_scheduler_job_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe Pipelines::StageInactivityCheckSchedulerJob do
     described_class.new.perform
   end
 
+  # The scheduler filter is an optimisation, not the authority: a job enqueued by any other
+  # caller must still be refused by the service itself.
+  it 'refuses an item in an archived pipeline even when the job is invoked directly' do
+    _pipeline, item = pipeline_with_item(active: false)
+    item.stage_movements.update_all(created_at: 31.minutes.ago)
+
+    expect { Pipelines::ProcessStageInactivityActionsJob.perform_now(item.id) }
+      .not_to change(StageInactivityExecution, :count)
+  end
+
   it 'reports how many items it skipped' do
     pipeline_with_item(active: false)
     allow(Pipelines::ProcessStageInactivityActionsJob).to receive(:perform_later)

--- a/spec/jobs/pipelines/stage_inactivity_check_scheduler_job_spec.rb
+++ b/spec/jobs/pipelines/stage_inactivity_check_scheduler_job_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2201: the scheduler runs every minute. Filtering archived pipelines here keeps an
+# archived board from enqueueing a job per item forever; the service guards it as well,
+# since this filter is an optimisation and not the authority.
+RSpec.describe Pipelines::StageInactivityCheckSchedulerJob do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Test Contact', email: "contact-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) do
+    Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+  end
+
+  let(:inactivity_rules) do
+    { 'rules' => [{ 'id' => SecureRandom.uuid, 'trigger' => 'inactivity',
+                    'trigger_value' => { 'minutes' => 30, 'base' => 'stage_stagnation' },
+                    'action' => 'send_direct_message', 'action_value' => 'Still there?' }] }
+  end
+
+  def pipeline_with_item(active:)
+    pipeline = Pipeline.create!(name: "P #{SecureRandom.hex(3)}", pipeline_type: 'custom', created_by: user)
+    stage = PipelineStage.create!(pipeline: pipeline, name: 'A', position: 1, automation_rules: inactivity_rules)
+    item = PipelineItem.create!(pipeline: pipeline, pipeline_stage: stage, conversation: conversation)
+    pipeline.update!(is_active: false) unless active
+    [pipeline, item]
+  end
+
+  it 'enqueues a job for an item in an active pipeline' do
+    _pipeline, item = pipeline_with_item(active: true)
+
+    expect(Pipelines::ProcessStageInactivityActionsJob).to receive(:perform_later).with(item.id)
+
+    described_class.new.perform
+  end
+
+  it 'does not enqueue anything for an item in an archived pipeline' do
+    pipeline_with_item(active: false)
+
+    expect(Pipelines::ProcessStageInactivityActionsJob).not_to receive(:perform_later)
+
+    described_class.new.perform
+  end
+
+  it 'reports how many items it skipped' do
+    pipeline_with_item(active: false)
+    allow(Pipelines::ProcessStageInactivityActionsJob).to receive(:perform_later)
+    allow(Rails.logger).to receive(:info)
+
+    described_class.new.perform
+
+    expect(Rails.logger).to have_received(:info).with(/1 items skipped in archived pipelines/)
+  end
+end

--- a/spec/jobs/pipelines/stage_inactivity_check_scheduler_job_spec.rb
+++ b/spec/jobs/pipelines/stage_inactivity_check_scheduler_job_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe Pipelines::StageInactivityCheckSchedulerJob do
 
     described_class.new.perform
 
-    expect(Rails.logger).to have_received(:info).with(/1 items skipped in archived pipelines/)
+    expect(Rails.logger).to have_received(:info).with(/1 item skipped in archived pipelines/)
+  end
+
+  # The active/archived decision must read the same pipeline the service guard reads —
+  # through the stage, not through pipeline_id. Nothing constrains the two columns to agree,
+  # so on a drifted row (pipeline_id archived, stage on an active pipeline) a pipeline_id-based
+  # filter would drop an item the service would have fired: the active board silently stops.
+  it 'honours the stage pipeline, not pipeline_id, when the two disagree' do
+    _pipeline, item = pipeline_with_item(active: true)
+    archived = Pipeline.create!(name: "Arch #{SecureRandom.hex(3)}", pipeline_type: 'custom', created_by: user)
+    archived.update!(is_active: false)
+    item.update_columns(pipeline_id: archived.id) # rubocop:disable Rails/SkipsModelValidations
+
+    expect(Pipelines::ProcessStageInactivityActionsJob).to receive(:perform_later).with(item.id)
+
+    described_class.new.perform
   end
 end

--- a/spec/services/pipelines/stage_automation_service_spec.rb
+++ b/spec/services/pipelines/stage_automation_service_spec.rb
@@ -197,11 +197,11 @@ RSpec.describe Pipelines::StageAutomationService do
 
       it 'logs the skip with the pipeline id and the reason' do
         pipeline.update!(is_active: false)
-        allow(Rails.logger).to receive(:info)
+        allow(Rails.logger).to receive(:warn)
 
         service.perform
 
-        expect(Rails.logger).to have_received(:info).with(/#{pipeline.id} is archived/)
+        expect(Rails.logger).to have_received(:warn).with(/#{pipeline.id} is archived/)
       end
 
       it 'still executes the rule while the pipeline is active' do

--- a/spec/services/pipelines/stage_automation_service_spec.rb
+++ b/spec/services/pipelines/stage_automation_service_spec.rb
@@ -176,5 +176,87 @@ RSpec.describe Pipelines::StageAutomationService do
         expect(Current.executed_by).to be_nil
       end
     end
+
+    # EVO-2201: an archived pipeline must stop acting on its own — its rules can message
+    # the customer from a board the operator turned off and can no longer see.
+    context 'when the pipeline is archived' do
+      let(:changed_attributes) { { 'label_list' => [[], ['urgent']] } }
+
+      before do
+        stage_a.update!(automation_rules: {
+          'rules' => [{ 'trigger' => 'label_added', 'trigger_value' => 'urgent',
+                        'action' => 'move_to_stage', 'action_value' => stage_b.id }]
+        })
+      end
+
+      it 'does not execute the rule' do
+        pipeline.update!(is_active: false)
+
+        expect { service.perform }.not_to change { pipeline_item.reload.pipeline_stage_id }
+      end
+
+      it 'logs the skip with the pipeline id and the reason' do
+        pipeline.update!(is_active: false)
+        allow(Rails.logger).to receive(:info)
+
+        service.perform
+
+        expect(Rails.logger).to have_received(:info).with(/#{pipeline.id} is archived/)
+      end
+
+      it 'still executes the rule while the pipeline is active' do
+        expect { service.perform }.to change { pipeline_item.reload.pipeline_stage_id }.to(stage_b.id)
+      end
+
+      # A conversation may sit in several pipelines: one archived must not silence the rest.
+      it 'evaluates the active pipeline of a conversation that also sits in an archived one' do
+        pipeline.update!(is_active: false)
+
+        live = Pipeline.create!(name: 'Live', pipeline_type: 'custom', created_by: user)
+        live_a = PipelineStage.create!(pipeline: live, name: 'A', position: 1)
+        live_b = PipelineStage.create!(pipeline: live, name: 'B', position: 2)
+        live_a.update!(automation_rules: {
+          'rules' => [{ 'trigger' => 'label_added', 'trigger_value' => 'urgent',
+                        'action' => 'move_to_stage', 'action_value' => live_b.id }]
+        })
+        live_item = PipelineItem.create!(pipeline: live, pipeline_stage: live_a, conversation: conversation)
+
+        service.perform
+
+        expect(live_item.reload.pipeline_stage_id).to eq(live_b.id)
+        expect(pipeline_item.reload.pipeline_stage_id).to eq(stage_a.id)
+      end
+    end
+
+    # Refusing the move keeps the conversation visible where it is, instead of pushing it
+    # into a board nobody can see.
+    context 'when move_to_pipeline targets an archived pipeline' do
+      let(:changed_attributes) { { 'label_list' => [[], ['urgent']] } }
+      let(:target) do
+        t = Pipeline.create!(name: 'Target', pipeline_type: 'custom', created_by: user)
+        PipelineStage.create!(pipeline: t, name: 'Inbox', position: 1)
+        t
+      end
+
+      before do
+        stage_a.update!(automation_rules: {
+          'rules' => [{ 'trigger' => 'label_added', 'trigger_value' => 'urgent',
+                        'action' => 'move_to_pipeline', 'action_value' => target.id }]
+        })
+      end
+
+      # move_to_pipeline relocates the existing item rather than creating a second one.
+      it 'refuses the move and says why' do
+        target.update!(is_active: false)
+        allow(Rails.logger).to receive(:warn)
+
+        expect { service.perform }.not_to change { pipeline_item.reload.pipeline_id }
+        expect(Rails.logger).to have_received(:warn).with(/#{target.id} is archived/)
+      end
+
+      it 'performs the move while the target is active' do
+        expect { service.perform }.to change { pipeline_item.reload.pipeline_id }.to(target.id)
+      end
+    end
   end
 end

--- a/spec/services/pipelines/stage_inactivity_actions_service_spec.rb
+++ b/spec/services/pipelines/stage_inactivity_actions_service_spec.rb
@@ -116,4 +116,34 @@ RSpec.describe Pipelines::StageInactivityActionsService do
       expect(remaining).to eq(['stage_stagnation'])
     end
   end
+
+  # EVO-2201: this path is time-based and fires unattended, so an archived pipeline that
+  # kept its inactivity rules would message customers from a board the operator turned off.
+  describe 'archived pipeline' do
+    before do
+      set_rule(minutes: 30, base: 'stage_stagnation')
+      pipeline_item.stage_movements.update_all(created_at: 31.minutes.ago)
+    end
+
+    it 'does not fire once the pipeline is archived' do
+      pipeline.update!(is_active: false)
+
+      expect { described_class.new(pipeline_item.reload).process }
+        .not_to change(StageInactivityExecution, :count)
+    end
+
+    it 'logs the skip with the pipeline id and the reason' do
+      pipeline.update!(is_active: false)
+      allow(Rails.logger).to receive(:info)
+
+      described_class.new(pipeline_item.reload).process
+
+      expect(Rails.logger).to have_received(:info).with(/#{pipeline.id} is archived/)
+    end
+
+    it 'still fires while the pipeline is active' do
+      expect { described_class.new(pipeline_item.reload).process }
+        .to change(StageInactivityExecution, :count).by(1)
+    end
+  end
 end

--- a/spec/services/pipelines/stage_inactivity_actions_service_spec.rb
+++ b/spec/services/pipelines/stage_inactivity_actions_service_spec.rb
@@ -134,11 +134,11 @@ RSpec.describe Pipelines::StageInactivityActionsService do
 
     it 'logs the skip with the pipeline id and the reason' do
       pipeline.update!(is_active: false)
-      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:warn)
 
       described_class.new(pipeline_item.reload).process
 
-      expect(Rails.logger).to have_received(:info).with(/#{pipeline.id} is archived/)
+      expect(Rails.logger).to have_received(:warn).with(/#{pipeline.id} is archived/)
     end
 
     it 'still fires while the pipeline is active' do


### PR DESCRIPTION
## Summary

An archived pipeline disappears from every picker but kept acting on its own. Its rules can send AI messages, direct messages and templates, so a board the operator believes is off was still reaching out to customers.

- **Event path** skips an archived pipeline per item, not per conversation: a conversation may sit in several pipelines, and one archived among them must not silence the active ones.
- **Inactivity path is guarded too.** The card named only the event service, but time-based rules live in a second service (`StageInactivityActionsService`) driven by a scheduler that runs every minute. Gating one and not the other would have left the unattended half running — the half that fires at 3am with nobody watching.
- **The scheduler** filters archived pipelines out of its query, so an archived board stops enqueueing a job per item every minute. The service still guards it: the filter is an optimisation, not the authority, and a spec drives the job directly to prove it.
- **`move_to_pipeline` refuses an archived target.** Refusing leaves the conversation visible where it is; allowing it would push the conversation into a board nobody can see.

Every deliberate skip is logged at `warn` with the pipeline id and the reason — a silent return would reproduce the class of bug EVO-2122 was about.

## ⚠️ Known consequence: reactivation can fire a burst

The inactivity clock is absolute — `elapsed_minutes` compares `Time.current` against stage entry or the last incoming message. It does not pause while the pipeline is archived.

So archiving a pipeline for three days and then reactivating it makes **every item that crossed its threshold during that window fire on the next scheduler tick**. With `send_direct_message` or `send_ai_message`, that is a burst of days-late messages to customers.

This is a consequence of the fix, not a pre-existing defect: before, those messages went out spread across the archived window (wrongly, but diluted). `StageInactivityExecution` only protects rules that already fired.

Left as-is deliberately — the rule's condition is genuinely true, and deciding otherwise (resetting the clock on reactivation, or suppressing retroactive sends) is a product call with its own scope. Raised on the card for @guilherme.gomes.

## Security

No authZ surface: both services are internal, driven by an event listener and a scheduler. No new user input reaches a query; the filter is a boolean column.

## Test plan

- `bundle exec rspec spec/services/pipelines spec/jobs/pipelines spec/listeners/pipeline_stage_automation_listener_spec.rb` — 38 examples, 0 failures
- Negative control: with the three guards disabled, 8 of them fail
- `bundle exec rubocop` on the touched files — 16 offenses, identical to the `develop` baseline, no new cop
- `ruby -c` on every touched file — Syntax OK
- Manual smoke on a live install: with the pipeline archived the stage rule did not execute; reactivated, the same rule executed again

## Note on observability

The whole skip surface is the server log. That is what the card asked for, and unlike EVO-2200 nothing is destroyed here — the automation simply does not run. Giving the operator a UI surface for skipped automations is a separate product decision.

## Changed Files

- `app/services/pipelines/stage_automation_service.rb`
- `app/services/pipelines/stage_inactivity_actions_service.rb`
- `app/jobs/pipelines/stage_inactivity_check_scheduler_job.rb`
- `spec/services/pipelines/stage_automation_service_spec.rb`
- `spec/services/pipelines/stage_inactivity_actions_service_spec.rb`
- `spec/jobs/pipelines/stage_inactivity_check_scheduler_job_spec.rb` (new)

## Linked Issue

- EVO-2201 — https://linear.app/evoai/issue/EVO-2201

## Summary by Sourcery

Prevent pipeline stage automations and inactivity-based actions from running on archived pipelines while keeping active pipelines for the same conversation unaffected.

New Features:
- Add safeguards so stage automation and inactivity services skip items belonging to archived pipelines and log the reason for each skip.
- Block move_to_pipeline actions that target archived pipelines to keep conversations in visible boards.
- Extend the stage inactivity scheduler to exclude items in archived pipelines and report skipped item counts in logs.

Tests:
- Add and update service specs to cover archived vs active pipeline behavior for stage automations and inactivity rules, including logging expectations.
- Introduce a new job spec for the stage inactivity scheduler to verify filtering of archived pipelines, direct job invocation behavior, and log reporting.