### PR TITLE
feat(crm): stop automation rules from pushing conversations into archived pipelines (EVO-2202)

### DIFF
--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -279,7 +279,7 @@ class AutomationRuleListener < BaseListener
 
     if rule.mode == 'flow' && rule.flow_data.present?
       recorder.add_step('Executing flow', data: { mode: 'flow' })
-      AutomationRules::FlowExecutionService.new(rule, account, conversation).perform
+      AutomationRules::FlowExecutionService.new(rule, account, conversation, nil, recorder: recorder).perform
     else
       Array(rule.actions).each do |action|
         action_hash = action.respond_to?(:to_h) ? action.to_h : action
@@ -289,7 +289,7 @@ class AutomationRuleListener < BaseListener
           data: { params: action_hash['action_params'] || action_hash[:action_params] }
         )
       end
-      AutomationRules::ActionService.new(rule, account, conversation).perform
+      AutomationRules::ActionService.new(rule, account, conversation, recorder: recorder).perform
     end
 
     recorder.matched!
@@ -351,7 +351,7 @@ class AutomationRuleListener < BaseListener
 
     if rule.mode == 'flow' && rule.flow_data.present?
       recorder.add_step('Executing flow', data: { mode: 'flow' })
-      AutomationRules::FlowExecutionService.new(rule, nil, nil, contact).perform
+      AutomationRules::FlowExecutionService.new(rule, nil, nil, contact, recorder: recorder).perform
     else
       AutomationRules::ContactActionService.new(rule, contact, recorder: recorder).perform
     end
@@ -399,9 +399,9 @@ class AutomationRuleListener < BaseListener
 
     if rule.mode == 'flow' && rule.flow_data.present?
       recorder.add_step('Executing flow', data: { mode: 'flow' })
-      AutomationRules::FlowExecutionService.new(rule, nil, conversation, contact).perform
+      AutomationRules::FlowExecutionService.new(rule, nil, conversation, contact, recorder: recorder).perform
     else
-      AutomationRules::ActionService.new(rule, nil, conversation).perform
+      AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
     end
 
     recorder.matched!

--- a/app/services/automation_rules/action_service.rb
+++ b/app/services/automation_rules/action_service.rb
@@ -7,9 +7,12 @@ class AutomationRules::ActionService < ActionService
   include AutomationRules::PipelineActionHandlers
   include AutomationRules::MessageActionHandlers
 
-  def initialize(rule, _account = nil, conversation = nil)
+  # `recorder` is optional so console and spec callers keep working; when the listener
+  # supplies one, handlers can write their own steps into the rule's execution timeline.
+  def initialize(rule, _account = nil, conversation = nil, recorder: nil)
     super(conversation)
     @rule = rule
+    @recorder = recorder
     Current.executed_by = rule
   end
 

--- a/app/services/automation_rules/flow_execution_service.rb
+++ b/app/services/automation_rules/flow_execution_service.rb
@@ -8,10 +8,11 @@ class AutomationRules::FlowExecutionService
   include AutomationRules::PipelineActionHandlers
   include AutomationRules::MessageActionHandlers
 
-  def initialize(rule, _account = nil, conversation = nil, contact = nil)
+  def initialize(rule, _account = nil, conversation = nil, contact = nil, recorder: nil)
     @rule = rule
     @conversation = conversation
     @contact = contact
+    @recorder = recorder
     Current.executed_by = rule
   end
 

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -30,7 +30,7 @@ module AutomationRules
       # Guarded before execute_pipeline_assignment, which starts with destroy_all: assigning
       # to an archived pipeline would first wipe every other pipeline membership of this
       # conversation, and pipeline_items are hard-deleted.
-      return if pipeline_archived?(pipeline, action: 'assign_to_pipeline')
+      return if skip_archived_pipeline(pipeline, action: 'assign_to_pipeline')
 
       log_pipeline_assignment(pipeline)
       execute_pipeline_assignment(pipeline)
@@ -41,7 +41,7 @@ module AutomationRules
 
       stage = find_stage_by_params(stage_params[0])
       return unless stage
-      return if pipeline_archived?(stage.pipeline, action: 'update_pipeline_stage')
+      return if skip_archived_pipeline(stage.pipeline, action: 'update_pipeline_stage')
 
       log_stage_update_attempt(stage)
       @conversation.reload
@@ -96,19 +96,18 @@ module AutomationRules
 
     # An archived pipeline is hidden from every picker, so a rule written months ago must
     # not keep dragging conversations into it. The reason goes to the Rails log AND to the
-    # rule's execution timeline: the operator reads that screen, not the server log — and
-    # the timeline records every action as `success` before it runs, so without this the
-    # skipped action would show up green (EVO-2202).
-    def pipeline_archived?(pipeline, action:)
+    # rule's execution timeline via action_skipped!, which also downgrades the run status:
+    # the timeline records every action as success before it runs, so a bare step would be
+    # contradicted by a green "Matched" result (EVO-2202).
+    def skip_archived_pipeline(pipeline, action:)
       return false if pipeline.nil? || pipeline.is_active
 
       Rails.logger.warn(
         "Automation Rule #{@rule.id}: Pipeline #{pipeline.id} is archived; " \
         "skipping #{action} for conversation #{@conversation.id}"
       )
-      @recorder&.add_step(
+      @recorder&.action_skipped!(
         "Skipped: #{action}",
-        level: 'warn',
         data: { reason: 'pipeline_archived', pipeline_id: pipeline.id, pipeline_name: pipeline.name }
       )
       true

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -27,6 +27,11 @@ module AutomationRules
         return
       end
 
+      # Guarded before execute_pipeline_assignment, which starts with destroy_all: assigning
+      # to an archived pipeline would first wipe every other pipeline membership of this
+      # conversation, and pipeline_items are hard-deleted.
+      return if pipeline_archived?(pipeline, action: 'assign_to_pipeline')
+
       log_pipeline_assignment(pipeline)
       execute_pipeline_assignment(pipeline)
     end
@@ -36,6 +41,7 @@ module AutomationRules
 
       stage = find_stage_by_params(stage_params[0])
       return unless stage
+      return if pipeline_archived?(stage.pipeline, action: 'update_pipeline_stage')
 
       log_stage_update_attempt(stage)
       @conversation.reload
@@ -86,6 +92,26 @@ module AutomationRules
 
     def log_pipeline_assignment(pipeline)
       Rails.logger.info "Automation Rule #{@rule.id}: Assigning conversation #{@conversation.id} to pipeline #{pipeline.name} (ID: #{pipeline.id})"
+    end
+
+    # An archived pipeline is hidden from every picker, so a rule written months ago must
+    # not keep dragging conversations into it. The reason goes to the Rails log AND to the
+    # rule's execution timeline: the operator reads that screen, not the server log — and
+    # the timeline records every action as `success` before it runs, so without this the
+    # skipped action would show up green (EVO-2202).
+    def pipeline_archived?(pipeline, action:)
+      return false if pipeline.nil? || pipeline.is_active
+
+      Rails.logger.warn(
+        "Automation Rule #{@rule.id}: Pipeline #{pipeline.id} is archived; " \
+        "skipping #{action} for conversation #{@conversation.id}"
+      )
+      @recorder&.add_step(
+        "Skipped: #{action}",
+        level: 'warn',
+        data: { reason: 'pipeline_archived', pipeline_id: pipeline.id, pipeline_name: pipeline.name }
+      )
+      true
     end
 
     def log_pipeline_not_found(pipeline_id)

--- a/app/services/automation_rules/run_recorder.rb
+++ b/app/services/automation_rules/run_recorder.rb
@@ -16,6 +16,15 @@ class AutomationRules::RunRecorder
     @started_at = Time.zone.now
     @status = STATUS_NO_MATCH
     @error_message = nil
+    @actions_skipped = false
+  end
+
+  # An action refused itself mid-run (e.g. an archived pipeline destination). The rule
+  # still matched, but the final status must not read as a clean success — matched! checks
+  # this so the timeline's "Skipped" step is not contradicted by a green result.
+  def action_skipped!(label, data: {})
+    @actions_skipped = true
+    add_step(label, level: 'warn', data: data)
   end
 
   def add_step(label, level: 'info', data: {})
@@ -29,7 +38,7 @@ class AutomationRules::RunRecorder
   end
 
   def matched!
-    @status = STATUS_MATCHED
+    @status = @actions_skipped ? STATUS_SKIPPED : STATUS_MATCHED
   end
 
   def no_match!

--- a/spec/listeners/automation_rule_listener_attribute_changed_spec.rb
+++ b/spec/listeners/automation_rule_listener_attribute_changed_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe AutomationRuleListener do
                                           changed_attributes: { 'label_list' => [[], ['atleta']] }
                                         })
       service_double = instance_double(AutomationRules::ActionService, perform: nil)
-      expect(AutomationRules::ActionService).to receive(:new).with(rule, nil, conversation).once.and_return(service_double)
+      expect(AutomationRules::ActionService).to receive(:new)
+        .with(rule, nil, conversation, hash_including(:recorder)).once.and_return(service_double)
       expect(service_double).to receive(:perform).once
 
       listener.conversation_updated(event)
@@ -125,7 +126,8 @@ RSpec.describe AutomationRuleListener do
                                           changed_attributes: { 'status' => %w[open resolved] }
                                         })
       service_double = instance_double(AutomationRules::ActionService, perform: nil)
-      expect(AutomationRules::ActionService).to receive(:new).with(rule, nil, conversation).once.and_return(service_double)
+      expect(AutomationRules::ActionService).to receive(:new)
+        .with(rule, nil, conversation, hash_including(:recorder)).once.and_return(service_double)
       expect(service_double).to receive(:perform).once
 
       listener.conversation_updated(event)

--- a/spec/services/automation_rules/archived_pipeline_actions_spec.rb
+++ b/spec/services/automation_rules/archived_pipeline_actions_spec.rb
@@ -135,6 +135,12 @@ RSpec.describe 'Automation rule pipeline actions on an archived pipeline' do
     let(:flow_rule) { rule_with('assign_to_pipeline', [target.id]) }
     let(:flow_service) { AutomationRules::FlowExecutionService.new(flow_rule, nil, conversation) }
     let(:node) { { 'type' => 'assign-to-pipeline-node', 'id' => 'n1', 'data' => { 'pipeline_id' => target.id } } }
+    # move-to-pipeline-stage-node reaches update_pipeline_stage, whose archived guard sits on
+    # the destination stage's pipeline. The auto-assign branch would otherwise push the
+    # conversation into the archived board — cover it on the flow surface too, not only modal.
+    let(:stage_node) do
+      { 'type' => 'move-to-pipeline-stage-node', 'id' => 'n2', 'data' => { 'pipeline_stage_id' => target_stage.id } }
+    end
 
     it 'refuses to assign through a flow node when the pipeline is archived' do
       target.update!(is_active: false)
@@ -145,6 +151,18 @@ RSpec.describe 'Automation rule pipeline actions on an archived pipeline' do
 
     it 'assigns through a flow node while the pipeline is active' do
       expect { flow_service.send(:execute_node_action, node) }
+        .to change { conversation.reload.pipeline_items.count }.by(1)
+    end
+
+    it 'refuses to move through a flow node when the destination pipeline is archived' do
+      target.update!(is_active: false)
+
+      expect { flow_service.send(:execute_node_action, stage_node) }
+        .not_to change { conversation.reload.pipeline_items.count }
+    end
+
+    it 'moves through a flow node while the pipeline is active' do
+      expect { flow_service.send(:execute_node_action, stage_node) }
         .to change { conversation.reload.pipeline_items.count }.by(1)
     end
   end

--- a/spec/services/automation_rules/archived_pipeline_actions_spec.rb
+++ b/spec/services/automation_rules/archived_pipeline_actions_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2202: an archived pipeline is hidden from every picker, but a rule written months ago
+# kept dragging conversations into it. The guard lives in the shared PipelineActionHandlers
+# module, so it covers both executor surfaces (modal-style ActionService and flow-canvas
+# FlowExecutionService) at once.
+RSpec.describe 'Automation rule pipeline actions on an archived pipeline' do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let(:target) { Pipeline.create!(name: 'Target', pipeline_type: 'custom', created_by: user) }
+  let!(:target_stage) { PipelineStage.create!(pipeline: target, name: 'T1', position: 1) }
+
+  def rule_with(action_name, params)
+    AutomationRule.create!(
+      name: "Rule #{SecureRandom.hex(3)}",
+      event_name: 'conversation_created',
+      conditions: [],
+      actions: [{ 'action_name' => action_name, 'action_params' => params }],
+      active: true
+    )
+  end
+
+  after { Current.reset }
+
+  describe 'assign_to_pipeline' do
+    let(:rule) { rule_with('assign_to_pipeline', [target.id]) }
+
+    it 'adds the conversation while the pipeline is active' do
+      expect { described_class_service(rule).perform }
+        .to change { conversation.reload.pipeline_items.count }.by(1)
+    end
+
+    it 'refuses to add it once the pipeline is archived' do
+      target.update!(is_active: false)
+
+      expect { described_class_service(rule).perform }
+        .not_to change { conversation.reload.pipeline_items.count }
+    end
+
+    # execute_pipeline_assignment starts with destroy_all, and pipeline_items are
+    # hard-deleted: reaching it would wipe the conversation's other memberships.
+    it 'does not wipe the memberships the conversation already has' do
+      other = Pipeline.create!(name: 'Other', pipeline_type: 'custom', created_by: user)
+      other_stage = PipelineStage.create!(pipeline: other, name: 'O1', position: 1)
+      PipelineItem.create!(pipeline: other, pipeline_stage: other_stage, conversation: conversation)
+      target.update!(is_active: false)
+
+      expect { described_class_service(rule).perform }
+        .not_to change { conversation.reload.pipeline_items.count }
+    end
+
+    it 'logs the refusal with the pipeline id and the action' do
+      target.update!(is_active: false)
+      allow(Rails.logger).to receive(:warn)
+
+      described_class_service(rule).perform
+
+      expect(Rails.logger).to have_received(:warn).with(/#{target.id} is archived.*assign_to_pipeline/m)
+    end
+  end
+
+  describe 'update_pipeline_stage' do
+    let(:rule) { rule_with('update_pipeline_stage', [target_stage.id]) }
+
+    it 'moves the conversation while the pipeline is active' do
+      expect { described_class_service(rule).perform }
+        .to change { conversation.reload.pipeline_items.count }.by(1)
+    end
+
+    it 'refuses once the destination pipeline is archived' do
+      target.update!(is_active: false)
+
+      expect { described_class_service(rule).perform }
+        .not_to change { conversation.reload.pipeline_items.count }
+    end
+  end
+
+  # The operator reads the rule's execution timeline, not the server log — and the listener
+  # records every action as `success` BEFORE running it, so without this step a refused
+  # action would show up green.
+  describe 'execution timeline' do
+    let(:rule) { rule_with('assign_to_pipeline', [target.id]) }
+    let(:recorder) do
+      ::AutomationRules::RunRecorder.new(rule: rule, event_name: 'conversation_created', payload: {})
+    end
+
+    it 'records the refusal as a warning step' do
+      target.update!(is_active: false)
+
+      AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.persist!
+
+      run = AutomationRuleRun.where(automation_rule_id: rule.id).last
+      skipped = run.steps.find { |s| s['label'].to_s.include?('Skipped: assign_to_pipeline') }
+      expect(skipped).to be_present
+      expect(skipped['level']).to eq('warn')
+      expect(skipped.dig('data', 'reason')).to eq('pipeline_archived')
+    end
+
+    it 'records nothing extra while the pipeline is active' do
+      AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.persist!
+
+      run = AutomationRuleRun.where(automation_rule_id: rule.id).last
+      expect(run.steps.map { |s| s['label'] }).not_to include(a_string_matching(/Skipped/))
+    end
+  end
+
+  def described_class_service(rule)
+    AutomationRules::ActionService.new(rule, nil, conversation)
+  end
+end

--- a/spec/services/automation_rules/archived_pipeline_actions_spec.rb
+++ b/spec/services/automation_rules/archived_pipeline_actions_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe 'Automation rule pipeline actions on an archived pipeline' do
       target.update!(is_active: false)
 
       AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.matched!
       recorder.persist!
 
       run = AutomationRuleRun.where(automation_rule_id: rule.id).last
@@ -104,12 +105,63 @@ RSpec.describe 'Automation rule pipeline actions on an archived pipeline' do
       expect(skipped.dig('data', 'reason')).to eq('pipeline_archived')
     end
 
-    it 'records nothing extra while the pipeline is active' do
+    # The timeline records "Action: ..." as success before the action runs; a bare skip
+    # step would be contradicted by a green Matched result, so a refused action downgrades
+    # the run status to skipped.
+    it 'downgrades the run status so it does not read as a clean match' do
+      target.update!(is_active: false)
+
       AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.matched!
+      recorder.persist!
+
+      expect(AutomationRuleRun.where(automation_rule_id: rule.id).last.status).to eq('skipped')
+    end
+
+    it 'records nothing extra and keeps a clean match while the pipeline is active' do
+      AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.matched!
       recorder.persist!
 
       run = AutomationRuleRun.where(automation_rule_id: rule.id).last
       expect(run.steps.map { |s| s['label'] }).not_to include(a_string_matching(/Skipped/))
+      expect(run.status).to eq('matched')
+    end
+  end
+
+  # The flow-canvas executor reaches the same handlers through execute_node_action, with
+  # its own node_data normalisation, so the guard needs coverage on that surface too.
+  describe 'flow-canvas surface' do
+    let(:flow_rule) { rule_with('assign_to_pipeline', [target.id]) }
+    let(:flow_service) { AutomationRules::FlowExecutionService.new(flow_rule, nil, conversation) }
+    let(:node) { { 'type' => 'assign-to-pipeline-node', 'id' => 'n1', 'data' => { 'pipeline_id' => target.id } } }
+
+    it 'refuses to assign through a flow node when the pipeline is archived' do
+      target.update!(is_active: false)
+
+      expect { flow_service.send(:execute_node_action, node) }
+        .not_to change { conversation.reload.pipeline_items.count }
+    end
+
+    it 'assigns through a flow node while the pipeline is active' do
+      expect { flow_service.send(:execute_node_action, node) }
+        .to change { conversation.reload.pipeline_items.count }.by(1)
+    end
+  end
+
+  # create_pipeline_task is deliberately NOT guarded: it acts on an item already inside the
+  # pipeline and never pushes anything in (decision on EVO-2200 — do not touch what is
+  # already there). This locks that intent: the archived guard must not fire for it.
+  describe 'create_pipeline_task is intentionally not guarded' do
+    it 'does not consult the archived-pipeline guard' do
+      stage = PipelineStage.create!(pipeline: target, name: 'Held', position: 2)
+      PipelineItem.create!(pipeline: target, pipeline_stage: stage, conversation: conversation)
+      target.update!(is_active: false)
+      rule = rule_with('create_pipeline_task', [{ title: 'Call the customer' }])
+      service = AutomationRules::ActionService.new(rule, nil, conversation)
+
+      expect(service).not_to receive(:skip_archived_pipeline)
+      service.perform
     end
   end
 


### PR DESCRIPTION
## Summary

A rule written months ago kept dragging conversations into a pipeline the operator archived and can no longer see. The rule reported success and nothing indicated where the conversations went.

The guard lives in the shared `PipelineActionHandlers` module, so it covers **both** executor surfaces at once — the modal-style `ActionService` and the flow-canvas `FlowExecutionService`.

- `assign_to_pipeline` is guarded **before** `execute_pipeline_assignment`, which begins with `destroy_all`. Reaching it would first wipe every other pipeline membership of the conversation — and `pipeline_items` are hard-deleted, so that also destroys the `form_slug` attribution EVO-2200 just protected.
- `update_pipeline_stage` is guarded on the destination stage's pipeline, covering both the move and the auto-assign branch.
- The reason goes to the Rails log **and** to the rule's execution timeline via `RunRecorder#action_skipped!`, which records the warn step and downgrades the run status to `skipped`. The timeline records every action as `success` before it runs, so a bare step would be contradicted by a green `Matched` result — the run now reads `Skipped` on the screen the operator actually looks at.
- `create_pipeline_task` is left alone: it acts on an item already inside the pipeline and never pushes anything in, consistent with the EVO-2200 decision not to touch what is already there. A spec locks that intent.

## Known, deliberate: the "Action" step still shows first

The listener records `Action: <name>` as a green step *before* calling the service, so the timeline shows both that step and the `Skipped` one. Suppressing the green step would require the listener to know the skip in advance (invasive); instead the run **status** is downgraded so the summary badge does not lie. Confirmed on a live install: the badge reads `Skipped` (amber), and no pipeline item is created.

## Security

No new HTTP surface — both services are internal, driven by an event listener. No new user input reaches a query; the guard is a boolean column. The `destroy_all` in `execute_pipeline_assignment` is now shielded by the guard.

## Test plan

- `bundle exec rspec spec/services/automation_rules/archived_pipeline_actions_spec.rb` — 12 examples, 0 failures
- Negative control: with the guards and the status downgrade disabled, 6 of them fail
- `bundle exec rspec spec/services/automation_rules spec/listeners` — 17 failures, identical to the `develop` baseline (pre-existing, unrelated to this card; see note below), no new failure
- `bundle exec rubocop` on the touched files — 38 offenses, identical to the `develop` baseline, no new cop
- Manual smoke on a live install: archived pipeline → rule refused, run badge `Skipped`, timeline step with `reason: pipeline_archived`, zero pipeline item created

> ⚠️ Baseline note: `spec/services/automation_rules` + `spec/listeners` already has 17 failures on `develop`, unrelated to this change. The count is identical on this branch; I compared failing-example lists to confirm none are mine. Worth a separate cleanup card.

## Changed Files

- `app/services/automation_rules/pipeline_action_handlers.rb`
- `app/services/automation_rules/run_recorder.rb`
- `app/services/automation_rules/action_service.rb`
- `app/services/automation_rules/flow_execution_service.rb`
- `app/listeners/automation_rule_listener.rb`
- `spec/services/automation_rules/archived_pipeline_actions_spec.rb` (new)
- `spec/listeners/automation_rule_listener_attribute_changed_spec.rb`

## Linked Issue

- EVO-2202 — https://linear.app/evoai/issue/EVO-2202