### PR TITLE
test(crm): cover the pipelines.delete permission gate (EVO-2205)

### DIFF
--- a/spec/requests/api/v1/pipeline_deletion_spec.rb
+++ b/spec/requests/api/v1/pipeline_deletion_spec.rb
@@ -80,4 +80,16 @@ RSpec.describe 'Pipeline deletion', type: :request do
       .not_to change(Pipeline, :count)
     expect(response).to have_http_status(:unprocessable_entity)
   end
+
+  # `require_permissions` gates destroy behind `pipelines.delete` (pipelines_controller.rb:9),
+  # and every example above stubs the permission to true — so nothing here exercised the gate.
+  # The pipeline is empty on purpose: with an active item present, a refusal would be
+  # indistinguishable from the active-items guard doing the work.
+  it 'keeps deletion behind pipelines.delete' do
+    allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?).and_return(false)
+
+    expect { delete "/api/v1/pipelines/#{pipeline.id}", as: :json }
+      .not_to change(Pipeline, :count)
+    expect(response).to have_http_status(:forbidden)
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up ao #248 (já mergeado). `require_permissions` protege `destroy` com `pipelines.delete` (`pipelines_controller.rb:9`), mas **todos** os exemplos de `pipeline_deletion_spec.rb` stubam `has_user_permission?` como `true` — então o gate em si nunca foi exercitado. Uma regressão nele passaria verde pelo spec inteiro.

Era o único dos três specs de request de pipeline que nunca varia a permissão:

| Spec | Como trata `has_user_permission?` |
|---|---|
| `pipelines_activation_spec.rb` | `true` **e** `false` — cobre o gate |
| `pipeline_dependents_spec.rb` | bloco seletivo por chave |
| `pipeline_deletion_spec.rb` | só `true` — **sem cobertura** |

## Detalhe de implementação

O pipeline do novo exemplo está **vazio de propósito**. Com um item ativo presente, uma recusa seria indistinguível da guarda de itens ativos fazendo o trabalho — o teste passaria pelo motivo errado. Vazio, a única coisa capaz de impedir o delete é o gate.

Segue o padrão de `pipelines_activation_spec.rb:93-100` (mesmo controller, ação `archive`).

## Test plan

- [ ] `bundle exec rspec spec/requests/api/v1/pipeline_deletion_spec.rb` — 6 exemplos
- [ ] `bundle exec rubocop` no arquivo tocado

⚠️ **Não rodei nenhum dos dois localmente** — a máquina onde isto foi escrito não tem ruby/bundler nem Postgres. Conferi os limites do RuboCop na mão: linha máx. 118 (limite 150), 3 expectations (limite 7), exemplo de 7 linhas (limite 25). O CI é a primeira execução real.

## Changed Files

- `spec/requests/api/v1/pipeline_deletion_spec.rb` (+12)

## Linked Issue

- EVO-2205 — https://linear.app/evoai/issue/EVO-2205

## Summary by Sourcery

Tests:
- Add a request spec that verifies pipeline deletion is forbidden when the user lacks the pipelines.delete permission.