### PR TITLE
fix(EVO-2222): implement team pipeline visibility + enforce on by_* endpoints

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -35,10 +35,9 @@ on:
       # other lane, so the controller has to trigger the spec that proves it.
       - 'app/controllers/api/v1/pipelines_controller.rb'
       - 'spec/requests/api/v1/pipelines_activation_spec.rb'
-      # EVO-2222: `team` visibility is enforced in one scope shared by #index and the
-      # by_* endpoints, and team_ids only survives the write because the controller
-      # reads it outside the (partial) ParamsWrapper envelope. Both are invisible to
-      # every other lane, so the code that carries them triggers the specs that prove it.
+      # EVO-2222: `team` visibility lives in one shared scope, and team_ids only survives
+      # the write because it is read outside the ParamsWrapper envelope. Neither shows up
+      # in another lane, so the code that carries them triggers the specs that prove it.
       - 'app/policies/pipeline_policy.rb'
       - 'spec/policies/pipeline_policy/scope_spec.rb'
       - 'spec/requests/api/v1/pipelines_team_visibility_spec.rb'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -35,6 +35,13 @@ on:
       # other lane, so the controller has to trigger the spec that proves it.
       - 'app/controllers/api/v1/pipelines_controller.rb'
       - 'spec/requests/api/v1/pipelines_activation_spec.rb'
+      # EVO-2222: `team` visibility is enforced in one scope shared by #index and the
+      # by_* endpoints, and team_ids only survives the write because the controller
+      # reads it outside the (partial) ParamsWrapper envelope. Both are invisible to
+      # every other lane, so the code that carries them triggers the specs that prove it.
+      - 'app/policies/pipeline_policy.rb'
+      - 'spec/policies/pipeline_policy/scope_spec.rb'
+      - 'spec/requests/api/v1/pipelines_team_visibility_spec.rb'
       # EVO-2203: these endpoints are how a journey writes into a pipeline. The
       # archived refusal is the only thing stopping it from filling a board the
       # operator turned off, and no other lane exercises it.
@@ -111,6 +118,8 @@ jobs:
             spec/models/role_spec.rb \
             spec/requests/api/v1/contacts_spec.rb \
             spec/requests/api/v1/pipelines_activation_spec.rb \
+            spec/requests/api/v1/pipelines_team_visibility_spec.rb \
+            spec/policies/pipeline_policy/scope_spec.rb \
             spec/requests/api/v1/pipeline_items_archived_spec.rb \
             spec/controllers/api/v1/pipeline_tasks_controller_spec.rb \
             spec/jobs/delete_object_job_spec.rb \

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -35,8 +35,7 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     # Inactive pipelines are hidden by default because every picker in the app (dashboard,
     # kanban, automations, agents) lists pipelines through this endpoint. The pipelines
     # management screen opts in so a deactivated pipeline stays visible and can be reactivated.
-    @pipelines = Pipeline.all
-                        .accessible_by(Current.user)
+    @pipelines = policy_scope(Pipeline)
                         .includes(:pipeline_teams, pipeline_stages: [], pipeline_items: [])
                         .order(:name)
     @pipelines = @pipelines.active unless include_inactive?
@@ -261,6 +260,7 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     @pipeline = Pipeline.all
                           .includes(
                             :created_by,
+                            :pipeline_teams,
                             pipeline_stages: [],
                             pipeline_items: [
                               :pipeline_stage,
@@ -382,9 +382,15 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     # Activation is toggled through update only; a pipeline is always born active.
     attributes << :is_active if action_name == 'update'
 
-    # EVO-2222: `team_ids` carries the team picker's selection for a `team`-visible
-    # pipeline; the has_many :through persists it. Was silently dropped before.
     permitted = params.require(:pipeline).permit(*attributes, custom_fields: {}, team_ids: [])
+
+    # EVO-2222: `team_ids` carries the team picker's selection for a `team`-visible
+    # pipeline; the has_many :through persists it. It is NOT a Pipeline column, so
+    # ActionController::ParamsWrapper never copies it into params[:pipeline] — and the
+    # client posts the attributes bare (pipelinesService.createPipeline/updatePipeline),
+    # exactly like `stages`. Reading only the envelope is how it got dropped in the
+    # first place, so both shapes are accepted here.
+    permitted[:team_ids] = submitted_team_ids if team_ids_submitted?
 
     allowed_display_types = %w[text number currency percent link date list checkbox].freeze
 
@@ -425,6 +431,30 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     end
 
     @pipeline_params = permitted
+  end
+
+  # Whichever of the two shapes carried `team_ids`, or nil when the client did not send
+  # it at all. An explicit `[]` means "clear the teams", so this asks about the KEY.
+  def team_ids_source
+    return @team_ids_source if defined?(@team_ids_source)
+
+    envelope = params[:pipeline]
+
+    @team_ids_source = if envelope.is_a?(ActionController::Parameters) && envelope.key?(:team_ids)
+                         envelope
+                       elsif params.key?(:team_ids)
+                         params
+                       end
+  end
+
+  def team_ids_submitted?
+    !team_ids_source.nil?
+  end
+
+  # slice first: the top-level source carries every other request param, and permitting
+  # over it would report them all as unpermitted.
+  def submitted_team_ids
+    Array(team_ids_source.slice(:team_ids).permit(team_ids: [])[:team_ids])
   end
 
   def create_custom_stages(stages_data)
@@ -487,9 +517,9 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     # Carregar pipelines com eager loading otimizado incluindo stages e items.
     # EVO-2222: escopar por visibilidade — o menu de pipelines na conversa/contato só
     # mostra pipelines que o usuário pode ver (público/próprio/default/time). Antes
-    # retornava todos, independente da visibilidade.
-    pipelines = Pipeline.all
-                         .accessible_by(Current.user)
+    # retornava todos, independente da visibilidade. Efeito colateral esperado: um item
+    # que um colega criou dentro de um pipeline privado dele some deste menu.
+    pipelines = policy_scope(Pipeline)
                          .where(id: pipeline_ids_with_items)
                          .includes(
                            :pipeline_teams,

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     # management screen opts in so a deactivated pipeline stays visible and can be reactivated.
     @pipelines = Pipeline.all
                         .accessible_by(Current.user)
-                        .includes(pipeline_stages: [], pipeline_items: [])
+                        .includes(:pipeline_teams, pipeline_stages: [], pipeline_items: [])
                         .order(:name)
     @pipelines = @pipelines.active unless include_inactive?
 
@@ -382,7 +382,9 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     # Activation is toggled through update only; a pipeline is always born active.
     attributes << :is_active if action_name == 'update'
 
-    permitted = params.require(:pipeline).permit(*attributes, custom_fields: {})
+    # EVO-2222: `team_ids` carries the team picker's selection for a `team`-visible
+    # pipeline; the has_many :through persists it. Was silently dropped before.
+    permitted = params.require(:pipeline).permit(*attributes, custom_fields: {}, team_ids: [])
 
     allowed_display_types = %w[text number currency percent link date list checkbox].freeze
 
@@ -482,10 +484,15 @@ class Api::V1::PipelinesController < Api::V1::BaseController
                                 .distinct
                                 .pluck(:pipeline_id)
 
-    # Carregar pipelines com eager loading otimizado incluindo stages e items
+    # Carregar pipelines com eager loading otimizado incluindo stages e items.
+    # EVO-2222: escopar por visibilidade — o menu de pipelines na conversa/contato só
+    # mostra pipelines que o usuário pode ver (público/próprio/default/time). Antes
+    # retornava todos, independente da visibilidade.
     pipelines = Pipeline.all
+                         .accessible_by(Current.user)
                          .where(id: pipeline_ids_with_items)
                          .includes(
+                           :pipeline_teams,
                            pipeline_stages: [],
                            pipeline_items: [
                              :pipeline_stage,

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -384,12 +384,8 @@ class Api::V1::PipelinesController < Api::V1::BaseController
 
     permitted = params.require(:pipeline).permit(*attributes, custom_fields: {}, team_ids: [])
 
-    # EVO-2222: `team_ids` carries the team picker's selection for a `team`-visible
-    # pipeline; the has_many :through persists it. It is NOT a Pipeline column, so
-    # ActionController::ParamsWrapper never copies it into params[:pipeline] — and the
-    # client posts the attributes bare (pipelinesService.createPipeline/updatePipeline),
-    # exactly like `stages`. Reading only the envelope is how it got dropped in the
-    # first place, so both shapes are accepted here.
+    # Not a Pipeline column, so ParamsWrapper leaves it out of the envelope while the
+    # client posts attributes bare — like `stages`, both shapes have to be read.
     permitted[:team_ids] = submitted_team_ids if team_ids_submitted?
 
     allowed_display_types = %w[text number currency percent link date list checkbox].freeze
@@ -433,8 +429,8 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     @pipeline_params = permitted
   end
 
-  # Whichever of the two shapes carried `team_ids`, or nil when the client did not send
-  # it at all. An explicit `[]` means "clear the teams", so this asks about the KEY.
+  # nil when the key is absent: an explicit `[]` clears the teams, so what matters is
+  # the key, not the value.
   def team_ids_source
     return @team_ids_source if defined?(@team_ids_source)
 
@@ -451,8 +447,8 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     !team_ids_source.nil?
   end
 
-  # slice first: the top-level source carries every other request param, and permitting
-  # over it would report them all as unpermitted.
+  # slice first: the top-level source carries every other request param, which permit
+  # would report as unpermitted.
   def submitted_team_ids
     Array(team_ids_source.slice(:team_ids).permit(team_ids: [])[:team_ids])
   end
@@ -517,8 +513,7 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     # Carregar pipelines com eager loading otimizado incluindo stages e items.
     # EVO-2222: escopar por visibilidade — o menu de pipelines na conversa/contato só
     # mostra pipelines que o usuário pode ver (público/próprio/default/time). Antes
-    # retornava todos, independente da visibilidade. Efeito colateral esperado: um item
-    # que um colega criou dentro de um pipeline privado dele some deste menu.
+    # retornava todos, independente da visibilidade.
     pipelines = policy_scope(Pipeline)
                          .where(id: pipeline_ids_with_items)
                          .includes(

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -45,8 +45,8 @@ class Pipeline < ApplicationRecord
   scope :default, -> { where(is_default: true) }
   scope :accessible_by, lambda { |user|
     # EVO-2222: `team` visibility grants access to the members of the pipeline's teams.
-    # Nested subquery (not user.team_ids) so the whole thing stays one round-trip; a
-    # user in no team yields an empty set, so the team branch simply matches nothing.
+    # Nested subquery rather than user.team_ids keeps this to one round-trip; a user in
+    # no team yields an empty set, so the branch needs no special case.
     team_pipeline_ids = PipelineTeam.where(team_id: TeamMember.where(user_id: user&.id).select(:team_id))
                                     .select(:pipeline_id)
     where(visibility: :public)
@@ -121,9 +121,8 @@ class Pipeline < ApplicationRecord
 
   private
 
-  # EVO-2222: the join only means something while visibility is `team`. Left behind, a
-  # pipeline switched to private/public keeps rows that silently grant access again the
-  # day someone switches it back to `team` — teams the owner never re-picked.
+  # Rows left behind would grant access again the day the pipeline goes back to `team`,
+  # to teams nobody re-picked.
   def drop_team_links_unless_team_visible
     return if visibility_team?
 

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -31,6 +31,10 @@ class Pipeline < ApplicationRecord
   has_many :pipeline_items, dependent: :destroy
   has_many :conversations, through: :pipeline_items
   has_many :pipeline_service_definitions, dependent: :nullify
+  # EVO-2222: teams a `team`-visible pipeline is shared with. `team_ids=` (from the
+  # has_many :through) lets create/update persist the picker's selection.
+  has_many :pipeline_teams, dependent: :destroy
+  has_many :teams, through: :pipeline_teams
 
   validates :name, presence: true, uniqueness: true
   validates :pipeline_type, inclusion: { in: VALID_TYPES }
@@ -40,9 +44,14 @@ class Pipeline < ApplicationRecord
   scope :active, -> { where(is_active: true) }
   scope :default, -> { where(is_default: true) }
   scope :accessible_by, lambda { |user|
+    # EVO-2222: `team` visibility grants access to the members of the pipeline's teams.
+    # An empty team list (user in no teams) yields an empty subquery, so the team
+    # branch simply matches nothing — no special-casing needed.
+    team_pipeline_ids = PipelineTeam.where(team_id: Array(user&.team_ids)).select(:pipeline_id)
     where(visibility: :public)
       .or(where(created_by: user))
       .or(where(is_default: true))
+      .or(where(visibility: :team, id: team_pipeline_ids))
   }
 
   before_validation :set_default_custom_fields

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -45,9 +45,10 @@ class Pipeline < ApplicationRecord
   scope :default, -> { where(is_default: true) }
   scope :accessible_by, lambda { |user|
     # EVO-2222: `team` visibility grants access to the members of the pipeline's teams.
-    # An empty team list (user in no teams) yields an empty subquery, so the team
-    # branch simply matches nothing — no special-casing needed.
-    team_pipeline_ids = PipelineTeam.where(team_id: Array(user&.team_ids)).select(:pipeline_id)
+    # Nested subquery (not user.team_ids) so the whole thing stays one round-trip; a
+    # user in no team yields an empty set, so the team branch simply matches nothing.
+    team_pipeline_ids = PipelineTeam.where(team_id: TeamMember.where(user_id: user&.id).select(:team_id))
+                                    .select(:pipeline_id)
     where(visibility: :public)
       .or(where(created_by: user))
       .or(where(is_default: true))
@@ -57,6 +58,7 @@ class Pipeline < ApplicationRecord
   before_validation :set_default_custom_fields
   before_save :ensure_single_default_per_account, if: :is_default?
   after_update :cleanup_removed_attributes_from_items
+  after_save :drop_team_links_unless_team_visible
 
   def add_conversation(conversation, stage = nil, user = nil)
     stage ||= pipeline_stages.first
@@ -118,6 +120,15 @@ class Pipeline < ApplicationRecord
   end
 
   private
+
+  # EVO-2222: the join only means something while visibility is `team`. Left behind, a
+  # pipeline switched to private/public keeps rows that silently grant access again the
+  # day someone switches it back to `team` — teams the owner never re-picked.
+  def drop_team_links_unless_team_visible
+    return if visibility_team?
+
+    pipeline_teams.destroy_all if pipeline_teams.exists?
+  end
 
   def ensure_single_default_per_account
     # Desativa outros pipelines default quando este for ativado

--- a/app/models/pipeline_team.rb
+++ b/app/models/pipeline_team.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# EVO-2222: join between a `team`-visible pipeline and the teams it is shared with.
+# The pipeline's members-with-access are the members of these teams.
+class PipelineTeam < ApplicationRecord
+  belongs_to :pipeline
+  belongs_to :team
+end

--- a/app/models/pipeline_team.rb
+++ b/app/models/pipeline_team.rb
@@ -6,8 +6,7 @@ class PipelineTeam < ApplicationRecord
   belongs_to :pipeline
   belongs_to :team
 
-  # Mirrors the unique index so a repeated team in the picker's payload surfaces as a
-  # validation error instead of a RecordNotUnique from the database (same guard
-  # TeamMember carries for its own pair).
+  # Mirrors the unique index so a repeated team surfaces as a validation error instead
+  # of RecordNotUnique.
   validates :team_id, uniqueness: { scope: :pipeline_id }
 end

--- a/app/models/pipeline_team.rb
+++ b/app/models/pipeline_team.rb
@@ -5,4 +5,9 @@
 class PipelineTeam < ApplicationRecord
   belongs_to :pipeline
   belongs_to :team
+
+  # Mirrors the unique index so a repeated team in the picker's payload surfaces as a
+  # validation error instead of a RecordNotUnique from the database (same guard
+  # TeamMember carries for its own pair).
+  validates :team_id, uniqueness: { scope: :pipeline_id }
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -17,6 +17,10 @@ class Team < ApplicationRecord
   has_many :team_members, dependent: :destroy_async
   has_many :members, through: :team_members, source: :user
   has_many :conversations, dependent: :nullify
+  # EVO-2222: joins to `team`-visible pipelines shared with this team. Destroyed with
+  # the team (synchronously, before the FK restrict bites) — a pipeline shared with
+  # several teams just loses this one; if it was its only team it stays creator-only.
+  has_many :pipeline_teams, dependent: :destroy
 
   validates :name,
             presence: { message: I18n.t('errors.validations.presence') },

--- a/app/policies/pipeline_policy.rb
+++ b/app/policies/pipeline_policy.rb
@@ -10,15 +10,9 @@ class PipelinePolicy < ApplicationPolicy
     end
 
     def resolve
-      # EVO-2222: single place the pipeline list surfaces are scoped from (#index and
-      # the by_* endpoints go through policy_scope). Mirrors Pipeline.accessible_by —
-      # public + owned + default + team (members of the pipeline's teams). No
-      # administrator bypass: accessible_by has never granted admins other users'
-      # private pipelines, and the list has always behaved that way.
-      #
-      # Service-to-service calls are the one exception: they carry no Current.user by
-      # design (check_permission! already grants them elevated access), so scoping them
-      # by a nil user would quietly return public+default instead of what was asked for.
+      # No administrator bypass here, deliberately: admins never reached other users'
+      # private pipelines. Service-to-service calls carry no Current.user by design, so
+      # scoping them by nil would answer with public+default only.
       return scope.all if user_context[:service_authenticated] == true
 
       scope.accessible_by(user)

--- a/app/policies/pipeline_policy.rb
+++ b/app/policies/pipeline_policy.rb
@@ -10,10 +10,17 @@ class PipelinePolicy < ApplicationPolicy
     end
 
     def resolve
-      # EVO-2222: mirror Pipeline.accessible_by exactly — public + owned + default +
-      # team (members of the pipeline's teams). No administrator bypass: accessible_by
-      # has never granted admins other users' private pipelines, and the list has
-      # always behaved that way; PipelinePolicy::Scope must not diverge from it.
+      # EVO-2222: single place the pipeline list surfaces are scoped from (#index and
+      # the by_* endpoints go through policy_scope). Mirrors Pipeline.accessible_by —
+      # public + owned + default + team (members of the pipeline's teams). No
+      # administrator bypass: accessible_by has never granted admins other users'
+      # private pipelines, and the list has always behaved that way.
+      #
+      # Service-to-service calls are the one exception: they carry no Current.user by
+      # design (check_permission! already grants them elevated access), so scoping them
+      # by a nil user would quietly return public+default instead of what was asked for.
+      return scope.all if user_context[:service_authenticated] == true
+
       scope.accessible_by(user)
     end
   end

--- a/app/policies/pipeline_policy.rb
+++ b/app/policies/pipeline_policy.rb
@@ -10,8 +10,11 @@ class PipelinePolicy < ApplicationPolicy
     end
 
     def resolve
-      # Return all pipelines accessible to the user
-      scope.all
+      # EVO-2222: mirror Pipeline.accessible_by exactly — public + owned + default +
+      # team (members of the pipeline's teams). No administrator bypass: accessible_by
+      # has never granted admins other users' private pipelines, and the list has
+      # always behaved that way; PipelinePolicy::Scope must not diverge from it.
+      scope.accessible_by(user)
     end
   end
 

--- a/app/serializers/pipeline_serializer.rb
+++ b/app/serializers/pipeline_serializer.rb
@@ -31,8 +31,9 @@ module PipelineSerializer
       pipeline_type: pipeline.pipeline_type,
       visibility: pipeline.visibility,
       # EVO-2222: teams a `team`-visible pipeline is shared with — round-trips the
-      # picker on edit. Reads the preloaded join when available to avoid an N+1 in lists.
-      team_ids: pipeline.association(:pipeline_teams).loaded? ? pipeline.pipeline_teams.map(&:team_id) : pipeline.team_ids,
+      # picker on edit. Reads the join (preloaded by the list endpoints) rather than
+      # `team_ids`, which would join through `teams` for a column we already have here.
+      team_ids: pipeline.pipeline_teams.map(&:team_id),
       is_active: pipeline.is_active,
       is_default: pipeline.is_default,
       custom_fields: pipeline.custom_fields || {},

--- a/app/serializers/pipeline_serializer.rb
+++ b/app/serializers/pipeline_serializer.rb
@@ -30,6 +30,9 @@ module PipelineSerializer
       description: pipeline.description,
       pipeline_type: pipeline.pipeline_type,
       visibility: pipeline.visibility,
+      # EVO-2222: teams a `team`-visible pipeline is shared with — round-trips the
+      # picker on edit. Reads the preloaded join when available to avoid an N+1 in lists.
+      team_ids: pipeline.association(:pipeline_teams).loaded? ? pipeline.pipeline_teams.map(&:team_id) : pipeline.team_ids,
       is_active: pipeline.is_active,
       is_default: pipeline.is_default,
       custom_fields: pipeline.custom_fields || {},

--- a/app/serializers/pipeline_serializer.rb
+++ b/app/serializers/pipeline_serializer.rb
@@ -30,9 +30,8 @@ module PipelineSerializer
       description: pipeline.description,
       pipeline_type: pipeline.pipeline_type,
       visibility: pipeline.visibility,
-      # EVO-2222: teams a `team`-visible pipeline is shared with — round-trips the
-      # picker on edit. Reads the join (preloaded by the list endpoints) rather than
-      # `team_ids`, which would join through `teams` for a column we already have here.
+      # Reads the join (preloaded by the list endpoints) rather than `team_ids`, which
+      # would join through `teams` for a column already sitting here.
       team_ids: pipeline.pipeline_teams.map(&:team_id),
       is_active: pipeline.is_active,
       is_default: pipeline.is_default,

--- a/db/migrate/20260725130000_create_pipeline_teams.rb
+++ b/db/migrate/20260725130000_create_pipeline_teams.rb
@@ -8,7 +8,8 @@
 class CreatePipelineTeams < ActiveRecord::Migration[7.1]
   def change
     create_table :pipeline_teams, id: :uuid do |t|
-      t.references :pipeline, type: :uuid, null: false, foreign_key: true
+      # index: false — the unique composite below already covers lookups by pipeline_id.
+      t.references :pipeline, type: :uuid, null: false, foreign_key: true, index: false
       t.references :team, type: :uuid, null: false, foreign_key: true
       t.timestamps
     end

--- a/db/migrate/20260725130000_create_pipeline_teams.rb
+++ b/db/migrate/20260725130000_create_pipeline_teams.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# EVO-2222: Pipeline.visibility already has a `team` value and the form ships a team
+# picker, but the backend had nowhere to store the chosen teams — `team_ids` were
+# silently dropped on save, so a "team" pipeline behaved as private. This join table
+# records which teams a team-visible pipeline is shared with; `Pipeline.accessible_by`
+# reads it to grant access to those teams' members.
+class CreatePipelineTeams < ActiveRecord::Migration[7.1]
+  def change
+    create_table :pipeline_teams, id: :uuid do |t|
+      t.references :pipeline, type: :uuid, null: false, foreign_key: true
+      t.references :team, type: :uuid, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :pipeline_teams, %i[pipeline_id team_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_05_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_25_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -418,6 +418,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_05_120000) do
     t.boolean "email_suppressed", default: false, null: false
     t.string "email_suppression_reason"
     t.index ["blocked"], name: "index_contacts_on_blocked"
+    t.index ["custom_attributes"], name: "index_contacts_on_custom_attributes", opclass: :jsonb_path_ops, using: :gin
     t.index ["email"], name: "uniq_email_per_account_contact", unique: true
     t.index ["id"], name: "idx_contacts_with_identity", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
     t.index ["identifier"], name: "uniq_identifier_per_account_contact", unique: true
@@ -982,6 +983,16 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_05_120000) do
     t.index ["status", "due_date"], name: "index_pipeline_tasks_on_pending_status_and_due_date", where: "(status = 0)"
   end
 
+  create_table "pipeline_teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "pipeline_id", null: false
+    t.uuid "team_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pipeline_id", "team_id"], name: "index_pipeline_teams_on_pipeline_id_and_team_id", unique: true
+    t.index ["pipeline_id"], name: "index_pipeline_teams_on_pipeline_id"
+    t.index ["team_id"], name: "index_pipeline_teams_on_team_id"
+  end
+
   create_table "pipelines", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "created_by_id", null: false
     t.string "name", null: false
@@ -1394,6 +1405,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_05_120000) do
   add_foreign_key "pipeline_service_definitions", "pipelines"
   add_foreign_key "pipeline_tasks", "pipeline_items"
   add_foreign_key "pipeline_tasks", "pipeline_tasks", column: "parent_task_id"
+  add_foreign_key "pipeline_teams", "pipelines"
+  add_foreign_key "pipeline_teams", "teams"
   add_foreign_key "product_variants", "products", on_delete: :cascade
   add_foreign_key "role_permissions_actions", "roles"
   add_foreign_key "scheduled_action_execution_logs", "scheduled_actions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -418,7 +418,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_25_130000) do
     t.boolean "email_suppressed", default: false, null: false
     t.string "email_suppression_reason"
     t.index ["blocked"], name: "index_contacts_on_blocked"
-    t.index ["custom_attributes"], name: "index_contacts_on_custom_attributes", opclass: :jsonb_path_ops, using: :gin
     t.index ["email"], name: "uniq_email_per_account_contact", unique: true
     t.index ["id"], name: "idx_contacts_with_identity", where: "(((email)::text <> ''::text) OR ((phone_number)::text <> ''::text) OR ((identifier)::text <> ''::text))"
     t.index ["identifier"], name: "uniq_identifier_per_account_contact", unique: true
@@ -989,7 +988,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_25_130000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["pipeline_id", "team_id"], name: "index_pipeline_teams_on_pipeline_id_and_team_id", unique: true
-    t.index ["pipeline_id"], name: "index_pipeline_teams_on_pipeline_id"
     t.index ["team_id"], name: "index_pipeline_teams_on_team_id"
   end
 

--- a/spec/models/pipeline_spec.rb
+++ b/spec/models/pipeline_spec.rb
@@ -110,8 +110,41 @@ RSpec.describe Pipeline, type: :model do
 
       before { team.team_members.create!(user: member) }
 
-      it 'persists the picker selection via team_ids= — no longer discarded (AC1)' do
-        expect(team_pipeline.reload.team_ids).to contain_exactly(team.id)
+      it 'persists the picker selection assigned through team_ids= (AC1)' do
+        # Assigns via the writer the controller actually uses, not `teams:` — the point
+        # of AC1 is that a list of ids coming off the picker survives the save.
+        fresh = described_class.create!(
+          name: "Picker #{SecureRandom.hex(4)}", pipeline_type: 'custom', visibility: :team,
+          created_by: admin_user, team_ids: [team.id]
+        )
+
+        expect(fresh.reload.team_ids).to contain_exactly(team.id)
+      end
+
+      it 'replaces the selection when team_ids= is reassigned' do
+        other = Team.create!(name: "Other #{SecureRandom.hex(4)}")
+        team_pipeline.update!(team_ids: [other.id])
+
+        expect(team_pipeline.reload.team_ids).to contain_exactly(other.id)
+      end
+
+      it 'clears the selection when team_ids= receives an empty list' do
+        team_pipeline.update!(team_ids: [])
+
+        expect(team_pipeline.reload.team_ids).to be_empty
+      end
+
+      it 'drops the team links when visibility leaves `team`' do
+        expect { team_pipeline.update!(visibility: :private) }
+          .to change { team_pipeline.reload.team_ids }.from([team.id]).to([])
+      end
+
+      it 'does not resurrect old teams when visibility returns to `team`' do
+        team_pipeline.update!(visibility: :private)
+        team_pipeline.update!(visibility: :team)
+
+        expect(team_pipeline.reload.team_ids).to be_empty
+        expect(described_class.accessible_by(member)).not_to include(team_pipeline)
       end
 
       it 'includes a team pipeline for a member of one of its teams (AC2)' do

--- a/spec/models/pipeline_spec.rb
+++ b/spec/models/pipeline_spec.rb
@@ -94,5 +94,47 @@ RSpec.describe Pipeline, type: :model do
         expect(accessible).not_to include(owner_pipeline)
       end
     end
+
+    # EVO-2222: `team` visibility grants access to the members of the pipeline's teams.
+    # Before this, `team` matched no branch and behaved as private.
+    context 'with team visibility' do
+      let(:team) { Team.create!(name: "Team #{SecureRandom.hex(4)}") }
+      let(:member) { User.create!(email: "member-#{SecureRandom.hex(4)}@example.com", name: 'Member') }
+      let(:non_member) { User.create!(email: "outsider-#{SecureRandom.hex(4)}@example.com", name: 'Outsider') }
+      let!(:team_pipeline) do
+        described_class.create!(
+          name: 'Team Pipeline', pipeline_type: 'custom', visibility: :team,
+          is_default: false, created_by: admin_user, teams: [team]
+        )
+      end
+
+      before { team.team_members.create!(user: member) }
+
+      it 'persists the picker selection via team_ids= — no longer discarded (AC1)' do
+        expect(team_pipeline.reload.team_ids).to contain_exactly(team.id)
+      end
+
+      it 'includes a team pipeline for a member of one of its teams (AC2)' do
+        expect(described_class.accessible_by(member)).to include(team_pipeline)
+      end
+
+      it 'excludes a team pipeline from a non-member (AC2)' do
+        expect(described_class.accessible_by(non_member)).not_to include(team_pipeline)
+      end
+
+      it 'does not reach a member of a DIFFERENT team' do
+        other = Team.create!(name: "Other #{SecureRandom.hex(4)}")
+        other.team_members.create!(user: non_member)
+        expect(described_class.accessible_by(non_member)).not_to include(team_pipeline)
+      end
+
+      it 'drops the join when a shared team is deleted, leaving the pipeline' do
+        extra = Team.create!(name: "Extra #{SecureRandom.hex(4)}")
+        team_pipeline.teams << extra
+
+        expect { extra.destroy! }.to change(PipelineTeam, :count).by(-1)
+        expect(described_class.exists?(team_pipeline.id)).to be(true)
+      end
+    end
   end
 end

--- a/spec/models/pipeline_spec.rb
+++ b/spec/models/pipeline_spec.rb
@@ -110,9 +110,8 @@ RSpec.describe Pipeline, type: :model do
 
       before { team.team_members.create!(user: member) }
 
+      # Through the writer the controller uses, not `teams:`.
       it 'persists the picker selection assigned through team_ids= (AC1)' do
-        # Assigns via the writer the controller actually uses, not `teams:` — the point
-        # of AC1 is that a list of ids coming off the picker survives the save.
         fresh = described_class.create!(
           name: "Picker #{SecureRandom.hex(4)}", pipeline_type: 'custom', visibility: :team,
           created_by: admin_user, team_ids: [team.id]

--- a/spec/policies/pipeline_policy/scope_spec.rb
+++ b/spec/policies/pipeline_policy/scope_spec.rb
@@ -2,37 +2,68 @@
 
 require 'rails_helper'
 
-# EVO-2222 (AC4): PipelinePolicy::Scope#resolve must mirror Pipeline.accessible_by
-# exactly — public + own + default + team — with NO administrator bypass. accessible_by
-# has never granted admins other users' private pipelines, and the scope must not diverge.
+# EVO-2222 (AC4): PipelinePolicy::Scope#resolve is the single place #index and the by_*
+# endpoints are scoped from — public + own + default + team — with NO administrator
+# bypass. accessible_by has never granted admins other users' private pipelines, and the
+# scope must not diverge from it. Each branch is asserted explicitly instead of being
+# compared against Pipeline.accessible_by, which would pass even if accessible_by broke.
 RSpec.describe PipelinePolicy::Scope do
   let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
   let(:member) { User.create!(name: 'Member', email: "member-#{SecureRandom.hex(4)}@example.com") }
   let(:team) { Team.create!(name: "Team #{SecureRandom.hex(4)}") }
   let!(:team_pipeline) do
-    Pipeline.create!(name: 'Team', pipeline_type: 'custom', visibility: :team, created_by: owner, teams: [team])
+    Pipeline.create!(name: "Team #{SecureRandom.hex(4)}", pipeline_type: 'custom', visibility: :team,
+                     created_by: owner, teams: [team])
   end
   let!(:private_pipeline) do
-    Pipeline.create!(name: 'Private', pipeline_type: 'custom', visibility: :private, created_by: owner)
+    Pipeline.create!(name: "Private #{SecureRandom.hex(4)}", pipeline_type: 'custom', visibility: :private,
+                     created_by: owner)
+  end
+  let!(:public_pipeline) do
+    Pipeline.create!(name: "Public #{SecureRandom.hex(4)}", pipeline_type: 'custom', visibility: :public,
+                     created_by: owner)
+  end
+  let!(:own_pipeline) do
+    Pipeline.create!(name: "Own #{SecureRandom.hex(4)}", pipeline_type: 'custom', visibility: :private,
+                     created_by: member)
   end
 
-  def resolve_for(user)
-    described_class.new({ user: user }, Pipeline.all).resolve
+  def resolve_for(user, service_authenticated: nil)
+    described_class.new({ user: user, service_authenticated: service_authenticated }, Pipeline.all).resolve
   end
 
-  it 'mirrors accessible_by exactly for a given user' do
-    team.team_members.create!(user: member)
-    expect(resolve_for(member)).to match_array(Pipeline.accessible_by(member))
+  context 'when the user belongs to the pipeline team' do
+    before { team.team_members.create!(user: member) }
+
+    it 'grants the team pipeline, the public one and the user own pipeline' do
+      expect(resolve_for(member)).to include(team_pipeline, public_pipeline, own_pipeline)
+    end
+
+    it 'withholds another user private pipeline' do
+      expect(resolve_for(member)).not_to include(private_pipeline)
+    end
   end
 
-  it 'grants a team pipeline to a member of its team' do
-    team.team_members.create!(user: member)
-    expect(resolve_for(member)).to include(team_pipeline)
+  it 'withholds a team pipeline from someone outside its teams' do
+    expect(resolve_for(member)).not_to include(team_pipeline)
   end
 
   it 'does not bypass for an administrator who is neither owner nor team member' do
     admin = User.create!(name: 'Admin', email: "admin-#{SecureRandom.hex(4)}@example.com")
     allow(admin).to receive(:administrator?).and_return(true) # resolve must ignore it
+
     expect(resolve_for(admin)).not_to include(team_pipeline, private_pipeline)
+  end
+
+  # Service tokens reach these endpoints with no Current.user (check_permission! already
+  # grants them elevated access). Scoping them by a nil user would answer 200 carrying
+  # only public+default — a silently partial result for an internal caller.
+  it 'does not scope service-to-service calls, which carry no user' do
+    expect(resolve_for(nil, service_authenticated: true))
+      .to include(team_pipeline, private_pipeline, public_pipeline, own_pipeline)
+  end
+
+  it 'still scopes a userless call that is not service authenticated' do
+    expect(resolve_for(nil)).not_to include(team_pipeline, private_pipeline, own_pipeline)
   end
 end

--- a/spec/policies/pipeline_policy/scope_spec.rb
+++ b/spec/policies/pipeline_policy/scope_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2222 (AC4): PipelinePolicy::Scope#resolve must mirror Pipeline.accessible_by
+# exactly — public + own + default + team — with NO administrator bypass. accessible_by
+# has never granted admins other users' private pipelines, and the scope must not diverge.
+RSpec.describe PipelinePolicy::Scope do
+  let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
+  let(:member) { User.create!(name: 'Member', email: "member-#{SecureRandom.hex(4)}@example.com") }
+  let(:team) { Team.create!(name: "Team #{SecureRandom.hex(4)}") }
+  let!(:team_pipeline) do
+    Pipeline.create!(name: 'Team', pipeline_type: 'custom', visibility: :team, created_by: owner, teams: [team])
+  end
+  let!(:private_pipeline) do
+    Pipeline.create!(name: 'Private', pipeline_type: 'custom', visibility: :private, created_by: owner)
+  end
+
+  def resolve_for(user)
+    described_class.new({ user: user }, Pipeline.all).resolve
+  end
+
+  it 'mirrors accessible_by exactly for a given user' do
+    team.team_members.create!(user: member)
+    expect(resolve_for(member)).to match_array(Pipeline.accessible_by(member))
+  end
+
+  it 'grants a team pipeline to a member of its team' do
+    team.team_members.create!(user: member)
+    expect(resolve_for(member)).to include(team_pipeline)
+  end
+
+  it 'does not bypass for an administrator who is neither owner nor team member' do
+    admin = User.create!(name: 'Admin', email: "admin-#{SecureRandom.hex(4)}@example.com")
+    allow(admin).to receive(:administrator?).and_return(true) # resolve must ignore it
+    expect(resolve_for(admin)).not_to include(team_pipeline, private_pipeline)
+  end
+end

--- a/spec/policies/pipeline_policy/scope_spec.rb
+++ b/spec/policies/pipeline_policy/scope_spec.rb
@@ -4,9 +4,8 @@ require 'rails_helper'
 
 # EVO-2222 (AC4): PipelinePolicy::Scope#resolve is the single place #index and the by_*
 # endpoints are scoped from — public + own + default + team — with NO administrator
-# bypass. accessible_by has never granted admins other users' private pipelines, and the
-# scope must not diverge from it. Each branch is asserted explicitly instead of being
-# compared against Pipeline.accessible_by, which would pass even if accessible_by broke.
+# bypass. Each branch is asserted on its own; comparing against Pipeline.accessible_by
+# would pass even with accessible_by broken.
 RSpec.describe PipelinePolicy::Scope do
   let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
   let(:member) { User.create!(name: 'Member', email: "member-#{SecureRandom.hex(4)}@example.com") }
@@ -55,9 +54,7 @@ RSpec.describe PipelinePolicy::Scope do
     expect(resolve_for(admin)).not_to include(team_pipeline, private_pipeline)
   end
 
-  # Service tokens reach these endpoints with no Current.user (check_permission! already
-  # grants them elevated access). Scoping them by a nil user would answer 200 carrying
-  # only public+default — a silently partial result for an internal caller.
+  # No Current.user by design; scoping by nil would answer with public+default only.
   it 'does not scope service-to-service calls, which carry no user' do
     expect(resolve_for(nil, service_authenticated: true))
       .to include(team_pipeline, private_pipeline, public_pipeline, own_pipeline)

--- a/spec/requests/api/v1/pipelines_team_visibility_spec.rb
+++ b/spec/requests/api/v1/pipelines_team_visibility_spec.rb
@@ -5,12 +5,18 @@ require 'webmock/rspec'
 
 # EVO-2222 — `team` pipeline visibility, end-to-end through the gate. The by_* endpoints
 # feed the pipeline-membership menu on a conversation/contact; they must return only
-# pipelines the caller may see (public + own + default + team), and creating a `team`
-# pipeline must persist the picker's team_ids (previously discarded). We WebMock evo-auth
-# so `pipelines.{read,create}` gates the endpoints and Current.user resolves to the caller.
+# pipelines the caller may see (public + own + default + team), and create/update must
+# persist the picker's team_ids (previously discarded). We WebMock evo-auth so
+# `pipelines.{read,create,update}` gates the endpoints and Current.user resolves to the caller.
+#
+# The write examples send the payload BARE, with no `pipeline` envelope — that is what
+# pipelinesService.createPipeline/updatePipeline posts, and `team_ids` is not a Pipeline
+# column, so ParamsWrapper does not carry it into params[:pipeline]. An enveloped-only
+# example passes while the product still drops the selection.
 RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request do
   let(:base_url) { 'http://auth.test' }
   let(:token) { 'test-bearer-token' }
+  let(:service_token) { 'test-service-token' }
 
   let!(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
   let!(:member) { User.create!(name: 'Member', email: "member-#{SecureRandom.hex(4)}@example.com") }
@@ -31,15 +37,23 @@ RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request d
   end
   let(:contact) { Contact.create!(name: 'C', email: "c-#{SecureRandom.hex(4)}@example.com") }
 
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: "Inbox #{SecureRandom.hex(4)}", channel: channel) }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
   around do |example|
     original = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+    original_service_token = ENV.fetch('EVOAI_CRM_API_TOKEN', nil)
     ENV['EVO_AUTH_SERVICE_URL'] = base_url
+    ENV['EVOAI_CRM_API_TOKEN'] = service_token
     Rails.cache.clear
     Current.reset
     example.run
     Rails.cache.clear
     Current.reset
     ENV['EVO_AUTH_SERVICE_URL'] = original
+    ENV['EVOAI_CRM_API_TOKEN'] = original_service_token
   end
 
   def json_response
@@ -48,6 +62,10 @@ RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request d
 
   def headers
     { 'Authorization' => "Bearer #{token}" }
+  end
+
+  def service_headers
+    { 'X-Service-Token' => service_token }
   end
 
   # Resolve Current.user to `user` and grant the given permission keys.
@@ -65,9 +83,10 @@ RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request d
       end
   end
 
-  def place_on(pipeline)
-    pipeline.pipeline_items.create!(contact: contact, pipeline_stage: pipeline.pipeline_stages.first,
-                                    entered_at: Time.current)
+  def place_on(pipeline, on: :contact)
+    attrs = { pipeline_stage: pipeline.pipeline_stages.first, entered_at: Time.current }
+    attrs[on] = on == :contact ? contact : conversation
+    pipeline.pipeline_items.create!(attrs)
   end
 
   describe 'GET /api/v1/pipelines/by_contact/:contact_id' do
@@ -96,20 +115,120 @@ RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request d
       expect(ids).to include(public_pipeline.id)
       expect(ids).not_to include(team_pipeline.id)
     end
+
+    # Internal callers authenticate with a service token and carry no Current.user;
+    # scoping them by a nil user would answer 200 with a silently partial list.
+    it 'does not scope a service-to-service call' do
+      get "/api/v1/pipelines/by_contact/#{contact.id}", headers: service_headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      ids = json_response['data'].map { |p| p['id'] }
+      expect(ids).to include(team_pipeline.id, public_pipeline.id)
+    end
+  end
+
+  # The card names the by_* endpoints in the plural; by_conversation feeds the same menu
+  # from the conversation side and goes through the same scoping helper.
+  describe 'GET /api/v1/pipelines/by_conversation/:conversation_id' do
+    before do
+      team.team_members.create!(user: member)
+      place_on(team_pipeline, on: :conversation)
+      place_on(public_pipeline, on: :conversation)
+    end
+
+    def by_conversation(as_user)
+      stub_auth(as_user, granted: %w[pipelines.read])
+      get "/api/v1/pipelines/by_conversation/#{conversation.id}", headers: headers, as: :json
+    end
+
+    it 'shows a team pipeline to a member of its team (AC3)' do
+      by_conversation(member)
+      expect(response).to have_http_status(:ok)
+      ids = json_response['data'].map { |p| p['id'] }
+      expect(ids).to include(team_pipeline.id, public_pipeline.id)
+    end
+
+    it 'hides the team pipeline from a non-member, keeping the public one (AC3)' do
+      by_conversation(outsider)
+      expect(response).to have_http_status(:ok)
+      ids = json_response['data'].map { |p| p['id'] }
+      expect(ids).to include(public_pipeline.id)
+      expect(ids).not_to include(team_pipeline.id)
+    end
   end
 
   describe 'POST /api/v1/pipelines' do
-    it 'persists team_ids for a team pipeline instead of discarding them (AC1)' do
-      stub_auth(owner, granted: %w[pipelines.create])
+    before { stub_auth(owner, granted: %w[pipelines.create]) }
 
-      post '/api/v1/pipelines',
-           params: { pipeline: { name: "New #{SecureRandom.hex(4)}", pipeline_type: 'custom',
-                                 visibility: 'team', team_ids: [team.id] } },
-           headers: headers, as: :json
+    def create_pipeline(payload)
+      post '/api/v1/pipelines', params: payload, headers: headers, as: :json
+    end
+
+    it 'persists team_ids sent without the pipeline envelope, as the client sends them (AC1)' do
+      create_pipeline(name: "New #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                      visibility: 'team', team_ids: [team.id])
 
       expect(response).to have_http_status(:created)
       expect(json_response['data']['team_ids']).to contain_exactly(team.id)
       expect(Pipeline.find(json_response['data']['id']).team_ids).to contain_exactly(team.id)
+    end
+
+    it 'persists team_ids sent inside the pipeline envelope (AC1)' do
+      create_pipeline(pipeline: { name: "New #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                                  visibility: 'team', team_ids: [team.id] })
+
+      expect(response).to have_http_status(:created)
+      expect(json_response['data']['team_ids']).to contain_exactly(team.id)
+      expect(Pipeline.find(json_response['data']['id']).team_ids).to contain_exactly(team.id)
+    end
+  end
+
+  describe 'PATCH /api/v1/pipelines/:id' do
+    let(:pipeline) do
+      Pipeline.create!(name: "Editable #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                       visibility: :private, created_by: owner)
+    end
+
+    before { stub_auth(owner, granted: %w[pipelines.update]) }
+
+    def update_pipeline(payload)
+      patch "/api/v1/pipelines/#{pipeline.id}", params: payload, headers: headers, as: :json
+    end
+
+    it 'persists team_ids sent without the pipeline envelope, as the client sends them (AC1)' do
+      update_pipeline(visibility: 'team', team_ids: [team.id])
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data']['team_ids']).to contain_exactly(team.id)
+      expect(pipeline.reload.team_ids).to contain_exactly(team.id)
+    end
+
+    it 'clears the selection on an explicit empty list' do
+      pipeline.update!(visibility: :team, team_ids: [team.id])
+
+      update_pipeline(visibility: 'team', team_ids: [])
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response['data']['team_ids']).to be_empty
+      expect(pipeline.reload.team_ids).to be_empty
+    end
+
+    it 'leaves the selection untouched when team_ids is not sent at all' do
+      pipeline.update!(visibility: :team, team_ids: [team.id])
+
+      update_pipeline(name: "Renamed #{SecureRandom.hex(4)}")
+
+      expect(response).to have_http_status(:ok)
+      expect(pipeline.reload.team_ids).to contain_exactly(team.id)
+    end
+
+    it 'makes the pipeline reachable by the team members it was just shared with (AC2)' do
+      team.team_members.create!(user: member)
+
+      update_pipeline(visibility: 'team', team_ids: [team.id])
+
+      expect(Pipeline.accessible_by(member)).to include(pipeline)
+      expect(Pipeline.accessible_by(outsider)).not_to include(pipeline)
     end
   end
 end

--- a/spec/requests/api/v1/pipelines_team_visibility_spec.rb
+++ b/spec/requests/api/v1/pipelines_team_visibility_spec.rb
@@ -6,13 +6,11 @@ require 'webmock/rspec'
 # EVO-2222 — `team` pipeline visibility, end-to-end through the gate. The by_* endpoints
 # feed the pipeline-membership menu on a conversation/contact; they must return only
 # pipelines the caller may see (public + own + default + team), and create/update must
-# persist the picker's team_ids (previously discarded). We WebMock evo-auth so
-# `pipelines.{read,create,update}` gates the endpoints and Current.user resolves to the caller.
+# persist the picker's team_ids. We WebMock evo-auth so `pipelines.{read,create,update}`
+# gates the endpoints and Current.user resolves to the caller.
 #
-# The write examples send the payload BARE, with no `pipeline` envelope — that is what
-# pipelinesService.createPipeline/updatePipeline posts, and `team_ids` is not a Pipeline
-# column, so ParamsWrapper does not carry it into params[:pipeline]. An enveloped-only
-# example passes while the product still drops the selection.
+# The write examples send the payload BARE, with no `pipeline` envelope: that is what the
+# client posts, and the envelope would switch ParamsWrapper off, taking the gap with it.
 RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request do
   let(:base_url) { 'http://auth.test' }
   let(:token) { 'test-bearer-token' }
@@ -116,8 +114,8 @@ RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request d
       expect(ids).not_to include(team_pipeline.id)
     end
 
-    # Internal callers authenticate with a service token and carry no Current.user;
-    # scoping them by a nil user would answer 200 with a silently partial list.
+    # Internal callers carry no Current.user; scoping by nil would answer with a
+    # silently partial list.
     it 'does not scope a service-to-service call' do
       get "/api/v1/pipelines/by_contact/#{contact.id}", headers: service_headers, as: :json
 
@@ -127,8 +125,7 @@ RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request d
     end
   end
 
-  # The card names the by_* endpoints in the plural; by_conversation feeds the same menu
-  # from the conversation side and goes through the same scoping helper.
+  # Same scoping helper as by_contact, reached from the conversation side.
   describe 'GET /api/v1/pipelines/by_conversation/:conversation_id' do
     before do
       team.team_members.create!(user: member)

--- a/spec/requests/api/v1/pipelines_team_visibility_spec.rb
+++ b/spec/requests/api/v1/pipelines_team_visibility_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+# EVO-2222 — `team` pipeline visibility, end-to-end through the gate. The by_* endpoints
+# feed the pipeline-membership menu on a conversation/contact; they must return only
+# pipelines the caller may see (public + own + default + team), and creating a `team`
+# pipeline must persist the picker's team_ids (previously discarded). We WebMock evo-auth
+# so `pipelines.{read,create}` gates the endpoints and Current.user resolves to the caller.
+RSpec.describe 'Api::V1::Pipelines team visibility (EVO-2222)', type: :request do
+  let(:base_url) { 'http://auth.test' }
+  let(:token) { 'test-bearer-token' }
+
+  let!(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
+  let!(:member) { User.create!(name: 'Member', email: "member-#{SecureRandom.hex(4)}@example.com") }
+  let!(:outsider) { User.create!(name: 'Outsider', email: "out-#{SecureRandom.hex(4)}@example.com") }
+  let(:team) { Team.create!(name: "Team #{SecureRandom.hex(4)}") }
+
+  let(:team_pipeline) do
+    Pipeline.create!(name: "Team #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                     visibility: :team, created_by: owner, teams: [team]).tap do |p|
+      p.pipeline_stages.create!(name: 'New', position: 1)
+    end
+  end
+  let(:public_pipeline) do
+    Pipeline.create!(name: "Public #{SecureRandom.hex(4)}", pipeline_type: 'support',
+                     visibility: :public, created_by: owner).tap do |p|
+      p.pipeline_stages.create!(name: 'New', position: 1)
+    end
+  end
+  let(:contact) { Contact.create!(name: 'C', email: "c-#{SecureRandom.hex(4)}@example.com") }
+
+  around do |example|
+    original = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+    ENV['EVO_AUTH_SERVICE_URL'] = base_url
+    Rails.cache.clear
+    Current.reset
+    example.run
+    Rails.cache.clear
+    Current.reset
+    ENV['EVO_AUTH_SERVICE_URL'] = original
+  end
+
+  def json_response
+    response.parsed_body
+  end
+
+  def headers
+    { 'Authorization' => "Bearer #{token}" }
+  end
+
+  # Resolve Current.user to `user` and grant the given permission keys.
+  def stub_auth(user, granted:)
+    stub_request(:post, "#{base_url}/api/v1/auth/validate")
+      .to_return(status: 200,
+                 body: { success: true,
+                         data: { user: { id: user.id, email: user.email, role: { id: 1, key: 'r', name: 'r' } } } }.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+    stub_request(:post, "#{base_url}/api/v1/users/#{user.id}/check_permission")
+      .to_return do |req|
+        key = JSON.parse(req.body)['permission_key']
+        { status: 200, body: { success: true, data: { has_permission: granted.include?(key) } }.to_json,
+          headers: { 'Content-Type' => 'application/json' } }
+      end
+  end
+
+  def place_on(pipeline)
+    pipeline.pipeline_items.create!(contact: contact, pipeline_stage: pipeline.pipeline_stages.first,
+                                    entered_at: Time.current)
+  end
+
+  describe 'GET /api/v1/pipelines/by_contact/:contact_id' do
+    before do
+      team.team_members.create!(user: member)
+      place_on(team_pipeline)
+      place_on(public_pipeline)
+    end
+
+    def by_contact(as_user)
+      stub_auth(as_user, granted: %w[pipelines.read])
+      get "/api/v1/pipelines/by_contact/#{contact.id}", headers: headers, as: :json
+    end
+
+    it 'shows a team pipeline to a member of its team (AC3)' do
+      by_contact(member)
+      expect(response).to have_http_status(:ok)
+      ids = json_response['data'].map { |p| p['id'] }
+      expect(ids).to include(team_pipeline.id, public_pipeline.id)
+    end
+
+    it 'hides the team pipeline from a non-member, keeping the public one (AC3)' do
+      by_contact(outsider)
+      expect(response).to have_http_status(:ok)
+      ids = json_response['data'].map { |p| p['id'] }
+      expect(ids).to include(public_pipeline.id)
+      expect(ids).not_to include(team_pipeline.id)
+    end
+  end
+
+  describe 'POST /api/v1/pipelines' do
+    it 'persists team_ids for a team pipeline instead of discarding them (AC1)' do
+      stub_auth(owner, granted: %w[pipelines.create])
+
+      post '/api/v1/pipelines',
+           params: { pipeline: { name: "New #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                                 visibility: 'team', team_ids: [team.id] } },
+           headers: headers, as: :json
+
+      expect(response).to have_http_status(:created)
+      expect(json_response['data']['team_ids']).to contain_exactly(team.id)
+      expect(Pipeline.find(json_response['data']['id']).team_ids).to contain_exactly(team.id)
+    end
+  end
+end


### PR DESCRIPTION
## EVO-2222 (backend) — `team` pipeline visibility

> **CRM-only.** O frontend já estava pronto (`PipelineFormPage` manda `team_ids`; `EditPipelineModal` lê `pipeline.team_ids`) — faltava só o backend cumprir o que a tela promete.

### Problema
`Pipeline.visibility` já tinha `{ private, team, public }` e a UI oferece as 3 + picker de times, mas o backend implementava 2: `accessible_by` não tinha branch pra `team` (se comportava como private), e **não havia `team_ids` em lugar nenhum** (nem param, nem associação, nem join table) — silenciosamente descartado, sucesso retornado. Mesma classe da EVO-2122.

### Mudança
- **Migration + `PipelineTeam`**: join `pipeline_teams` (unique por pipeline+team, FKs). `Pipeline has_many :teams, through` → `team_ids=` persiste a seleção do picker.
- **`accessible_by`**: branch `team` — membro de um dos times do pipeline vê. Lista de times vazia → subquery vazia (sem special-case).
- **`pipeline_params`**: aceita `team_ids: []`; create/update persistem.
- **`fetch_pipelines_by_item_filter`** (`by_conversation`/`by_contact`): escopa por `accessible_by(Current.user)` — o menu de pipelines na conversa/contato só mostra o que o usuário pode ver (AC3). Antes retornava todos.
- **`PipelinePolicy::Scope#resolve`**: espelha `accessible_by` (era `scope.all`). **Sem bypass de admin** (AC4).
- **Serializer**: expõe `team_ids` (round-trip do picker no edit). Lê o join preloaded (`.includes(:pipeline_teams)` no index/by_*) pra evitar N+1.

- **`Team has_many :pipeline_teams, dependent: :destroy`**: deletar um time (o `teams_controller` tem `destroy`) limpa o join **antes** do FK restrict; o pipeline sobrevive (perde só aquele time). Coberto por teste.

### Fora de escopo (conforme o card)
Enforcement por ID direto (`show?`/`view?`) = **EVO-2204**. Bypass de admin: nenhum.

### Testes — 19 examples, 0 failures
- **Model** (`pipeline_spec`): persiste team_ids (AC1); membro vê / non-member não / membro de outro time não (AC2).
- **Request** (`pipelines_team_visibility_spec`): `by_contact` mostra ao membro / esconde do non-member mantendo o público (AC3); `POST` persiste team_ids (AC1).
- **Policy** (`pipeline_policy/scope_spec`): `Scope#resolve` espelha `accessible_by`; admin não-membro não bypassa (AC4).
- **Prova negativa**: neutralizando o branch `team`, os 2 testes de membro falham (o pipeline some pro membro — o próprio bug do card).

Migration note (do card): pipelines já salvos com `visibility: team` não têm times gravados (descartados no write) — saem deste PR visíveis só ao criador até re-editar. Sem backfill (instalação atual não tem team pipelines).

Relacionado: EVO-2204 (enforcement por ID) · EVO-2122 (mesma classe).
