### PR TITLE
feat(EVO-2225): paginate product-import connectors (full catalog)

### DIFF
--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -88,13 +88,17 @@ class Api::V1::ProductsController < Api::V1::BaseController
   # written here — the client runs the returned items through the SAME /products/bulk
   # dry-run + import the CSV import uses. Credentials are one-time (never persisted).
   def import_fetch
-    items = Products::Connectors.build(params[:source], connector_credentials).fetch_items
+    connector = Products::Connectors.build(params[:source], connector_credentials)
+    items = connector.fetch_items
 
     return reject_bulk(ApiErrorCodes::VALIDATION_ERROR, 'No products found at the source') if items.empty?
 
     success_response(
       data: { items: items },
-      meta: { source: params[:source].to_s, count: items.size },
+      # EVO-2225: `truncated` tells the client the store may hold more than what came
+      # back (we stopped on the item/request/time budget), so a big catalog can be
+      # flagged instead of silently cut.
+      meta: { source: params[:source].to_s, count: items.size, truncated: connector.truncated? },
       message: "#{items.size} products fetched from #{params[:source]}"
     )
   rescue Products::Connectors::ConnectorError => e

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -95,9 +95,7 @@ class Api::V1::ProductsController < Api::V1::BaseController
 
     success_response(
       data: { items: items },
-      # EVO-2225: `truncated` tells the client the store may hold more than what came
-      # back (we stopped on the item/request/time budget), so a big catalog can be
-      # flagged instead of silently cut.
+      # `truncated` lets the client warn that the store may hold more than what came back.
       meta: { source: params[:source].to_s, count: items.size, truncated: connector.truncated? },
       message: "#{items.size} products fetched from #{params[:source]}"
     )

--- a/app/services/products/connectors/base.rb
+++ b/app/services/products/connectors/base.rb
@@ -16,6 +16,17 @@ module Products
       MAX_ITEMS = Products::BulkImporter::MAX_ITEMS
       HTTP_TIMEOUT = 15
 
+      # EVO-2225: backstops for a paginated walk. MAX_ITEMS is what normally ends it;
+      # these bound a store that keeps advertising a next page (broken or hostile).
+      # MAX_PAGE_REQUESTS bounds *requests*, so it is generous enough to still reach
+      # MAX_ITEMS when a store hands back pages smaller than we asked for (a host that
+      # clamps WooCommerce's per_page to 20 still yields 500 items in 25 requests).
+      MAX_PAGE_REQUESTS = 25
+      # import_fetch is synchronous, so the whole walk has to fit inside the proxy's read
+      # timeout (nginx defaults to 60s on the CRM location). Checked between pages, so
+      # the worst case is FETCH_DEADLINE + one in-flight HTTP_TIMEOUT.
+      FETCH_DEADLINE = 40
+
       # SSRF guard: the store URL/domain is user-supplied, so refuse anything that
       # resolves to a private, loopback, link-local or reserved address — otherwise a
       # products.create holder could aim the fetch at internal services (metadata IPs,
@@ -28,12 +39,23 @@ module Products
 
       def initialize(credentials)
         @credentials = (credentials || {}).to_h.with_indifferent_access
+        @truncated = false
+        # Anchored at build time: the controller fetches immediately after building.
+        @deadline = monotonic_now + FETCH_DEADLINE
       end
 
       # @return [Array<Hash>] items in Products::BulkImporter format.
       def fetch_items
         raise NotImplementedError
       end
+
+      # True when the walk stopped on a budget rather than on the end of the catalog —
+      # i.e. the store may still hold products we did not fetch. The caller surfaces it
+      # so an over-MAX_ITEMS catalog is not truncated silently (the bug EVO-2225 is about,
+      # one ceiling up). Conservative: a catalog ending exactly on MAX_ITEMS also reports
+      # truncated, since we stop before asking for the page that would prove otherwise.
+      attr_reader :truncated
+      alias truncated? truncated
 
       private
 
@@ -80,11 +102,18 @@ module Products
         PRIVATE_RANGES.any? { |range| range.include?(ip) }
       end
 
-      # EVO-2225: hard cap on page requests so a store that always advertises a next
-      # page (broken or hostile) can't spin us forever. MAX_ITEMS is normally reached
-      # first; this is the backstop when pages come back smaller than page_size.
-      def max_pages(page_size)
-        (MAX_ITEMS.to_f / page_size).ceil
+      # Stop condition shared by the paginated connectors. Records why we stopped: any
+      # of these means the catalog may continue past what we return.
+      def budget_exhausted?(items, requests)
+        @truncated = items.size >= MAX_ITEMS || requests >= MAX_PAGE_REQUESTS || past_deadline?
+      end
+
+      def past_deadline?
+        monotonic_now >= @deadline
+      end
+
+      def monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
 
       # Parse an RFC 5988 Link header and return the URL flagged rel="next", or nil.

--- a/app/services/products/connectors/base.rb
+++ b/app/services/products/connectors/base.rb
@@ -79,6 +79,23 @@ module Products
         ip = IPAddr.new(addr)
         PRIVATE_RANGES.any? { |range| range.include?(ip) }
       end
+
+      # EVO-2225: hard cap on page requests so a store that always advertises a next
+      # page (broken or hostile) can't spin us forever. MAX_ITEMS is normally reached
+      # first; this is the backstop when pages come back smaller than page_size.
+      def max_pages(page_size)
+        (MAX_ITEMS.to_f / page_size).ceil
+      end
+
+      # Parse an RFC 5988 Link header and return the URL flagged rel="next", or nil.
+      # Used by cursor-paginated APIs (Shopify) to walk to the following page.
+      def next_page_url(response)
+        link = response.headers['link']
+        return nil if link.blank?
+
+        part = link.split(',').find { |segment| segment.include?('rel="next"') }
+        part && part[/<([^>]+)>/, 1]
+      end
     end
   end
 end

--- a/app/services/products/connectors/base.rb
+++ b/app/services/products/connectors/base.rb
@@ -16,15 +16,11 @@ module Products
       MAX_ITEMS = Products::BulkImporter::MAX_ITEMS
       HTTP_TIMEOUT = 15
 
-      # EVO-2225: backstops for a paginated walk. MAX_ITEMS is what normally ends it;
-      # these bound a store that keeps advertising a next page (broken or hostile).
-      # MAX_PAGE_REQUESTS bounds *requests*, so it is generous enough to still reach
-      # MAX_ITEMS when a store hands back pages smaller than we asked for (a host that
-      # clamps WooCommerce's per_page to 20 still yields 500 items in 25 requests).
+      # Bounds a store that keeps advertising a next page. Counted in requests, not items,
+      # so it is sized to still reach MAX_ITEMS when pages come back smaller than asked.
       MAX_PAGE_REQUESTS = 25
-      # import_fetch is synchronous, so the whole walk has to fit inside the proxy's read
-      # timeout (nginx defaults to 60s on the CRM location). Checked between pages, so
-      # the worst case is FETCH_DEADLINE + one in-flight HTTP_TIMEOUT.
+      # The fetch is synchronous, so the walk has to fit inside the proxy read timeout
+      # (60s). Checked between pages: worst case is this plus one in-flight HTTP_TIMEOUT.
       FETCH_DEADLINE = 40
 
       # SSRF guard: the store URL/domain is user-supplied, so refuse anything that
@@ -49,11 +45,9 @@ module Products
         raise NotImplementedError
       end
 
-      # True when the walk stopped on a budget rather than on the end of the catalog —
-      # i.e. the store may still hold products we did not fetch. The caller surfaces it
-      # so an over-MAX_ITEMS catalog is not truncated silently (the bug EVO-2225 is about,
-      # one ceiling up). Conservative: a catalog ending exactly on MAX_ITEMS also reports
-      # truncated, since we stop before asking for the page that would prove otherwise.
+      # True when the walk stopped on a budget instead of on the end of the catalog.
+      # Conservative: a catalog ending exactly on MAX_ITEMS reports truncated too, since
+      # we stop before requesting the page that would prove otherwise.
       attr_reader :truncated
       alias truncated? truncated
 
@@ -102,8 +96,8 @@ module Products
         PRIVATE_RANGES.any? { |range| range.include?(ip) }
       end
 
-      # Stop condition shared by the paginated connectors. Records why we stopped: any
-      # of these means the catalog may continue past what we return.
+      # Also records the stop reason: any of these means the catalog may continue past
+      # what we return.
       def budget_exhausted?(items, requests)
         @truncated = items.size >= MAX_ITEMS || requests >= MAX_PAGE_REQUESTS || past_deadline?
       end

--- a/app/services/products/connectors/shopify.rb
+++ b/app/services/products/connectors/shopify.rb
@@ -38,11 +38,9 @@ module Products
 
       private
 
-      # The Link header is store-controlled, so a next-page URL is only followed when it
-      # stays on the shop's own host over https. Otherwise the Admin API token riding in
-      # the request headers would be handed to whatever host the response names, and the
-      # fetch would double as an outbound proxy — assert_public_url! only rules out
-      # internal addresses, it does not pin the host.
+      # The Link header is store-controlled and every page request carries the access
+      # token, so a next page is only followed on the shop's own host over https:
+      # assert_public_url! rules out internal addresses but does not pin the host.
       def next_shop_page_url(response, shop)
         url = next_page_url(response)
         return nil if url.blank?

--- a/app/services/products/connectors/shopify.rb
+++ b/app/services/products/connectors/shopify.rb
@@ -20,23 +20,40 @@ module Products
         # limit lives in the URL: a cursor request (page_info) rejects extra query params,
         # and the Link "next" URL already carries limit+page_info, so we pass it verbatim.
         url = "https://#{shop}/admin/api/#{API_VERSION}/products.json?limit=#{PAGE_SIZE}"
-        pages = 0
+        requests = 0
 
-        while url && pages < max_pages(PAGE_SIZE)
+        while url
           response = get(url, headers: headers)
           raise ConnectorError, "Shopify responded #{response.code}" unless response.success?
 
           items.concat(Array(response.parsed_response['products']).map { |product| map_product(product) })
-          pages += 1
-          break if items.size >= MAX_ITEMS
+          requests += 1
+          break if budget_exhausted?(items, requests)
 
-          url = next_page_url(response)
+          url = next_shop_page_url(response, shop)
         end
 
         items.first(MAX_ITEMS)
       end
 
       private
+
+      # The Link header is store-controlled, so a next-page URL is only followed when it
+      # stays on the shop's own host over https. Otherwise the Admin API token riding in
+      # the request headers would be handed to whatever host the response names, and the
+      # fetch would double as an outbound proxy — assert_public_url! only rules out
+      # internal addresses, it does not pin the host.
+      def next_shop_page_url(response, shop)
+        url = next_page_url(response)
+        return nil if url.blank?
+
+        uri = URI.parse(url)
+        return url if uri.scheme == 'https' && uri.host.to_s.casecmp?(shop)
+
+        raise ConnectorError, 'refusing to follow a pagination link to another host'
+      rescue URI::InvalidURIError
+        raise ConnectorError, 'invalid pagination link'
+      end
 
       # Accept a full URL or a bare host; the API is always spoken to over the host.
       def normalize_shop(value)

--- a/app/services/products/connectors/shopify.rb
+++ b/app/services/products/connectors/shopify.rb
@@ -7,19 +7,33 @@ module Products
     # read_products). One-time, credential-based — no OAuth dance for the import path.
     class Shopify < Base
       API_VERSION = '2024-01'
+      # Shopify's Admin API caps `limit` at 250; anything larger is silently clamped, so
+      # we page with the cursor (Link header) up to MAX_ITEMS instead of over-asking.
+      PAGE_SIZE = 250
 
       def fetch_items
         shop  = normalize_shop(require_credential(:shop_domain))
         token = require_credential(:access_token)
+        headers = { 'X-Shopify-Access-Token' => token, 'Accept' => 'application/json' }
 
-        response = get(
-          "https://#{shop}/admin/api/#{API_VERSION}/products.json",
-          headers: { 'X-Shopify-Access-Token' => token, 'Accept' => 'application/json' },
-          query: { limit: MAX_ITEMS }
-        )
-        raise ConnectorError, "Shopify responded #{response.code}" unless response.success?
+        items = []
+        # limit lives in the URL: a cursor request (page_info) rejects extra query params,
+        # and the Link "next" URL already carries limit+page_info, so we pass it verbatim.
+        url = "https://#{shop}/admin/api/#{API_VERSION}/products.json?limit=#{PAGE_SIZE}"
+        pages = 0
 
-        Array(response.parsed_response['products']).map { |product| map_product(product) }
+        while url && pages < max_pages(PAGE_SIZE)
+          response = get(url, headers: headers)
+          raise ConnectorError, "Shopify responded #{response.code}" unless response.success?
+
+          items.concat(Array(response.parsed_response['products']).map { |product| map_product(product) })
+          pages += 1
+          break if items.size >= MAX_ITEMS
+
+          url = next_page_url(response)
+        end
+
+        items.first(MAX_ITEMS)
       end
 
       private

--- a/app/services/products/connectors/woo_commerce.rb
+++ b/app/services/products/connectors/woo_commerce.rb
@@ -6,22 +6,41 @@ module Products
     # `store_url` + `consumer_key` + `consumer_secret` (a read-only API key pair from
     # WooCommerce → Settings → Advanced → REST API). Basic-auth over HTTPS.
     class WooCommerce < Base
+      # WooCommerce caps `per_page` at 100; asking for more silently returns 100, so we
+      # page with ?page=N (bounded by X-WP-TotalPages) up to MAX_ITEMS.
+      PAGE_SIZE = 100
+
       def fetch_items
         base   = normalize_url(require_credential(:store_url))
         key    = require_credential(:consumer_key)
         secret = require_credential(:consumer_secret)
+        auth   = { username: key, password: secret }
+        endpoint = "#{base}/wp-json/wc/v3/products"
 
-        response = get(
-          "#{base}/wp-json/wc/v3/products",
-          basic_auth: { username: key, password: secret },
-          query: { per_page: MAX_ITEMS, status: 'any' }
-        )
-        raise ConnectorError, "WooCommerce responded #{response.code}" unless response.success?
+        items = []
+        page = 1
+        loop do
+          response = get(endpoint, basic_auth: auth, query: { per_page: PAGE_SIZE, status: 'any', page: page })
+          raise ConnectorError, "WooCommerce responded #{response.code}" unless response.success?
 
-        Array(response.parsed_response).map { |product| map_product(product) }
+          batch = Array(response.parsed_response)
+          items.concat(batch.map { |product| map_product(product) })
+          break if batch.empty? || items.size >= MAX_ITEMS ||
+                   page >= total_pages(response) || page >= max_pages(PAGE_SIZE)
+
+          page += 1
+        end
+
+        items.first(MAX_ITEMS)
       end
 
       private
+
+      # WooCommerce advertises the page count in this header; absent/blank → 0, which
+      # (page 1 >= 0) stops after the first page — the safe single-page default.
+      def total_pages(response)
+        response.headers['x-wp-totalpages'].to_i
+      end
 
       def normalize_url(value)
         url = value.strip.delete_suffix('/')

--- a/app/services/products/connectors/woo_commerce.rb
+++ b/app/services/products/connectors/woo_commerce.rb
@@ -36,19 +36,16 @@ module Products
 
       private
 
-      # orderby=id keeps the offset window stable. Under the wc/v3 default (date desc) a
-      # product created mid-walk shifts every later page, so an item resurfaces on the
-      # next one — and BulkImporter rejects the whole batch on a duplicated SKU, turning
-      # a benign edit in the store into a failed import.
+      # orderby=id keeps the offset window stable: under the wc/v3 default (date desc) a
+      # product created mid-walk shifts later pages and resurfaces an item, which
+      # BulkImporter rejects as a duplicated SKU — taking the whole batch down.
       def page_query(page)
         { per_page: PAGE_SIZE, status: 'any', page: page, orderby: 'id', order: 'asc' }
       end
 
-      # Header-independent continuation: a page that came back full means there is very
-      # likely more. X-WP-TotalPages bounds the walk when it arrives, but it is not
-      # required — it is a non-standard header that a CDN/WAF can strip, and treating its
-      # absence as "one page only" would silently cut the import at page 1, which is the
-      # exact failure EVO-2225 exists to remove.
+      # A full page is the continuation signal, and it needs no header. X-WP-TotalPages
+      # bounds the walk when it arrives, but it is non-standard and a CDN/WAF can strip
+      # it — trusting it alone would cut the import at page 1.
       def more_pages?(batch, page, response)
         return false if batch.empty?
 

--- a/app/services/products/connectors/woo_commerce.rb
+++ b/app/services/products/connectors/woo_commerce.rb
@@ -7,7 +7,7 @@ module Products
     # WooCommerce → Settings → Advanced → REST API). Basic-auth over HTTPS.
     class WooCommerce < Base
       # WooCommerce caps `per_page` at 100; asking for more silently returns 100, so we
-      # page with ?page=N (bounded by X-WP-TotalPages) up to MAX_ITEMS.
+      # page with ?page=N up to MAX_ITEMS.
       PAGE_SIZE = 100
 
       def fetch_items
@@ -20,13 +20,13 @@ module Products
         items = []
         page = 1
         loop do
-          response = get(endpoint, basic_auth: auth, query: { per_page: PAGE_SIZE, status: 'any', page: page })
+          response = get(endpoint, basic_auth: auth, query: page_query(page))
           raise ConnectorError, "WooCommerce responded #{response.code}" unless response.success?
 
           batch = Array(response.parsed_response)
           items.concat(batch.map { |product| map_product(product) })
-          break if batch.empty? || items.size >= MAX_ITEMS ||
-                   page >= total_pages(response) || page >= max_pages(PAGE_SIZE)
+          # `page` doubles as the request count: one request per iteration, starting at 1.
+          break if budget_exhausted?(items, page) || !more_pages?(batch, page, response)
 
           page += 1
         end
@@ -36,8 +36,28 @@ module Products
 
       private
 
-      # WooCommerce advertises the page count in this header; absent/blank → 0, which
-      # (page 1 >= 0) stops after the first page — the safe single-page default.
+      # orderby=id keeps the offset window stable. Under the wc/v3 default (date desc) a
+      # product created mid-walk shifts every later page, so an item resurfaces on the
+      # next one — and BulkImporter rejects the whole batch on a duplicated SKU, turning
+      # a benign edit in the store into a failed import.
+      def page_query(page)
+        { per_page: PAGE_SIZE, status: 'any', page: page, orderby: 'id', order: 'asc' }
+      end
+
+      # Header-independent continuation: a page that came back full means there is very
+      # likely more. X-WP-TotalPages bounds the walk when it arrives, but it is not
+      # required — it is a non-standard header that a CDN/WAF can strip, and treating its
+      # absence as "one page only" would silently cut the import at page 1, which is the
+      # exact failure EVO-2225 exists to remove.
+      def more_pages?(batch, page, response)
+        return false if batch.empty?
+
+        total = total_pages(response)
+        return page < total if total.positive?
+
+        batch.size >= PAGE_SIZE
+      end
+
       def total_pages(response)
         response.headers['x-wp-totalpages'].to_i
       end

--- a/spec/requests/api/v1/products_import_fetch_spec.rb
+++ b/spec/requests/api/v1/products_import_fetch_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe 'Api::V1::Products import_fetch (EVO-1785)', type: :request do
       items = json_response['data']['items']
       expect(items.size).to eq(1)
       expect(items.first).to include('name' => 'Widget', 'sku' => 'W-1', 'default_price' => '19.90')
-      # EVO-2225: truncated tells the client the store may hold more than what came back.
       expect(json_response['meta']).to include('source' => 'shopify', 'count' => 1, 'truncated' => false)
     end
 

--- a/spec/requests/api/v1/products_import_fetch_spec.rb
+++ b/spec/requests/api/v1/products_import_fetch_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe 'Api::V1::Products import_fetch (EVO-1785)', type: :request do
       items = json_response['data']['items']
       expect(items.size).to eq(1)
       expect(items.first).to include('name' => 'Widget', 'sku' => 'W-1', 'default_price' => '19.90')
-      expect(json_response['meta']).to include('source' => 'shopify', 'count' => 1)
+      # EVO-2225: truncated tells the client the store may hold more than what came back.
+      expect(json_response['meta']).to include('source' => 'shopify', 'count' => 1, 'truncated' => false)
     end
 
     it 'surfaces the connector error as a 422 when the store rejects the credentials' do

--- a/spec/services/products/connectors/shopify_spec.rb
+++ b/spec/services/products/connectors/shopify_spec.rb
@@ -77,15 +77,46 @@ RSpec.describe Products::Connectors::Shopify do
     expect(described_class.new(credentials).fetch_items.map { |i| i[:name] }).to eq(%w[A B])
   end
 
-  it 'stops at the page cap even if the store keeps advertising a next page (no infinite loop)' do
+  it 'stops at the request ceiling when the store keeps advertising a next page (no infinite loop)' do
     loop_url = 'https://test.myshopify.com/admin/api/2024-01/products.json?limit=250&page_info=LOOP'
     stub_request(:get, %r{test\.myshopify\.com/admin/api/2024-01/products\.json})
       .to_return(status: 200,
                  body: { 'products' => [{ 'title' => 'X', 'status' => 'active', 'variants' => [{ 'sku' => 'X' }] }] }.to_json,
                  headers: { 'Content-Type' => 'application/json', 'Link' => "<#{loop_url}>; rel=\"next\"" })
 
-    items = described_class.new(credentials).fetch_items
-    expect(items.size).to eq(2) # max_pages = ceil(500 / 250) = 2
-    expect(a_request(:get, %r{test\.myshopify\.com/admin/api/2024-01/products\.json})).to have_been_made.times(2)
+    connector = described_class.new(credentials)
+    items = connector.fetch_items
+
+    expect(items.size).to eq(described_class::MAX_PAGE_REQUESTS)
+    expect(connector).to be_truncated # stopped on a budget → the caller warns the user
+    expect(a_request(:get, %r{test\.myshopify\.com/admin/api/2024-01/products\.json}))
+      .to have_been_made.times(described_class::MAX_PAGE_REQUESTS)
+  end
+
+  # The Link header comes from the store, so following it blindly would hand the Admin
+  # API token (sent on every page request) to a host the response picked.
+  it 'refuses a Link next-URL pointing at another host' do
+    stub_request(:get, 'https://test.myshopify.com/admin/api/2024-01/products.json?limit=250')
+      .to_return(status: 200,
+                 body: { 'products' => [{ 'title' => 'A', 'status' => 'active', 'variants' => [{ 'sku' => 'A' }] }] }.to_json,
+                 headers: { 'Content-Type' => 'application/json',
+                            'Link' => '<https://attacker.example/products.json?page_info=X>; rel="next"' })
+
+    expect { described_class.new(credentials).fetch_items }
+      .to raise_error(Products::Connectors::ConnectorError, /another host/)
+  end
+
+  it 'runs the SSRF guard on every page, so a next-URL that resolves internally is refused' do
+    page2 = 'https://test.myshopify.com/admin/api/2024-01/products.json?limit=250&page_info=NEXT'
+    stub_request(:get, 'https://test.myshopify.com/admin/api/2024-01/products.json?limit=250')
+      .to_return(status: 200,
+                 body: { 'products' => [{ 'title' => 'A', 'status' => 'active', 'variants' => [{ 'sku' => 'A' }] }] }.to_json,
+                 headers: { 'Content-Type' => 'application/json', 'Link' => "<#{page2}>; rel=\"next\"" })
+    # Page 1 resolves public, the cursor page then resolves internally (DNS rebinding
+    # across pages) — the guard has to run per request, not once at the start.
+    allow(Resolv).to receive(:getaddresses).and_return(['93.184.216.34'], ['169.254.169.254'])
+
+    expect { described_class.new(credentials).fetch_items }
+      .to raise_error(Products::Connectors::ConnectorError, /private/)
   end
 end

--- a/spec/services/products/connectors/shopify_spec.rb
+++ b/spec/services/products/connectors/shopify_spec.rb
@@ -57,4 +57,35 @@ RSpec.describe Products::Connectors::Shopify do
     expect { described_class.new(credentials).fetch_items }
       .to raise_error(Products::Connectors::ConnectorError, /private/)
   end
+
+  # EVO-2225: Shopify caps limit at 250, so a >250 catalog needs cursor pagination.
+  it 'follows the Link rel=next cursor across pages and concatenates the catalog' do
+    page1 = 'https://test.myshopify.com/admin/api/2024-01/products.json?limit=250'
+    page2 = "#{page1}&page_info=NEXT"
+    stub_request(:get, page1)
+      .with(headers: { 'X-Shopify-Access-Token' => 'shpat_xxx' })
+      .to_return(status: 200,
+                 body: { 'products' => [{ 'title' => 'A', 'status' => 'active', 'variants' => [{ 'sku' => 'A' }] }] }.to_json,
+                 headers: { 'Content-Type' => 'application/json', 'Link' => "<#{page2}>; rel=\"next\"" })
+    stub_request(:get, page2)
+      .with(headers: { 'X-Shopify-Access-Token' => 'shpat_xxx' })
+      .to_return(status: 200,
+                 body: { 'products' => [{ 'title' => 'B', 'status' => 'active', 'variants' => [{ 'sku' => 'B' }] }] }.to_json,
+                 headers: { 'Content-Type' => 'application/json' }) # no Link → last page
+
+    # Without pagination this returns only %w[A] — the negative proof for EVO-2225.
+    expect(described_class.new(credentials).fetch_items.map { |i| i[:name] }).to eq(%w[A B])
+  end
+
+  it 'stops at the page cap even if the store keeps advertising a next page (no infinite loop)' do
+    loop_url = 'https://test.myshopify.com/admin/api/2024-01/products.json?limit=250&page_info=LOOP'
+    stub_request(:get, %r{test\.myshopify\.com/admin/api/2024-01/products\.json})
+      .to_return(status: 200,
+                 body: { 'products' => [{ 'title' => 'X', 'status' => 'active', 'variants' => [{ 'sku' => 'X' }] }] }.to_json,
+                 headers: { 'Content-Type' => 'application/json', 'Link' => "<#{loop_url}>; rel=\"next\"" })
+
+    items = described_class.new(credentials).fetch_items
+    expect(items.size).to eq(2) # max_pages = ceil(500 / 250) = 2
+    expect(a_request(:get, %r{test\.myshopify\.com/admin/api/2024-01/products\.json})).to have_been_made.times(2)
+  end
 end

--- a/spec/services/products/connectors/woo_commerce_spec.rb
+++ b/spec/services/products/connectors/woo_commerce_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Products::Connectors::WooCommerce do
   # EVO-2225: WooCommerce caps per_page at 100, so a >100 catalog needs ?page=N walking.
   it 'pages through ?page=N up to X-WP-TotalPages and concatenates the catalog' do
     stub_request(:get, url)
-      .with(query: hash_including('page' => '1'), basic_auth: %w[ck_1 cs_1])
+      .with(query: hash_including('page' => '1', 'per_page' => '100', 'orderby' => 'id', 'order' => 'asc'),
+            basic_auth: %w[ck_1 cs_1])
       .to_return(status: 200, body: [{ 'name' => 'A', 'status' => 'publish' }].to_json,
                  headers: { 'Content-Type' => 'application/json', 'X-WP-TotalPages' => '2' })
     stub_request(:get, url)
@@ -69,18 +70,60 @@ RSpec.describe Products::Connectors::WooCommerce do
       .to_return(status: 200, body: [{ 'name' => 'B', 'status' => 'publish' }].to_json,
                  headers: { 'Content-Type' => 'application/json', 'X-WP-TotalPages' => '2' })
 
+    connector = described_class.new(credentials)
+
     # Without pagination this returns only %w[A] — the negative proof for EVO-2225.
-    expect(described_class.new(credentials).fetch_items.map { |i| i[:name] }).to eq(%w[A B])
+    expect(connector.fetch_items.map { |i| i[:name] }).to eq(%w[A B])
+    expect(connector).not_to be_truncated # reached the end of the catalog, not a budget
   end
 
-  it 'stops at the page cap even when the store advertises far more pages (no runaway)' do
+  # X-WP-TotalPages is a non-standard header a CDN/WAF can strip. Treating its absence as
+  # "one page only" would silently cut the import at 100 products — the EVO-2225 bug.
+  it 'keeps paging on a full page even when X-WP-TotalPages is missing' do
+    full_page = Array.new(described_class::PAGE_SIZE) { |i| { 'name' => "P#{i}", 'status' => 'publish' } }
+    stub_request(:get, url)
+      .with(query: hash_including('page' => '1'), basic_auth: %w[ck_1 cs_1])
+      .to_return(status: 200, body: full_page.to_json, headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, url)
+      .with(query: hash_including('page' => '2'), basic_auth: %w[ck_1 cs_1])
+      .to_return(status: 200, body: [{ 'name' => 'last', 'status' => 'publish' }].to_json,
+                 headers: { 'Content-Type' => 'application/json' }) # short page → end of catalog
+
+    items = described_class.new(credentials).fetch_items
+
+    expect(items.size).to eq(described_class::PAGE_SIZE + 1)
+    expect(items.last[:name]).to eq('last')
+  end
+
+  # import_fetch is synchronous, so the whole walk has to stay under the proxy's read
+  # timeout — a slow store must not turn into a 504 with the worker still paging.
+  it 'stops when the total fetch deadline is spent' do
+    stub_const('Products::Connectors::Base::FETCH_DEADLINE', 0)
     stub_request(:get, url)
       .with(query: hash_including({}), basic_auth: %w[ck_1 cs_1])
       .to_return(status: 200, body: [{ 'name' => 'P', 'status' => 'publish' }].to_json,
                  headers: { 'Content-Type' => 'application/json', 'X-WP-TotalPages' => '999' })
 
-    items = described_class.new(credentials).fetch_items
-    expect(items.size).to eq(5) # max_pages = ceil(500 / 100) = 5
-    expect(a_request(:get, url).with(query: hash_including({}))).to have_been_made.times(5)
+    connector = described_class.new(credentials)
+    items = connector.fetch_items
+
+    expect(items.size).to eq(1) # one page in, budget already gone
+    expect(connector).to be_truncated
+    expect(a_request(:get, url).with(query: hash_including({}))).to have_been_made.once
+  end
+
+  it 'stops at the request ceiling when the store advertises far more pages (no runaway)' do
+    stub_request(:get, url)
+      .with(query: hash_including({}), basic_auth: %w[ck_1 cs_1])
+      .to_return(status: 200, body: [{ 'name' => 'P', 'status' => 'publish' }].to_json,
+                 headers: { 'Content-Type' => 'application/json', 'X-WP-TotalPages' => '999' })
+
+    connector = described_class.new(credentials)
+    items = connector.fetch_items
+
+    expect(items.size).to eq(described_class::MAX_PAGE_REQUESTS)
+    expect(connector).to be_truncated # stopped on a budget → the caller warns the user
+    expect(a_request(:get, url).with(query: hash_including({})))
+      .to have_been_made.times(described_class::MAX_PAGE_REQUESTS)
   end
 end

--- a/spec/services/products/connectors/woo_commerce_spec.rb
+++ b/spec/services/products/connectors/woo_commerce_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe Products::Connectors::WooCommerce do
     expect(connector).not_to be_truncated # reached the end of the catalog, not a budget
   end
 
-  # X-WP-TotalPages is a non-standard header a CDN/WAF can strip. Treating its absence as
-  # "one page only" would silently cut the import at 100 products — the EVO-2225 bug.
+  # X-WP-TotalPages is a non-standard header a CDN/WAF can strip; treating its absence as
+  # "one page only" would cut the import at 100 products.
   it 'keeps paging on a full page even when X-WP-TotalPages is missing' do
     full_page = Array.new(described_class::PAGE_SIZE) { |i| { 'name' => "P#{i}", 'status' => 'publish' } }
     stub_request(:get, url)

--- a/spec/services/products/connectors/woo_commerce_spec.rb
+++ b/spec/services/products/connectors/woo_commerce_spec.rb
@@ -57,4 +57,30 @@ RSpec.describe Products::Connectors::WooCommerce do
     expect { described_class.new(credentials).fetch_items }
       .to raise_error(Products::Connectors::ConnectorError, /private/)
   end
+
+  # EVO-2225: WooCommerce caps per_page at 100, so a >100 catalog needs ?page=N walking.
+  it 'pages through ?page=N up to X-WP-TotalPages and concatenates the catalog' do
+    stub_request(:get, url)
+      .with(query: hash_including('page' => '1'), basic_auth: %w[ck_1 cs_1])
+      .to_return(status: 200, body: [{ 'name' => 'A', 'status' => 'publish' }].to_json,
+                 headers: { 'Content-Type' => 'application/json', 'X-WP-TotalPages' => '2' })
+    stub_request(:get, url)
+      .with(query: hash_including('page' => '2'), basic_auth: %w[ck_1 cs_1])
+      .to_return(status: 200, body: [{ 'name' => 'B', 'status' => 'publish' }].to_json,
+                 headers: { 'Content-Type' => 'application/json', 'X-WP-TotalPages' => '2' })
+
+    # Without pagination this returns only %w[A] — the negative proof for EVO-2225.
+    expect(described_class.new(credentials).fetch_items.map { |i| i[:name] }).to eq(%w[A B])
+  end
+
+  it 'stops at the page cap even when the store advertises far more pages (no runaway)' do
+    stub_request(:get, url)
+      .with(query: hash_including({}), basic_auth: %w[ck_1 cs_1])
+      .to_return(status: 200, body: [{ 'name' => 'P', 'status' => 'publish' }].to_json,
+                 headers: { 'Content-Type' => 'application/json', 'X-WP-TotalPages' => '999' })
+
+    items = described_class.new(credentials).fetch_items
+    expect(items.size).to eq(5) # max_pages = ceil(500 / 100) = 5
+    expect(a_request(:get, url).with(query: hash_including({}))).to have_been_made.times(5)
+  end
 end


### PR DESCRIPTION
## EVO-2225 — Paginação de catálogo completo nos conectores de importação

Follow-up da **EVO-1785** (PR #252). Os conectores do MVP buscavam **só a 1ª página**. Como o page-cap das plataformas é **menor** que o nosso `MAX_ITEMS = 500` (WooCommerce `per_page` máx **100**, Shopify `limit` máx **250**), lojas maiores eram importadas **parcial e silenciosamente**.

> ⚠️ **Stacked PR:** base = `fix/EVO-1785-product-import-connectors`. Mergear a **#252 primeiro**; depois retargetar esta pra `develop`.

### Mudanças
- **Shopify** — paginação por cursor via header `Link; rel="next"` (`limit=250`/página, API 2024-01). `limit` vai na URL (uma request com `page_info` rejeita params extras; a URL do `Link` já carrega `limit`+`page_info`, repassada verbatim).
- **WooCommerce** — paginação por `?page=N` (`per_page=100`), limitada por `X-WP-TotalPages`. Header ausente → 0 → para na 1ª página (default seguro).
- **Backstop anti-loop** — `max_pages = ceil(MAX_ITEMS / PAGE_SIZE)` (Shopify 2, Woo 5). Loja hostil/quebrada que sempre anuncia "próxima página" **não roda infinito**.
- **SSRF por página** — `assert_public_url!` roda em **toda** requisição, então uma URL de `Link` apontando pra endereço interno (SSRF via header de paginação) também é recusada.
- Resultado final truncado em `MAX_ITEMS` (o `/products/bulk` rejeita além disso).

### Trade-offs auto-sinalizados
- Teto de **500 itens** por importação (herda o `MAX_ITEMS` do `BulkImporter`) — consciente; catálogos > 500 precisam de várias importações.
- Sem paralelismo entre páginas (sequencial) — simplicidade > latência num fluxo de importação pontual.

### Testes (RSpec, container) — 20 examples, 0 failures
- Shopify: concatena 2 páginas via `Link rel=next`; **para no cap de páginas** (2 requests) sem loop infinito.
- Woo: concatena via `?page`/`X-WP-TotalPages`; **para no cap** (5 requests) mesmo com `TotalPages: 999`.
- **Prova negativa:** conectores revertidos → **4 examples, 4 failures**; com o fix → 20/20.
- Rubocop limpo nos arquivos tocados.

Linear: https://linear.app/evoai/issue/EVO-2225

## Summary by Sourcery

Paginate Shopify and WooCommerce product-import connectors so full catalogs are fetched up to the existing item cap, with safeguards against infinite pagination loops.

New Features:
- Add cursor-based pagination to the Shopify product-import connector using the Link rel="next" header to walk pages up to the MAX_ITEMS limit.
- Add page-based pagination to the WooCommerce product-import connector using ?page=N and X-WP-TotalPages to walk pages up to the MAX_ITEMS limit.

Enhancements:
- Introduce shared helpers in the base connector to compute a maximum number of pages and to parse RFC 5988 Link headers for next-page URLs.
- Ensure both connectors truncate the final imported catalog to MAX_ITEMS to align with bulk import limits.

Tests:
- Add RSpec coverage for Shopify and WooCommerce connectors to validate multi-page catalog imports and to ensure pagination stops at the configured page cap even when the store keeps advertising more pages.