### PR TITLE
feat(EVO-2227): feed audio transcription into agent input (Phase 1)

### DIFF
--- a/app/jobs/bot_runtime/send_event_job.rb
+++ b/app/jobs/bot_runtime/send_event_job.rb
@@ -13,15 +13,39 @@ module BotRuntime
       Rails.logger.info "[BotRuntime::SendEventJob] Sending event: " \
                         "conversation_id=#{event[:conversation_id]} agent_bot_id=#{event[:agent_bot_id]}"
 
-      # EVO-2227: fold the audio transcription into the text content here (async,
-      # off the sync inbound-webhook path) so voice notes are understood on any
-      # provider. Best-effort — the enricher returns the event unchanged on error.
+      # EVO-2227 Fase 1.5: re-read the message's real attachments at send time
+      # (async, after the media is persisted) so the audio FILE reaches the agent —
+      # the sync-listener build gated media out. Native-audio providers use the file.
+      event = refresh_attachments(event)
+
+      # EVO-2227 Fase 1: fold the audio transcription into the text content here
+      # (async, off the sync inbound-webhook path) so voice notes are also understood
+      # by text-only providers. Best-effort — returns the event unchanged on error.
       event = BotRuntime::TranscriptionEnricher.enrich(event)
 
       BotRuntime::Client.new.send_event(event)
 
       Rails.logger.info "[BotRuntime::SendEventJob] Event sent successfully: " \
                         "conversation_id=#{event[:conversation_id]}"
+    end
+
+    private
+
+    # Override the event's media with the message's real, persisted attachments.
+    # Best-effort: a blank result (no media, or a lookup error) leaves the event
+    # untouched so a text-only delegation is unaffected.
+    def refresh_attachments(event)
+      message_id = event[:message_id]
+      return event if message_id.blank?
+
+      attachments = BotRuntime::AttachmentBuilder.build(message_id)
+      return event if attachments.blank?
+
+      Rails.logger.info "[BotRuntime::SendEventJob] Forwarding #{attachments.size} attachment(s) for message #{message_id}"
+      event.merge(attachments: attachments)
+    rescue StandardError => e
+      Rails.logger.error "[BotRuntime::SendEventJob] refresh_attachments failed: #{e.class}: #{e.message}"
+      event
     end
   end
 end

--- a/app/jobs/bot_runtime/send_event_job.rb
+++ b/app/jobs/bot_runtime/send_event_job.rb
@@ -13,6 +13,11 @@ module BotRuntime
       Rails.logger.info "[BotRuntime::SendEventJob] Sending event: " \
                         "conversation_id=#{event[:conversation_id]} agent_bot_id=#{event[:agent_bot_id]}"
 
+      # EVO-2227: fold the audio transcription into the text content here (async,
+      # off the sync inbound-webhook path) so voice notes are understood on any
+      # provider. Best-effort — the enricher returns the event unchanged on error.
+      event = BotRuntime::TranscriptionEnricher.enrich(event)
+
       BotRuntime::Client.new.send_event(event)
 
       Rails.logger.info "[BotRuntime::SendEventJob] Event sent successfully: " \

--- a/app/services/bot_runtime/attachment_builder.rb
+++ b/app/services/bot_runtime/attachment_builder.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module BotRuntime
+  # EVO-2227 (Fase 1.5): builds the media payload the bot_runtime forwards to the
+  # AI agent as A2A file parts, straight from the PERSISTED message.
+  #
+  # Why this exists separately from DelegationService#build_attachments: the
+  # delegation event is assembled inside the SYNC MESSAGE_CREATED listener, and it
+  # gated media on `payload[:attachments].present?`. For an inbound WhatsApp voice
+  # note that gate evaluated false (the dispatched payload had no :attachments
+  # key), so the audio — though downloaded and attached to the message — never
+  # reached the agent ("Total files extracted: 0" → 400). Re-reading the message's
+  # real attachments at SEND time (async, in SendEventJob) makes the audio reach
+  # the agent for ANY provider (native-audio models use the file; the transcription
+  # from TranscriptionEnricher covers text-only models).
+  class AttachmentBuilder
+    ATTACHMENT_PRELOAD = { attachments: { file_attachment: :blob } }.freeze
+
+    def self.build(message_id)
+      new(message_id).build
+    end
+
+    def initialize(message_id)
+      @message_id = message_id
+    end
+
+    def build
+      return [] if @message_id.blank?
+
+      message = Message.includes(ATTACHMENT_PRELOAD).find_by(id: @message_id)
+      return [] if message.nil?
+
+      message.attachments
+             .sort_by { |att| [att.created_at, att.id.to_s] }
+             .filter_map { |att| payload(att) }
+    rescue StandardError => e
+      Rails.logger.error("[BotRuntime::AttachmentBuilder] message=#{@message_id}: #{e.class}: #{e.message}")
+      []
+    end
+
+    private
+
+    # The bot_runtime fetches this URL server-side, so it's an outbound media URL
+    # (BlobUrlOptions.outbound_media_url honors ACTIVE_STORAGE_URL and signs with a
+    # short TTL). Rescued per attachment so one broken record doesn't drop the media
+    # of the whole message.
+    def payload(attachment)
+      return if attachment.file_type.blank?
+      return unless attachment.file.attached? && attachment.with_attached_file?
+
+      blob = attachment.file.blob
+      {
+        url: BlobUrlOptions.outbound_media_url(blob),
+        content_type: blob.content_type,
+        file_type: attachment.file_type
+      }
+    rescue StandardError => e
+      Rails.logger.error("[BotRuntime::AttachmentBuilder] attachment #{attachment.id}: #{e.class}: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/bot_runtime/transcription_enricher.rb
+++ b/app/services/bot_runtime/transcription_enricher.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module BotRuntime
+  # EVO-2227 (Fase 1): injects the audio transcription into the text content sent
+  # to the AI agent, so a voice note is understood on ANY provider — not just
+  # Gemini's native audio. The raw audio is still forwarded as a media part
+  # (DelegationService#build_attachments), so Gemini keeps native understanding
+  # while OpenAI (whose chat models reject inline audio) gets the transcript.
+  #
+  # Runs inside SendEventJob (async, off the inbound webhook request) because
+  # AgentBotListener is on the SYNC dispatcher — transcribing there would block
+  # the incoming-message request. Best-effort: any failure returns the event
+  # unchanged so the agent call still happens.
+  class TranscriptionEnricher
+    LABEL = 'Transcrição do áudio'
+
+    def self.enrich(event)
+      new(event).enrich
+    end
+
+    def initialize(event)
+      @event = event
+    end
+
+    def enrich
+      transcribe_and_merge
+    rescue StandardError => e
+      Rails.logger.error("[BotRuntime::TranscriptionEnricher] #{e.class}: #{e.message}")
+      @event
+    end
+
+    private
+
+    def transcribe_and_merge
+      message = target_message
+      return @event if message.nil?
+
+      audio_attachments = message.attachments.select(&:audio?)
+      return @event if audio_attachments.empty?
+
+      texts = audio_attachments.filter_map { |att| transcription_for(att) }
+      return @event if texts.empty?
+
+      @event.merge(message_content: combine(@event[:message_content], texts))
+    end
+
+    def target_message
+      message_id = @event[:message_id]
+      return if message_id.blank?
+
+      Message.find_by(id: message_id)
+    end
+
+    # Reuse the transcription the display-path job may already have stored; only
+    # transcribe now if it isn't there yet. The service is idempotent and persists
+    # to meta, so a concurrent AudioTranscriptionJob converges on the same text.
+    def transcription_for(attachment)
+      existing = attachment.meta&.[]('transcribed_text')
+      return existing if existing.present?
+
+      result = Messages::AudioTranscriptionService.new(attachment: attachment).perform
+      result[:transcribed_text] if result.is_a?(Hash) && result[:success]
+    end
+
+    def combine(original_content, texts)
+      transcript = texts.map { |text| "[#{LABEL}]: #{text}" }.join("\n")
+      base = original_content.to_s.strip
+      base.empty? ? transcript : "#{base}\n\n#{transcript}"
+    end
+  end
+end

--- a/spec/jobs/bot_runtime/send_event_job_spec.rb
+++ b/spec/jobs/bot_runtime/send_event_job_spec.rb
@@ -3,16 +3,32 @@
 require 'rails_helper'
 
 RSpec.describe BotRuntime::SendEventJob do
-  it 'enriches the event with the audio transcription before sending (EVO-2227)' do
-    event = { conversation_id: '1', agent_bot_id: '2', message_id: '42', message_content: 'oi' }
-    enriched = event.merge(message_content: "oi\n\n[Transcrição do áudio]: olá")
-    allow(BotRuntime::TranscriptionEnricher).to receive(:enrich).with(event).and_return(enriched)
+  let(:client) { instance_double(BotRuntime::Client, send_event: nil) }
 
-    client = instance_double(BotRuntime::Client, send_event: nil)
-    allow(BotRuntime::Client).to receive(:new).and_return(client)
+  before { allow(BotRuntime::Client).to receive(:new).and_return(client) }
+
+  it 'forwards the message attachments AND the transcription before sending (EVO-2227)' do
+    event = { conversation_id: '1', agent_bot_id: '2', message_id: '42', message_content: '' }
+    attachments = [{ url: 'http://evo-crm:3000/rails/a1', content_type: 'audio/ogg', file_type: 'audio' }]
+    allow(BotRuntime::AttachmentBuilder).to receive(:build).with('42').and_return(attachments)
+    allow(BotRuntime::TranscriptionEnricher).to receive(:enrich) do |ev|
+      ev.merge(message_content: '[Transcrição do áudio]: olá')
+    end
 
     described_class.new.perform(event)
 
-    expect(client).to have_received(:send_event).with(enriched)
+    expect(client).to have_received(:send_event).with(
+      hash_including(attachments: attachments, message_content: '[Transcrição do áudio]: olá')
+    )
+  end
+
+  it 'leaves the event untouched when the message has no attachments (text-only)' do
+    event = { message_id: '42', message_content: 'oi' }
+    allow(BotRuntime::AttachmentBuilder).to receive(:build).with('42').and_return([])
+    allow(BotRuntime::TranscriptionEnricher).to receive(:enrich) { |ev| ev }
+
+    described_class.new.perform(event)
+
+    expect(client).to have_received(:send_event).with(event)
   end
 end

--- a/spec/jobs/bot_runtime/send_event_job_spec.rb
+++ b/spec/jobs/bot_runtime/send_event_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BotRuntime::SendEventJob do
+  it 'enriches the event with the audio transcription before sending (EVO-2227)' do
+    event = { conversation_id: '1', agent_bot_id: '2', message_id: '42', message_content: 'oi' }
+    enriched = event.merge(message_content: "oi\n\n[Transcrição do áudio]: olá")
+    allow(BotRuntime::TranscriptionEnricher).to receive(:enrich).with(event).and_return(enriched)
+
+    client = instance_double(BotRuntime::Client, send_event: nil)
+    allow(BotRuntime::Client).to receive(:new).and_return(client)
+
+    described_class.new.perform(event)
+
+    expect(client).to have_received(:send_event).with(enriched)
+  end
+end

--- a/spec/services/bot_runtime/attachment_builder_spec.rb
+++ b/spec/services/bot_runtime/attachment_builder_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Stand-in for ActiveStorage::Attached::One: its #blob is resolved dynamically
+# (not a statically-defined instance method), so instance_double can't verify it.
+# A small real object avoids a bare RSpec double while staying rubocop-clean.
+class FakeAttachedFile
+  def initialize(attached:, blob:)
+    @attached = attached
+    @blob = blob
+  end
+
+  def attached?
+    @attached
+  end
+
+  attr_reader :blob
+end
+
+RSpec.describe BotRuntime::AttachmentBuilder do
+  subject(:built) { described_class.build('42') }
+
+  let(:t) { Time.zone.now }
+
+  def attachment(file_type:, attached: true, with_file: true, content_type: 'audio/ogg', id: SecureRandom.uuid)
+    blob = instance_double(ActiveStorage::Blob, content_type: content_type)
+    file = FakeAttachedFile.new(attached: attached, blob: blob)
+    att = instance_double(Attachment, id: id, created_at: t, file_type: file_type, file: file, with_attached_file?: with_file)
+    allow(BlobUrlOptions).to receive(:outbound_media_url).with(blob).and_return("http://evo-crm:3000/rails/#{id}")
+    att
+  end
+
+  def stub_message(attachments)
+    message = instance_double(Message, attachments: attachments)
+    relation = instance_double(ActiveRecord::Relation, find_by: message)
+    allow(Message).to receive(:includes).and_return(relation)
+    allow(relation).to receive(:find_by).with(id: '42').and_return(message)
+    message
+  end
+
+  it 'builds a media payload for an attached audio file' do
+    stub_message([attachment(file_type: 'audio', content_type: 'audio/ogg', id: 'a1')])
+    expect(built).to eq([{ url: 'http://evo-crm:3000/rails/a1', content_type: 'audio/ogg', file_type: 'audio' }])
+  end
+
+  it 'skips an attachment whose file is not actually attached (download failed)' do
+    stub_message([attachment(file_type: 'audio', attached: false)])
+    expect(built).to eq([])
+  end
+
+  it 'skips an attachment with a blank file_type' do
+    stub_message([attachment(file_type: '')])
+    expect(built).to eq([])
+  end
+
+  it 'returns [] when the message has no attachments' do
+    stub_message([])
+    expect(built).to eq([])
+  end
+
+  it 'returns [] when the message is not found' do
+    relation = instance_double(ActiveRecord::Relation, find_by: nil)
+    allow(Message).to receive(:includes).and_return(relation)
+    allow(relation).to receive(:find_by).with(id: '42').and_return(nil)
+    expect(built).to eq([])
+  end
+
+  it 'returns [] for a blank message id' do
+    expect(described_class.build(nil)).to eq([])
+  end
+
+  it 'is non-fatal: returns [] if lookup raises' do
+    allow(Message).to receive(:includes).and_raise(StandardError, 'boom')
+    expect(built).to eq([])
+  end
+end

--- a/spec/services/bot_runtime/transcription_enricher_spec.rb
+++ b/spec/services/bot_runtime/transcription_enricher_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BotRuntime::TranscriptionEnricher do
+  subject(:enriched) { described_class.enrich(event) }
+
+  let(:event) { { message_id: '42', message_content: 'oi' } }
+
+  def audio_attachment(transcribed: nil)
+    instance_double(Attachment, audio?: true, meta: transcribed ? { 'transcribed_text' => transcribed } : {})
+  end
+
+  def image_attachment
+    instance_double(Attachment, audio?: false, meta: {})
+  end
+
+  def stub_message(attachments)
+    message = instance_double(Message, attachments: attachments)
+    allow(Message).to receive(:find_by).with(id: '42').and_return(message)
+    message
+  end
+
+  it 'appends an existing transcription to the message content' do
+    stub_message([audio_attachment(transcribed: 'quero dois produtos')])
+    expect(enriched[:message_content]).to eq("oi\n\n[Transcrição do áudio]: quero dois produtos")
+  end
+
+  it 'uses only the transcript when the original content is blank (voice-only note)' do
+    event[:message_content] = ''
+    stub_message([audio_attachment(transcribed: 'bom dia')])
+    expect(enriched[:message_content]).to eq('[Transcrição do áudio]: bom dia')
+  end
+
+  it 'transcribes on the spot when meta has no transcription yet' do
+    stub_message([audio_attachment(transcribed: nil)])
+    service = instance_double(Messages::AudioTranscriptionService, perform: { success: true, transcribed_text: 'olá' })
+    allow(Messages::AudioTranscriptionService).to receive(:new).and_return(service)
+
+    expect(enriched[:message_content]).to eq("oi\n\n[Transcrição do áudio]: olá")
+    expect(Messages::AudioTranscriptionService).to have_received(:new)
+  end
+
+  it 'leaves the event unchanged when the message has no audio' do
+    stub_message([image_attachment])
+    expect(enriched).to eq(event)
+  end
+
+  it 'leaves the event unchanged when transcription fails/returns nothing' do
+    stub_message([audio_attachment(transcribed: nil)])
+    service = instance_double(Messages::AudioTranscriptionService, perform: { error: 'Transcription not enabled' })
+    allow(Messages::AudioTranscriptionService).to receive(:new).and_return(service)
+    expect(enriched).to eq(event)
+  end
+
+  it 'leaves the event unchanged when the message is not found' do
+    allow(Message).to receive(:find_by).with(id: '42').and_return(nil)
+    expect(enriched).to eq(event)
+  end
+
+  it 'leaves the event unchanged when there is no message_id' do
+    expect(described_class.enrich({ message_content: 'oi' })).to eq({ message_content: 'oi' })
+  end
+
+  it 'is non-fatal: returns the event unchanged if anything raises' do
+    allow(Message).to receive(:find_by).and_raise(StandardError, 'boom')
+    expect(enriched).to eq(event)
+  end
+end


### PR DESCRIPTION
## EVO-2227 Fase 1 — Áudio entendido em qualquer provider (transcrição no input do agente)

Primeira fase do agente multimodal. Hoje uma **nota de voz** chega ao agente só como **áudio cru** → entendida no **Gemini** (áudio nativo) mas **não no OpenAI** (modelos de chat rejeitam áudio inline), sem fallback. O CRM já transcreve (Whisper) mas só pra exibir no front — o texto **nunca** chegava ao agente.

### Solução
`BotRuntime::TranscriptionEnricher` injeta a transcrição no `message_content` do evento:
- **Reusa** `attachment.meta['transcribed_text']` se o job de exibição já rodou; senão **transcreve na hora** via `Messages::AudioTranscriptionService` (idempotente, persiste em meta → jobs concorrentes convergem).
- O **áudio cru continua sendo enviado** como media part → Gemini mantém entendimento nativo, OpenAI passa a receber o texto.

### Onde roda (decisão de arquitetura)
No **`SendEventJob`** (async, retriable) — **não** no `DelegationService`, porque o `AgentBotListener` está no **SYNC dispatcher** (`sync_dispatcher.rb:8`) e transcrever ali **bloquearia o request do webhook de entrada**. Best-effort: qualquer erro devolve o evento intacto e a chamada ao agente acontece mesmo assim.

### Testes — 9 examples, 0 failures · rubocop limpo nos arquivos tocados
- `TranscriptionEnricher`: reusa meta; transcreve on-miss; conteúdo vazio (voz pura); sem áudio; falha de transcrição; message não encontrada; sem id; **não-fatal** (raise → evento intacto).
- `SendEventJob`: comprova o wire (enriquece antes de enviar).
- `send_event_job` StringLiterals são **pré-existentes** (baselinados contra develop); o CRLF é do working-copy e o git normaliza pra LF (diff = só 5 linhas).

### Escopo
Só a **entrada de áudio**. Fases 2 (responder com imagem) e 3 (responder com áudio/TTS) vêm em PRs próprias.

Linear: https://linear.app/evoai/issue/EVO-2227

## Summary by Sourcery

Inject audio transcriptions into agent input so voice notes are understood across AI providers while keeping raw audio forwarding unchanged.

New Features:
- Add BotRuntime::TranscriptionEnricher service to merge audio transcription text into message_content for events sent to agents.

Enhancements:
- Update SendEventJob to enrich events with audio transcription asynchronously before calling the bot runtime client.

Tests:
- Add unit tests for TranscriptionEnricher covering reuse of stored transcripts, on-demand transcription, and best-effort fallback behavior.
- Add SendEventJob test to verify that events are enriched with audio transcription before being sent to the bot client.