### PR TITLE
fix(crm): enforce pipeline visibility on direct-id actions (EVO-2204)

### DIFF
--- a/app/controllers/api/v1/pipeline_items/products_controller.rb
+++ b/app/controllers/api/v1/pipeline_items/products_controller.rb
@@ -6,7 +6,15 @@ class Api::V1::PipelineItems::ProductsController < Api::V1::BaseController
     destroy: 'pipelines.update'
   })
 
+  # Mirrors PipelineItemsController: reads gate on :view?, mutations on :update?.
+  WRITE_ACTIONS = %w[create update destroy].freeze
+
   before_action :fetch_pipeline_item
+  # EVO-2204: the item was resolved by a bare find that ignored :pipeline_id entirely,
+  # so the products and the deal value of an item sitting in another user's private
+  # pipeline were readable and editable. Authorize the item's own pipeline, which also
+  # closes the mismatch between the id in the URL and the item actually loaded.
+  before_action :authorize_pipeline!
   before_action :fetch_link, only: %i[update destroy]
 
   def index
@@ -69,6 +77,14 @@ class Api::V1::PipelineItems::ProductsController < Api::V1::BaseController
       "Pipeline item with id #{params[:pipeline_item_id]} not found",
       status: :not_found
     )
+  end
+
+  # Automations and the ADK tool call this with a service token and no Current.user —
+  # apply_actor already reads that shape from the body, so the bypass is required.
+  def authorize_pipeline!
+    return if service_authenticated? || @pipeline_item.nil?
+
+    authorize @pipeline_item.pipeline, WRITE_ACTIONS.include?(action_name) ? :update? : :view?
   end
 
   def fetch_link

--- a/app/controllers/api/v1/pipeline_items/products_controller.rb
+++ b/app/controllers/api/v1/pipeline_items/products_controller.rb
@@ -10,10 +10,9 @@ class Api::V1::PipelineItems::ProductsController < Api::V1::BaseController
   WRITE_ACTIONS = %w[create update destroy].freeze
 
   before_action :fetch_pipeline_item
-  # EVO-2204: the item was resolved by a bare find that ignored :pipeline_id entirely,
-  # so the products and the deal value of an item sitting in another user's private
-  # pipeline were readable and editable. Authorize the item's own pipeline, which also
-  # closes the mismatch between the id in the URL and the item actually loaded.
+  # EVO-2204: the bare find ignored :pipeline_id, so the products and deal value of an
+  # item in another user's private pipeline were readable and editable through any URL.
+  # Authorizing the item's own pipeline closes the URL/item mismatch too.
   before_action :authorize_pipeline!
   before_action :fetch_link, only: %i[update destroy]
 

--- a/app/controllers/api/v1/pipeline_tasks_controller.rb
+++ b/app/controllers/api/v1/pipeline_tasks_controller.rb
@@ -6,10 +6,9 @@ class Api::V1::PipelineTasksController < Api::V1::BaseController
 
   before_action :set_pipeline_item, only: [:index, :create]
   before_action :set_task, only: [:show, :update, :destroy, :complete, :cancel, :reopen, :add_subtask, :move, :reorder]
-  # EVO-2204: these actions nest under a pipeline whose id was resolved by a bare find,
-  # so tasks inside another user's private board were readable (index/show, neither
-  # authorized at all) and plantable (create only checked admin-or-agent). Gate on the
-  # same :view? the sibling pipeline controllers use.
+  # EVO-2204: the nesting pipeline was resolved by a bare find and authorized nowhere, so
+  # tasks in another user's private board were readable and plantable. Same :view? gate
+  # the sibling pipeline controllers use.
   before_action :authorize_pipeline!, only: TASK_PIPELINE_ACTIONS
   before_action :authorize_task, only: [:update, :destroy, :complete, :cancel, :reopen, :add_subtask, :move, :reorder]
 

--- a/app/controllers/api/v1/pipeline_tasks_controller.rb
+++ b/app/controllers/api/v1/pipeline_tasks_controller.rb
@@ -1,6 +1,16 @@
 class Api::V1::PipelineTasksController < Api::V1::BaseController
+  TASK_PIPELINE_ACTIONS = [
+    :index, :create, :show, :update, :destroy,
+    :complete, :cancel, :reopen, :add_subtask, :move, :reorder
+  ].freeze
+
   before_action :set_pipeline_item, only: [:index, :create]
   before_action :set_task, only: [:show, :update, :destroy, :complete, :cancel, :reopen, :add_subtask, :move, :reorder]
+  # EVO-2204: these actions nest under a pipeline whose id was resolved by a bare find,
+  # so tasks inside another user's private board were readable (index/show, neither
+  # authorized at all) and plantable (create only checked admin-or-agent). Gate on the
+  # same :view? the sibling pipeline controllers use.
+  before_action :authorize_pipeline!, only: TASK_PIPELINE_ACTIONS
   before_action :authorize_task, only: [:update, :destroy, :complete, :cancel, :reopen, :add_subtask, :move, :reorder]
 
   def index
@@ -375,6 +385,14 @@ class Api::V1::PipelineTasksController < Api::V1::BaseController
   def set_task
     @pipeline = Pipeline.find(params[:pipeline_id]) if params[:pipeline_id].present?
     @task = PipelineTask.all.includes(subtasks: :subtasks, parent_task: :parent_task).find(params[:id])
+  end
+
+  # Journeys reach these endpoints with a service token and no Current.user, exactly
+  # like #create already assumes — same bypass, or evo-flow loses task creation.
+  def authorize_pipeline!
+    return if service_authenticated? || @pipeline.nil?
+
+    authorize @pipeline, :view?
   end
 
   def authorize_task

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -15,13 +15,14 @@ class Api::V1::PipelinesController < Api::V1::BaseController
     dependents: 'pipelines.update'
   })
 
+  # EVO-2204: authorize the pipeline (visibility + creator), not just the permission.
+  # First in the chain on purpose: a denied caller must not pay for the board
+  # eager-load below, and update must be denied regardless of the body it sent.
+  before_action :authorize_pipeline!,
+                only: [:show, :update, :destroy, :archive, :set_as_default, :stats, :dependents]
   before_action :fetch_pipeline, only: [:show, :update, :destroy, :archive, :set_as_default]
   before_action :fetch_pipeline_lean, only: [:dependents]
   before_action :fetch_pipeline_for_stats, only: [:stats], if: -> { params[:id].present? }
-  # EVO-2204: authorize the resolved pipeline (visibility + creator), not just the
-  # permission. Runs before param validation so a non-owner is denied regardless of body.
-  # Guarded on @pipeline so aggregate stats (no :id) stays permission-only.
-  before_action :authorize_pipeline!, only: [:show, :update, :destroy, :archive, :set_as_default, :stats]
   before_action :reject_update_without_permitted_attributes, only: [:update]
   before_action :validate_pipeline_limit, only: [:create]
   before_action :fetch_contact_for_by_contact, only: [:by_contact]
@@ -261,9 +262,14 @@ class Api::V1::PipelinesController < Api::V1::BaseController
   private
 
   # Pundit derives the query from action_name: show?/update?/destroy?/archive?/
-  # set_as_default?/stats? — each ANDs the permission with the visibility check.
+  # set_as_default?/stats?/dependents? — each ANDs the permission with the visibility
+  # check. Resolved bare here, not through the fetches: the graph they load is worth
+  # nothing on a denied request. Aggregate stats carries no :id and stays
+  # permission-only.
   def authorize_pipeline!
-    authorize @pipeline if @pipeline
+    return if params[:id].blank?
+
+    authorize Pipeline.find(params[:id])
   end
 
   def fetch_pipeline
@@ -298,8 +304,6 @@ class Api::V1::PipelinesController < Api::V1::BaseController
   # actions — loading that whole graph to answer a confirmation dialog is wasted work.
   def fetch_pipeline_lean
     @pipeline = Pipeline.find(params[:id])
-    # EVO-2204: dependents resolves a bare id too, so it needs the same visibility gate.
-    authorize @pipeline, :view?
   end
 
   def fetch_pipeline_for_stats

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -261,11 +261,8 @@ class Api::V1::PipelinesController < Api::V1::BaseController
 
   private
 
-  # Pundit derives the query from action_name: show?/update?/destroy?/archive?/
-  # set_as_default?/stats?/dependents? — each ANDs the permission with the visibility
-  # check. Resolved bare here, not through the fetches: the graph they load is worth
-  # nothing on a denied request. Aggregate stats carries no :id and stays
-  # permission-only.
+  # Pundit infers the query from action_name, so every gated action needs its own rule.
+  # Aggregate stats carries no :id and stays permission-only.
   def authorize_pipeline!
     return if params[:id].blank?
 

--- a/app/controllers/api/v1/pipelines_controller.rb
+++ b/app/controllers/api/v1/pipelines_controller.rb
@@ -17,8 +17,12 @@ class Api::V1::PipelinesController < Api::V1::BaseController
 
   before_action :fetch_pipeline, only: [:show, :update, :destroy, :archive, :set_as_default]
   before_action :fetch_pipeline_lean, only: [:dependents]
-  before_action :reject_update_without_permitted_attributes, only: [:update]
   before_action :fetch_pipeline_for_stats, only: [:stats], if: -> { params[:id].present? }
+  # EVO-2204: authorize the resolved pipeline (visibility + creator), not just the
+  # permission. Runs before param validation so a non-owner is denied regardless of body.
+  # Guarded on @pipeline so aggregate stats (no :id) stays permission-only.
+  before_action :authorize_pipeline!, only: [:show, :update, :destroy, :archive, :set_as_default, :stats]
+  before_action :reject_update_without_permitted_attributes, only: [:update]
   before_action :validate_pipeline_limit, only: [:create]
   before_action :fetch_contact_for_by_contact, only: [:by_contact]
   before_action :fetch_conversation_for_by_conversation, only: [:by_conversation]
@@ -256,6 +260,12 @@ class Api::V1::PipelinesController < Api::V1::BaseController
 
   private
 
+  # Pundit derives the query from action_name: show?/update?/destroy?/archive?/
+  # set_as_default?/stats? — each ANDs the permission with the visibility check.
+  def authorize_pipeline!
+    authorize @pipeline if @pipeline
+  end
+
   def fetch_pipeline
     @pipeline = Pipeline.all
                           .includes(
@@ -288,6 +298,8 @@ class Api::V1::PipelinesController < Api::V1::BaseController
   # actions — loading that whole graph to answer a confirmation dialog is wasted work.
   def fetch_pipeline_lean
     @pipeline = Pipeline.find(params[:id])
+    # EVO-2204: dependents resolves a bare id too, so it needs the same visibility gate.
+    authorize @pipeline, :view?
   end
 
   def fetch_pipeline_for_stats

--- a/app/policies/pipeline_policy.rb
+++ b/app/policies/pipeline_policy.rb
@@ -58,6 +58,13 @@ class PipelinePolicy < ApplicationPolicy
     permitted_read? && accessible_record?
   end
 
+  # Answers the archive confirmation dialog, and the controller gates it on
+  # `pipelines.update`. Authorizing it as a read would have quietly added a
+  # `pipelines.read` requirement the endpoint never had.
+  def dependents?
+    permitted_write? && accessible_record?
+  end
+
   private
 
   def permitted_read?
@@ -75,6 +82,13 @@ class PipelinePolicy < ApplicationPolicy
   # EVO-2204: enforce visibility on record-level actions through the SAME
   # Scope#resolve that filters #index (public / default / creator / team, with a
   # service-token bypass), so detail and list can never disagree.
+  #
+  # This is a READ predicate reused as the write gate, so anyone holding the
+  # permission may still edit or delete a public/default/team pipeline they did
+  # not create. Narrowing the write rules to the creator is NOT a local change:
+  # `update?` is also what pipeline_items authorizes item writes against
+  # (pipeline_items_controller WRITE_ACTIONS), so creator-only would stop team
+  # members from moving cards on a board shared with them. Needs its own rule.
   def accessible_record?
     scope.exists?(id: @record.id)
   end

--- a/app/policies/pipeline_policy.rb
+++ b/app/policies/pipeline_policy.rb
@@ -25,12 +25,11 @@ class PipelinePolicy < ApplicationPolicy
   end
 
   def show?
-    # Administrators or users with pipelines.read permission can view pipelines
-    @user&.administrator? || @user&.has_permission?('pipelines.read')
+    permitted_read? && accessible_record?
   end
 
   def view?
-    # Alias for show? - used by some controllers
+    # Alias for show? - used by child controllers (pipeline_stages, pipeline_items, ...)
     show?
   end
 
@@ -40,22 +39,43 @@ class PipelinePolicy < ApplicationPolicy
   end
 
   def update?
-    # Administrators or users with pipelines.update permission can update pipelines
-    @user&.administrator? || @user&.has_permission?('pipelines.update')
+    permitted_write? && accessible_record?
   end
 
   def destroy?
-    # Administrators or users with pipelines.delete permission can delete pipelines
-    @user&.administrator? || @user&.has_permission?('pipelines.delete')
+    permitted_delete? && accessible_record?
   end
 
   def archive?
-    # Administrators or users with pipelines.update permission can archive pipelines
-    @user&.administrator? || @user&.has_permission?('pipelines.update')
+    permitted_write? && accessible_record?
+  end
+
+  def set_as_default?
+    permitted_write? && accessible_record?
   end
 
   def stats?
-    # Administrators or users with pipelines.read permission can view pipeline statistics
+    permitted_read? && accessible_record?
+  end
+
+  private
+
+  def permitted_read?
     @user&.administrator? || @user&.has_permission?('pipelines.read')
+  end
+
+  def permitted_write?
+    @user&.administrator? || @user&.has_permission?('pipelines.update')
+  end
+
+  def permitted_delete?
+    @user&.administrator? || @user&.has_permission?('pipelines.delete')
+  end
+
+  # EVO-2204: enforce visibility on record-level actions through the SAME
+  # Scope#resolve that filters #index (public / default / creator / team, with a
+  # service-token bypass), so detail and list can never disagree.
+  def accessible_record?
+    scope.exists?(id: @record.id)
   end
 end

--- a/app/policies/pipeline_policy.rb
+++ b/app/policies/pipeline_policy.rb
@@ -79,16 +79,9 @@ class PipelinePolicy < ApplicationPolicy
     @user&.administrator? || @user&.has_permission?('pipelines.delete')
   end
 
-  # EVO-2204: enforce visibility on record-level actions through the SAME
-  # Scope#resolve that filters #index (public / default / creator / team, with a
-  # service-token bypass), so detail and list can never disagree.
-  #
-  # This is a READ predicate reused as the write gate, so anyone holding the
-  # permission may still edit or delete a public/default/team pipeline they did
-  # not create. Narrowing the write rules to the creator is NOT a local change:
-  # `update?` is also what pipeline_items authorizes item writes against
-  # (pipeline_items_controller WRITE_ACTIONS), so creator-only would stop team
-  # members from moving cards on a board shared with them. Needs its own rule.
+  # EVO-2204: routes through the SAME Scope#resolve that filters #index, so detail and
+  # list can never disagree. It is a READ predicate reused as the write gate — tightening
+  # that is not local, pipeline_items authorizes card writes against the same `update?`.
   def accessible_record?
     scope.exists?(id: @record.id)
   end

--- a/spec/policies/pipeline_policy_spec.rb
+++ b/spec/policies/pipeline_policy_spec.rb
@@ -2,12 +2,9 @@
 
 require 'rails_helper'
 
-# EVO-2204: the record-level rules AND the permission with the visibility model. The
-# request specs cover the pipelines controller; these pin the rules themselves, which is
-# what every other consumer asks — including oauth/pipeline_items_controller, whose
-# identity is the token's resource owner and which has no service-token bypass. That
-# path is a deliberate behaviour change (an OAuth app can no longer read a pipeline its
-# resource owner did not create) and is asserted here rather than left to review.
+# EVO-2204: the request specs cover the controller; these pin the rules themselves,
+# which is what every other consumer asks — including oauth/pipeline_items_controller,
+# whose identity is the token's resource owner and which has no service-token bypass.
 RSpec.describe PipelinePolicy do
   let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
   let(:other) { User.create!(name: 'Other', email: "other-#{SecureRandom.hex(4)}@example.com") }

--- a/spec/policies/pipeline_policy_spec.rb
+++ b/spec/policies/pipeline_policy_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2204: the record-level rules AND the permission with the visibility model. The
+# request specs cover the pipelines controller; these pin the rules themselves, which is
+# what every other consumer asks — including oauth/pipeline_items_controller, whose
+# identity is the token's resource owner and which has no service-token bypass. That
+# path is a deliberate behaviour change (an OAuth app can no longer read a pipeline its
+# resource owner did not create) and is asserted here rather than left to review.
+RSpec.describe PipelinePolicy do
+  let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
+  let(:other) { User.create!(name: 'Other', email: "other-#{SecureRandom.hex(4)}@example.com") }
+  let(:private_pipeline) do
+    Pipeline.create!(name: "Private #{SecureRandom.hex(4)}", pipeline_type: 'custom', created_by: owner)
+  end
+
+  # Permissions granted throughout: visibility is the only variable under test.
+  before do
+    [owner, other].each { |u| allow(u).to receive(:has_permission?).and_return(true) }
+  end
+
+  def policy_for(user, pipeline, service_authenticated: nil)
+    described_class.new(
+      { user: user, account: nil, service_authenticated: service_authenticated }, pipeline
+    )
+  end
+
+  def record_rules
+    %i[show? view? update? destroy? archive? set_as_default? stats? dependents?]
+  end
+
+  it 'grants the creator every record-level rule' do
+    policy = policy_for(owner, private_pipeline)
+
+    record_rules.each { |rule| expect(policy.public_send(rule)).to be(true), "#{rule} denied the creator" }
+  end
+
+  it 'denies a non-creator every record-level rule on a private pipeline' do
+    policy = policy_for(other, private_pipeline)
+
+    record_rules.each { |rule| expect(policy.public_send(rule)).to be(false), "#{rule} leaked to a non-creator" }
+  end
+
+  it 'denies a non-creator holding no permission, so both halves are required' do
+    allow(other).to receive(:has_permission?).and_return(false)
+
+    expect(policy_for(other, private_pipeline).show?).to be(false)
+  end
+
+  it 'grants a permitted user on a public pipeline' do
+    public_pipeline = Pipeline.create!(name: "Public #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                                       created_by: owner, visibility: :public)
+
+    expect(policy_for(other, public_pipeline).show?).to be(true)
+  end
+
+  it 'grants a permitted user on the account default' do
+    default_pipeline = Pipeline.create!(name: "Default #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                                        created_by: owner, is_default: true)
+
+    expect(policy_for(other, default_pipeline).show?).to be(true)
+  end
+
+  context 'with a team-visible pipeline' do
+    let(:team) { Team.create!(name: "Team #{SecureRandom.hex(4)}") }
+    let(:team_pipeline) do
+      Pipeline.create!(name: "Team #{SecureRandom.hex(4)}", pipeline_type: 'custom',
+                       created_by: owner, visibility: :team, teams: [team])
+    end
+
+    it 'grants a member of a shared team' do
+      team.team_members.create!(user: other)
+
+      expect(policy_for(other, team_pipeline).show?).to be(true)
+    end
+
+    it 'denies a user outside the shared teams' do
+      expect(policy_for(other, team_pipeline).show?).to be(false)
+    end
+  end
+
+  # Mirrors accessible_by, which never granted admins other users' private pipelines.
+  it 'does not bypass for an administrator who is not the creator' do
+    allow(other).to receive(:administrator?).and_return(true)
+
+    expect(policy_for(other, private_pipeline).show?).to be(false)
+  end
+
+  # index? stays permission-only: the list is narrowed by Scope#resolve, not by the rule.
+  it 'keeps index? permission-only' do
+    expect(policy_for(other, private_pipeline).index?).to be(true)
+  end
+end

--- a/spec/requests/api/v1/pipeline_deletion_spec.rb
+++ b/spec/requests/api/v1/pipeline_deletion_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe 'Pipeline deletion', type: :request do
       Current.evo_permission_cache ||= {}
     end
     allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?).and_return(true)
+    # EVO-2204: destroy now authorizes the pipeline, and the policy asks the User seam,
+    # not the controller one stubbed above — unstubbed it resolves for real and fails
+    # closed. `user` is the creator, so visibility passes and these specs stay about
+    # deletion.
+    allow_any_instance_of(User).to receive(:has_permission?).and_return(true)
   end
 
   after { Current.reset }

--- a/spec/requests/api/v1/pipeline_deletion_spec.rb
+++ b/spec/requests/api/v1/pipeline_deletion_spec.rb
@@ -17,10 +17,8 @@ RSpec.describe 'Pipeline deletion', type: :request do
       Current.evo_permission_cache ||= {}
     end
     allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?).and_return(true)
-    # EVO-2204: destroy now authorizes the pipeline, and the policy asks the User seam,
-    # not the controller one stubbed above — unstubbed it resolves for real and fails
-    # closed. `user` is the creator, so visibility passes and these specs stay about
-    # deletion.
+    # EVO-2204: destroy authorizes the pipeline now, and the policy asks the User seam,
+    # not the controller one stubbed above — unstubbed it resolves for real and denies.
     allow_any_instance_of(User).to receive(:has_permission?).and_return(true)
   end
 

--- a/spec/requests/api/v1/pipeline_dependents_spec.rb
+++ b/spec/requests/api/v1/pipeline_dependents_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe 'Pipeline dependents', type: :request do
       Current.evo_permission_cache ||= {}
     end
     allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?).and_return(true)
+    # EVO-2204: dependents now authorizes the pipeline (visibility + permission). `user` is
+    # the creator, so this isolates these specs to the dependents behaviour.
+    allow_any_instance_of(User).to receive(:has_permission?).and_return(true)
   end
 
   after { Current.reset }

--- a/spec/requests/api/v1/pipeline_visibility_authz_spec.rb
+++ b/spec/requests/api/v1/pipeline_visibility_authz_spec.rb
@@ -13,11 +13,23 @@ require 'rails_helper'
 # Scope#resolve that filters the list, so detail and list can never disagree.
 # Permissions are stubbed true throughout to isolate the visibility dimension.
 RSpec.describe 'Pipeline visibility authorization', type: :request do
+  # A Pundit denial is rendered as 401 UNAUTHORIZED app-wide (RequestExceptionHandler),
+  # which the frontend interceptor reads as session death and logs the user out. The
+  # status is wrong — it should be 403 — and EVO-2230 owns that app-wide change. Named
+  # here so flipping it is one edit and these specs do not read as if 401 were intended.
+  let(:denied) { :unauthorized }
+
   let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
   let(:other) { User.create!(name: 'Other', email: "other-#{SecureRandom.hex(4)}@example.com") }
 
   let(:private_pipeline) do
     Pipeline.create!(name: "Private #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: owner)
+  end
+
+  let(:stage) { private_pipeline.pipeline_stages.create!(name: 'New', position: 1) }
+  let(:contact) { Contact.create!(name: 'Lead', email: "lead-#{SecureRandom.hex(4)}@example.com") }
+  let(:item) do
+    private_pipeline.pipeline_items.create!(pipeline_stage: stage, contact: contact, entered_at: Time.current)
   end
 
   before do
@@ -86,55 +98,57 @@ RSpec.describe 'Pipeline visibility authorization', type: :request do
 
       it 'denies show' do
         get "/api/v1/pipelines/#{private_pipeline.id}", as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
       end
 
       it 'denies stats' do
         get "/api/v1/pipelines/#{private_pipeline.id}/stats", as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
       end
 
       it 'denies update and does not mutate' do
         patch "/api/v1/pipelines/#{private_pipeline.id}", params: { pipeline: { name: 'Hijacked' } }, as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
         expect(private_pipeline.reload.name).not_to eq('Hijacked')
       end
 
       it 'denies archive and does not deactivate' do
         patch "/api/v1/pipelines/#{private_pipeline.id}/archive", as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
         expect(private_pipeline.reload.is_active).to be(true)
       end
 
       it 'denies set_as_default and does not promote' do
         patch "/api/v1/pipelines/#{private_pipeline.id}/set_as_default", as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
         expect(private_pipeline.reload.is_default).to be(false)
       end
 
       it 'denies destroy and does not delete' do
         pipeline = private_pipeline
         delete "/api/v1/pipelines/#{pipeline.id}", as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
         expect(Pipeline.exists?(pipeline.id)).to be(true)
       end
 
       it 'denies dependents (EVO-2204: same bare-id path)' do
         get "/api/v1/pipelines/#{private_pipeline.id}/dependents", as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
       end
     end
 
-    # The visibility model is role-agnostic (accessible_by has no admin bypass):
-    # an administrator/super_admin is NOT exempt from it. Pinning this guards
-    # against a bypass being reintroduced by accident; whether admins SHOULD see
-    # everything is a deliberate product decision tracked separately (EVO-2222).
+    # The visibility model is role-agnostic (accessible_by has no admin bypass): an
+    # administrator/super_admin is NOT exempt from it. EVO-2222 settled that the list
+    # keeps behaving this way and explicitly declined to grant a bypass, so nothing
+    # owns the consequence: a private pipeline left behind by a departed user cannot be
+    # opened, reassigned or deleted by anyone. Pinned here so the behaviour is at least
+    # deliberate rather than accidental.
     context 'when the requester is an administrator but not the creator' do
       before { act_as(other, role: 'super_admin') }
 
       it 'still denies show' do
         get "/api/v1/pipelines/#{private_pipeline.id}", as: :json
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(denied)
       end
     end
   end
@@ -186,25 +200,69 @@ RSpec.describe 'Pipeline visibility authorization', type: :request do
       act_as(other)
 
       get "/api/v1/pipelines/#{team_pipeline.id}", as: :json
-      expect(response).to have_http_status(:unauthorized)
+      expect(response).to have_http_status(denied)
     end
   end
 
-  # AC4: child controllers authorize @pipeline, :view? — a read-level alias of the
-  # now visibility-aware show?. Proving one (pipeline_stages) proves the inheritance.
+  # AC4: every controller nested under :pipelines must reach the visibility model.
+  # Each is asserted on its own — the four that authorize @pipeline, :view? inherit it,
+  # but pipeline_tasks and pipeline_items/products resolved the pipeline with a bare
+  # find and authorized nothing, so "proving one proves the rest" was false and the
+  # private board still leaked through them.
   describe 'child controller inheritance (AC4)' do
-    it 'denies a non-creator listing stages of a private pipeline' do
-      act_as(other)
-
-      get "/api/v1/pipelines/#{private_pipeline.id}/pipeline_stages", as: :json
-      expect(response).to have_http_status(:unauthorized)
+    def child_paths
+      {
+        'pipeline_stages' => "/api/v1/pipelines/#{private_pipeline.id}/pipeline_stages",
+        'pipeline_items' => "/api/v1/pipelines/#{private_pipeline.id}/pipeline_items",
+        'pipeline_service_definitions' =>
+          "/api/v1/pipelines/#{private_pipeline.id}/pipeline_service_definitions",
+        'pipeline_tasks' =>
+          "/api/v1/pipelines/#{private_pipeline.id}/pipeline_items/#{item.id}/tasks",
+        'pipeline_items/products' =>
+          "/api/v1/pipelines/#{private_pipeline.id}/pipeline_items/#{item.id}/products"
+      }
     end
 
-    it 'allows the creator to list stages' do
+    it 'denies a non-creator on every child resource of a private pipeline' do
+      act_as(other)
+
+      child_paths.each do |name, path|
+        get path, as: :json
+        expect(response).to have_http_status(denied), "#{name} leaked: got #{response.status}"
+      end
+    end
+
+    it 'allows the creator on every child resource' do
       act_as(owner)
 
-      get "/api/v1/pipelines/#{private_pipeline.id}/pipeline_stages", as: :json
-      expect(response).to have_http_status(:ok)
+      child_paths.each do |name, path|
+        get path, as: :json
+        expect(response).to have_http_status(:ok), "#{name} denied the owner: got #{response.status}"
+      end
+    end
+
+    # The item is reached by its own id, and the products controller never read the
+    # :pipeline_id in the URL — so passing an accessible pipeline id must not launder
+    # access to an item that lives in a private one.
+    it 'denies products of a private-pipeline item even when the URL names another pipeline' do
+      decoy = Pipeline.create!(
+        name: "Decoy #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: other, visibility: :public
+      )
+      act_as(other)
+
+      get "/api/v1/pipelines/#{decoy.id}/pipeline_items/#{item.id}/products", as: :json
+      expect(response).to have_http_status(denied)
+    end
+
+    it 'denies a non-creator planting a task on a private-pipeline item' do
+      act_as(other)
+
+      expect do
+        post "/api/v1/pipelines/#{private_pipeline.id}/pipeline_items/#{item.id}/tasks",
+             params: { title: 'Injected' }, as: :json
+      end.not_to change(PipelineTask, :count)
+
+      expect(response).to have_http_status(denied)
     end
   end
 end

--- a/spec/requests/api/v1/pipeline_visibility_authz_spec.rb
+++ b/spec/requests/api/v1/pipeline_visibility_authz_spec.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2204: PipelinePolicy was permission-only, so the visibility model
+# (private / public / team, plus is_default and creator) was enforced only in
+# #index. Every direct-ID action resolved the pipeline with a bare find and never
+# consulted visibility, letting any user holding pipelines.* reach another user's
+# private pipeline (horizontal privilege escalation).
+#
+# These specs pin the fix: the record-level policy rules (and the child
+# controllers that authorize through them) now AND the permission with the same
+# Scope#resolve that filters the list, so detail and list can never disagree.
+# Permissions are stubbed true throughout to isolate the visibility dimension.
+RSpec.describe 'Pipeline visibility authorization', type: :request do
+  let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
+  let(:other) { User.create!(name: 'Other', email: "other-#{SecureRandom.hex(4)}@example.com") }
+
+  let(:private_pipeline) do
+    Pipeline.create!(name: "Private #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: owner)
+  end
+
+  before do
+    spec = self
+    allow_any_instance_of(Api::BaseController).to receive(:authenticate_request!) do
+      Current.user = spec.acting_user
+      Current.evo_role_key = spec.acting_role
+      Current.evo_permission_cache ||= {}
+    end
+    # Both users hold every pipelines.* permission: the only variable under test is visibility.
+    allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?).and_return(true)
+    allow_any_instance_of(User).to receive(:has_permission?).and_return(true)
+  end
+
+  after { Current.reset }
+
+  attr_accessor :acting_user, :acting_role
+
+  def act_as(user, role: nil)
+    self.acting_user = user
+    self.acting_role = role
+  end
+
+  describe 'a private pipeline' do
+    context 'when the requester is the creator' do
+      before { act_as(owner) }
+
+      it 'allows show' do
+        get "/api/v1/pipelines/#{private_pipeline.id}", as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows stats' do
+        get "/api/v1/pipelines/#{private_pipeline.id}/stats", as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows update' do
+        patch "/api/v1/pipelines/#{private_pipeline.id}", params: { pipeline: { name: 'Renamed' } }, as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows archive' do
+        patch "/api/v1/pipelines/#{private_pipeline.id}/archive", as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows set_as_default' do
+        patch "/api/v1/pipelines/#{private_pipeline.id}/set_as_default", as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows destroy' do
+        delete "/api/v1/pipelines/#{private_pipeline.id}", as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows dependents' do
+        get "/api/v1/pipelines/#{private_pipeline.id}/dependents", as: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the requester is not the creator (AC1, AC2)' do
+      before { act_as(other) }
+
+      it 'denies show' do
+        get "/api/v1/pipelines/#{private_pipeline.id}", as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'denies stats' do
+        get "/api/v1/pipelines/#{private_pipeline.id}/stats", as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'denies update and does not mutate' do
+        patch "/api/v1/pipelines/#{private_pipeline.id}", params: { pipeline: { name: 'Hijacked' } }, as: :json
+        expect(response).to have_http_status(:unauthorized)
+        expect(private_pipeline.reload.name).not_to eq('Hijacked')
+      end
+
+      it 'denies archive and does not deactivate' do
+        patch "/api/v1/pipelines/#{private_pipeline.id}/archive", as: :json
+        expect(response).to have_http_status(:unauthorized)
+        expect(private_pipeline.reload.is_active).to be(true)
+      end
+
+      it 'denies set_as_default and does not promote' do
+        patch "/api/v1/pipelines/#{private_pipeline.id}/set_as_default", as: :json
+        expect(response).to have_http_status(:unauthorized)
+        expect(private_pipeline.reload.is_default).to be(false)
+      end
+
+      it 'denies destroy and does not delete' do
+        pipeline = private_pipeline
+        delete "/api/v1/pipelines/#{pipeline.id}", as: :json
+        expect(response).to have_http_status(:unauthorized)
+        expect(Pipeline.exists?(pipeline.id)).to be(true)
+      end
+
+      it 'denies dependents (EVO-2204: same bare-id path)' do
+        get "/api/v1/pipelines/#{private_pipeline.id}/dependents", as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    # The visibility model is role-agnostic (accessible_by has no admin bypass):
+    # an administrator/super_admin is NOT exempt from it. Pinning this guards
+    # against a bypass being reintroduced by accident; whether admins SHOULD see
+    # everything is a deliberate product decision tracked separately (EVO-2222).
+    context 'when the requester is an administrator but not the creator' do
+      before { act_as(other, role: 'super_admin') }
+
+      it 'still denies show' do
+        get "/api/v1/pipelines/#{private_pipeline.id}", as: :json
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
+  describe 'a non-creator reading a shared pipeline' do
+    before { act_as(other) }
+
+    it 'is allowed when the pipeline is public' do
+      public_pipeline = Pipeline.create!(
+        name: "Public #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: owner, visibility: :public
+      )
+
+      get "/api/v1/pipelines/#{public_pipeline.id}", as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'is allowed when the pipeline is the account default' do
+      default_pipeline = Pipeline.create!(
+        name: "Default #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: owner, is_default: true
+      )
+
+      get "/api/v1/pipelines/#{default_pipeline.id}", as: :json
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # EVO-2222 shipped `team` visibility inside accessible_by; because the record
+  # check routes through the same scope, a team member reaches a team-visible
+  # pipeline while a non-member does not — detail stays consistent with the list.
+  describe 'a team-visible pipeline' do
+    let(:team) { Team.create!(name: "Team #{SecureRandom.hex(3)}") }
+    let(:team_pipeline) do
+      pipeline = Pipeline.create!(
+        name: "Team #{SecureRandom.hex(3)}", pipeline_type: 'sales', created_by: owner, visibility: :team
+      )
+      PipelineTeam.create!(pipeline: pipeline, team: team)
+      pipeline
+    end
+
+    it 'allows a member of the shared team' do
+      TeamMember.create!(team: team, user: other)
+      act_as(other)
+
+      get "/api/v1/pipelines/#{team_pipeline.id}", as: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'denies a user outside the shared team' do
+      act_as(other)
+
+      get "/api/v1/pipelines/#{team_pipeline.id}", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  # AC4: child controllers authorize @pipeline, :view? — a read-level alias of the
+  # now visibility-aware show?. Proving one (pipeline_stages) proves the inheritance.
+  describe 'child controller inheritance (AC4)' do
+    it 'denies a non-creator listing stages of a private pipeline' do
+      act_as(other)
+
+      get "/api/v1/pipelines/#{private_pipeline.id}/pipeline_stages", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'allows the creator to list stages' do
+      act_as(owner)
+
+      get "/api/v1/pipelines/#{private_pipeline.id}/pipeline_stages", as: :json
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/v1/pipeline_visibility_authz_spec.rb
+++ b/spec/requests/api/v1/pipeline_visibility_authz_spec.rb
@@ -13,10 +13,9 @@ require 'rails_helper'
 # Scope#resolve that filters the list, so detail and list can never disagree.
 # Permissions are stubbed true throughout to isolate the visibility dimension.
 RSpec.describe 'Pipeline visibility authorization', type: :request do
-  # A Pundit denial is rendered as 401 UNAUTHORIZED app-wide (RequestExceptionHandler),
-  # which the frontend interceptor reads as session death and logs the user out. The
-  # status is wrong — it should be 403 — and EVO-2230 owns that app-wide change. Named
-  # here so flipping it is one edit and these specs do not read as if 401 were intended.
+  # Not the intended contract: a Pundit denial renders 401 app-wide, which the frontend
+  # reads as session death and logs the user out. Should be 403 — EVO-2230 owns that.
+  # Named so the flip is one edit.
   let(:denied) { :unauthorized }
 
   let(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
@@ -137,12 +136,9 @@ RSpec.describe 'Pipeline visibility authorization', type: :request do
       end
     end
 
-    # The visibility model is role-agnostic (accessible_by has no admin bypass): an
-    # administrator/super_admin is NOT exempt from it. EVO-2222 settled that the list
-    # keeps behaving this way and explicitly declined to grant a bypass, so nothing
-    # owns the consequence: a private pipeline left behind by a departed user cannot be
-    # opened, reassigned or deleted by anyone. Pinned here so the behaviour is at least
-    # deliberate rather than accidental.
+    # accessible_by has no admin bypass, and EVO-2222 declined to add one. Pinned so the
+    # lockout (a departed user's private pipeline is unreachable by anyone, admins
+    # included) stays deliberate rather than drifting back in as an accident.
     context 'when the requester is an administrator but not the creator' do
       before { act_as(other, role: 'super_admin') }
 
@@ -204,11 +200,9 @@ RSpec.describe 'Pipeline visibility authorization', type: :request do
     end
   end
 
-  # AC4: every controller nested under :pipelines must reach the visibility model.
-  # Each is asserted on its own — the four that authorize @pipeline, :view? inherit it,
-  # but pipeline_tasks and pipeline_items/products resolved the pipeline with a bare
-  # find and authorized nothing, so "proving one proves the rest" was false and the
-  # private board still leaked through them.
+  # AC4: each child asserted on its own, not inferred from one. pipeline_tasks and
+  # pipeline_items/products authorized nothing, so "proving one proves the rest" was
+  # false and the private board still leaked through them.
   describe 'child controller inheritance (AC4)' do
     def child_paths
       {

--- a/spec/requests/api/v1/pipelines_activation_spec.rb
+++ b/spec/requests/api/v1/pipelines_activation_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'Pipeline activation', type: :request do
       Current.evo_permission_cache ||= {}
     end
     allow_any_instance_of(Api::BaseController).to receive(:has_user_permission?).and_return(true)
+    # EVO-2204: the direct-ID actions now authorize the pipeline, which re-checks the
+    # permission through the model seam. The owner holds it; visibility passes since
+    # `user` is the creator — this isolates these specs to the activation behaviour.
+    allow_any_instance_of(User).to receive(:has_permission?).and_return(true)
   end
 
   after { Current.reset }

--- a/spec/requests/api/v1/pundit_gated_creates_rbac_spec.rb
+++ b/spec/requests/api/v1/pundit_gated_creates_rbac_spec.rb
@@ -59,10 +59,8 @@ RSpec.describe 'Pundit-gated create actions RBAC', type: :request do
   end
 
   describe 'POST /api/v1/pipelines/:pipeline_id/pipeline_items/:pipeline_item_id/tasks' do
-    # EVO-2204 added a pipeline visibility gate ahead of the task policy. `user` is the
-    # creator and would pass it anyway, but the gate asks the permission seam, which
-    # reaches for the auth-service here — stubbed so these specs stay about
-    # PipelineTaskPolicy.
+    # EVO-2204 put a pipeline gate ahead of the task policy. `user` would pass it anyway,
+    # but it reaches the auth-service — stubbed to keep these specs about PipelineTaskPolicy.
     before { allow_any_instance_of(PipelinePolicy).to receive(:view?).and_return(true) }
 
     let(:pipeline) { Pipeline.create!(name: 'Sales', pipeline_type: 'sales', created_by: user) }

--- a/spec/requests/api/v1/pundit_gated_creates_rbac_spec.rb
+++ b/spec/requests/api/v1/pundit_gated_creates_rbac_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe 'Pundit-gated create actions RBAC', type: :request do
   end
 
   describe 'POST /api/v1/pipelines/:pipeline_id/pipeline_items/:pipeline_item_id/tasks' do
+    # EVO-2204 added a pipeline visibility gate ahead of the task policy. `user` is the
+    # creator and would pass it anyway, but the gate asks the permission seam, which
+    # reaches for the auth-service here — stubbed so these specs stay about
+    # PipelineTaskPolicy.
+    before { allow_any_instance_of(PipelinePolicy).to receive(:view?).and_return(true) }
+
     let(:pipeline) { Pipeline.create!(name: 'Sales', pipeline_type: 'sales', created_by: user) }
     let!(:stage) { PipelineStage.create!(pipeline: pipeline, name: 'Lead', position: 1) }
     let(:channel) { Channel::WebWidget.create!(website_url: 'https://pundit.example.com') }


### PR DESCRIPTION
## Summary

`PipelinePolicy` was permission-only, so the pipeline visibility model (`private` / `public` / `team` / `is_default` / creator) was enforced **only in `#index`**. Every direct-id action resolved the pipeline with a bare `Pipeline.all.find` and never consulted visibility, letting any user holding `pipelines.*` reach another user's private pipeline — horizontal privilege escalation (single-account community build).

This PR enforces visibility on the direct-id paths and makes the policy express the visibility model so the child controllers inherit the fix.

- `PipelinePolicy` `show?` / `update?` / `destroy?` / `archive?` / `stats?` + new `set_as_default?` now AND the permission with a visibility check.
- `accessible_record?` delegates to the **same `Scope#resolve`** that filters `#index` (single source of truth: public / default / creator / team, plus the service-token bypass) — detail and list can never diverge.
- `PipelinesController` authorizes the resolved pipeline on `show`, `update`, `destroy`, `archive`, `set_as_default`, `stats` (with `:id`) and `dependents`.
- Child controllers (`pipeline_stages`, `pipeline_items`, `pipeline_service_definitions`, `oauth/pipeline_items`) inherit the restriction through their existing `authorize @pipeline, :view?`.

### Review follow-up (`3c1d98f`)

- `pipeline_tasks` and `pipeline_items/products` also nest under `:pipelines`, but resolved the pipeline with a bare find and authorized **nothing** — tasks and deal products inside another user's private board stayed readable and writable with the same id the card's repro obtains. Both now gate on the pipeline (`:view?` for reads, `:update?` for product writes), keeping the service-token bypass journeys rely on. `products` also ignored `:pipeline_id` entirely, so an accessible pipeline id in the URL could launder access to an item in a private one.
- `authorize` moved ahead of the fetches and onto a lean row: a denied caller was loading the whole board graph only to be refused.
- `dependents` gets its own policy rule instead of borrowing `:view?`, which had quietly added a `pipelines.read` requirement to an endpoint gated on `pipelines.update`.
- `pipeline_deletion_spec` was red on this branch (5 of 6 examples) — it never stubbed the `User` permission seam the policy asks, so `DELETE /pipelines/:id` resolved it for real and failed closed.

## Scope

Narrow, per the scope decision on the card:

- **AC4 (`Scope#resolve` filters by visibility)** was already delivered upstream by **EVO-2222** (merged) — this PR builds on it; no change to the scope.
- **`by_conversation` / `by_contact` are already enforced**, also by EVO-2222: `fetch_pipelines_by_item_filter` resolves through `policy_scope(Pipeline)`. An earlier revision of this description claimed they were left open on purpose because enforcing them would hide legitimate chat-header membership — that was the pre-EVO-2222 argument and no longer describes the code.
- **`team` visibility** itself is EVO-2222's; unchanged here.
- **No admin bypass** on visibility — mirrors `accessible_by`, so list and detail agree. EVO-2222 explicitly declined to grant one, so nothing currently owns the consequence: a private pipeline left behind by a departed user cannot be opened, reassigned or deleted by anyone.
- **Write rules gate on the read scope**, deliberately: a non-creator holding the permission can still edit or delete a public/default pipeline. Not a local change — `pipeline_items` authorizes card writes against the same `update?`, so creator-only would stop team members from moving cards on a board shared with them. Recorded in the policy; needs its own rule.

## Validation

Full suite, this branch vs. the commit before the follow-up:

| | `cce9685` | `3c1d98f` |
|---|---|---|
| `bundle exec rspec` | 2622 examples, **138 failures** | 2633 examples, **133 failures** |
| `spec/requests/api/v1/pipeline_deletion_spec.rb` | **5 of 6 failing** (401) | 6/6 passing |

Failing-example lists compared, not just the totals: **no regressions introduced**, and exactly the five `pipeline_deletion_spec` failures resolved. The remaining 133 are pre-existing on both commits and unrelated (csat, templates, whatsapp, workers).

- Pipelines/products/policies slice: 280 examples, 1 failure — `pipeline_items_controller_spec:234`, which fails identically on `cce9685`.
- `bundle exec rubocop` on touched files: no new offense categories (+2 `RSpec/AnyInstance`, the pattern already used repo-wide).

## Reviewer notes / risks

- **OAuth:** `oauth/pipeline_items_controller` now denies an OAuth app reading a pipeline its resource-owner didn't create. Intended, but a behavior change — please confirm no external integration depends on cross-user pipeline reads.
- **Pundit denial → 401 logs the user out on the frontend.** The app-wide handler renders authz denials as `401 UNAUTHORIZED`, which the frontend interceptor treats as session death (logout). Traced end to end: `request_exception_handler.rb:15-17` → `ApiErrorCodes::UNAUTHORIZED`, and that code is in the frontend's `AUTH_INVALIDATION_ERROR_CODES` (`api.ts:17-24`) → `terminateSession()`. Pre-existing and systemic, but this PR widens its reach via deep links. Kept out deliberately: flipping the status touches ~20 assertions across 7 unrelated modules, which is why **EVO-2230** owns it. Two things that shrink that card — the frontend already handles `403` without logging out (`api.ts:175-177`), and `api/base_controller.rb:16` already has a `rescue_from` rendering `403`/`FORBIDDEN` that the around-handler shadows.
- **Aggregate `stats` (no `:id`)** still sums counts/values across all pipelines regardless of visibility — pre-existing, out of scope. Same shape as `pipeline_tasks#statistics`, which aggregates account-wide and ignores the pipeline in its URL.
- **Existence oracle:** a non-owner gets `401` for an existing private pipeline vs `404` for a non-existent id. Accepted.

## Linked Issue

- Fixes EVO-2204
- Follow-up: EVO-2230 (401→403 authz error-contract + frontend handling)

## Summary by Sourcery

Enforce pipeline visibility rules on all direct ID-based pipeline actions to prevent unauthorized access to private pipelines and ensure list and detail views use the same visibility model.

Bug Fixes:
- Apply visibility checks in pipeline policy record-level actions (show, update, destroy, archive, set_as_default, stats) in addition to permission checks to close a horizontal privilege escalation.
- Authorize pipelines in dependents and stats actions so direct ID requests respect visibility and creator ownership.
- Ensure child controllers that authorize pipelines via view? inherit the visibility restrictions for private, public, default, and team-visible pipelines.

Tests:
- Add comprehensive request specs to cover pipeline visibility authorization across owners, non-owners, admins, team-visible pipelines, and child controllers, pinning the new behavior.
- Update existing pipeline activation and dependents request specs to stub user permissions consistently with the new authorization flow.
