### PR TITLE
feat(ai): resolvedor de credencial única + migrações com gate (EVO-2250)

### DIFF
--- a/app/controllers/api/v1/admin/app_configs_controller.rb
+++ b/app/controllers/api/v1/admin/app_configs_controller.rb
@@ -23,8 +23,11 @@ module Api
             EVOLUTION_HUB_ENABLED
             EVOLUTION_HUB_API_KEY EVOLUTION_HUB_WEBHOOK_SECRET
           ],
+          # OPENAI_API_SECRET left this list in EVO-2250: the credential lives in
+          # the registry now. URL, model, toggle and the prompts stay — they are
+          # consumer config, not credential.
           'openai' => %w[
-            OPENAI_API_URL OPENAI_API_SECRET OPENAI_MODEL OPENAI_ENABLE_AUDIO_TRANSCRIPTION
+            OPENAI_API_URL OPENAI_MODEL OPENAI_ENABLE_AUDIO_TRANSCRIPTION
             OPENAI_PROMPT_REPLY OPENAI_PROMPT_SUMMARY OPENAI_PROMPT_REPHRASE
             OPENAI_PROMPT_FIX_GRAMMAR OPENAI_PROMPT_SHORTEN OPENAI_PROMPT_EXPAND
             OPENAI_PROMPT_FRIENDLY OPENAI_PROMPT_FORMAL OPENAI_PROMPT_SIMPLIFY

--- a/app/controllers/api/v1/admin/app_configs_controller.rb
+++ b/app/controllers/api/v1/admin/app_configs_controller.rb
@@ -23,9 +23,8 @@ module Api
             EVOLUTION_HUB_ENABLED
             EVOLUTION_HUB_API_KEY EVOLUTION_HUB_WEBHOOK_SECRET
           ],
-          # OPENAI_API_SECRET left this list in EVO-2250: the credential lives in
-          # the registry now. URL, model, toggle and the prompts stay — they are
-          # consumer config, not credential.
+          # No OPENAI_API_SECRET: the credential lives in the registry now. URL,
+          # model, toggle and prompts stay — consumer config, not credential.
           'openai' => %w[
             OPENAI_API_URL OPENAI_MODEL OPENAI_ENABLE_AUDIO_TRANSCRIPTION
             OPENAI_PROMPT_REPLY OPENAI_PROMPT_SUMMARY OPENAI_PROMPT_REPHRASE

--- a/app/controllers/api/v1/agent_bots_controller.rb
+++ b/app/controllers/api/v1/agent_bots_controller.rb
@@ -135,7 +135,7 @@ class Api::V1::AgentBotsController < Api::V1::BaseController
 
   def permitted_params
     params.permit(
-      :name, :description, :outgoing_url, :avatar, :avatar_url, :bot_type, :bot_provider, :api_key, :message_signature,
+      :name, :description, :outgoing_url, :avatar, :avatar_url, :bot_type, :bot_provider, :api_key, :credential_id, :message_signature,
       :text_segmentation_enabled, :text_segmentation_limit, :text_segmentation_min_size, :delay_per_character,
       :debounce_time,
       bot_config: {}

--- a/app/controllers/api/v1/agent_bots_controller.rb
+++ b/app/controllers/api/v1/agent_bots_controller.rb
@@ -133,9 +133,13 @@ class Api::V1::AgentBotsController < Api::V1::BaseController
     @agent_bot = AgentBot.find(params[:id])
   end
 
+  # ⚠️ `:api_key` is deliberately ABSENT (story 2.7 AC1): the inline key is no
+  # longer registrable, the vault reference replaces it. The COLUMN stays in the
+  # database with whatever it held — what retires is the write and the read, not
+  # the historical data.
   def permitted_params
     params.permit(
-      :name, :description, :outgoing_url, :avatar, :avatar_url, :bot_type, :bot_provider, :api_key, :credential_id, :message_signature,
+      :name, :description, :outgoing_url, :avatar, :avatar_url, :bot_type, :bot_provider, :credential_id, :message_signature,
       :text_segmentation_enabled, :text_segmentation_limit, :text_segmentation_min_size, :delay_per_character,
       :debounce_time,
       bot_config: {}

--- a/app/controllers/api/v1/global_config_controller.rb
+++ b/app/controllers/api/v1/global_config_controller.rb
@@ -55,12 +55,16 @@ class Api::V1::GlobalConfigController < Api::BaseController
     ActiveModel::Type::Boolean.new.cast(value)
   end
 
+  # The credential comes from the registry (EVO-2250), so asking
+  # GlobalConfigService for the key would report "not configured" on a migrated
+  # install and hide AI features that actually work. URL and model stay here:
+  # they are consumer config, not credential.
   def openai_configured?
     api_url = GlobalConfigService.load('OPENAI_API_URL', '').to_s.strip
-    api_key = GlobalConfigService.load('OPENAI_API_SECRET', '').to_s.strip
     model = GlobalConfigService.load('OPENAI_MODEL', '').to_s.strip
 
-    api_url.present? && api_key.present? && model.present?
+    api_url.present? && model.present? &&
+      Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist).present?
   end
 
   # Evolution Hub is "active" when both the toggle is on AND the required

--- a/app/controllers/api/v1/global_config_controller.rb
+++ b/app/controllers/api/v1/global_config_controller.rb
@@ -55,7 +55,7 @@ class Api::V1::GlobalConfigController < Api::BaseController
     ActiveModel::Type::Boolean.new.cast(value)
   end
 
-  # The credential comes from the registry (EVO-2250), so asking
+  # The credential comes from the registry, so asking
   # GlobalConfigService for the key would report "not configured" on a migrated
   # install and hide AI features that actually work. URL and model stay here:
   # they are consumer config, not credential.

--- a/app/controllers/hubspot/callbacks_controller.rb
+++ b/app/controllers/hubspot/callbacks_controller.rb
@@ -15,7 +15,7 @@ class Hubspot::CallbacksController < ApplicationController
 
     # ⚠️ NEVER render token_params: it carries the installation's client_secret
     # and the one-time authorization code. Logging the hash wrote the app secret
-    # in cleartext to every log sink, on every OAuth connection (EVO-2250).
+    # in cleartext to every log sink, on every OAuth connection.
     Rails.logger.info("Token exchange starting for redirect_uri #{token_params[:redirect_uri]}")
 
     token_response = oauth_client.request(:post, '/oauth/v1/token', {

--- a/app/controllers/hubspot/callbacks_controller.rb
+++ b/app/controllers/hubspot/callbacks_controller.rb
@@ -13,8 +13,10 @@ class Hubspot::CallbacksController < ApplicationController
       code: params[:code]
     }
 
-    Rails.logger.info("Token exchange params: #{token_params.inspect}")
-    Rails.logger.info("Token exchange URL: https://api.hubapi.com/oauth/v1/token")
+    # ⚠️ NEVER render token_params: it carries the installation's client_secret
+    # and the one-time authorization code. Logging the hash wrote the app secret
+    # in cleartext to every log sink, on every OAuth connection (EVO-2250).
+    Rails.logger.info("Token exchange starting for redirect_uri #{token_params[:redirect_uri]}")
 
     token_response = oauth_client.request(:post, '/oauth/v1/token', {
       body: URI.encode_www_form(token_params),

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -368,7 +368,7 @@ class AgentBotListener < BaseListener
     AgentBots::DeleteSessionJob.perform_later(
       agent_bot.id,
       conversation.id,
-      agent_bot.api_key,
+      AgentBots::CredentialResolution.api_key_for(agent_bot),
       agent_bot.outgoing_url
     )
 

--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -50,13 +50,9 @@ class AgentBot < ApplicationRecord
     }
   end
 
-  # ⚠️ NO api_key here, on purpose (EVO-2250 story 2.4).
-  #
-  # This hash reaches `Message#webhook_data` when a bot is the sender, and the
-  # webhook listener delivers that payload to URLs the CUSTOMER registered. The
-  # bot secret was travelling to third-party endpoints. It is not needed there:
-  # the bot's own dispatch reads the credential through
-  # AgentBots::CredentialResolution.
+  # ⚠️ NO api_key here: this hash reaches `Message#webhook_data`, which the
+  # webhook listener delivers to URLs the CUSTOMER registered. The bot's own
+  # dispatch reads the credential through AgentBots::CredentialResolution.
   def webhook_data
     {
       id: id,

--- a/app/models/agent_bot.rb
+++ b/app/models/agent_bot.rb
@@ -50,13 +50,19 @@ class AgentBot < ApplicationRecord
     }
   end
 
+  # ⚠️ NO api_key here, on purpose (EVO-2250 story 2.4).
+  #
+  # This hash reaches `Message#webhook_data` when a bot is the sender, and the
+  # webhook listener delivers that payload to URLs the CUSTOMER registered. The
+  # bot secret was travelling to third-party endpoints. It is not needed there:
+  # the bot's own dispatch reads the credential through
+  # AgentBots::CredentialResolution.
   def webhook_data
     {
       id: id,
       name: name,
       type: 'agent_bot',
-      outgoing_url: outgoing_url,
-      api_key: api_key
+      outgoing_url: outgoing_url
     }
   end
 

--- a/app/models/ai/agent_integration.rb
+++ b/app/models/ai/agent_integration.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Read-only view over `evo_core_agent_integrations` (EVO-2250, story 2.6).
+#
+# ⚠️ The table holds TWO different things: the static platform credentials of
+# external agents and native tools (dify, flowise, n8n, elevenlabs,
+# knowledge_nexus) AND the OAuth connection rows plus their `<provider>_credentials`
+# satellites. Only the first group belongs in the vault, so every reader here
+# filters by an explicit provider allowlist.
+class Ai::AgentIntegration < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord -- write-path validations make no sense on a read-only view of a foreign table
+  self.table_name = 'evo_core_agent_integrations'
+
+  # Providers whose config carries a STATIC secret the customer registered.
+  # Mirrors the negative of IsConnectionProvider in the Go side (story 2.5):
+  # OAuth connections and their satellite rows are never imported.
+  STATIC_PROVIDERS = %w[dify flowise n8n openai elevenlabs knowledge_nexus].freeze
+
+  scope :static_providers, -> { where(provider: STATIC_PROVIDERS) }
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/ai/agent_integration.rb
+++ b/app/models/ai/agent_integration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Read-only view over `evo_core_agent_integrations` (EVO-2250, story 2.6).
+# Read-only view over `evo_core_agent_integrations`.
 #
 # ⚠️ The table holds TWO different things: the static platform credentials of
 # external agents and native tools (dify, flowise, n8n, elevenlabs,

--- a/app/models/ai/credential.rb
+++ b/app/models/ai/credential.rb
@@ -31,6 +31,9 @@ class Ai::Credential < ActiveRecord::Base
   scope :for_scope, ->(scope) { where(scope: scope) }
   scope :openai_compatible, -> { where(provider: OPENAI_COMPATIBLE_PROVIDERS) }
 
+  # Writes belong to evo-ai-core-service. The one exception is the 1.5 migration,
+  # which uses `insert_all!` — that bypasses instantiation, so this guard still
+  # catches every accidental `save`/`update` through a loaded record.
   def readonly?
     true
   end

--- a/app/models/ai/credential.rb
+++ b/app/models/ai/credential.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Read-only view over `evo_core_api_keys`, the AI credential registry.
+#
+# The table belongs to evo-ai-core-service (Go), which owns its migrations and
+# every write. Both services share the same `evo_community` database, so the CRM
+# reads it directly instead of going over HTTP — the resolver runs inside
+# background jobs (audio transcription, moderation) where there is no logged-in
+# user whose bearer could be forwarded to the core.
+#
+# Writes stay in the core: `readonly?` makes an accidental save raise instead of
+# silently diverging from the owner of the schema.
+#
+# Not present in `db/schema.rb` on purpose — Rails does not own this table.
+# rubocop:disable Rails/ApplicationRecord -- ApplicationRecord adds write-path
+# validations (validates_column_content_length) and event mixins that make no
+# sense for a read-only view over a table another service owns.
+class Ai::Credential < ActiveRecord::Base
+  # rubocop:enable Rails/ApplicationRecord
+  self.table_name = 'evo_core_api_keys'
+
+  SCOPE_INSTALLATION = 'installation'
+  SCOPE_ACCOUNT = 'account'
+
+  # Mirrors IsOpenAICompatible in
+  # evo-ai-core-service-community/pkg/api_key/model/api_key.go — providers
+  # speaking the OpenAI wire protocol. The others only serve AI Agents.
+  OPENAI_COMPATIBLE_PROVIDERS = %w[openai azure custom custom_openai_compatible].freeze
+
+  scope :active, -> { where(is_active: true) }
+  scope :for_scope, ->(scope) { where(scope: scope) }
+  scope :openai_compatible, -> { where(provider: OPENAI_COMPATIBLE_PROVIDERS) }
+
+  def readonly?
+    true
+  end
+
+  def openai_compatible?
+    OPENAI_COMPATIBLE_PROVIDERS.include?(provider)
+  end
+end

--- a/app/models/ai/credential.rb
+++ b/app/models/ai/credential.rb
@@ -2,16 +2,12 @@
 
 # Read-only view over `evo_core_api_keys`, the AI credential registry.
 #
-# The table belongs to evo-ai-core-service (Go), which owns its migrations and
-# every write. Both services share the same `evo_community` database, so the CRM
-# reads it directly instead of going over HTTP — the resolver runs inside
-# background jobs (audio transcription, moderation) where there is no logged-in
-# user whose bearer could be forwarded to the core.
+# evo-ai-core-service owns the table and every write; the CRM reads it directly
+# because both share the `evo_community` database and the resolver runs inside
+# jobs, where there is no user bearer to forward over HTTP. `readonly?` makes an
+# accidental save raise rather than diverge from the schema's owner.
 #
-# Writes stay in the core: `readonly?` makes an accidental save raise instead of
-# silently diverging from the owner of the schema.
-#
-# Not present in `db/schema.rb` on purpose — Rails does not own this table.
+# Absent from `db/schema.rb` on purpose — Rails does not own this table.
 # rubocop:disable Rails/ApplicationRecord -- ApplicationRecord adds write-path
 # validations (validates_column_content_length) and event mixins that make no
 # sense for a read-only view over a table another service owns.
@@ -22,18 +18,16 @@ class Ai::Credential < ActiveRecord::Base
   SCOPE_INSTALLATION = 'installation'
   SCOPE_ACCOUNT = 'account'
 
-  # Mirrors IsOpenAICompatible in
-  # evo-ai-core-service-community/pkg/api_key/model/api_key.go — providers
-  # speaking the OpenAI wire protocol. The others only serve AI Agents.
+  # Providers speaking the OpenAI wire protocol; the others only serve AI Agents.
+  # Mirrors IsOpenAICompatible in the core's api_key model.
   OPENAI_COMPATIBLE_PROVIDERS = %w[openai azure custom custom_openai_compatible].freeze
 
   scope :active, -> { where(is_active: true) }
   scope :for_scope, ->(scope) { where(scope: scope) }
   scope :openai_compatible, -> { where(provider: OPENAI_COMPATIBLE_PROVIDERS) }
 
-  # Writes belong to evo-ai-core-service. The one exception is the 1.5 migration,
-  # which uses `insert_all!` — that bypasses instantiation, so this guard still
-  # catches every accidental `save`/`update` through a loaded record.
+  # The migration writes with `insert_all!`, which bypasses instantiation, so
+  # this still catches every accidental `save`/`update` on a loaded record.
   def readonly?
     true
   end

--- a/app/models/ai/custom_mcp_server.rb
+++ b/app/models/ai/custom_mcp_server.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Read-only view over `evo_core_custom_mcp_servers` (EVO-2250, story 2.6).
+# See Ai::CustomTool for why these views exist.
+class Ai::CustomMcpServer < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord -- write-path validations make no sense on a read-only view of a foreign table
+  self.table_name = 'evo_core_custom_mcp_servers'
+
+  scope :active, -> { where(is_active: true) }
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/ai/custom_mcp_server.rb
+++ b/app/models/ai/custom_mcp_server.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Read-only view over `evo_core_custom_mcp_servers` (EVO-2250, story 2.6).
+# Read-only view over `evo_core_custom_mcp_servers`.
 # See Ai::CustomTool for why these views exist.
 class Ai::CustomMcpServer < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord -- write-path validations make no sense on a read-only view of a foreign table
   self.table_name = 'evo_core_custom_mcp_servers'

--- a/app/models/ai/custom_tool.rb
+++ b/app/models/ai/custom_tool.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-# Read-only view over `evo_core_custom_tools` (EVO-2250, story 2.6).
-#
-# Same arrangement as Ai::IntegrationCredential: the table belongs to
-# evo-ai-core-service (Go), which owns its migrations and every write, and both
-# services share the `evo_community` database, so the migration reads it
-# directly instead of going over HTTP.
-#
-# Not present in `db/schema.rb` on purpose — Rails does not own this table.
+# Read-only view over `evo_core_custom_tools`. Same arrangement as
+# Ai::IntegrationCredential: the core owns the table, the CRM only reads it.
 class Ai::CustomTool < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord -- write-path validations make no sense on a read-only view of a foreign table
   self.table_name = 'evo_core_custom_tools'
 

--- a/app/models/ai/custom_tool.rb
+++ b/app/models/ai/custom_tool.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Read-only view over `evo_core_custom_tools` (EVO-2250, story 2.6).
+#
+# Same arrangement as Ai::IntegrationCredential: the table belongs to
+# evo-ai-core-service (Go), which owns its migrations and every write, and both
+# services share the `evo_community` database, so the migration reads it
+# directly instead of going over HTTP.
+#
+# Not present in `db/schema.rb` on purpose — Rails does not own this table.
+class Ai::CustomTool < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord -- write-path validations make no sense on a read-only view of a foreign table
+  self.table_name = 'evo_core_custom_tools'
+
+  scope :active, -> { where(is_active: true) }
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/ai/integration_credential.rb
+++ b/app/models/ai/integration_credential.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
 # Read-only view over `evo_core_integration_credentials`, the integration
-# credential vault (EVO-2250, epic 2).
-#
-# Same arrangement as Ai::Credential over `evo_core_api_keys`: the table belongs
-# to evo-ai-core-service (Go), which owns its migrations and every write, and
-# both services share the `evo_community` database, so the CRM reads it directly
-# — the resolver runs inside background jobs where there is no user bearer to
-# forward over HTTP.
-#
-# Not present in `db/schema.rb` on purpose — Rails does not own this table.
+# credential vault. Same arrangement as Ai::Credential: the core owns the table
+# and every write, and the CRM reads it directly because the resolver runs in
+# jobs, with no user bearer to forward over HTTP.
 class Ai::IntegrationCredential < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord -- write-path validations make no sense on a read-only view of a foreign table
   self.table_name = 'evo_core_integration_credentials'
 

--- a/app/models/ai/integration_credential.rb
+++ b/app/models/ai/integration_credential.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Read-only view over `evo_core_integration_credentials`, the integration
+# credential vault (EVO-2250, epic 2).
+#
+# Same arrangement as Ai::Credential over `evo_core_api_keys`: the table belongs
+# to evo-ai-core-service (Go), which owns its migrations and every write, and
+# both services share the `evo_community` database, so the CRM reads it directly
+# — the resolver runs inside background jobs where there is no user bearer to
+# forward over HTTP.
+#
+# Not present in `db/schema.rb` on purpose — Rails does not own this table.
+class Ai::IntegrationCredential < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord -- write-path validations make no sense on a read-only view of a foreign table
+  self.table_name = 'evo_core_integration_credentials'
+
+  KIND_STATIC = 'static'
+  KIND_OAUTH = 'oauth'
+
+  VALUE_FORMAT_SCALAR = 'scalar'
+  VALUE_FORMAT_COMPOSITE = 'composite'
+
+  scope :active, -> { where(is_active: true) }
+  scope :for_scope, ->(scope) { where(scope: scope) }
+  scope :static_kind, -> { where(kind: KIND_STATIC) }
+  scope :oauth_kind, -> { where(kind: KIND_OAUTH) }
+
+  def readonly?
+    true
+  end
+
+  def static?
+    kind == KIND_STATIC
+  end
+
+  def oauth?
+    kind == KIND_OAUTH
+  end
+end

--- a/app/models/ai/integration_credential.rb
+++ b/app/models/ai/integration_credential.rb
@@ -21,6 +21,7 @@ class Ai::IntegrationCredential < ActiveRecord::Base # rubocop:disable Rails/App
 
   scope :active, -> { where(is_active: true) }
   scope :for_scope, ->(scope) { where(scope: scope) }
+  scope :for_provider, ->(provider) { where(provider: provider) }
   scope :static_kind, -> { where(kind: KIND_STATIC) }
   scope :oauth_kind, -> { where(kind: KIND_OAUTH) }
 

--- a/app/models/ai/integration_credential.rb
+++ b/app/models/ai/integration_credential.rb
@@ -16,6 +16,11 @@ class Ai::IntegrationCredential < ActiveRecord::Base # rubocop:disable Rails/App
   KIND_STATIC = 'static'
   KIND_OAUTH = 'oauth'
 
+  # Mirrors the scope chain of Ai::Credential: this service stores the scope, and
+  # Ai::IntegrationCredentialResolver owns the precedence between links.
+  SCOPE_INSTALLATION = 'installation'
+  SCOPE_ACCOUNT = 'account'
+
   VALUE_FORMAT_SCALAR = 'scalar'
   VALUE_FORMAT_COMPOSITE = 'composite'
 

--- a/app/serializers/agent_bot_serializer.rb
+++ b/app/serializers/agent_bot_serializer.rb
@@ -14,6 +14,9 @@ module AgentBotSerializer
       bot_type: agent_bot.bot_type,
       bot_provider: agent_bot.bot_provider,
       bot_config: agent_bot.bot_config || {},
+      # The reference is an id, not a secret: the screen needs it to show which
+      # vault credential the bot uses. `api_key` stays out, as it always was.
+      credential_id: agent_bot.credential_id,
       avatar_url: agent_bot.avatar_url,
       message_signature: agent_bot.message_signature,
       text_segmentation_enabled: agent_bot.text_segmentation_enabled,

--- a/app/services/agent_bots/credential_resolution.rb
+++ b/app/services/agent_bots/credential_resolution.rb
@@ -71,14 +71,20 @@ module AgentBots::CredentialResolution
 
   def composite_pair(value)
     envelope = JSON.parse(value)
+
+    # ⚠️ A scalar secret parses FINE: `JSON.parse("12345")` returns an Integer,
+    # and indexing it raised TypeError outside the rescue below, taking the n8n
+    # bot request down. A non-Hash is not an envelope — it is exactly what the
+    # colon convention handles (review of 2026-07-29, MÉDIO 12).
+    return inline_pair(value) unless envelope.is_a?(Hash)
+
     user = envelope['user'].presence
     password = envelope['password'].presence
     return nil unless user && password
 
     [user, password]
   rescue JSON::ParserError
-    # Not an envelope: fall back to the colon convention, so a scalar credential
-    # holding "user:pass" keeps working.
+    # Not JSON at all: same fallback, for a credential holding "user:pass".
     inline_pair(value)
   end
 

--- a/app/services/agent_bots/credential_resolution.rb
+++ b/app/services/agent_bots/credential_resolution.rb
@@ -22,7 +22,7 @@ module AgentBots::CredentialResolution
     from_vault = vault_value(bot)
     return from_vault if from_vault.present?
 
-    bot.api_key.presence
+    inline_key(bot)
   end
 
   # Returns the [user, password] pair for n8n basic auth, or nil.
@@ -35,7 +35,25 @@ module AgentBots::CredentialResolution
     from_vault = vault_value(bot)
     return composite_pair(from_vault) if from_vault.present?
 
-    inline_pair(bot.api_key)
+    inline_pair(inline_key(bot))
+  end
+
+  # The RETIREMENT gate of story 2.7 (ACs 2, 3 and 4).
+  #
+  # Reading `bot.api_key` is conditioned on the installation NOT having migrated.
+  # Once it has, the inline column stops being read even though story 2.6
+  # deliberately left the value in the database: what retires is the READ, not
+  # the data.
+  #
+  # ⚠️ Fail-closed on purpose. `Ai::IntegrationMigrationState` answers "migrated"
+  # only when the 2.6 task ran OR there is nothing left inline anywhere; any
+  # doubt (including a database error) keeps the fallback alive, because the
+  # alternative is an installation waking up with no integrations and no error
+  # pointing at the cause.
+  def inline_key(bot)
+    return nil if Ai::IntegrationMigrationState.migrated?
+
+    bot.api_key.presence
   end
 
   def vault_value(bot)

--- a/app/services/agent_bots/credential_resolution.rb
+++ b/app/services/agent_bots/credential_resolution.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Resolves the secret a channel bot sends to its provider.
+#
+# The bot may point at the integration credential vault (EVO-2250 story 2.4);
+# the inline `api_key` stays the fallback until story 2.7 retires it, so no
+# installation has to migrate for this to work.
+#
+# Resolution is BY REFERENCE only. A bot configured with one credential must
+# never fall through to a different one: `Ai::IntegrationCredentialResolver`
+# owns that rule, and the provider-default path is deliberately not used here.
+#
+# ⚠️ `agent_bots` has no `account_id`, so there is no account link for the scope
+# chain to resolve against. That is a known gap of the table, not of this story.
+module AgentBots::CredentialResolution
+  module_function
+
+  # Returns the plaintext key in effect, or nil when neither the vault nor the
+  # inline value offers one. Never raises: a bot with no usable credential is an
+  # expected state, handled by the caller.
+  def api_key_for(bot)
+    from_vault = vault_value(bot)
+    return from_vault if from_vault.present?
+
+    bot.api_key.presence
+  end
+
+  # Returns the [user, password] pair for n8n basic auth, or nil.
+  #
+  # The stored shape changed but the wire format did not: today the pair is
+  # encoded inside `api_key` by the presence of a colon, and the vault keeps it
+  # structured in a composite envelope. What has to stay identical is the byte
+  # that goes out in the Authorization header.
+  def basic_auth_for(bot)
+    from_vault = vault_value(bot)
+    return composite_pair(from_vault) if from_vault.present?
+
+    inline_pair(bot.api_key)
+  end
+
+  def vault_value(bot)
+    return nil if bot.credential_id.blank?
+
+    resolution = Ai::IntegrationCredentialResolver.resolve_value(credential_id: bot.credential_id)
+    return nil unless resolution.present_value?
+
+    resolution.value
+  rescue StandardError => e
+    # A vault outage degrades to the inline value instead of taking the bot down.
+    Rails.logger.error("AgentBots::CredentialResolution: #{e.class}: #{e.message}")
+    nil
+  end
+
+  def composite_pair(value)
+    envelope = JSON.parse(value)
+    user = envelope['user'].presence
+    password = envelope['password'].presence
+    return nil unless user && password
+
+    [user, password]
+  rescue JSON::ParserError
+    # Not an envelope: fall back to the colon convention, so a scalar credential
+    # holding "user:pass" keeps working.
+    inline_pair(value)
+  end
+
+  def inline_pair(api_key)
+    return nil if api_key.blank? || api_key.exclude?(':')
+
+    user, password = api_key.split(':', 2)
+    return nil if user.blank? || password.blank?
+
+    [user, password]
+  end
+end

--- a/app/services/agent_bots/credential_resolution.rb
+++ b/app/services/agent_bots/credential_resolution.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
-# Resolves the secret a channel bot sends to its provider.
+# Resolves the secret a channel bot sends to its provider: the vault when the
+# bot references one, the inline `api_key` while the fallback lives.
 #
-# The bot may point at the integration credential vault (EVO-2250 story 2.4);
-# the inline `api_key` stays the fallback until story 2.7 retires it, so no
-# installation has to migrate for this to work.
+# BY REFERENCE only — a bot configured with one credential must never fall
+# through to a different one, so the provider-default path is not used here.
 #
-# Resolution is BY REFERENCE only. A bot configured with one credential must
-# never fall through to a different one: `Ai::IntegrationCredentialResolver`
-# owns that rule, and the provider-default path is deliberately not used here.
-#
-# ⚠️ `agent_bots` has no `account_id`, so there is no account link for the scope
-# chain to resolve against. That is a known gap of the table, not of this story.
+# ⚠️ `agent_bots` has no `account_id`, so the scope chain has nothing to resolve
+# against. A known gap of the table.
 module AgentBots::CredentialResolution
   module_function
 
@@ -25,12 +21,9 @@ module AgentBots::CredentialResolution
     inline_key(bot)
   end
 
-  # Returns the [user, password] pair for n8n basic auth, or nil.
-  #
-  # The stored shape changed but the wire format did not: today the pair is
-  # encoded inside `api_key` by the presence of a colon, and the vault keeps it
-  # structured in a composite envelope. What has to stay identical is the byte
-  # that goes out in the Authorization header.
+  # Returns the [user, password] pair for n8n basic auth, or nil. The storage
+  # shape differs — colon-encoded inline, a composite envelope in the vault —
+  # but the Authorization header on the wire must be byte-identical.
   def basic_auth_for(bot)
     from_vault = vault_value(bot)
     return composite_pair(from_vault) if from_vault.present?
@@ -38,21 +31,13 @@ module AgentBots::CredentialResolution
     inline_pair(inline_key(bot))
   end
 
-  # The RETIREMENT gate of story 2.7 (ACs 2, 3 and 4).
+  # The retirement gate: the inline column stops being READ once the migration
+  # has run, though the data stays. Fail-closed — any doubt, including a database
+  # error, keeps the fallback alive rather than waking an installation with no
+  # integrations and no error pointing at the cause.
   #
-  # Reading `bot.api_key` is conditioned on the installation NOT having migrated.
-  # Once it has, the inline column stops being read even though story 2.6
-  # deliberately left the value in the database: what retires is the READ, not
-  # the data.
-  #
-  # ⚠️ Fail-closed on purpose. `Ai::IntegrationMigrationState` answers "migrated"
-  # only when the 2.6 task ran OR there is nothing left inline anywhere; any
-  # doubt (including a database error) keeps the fallback alive, because the
-  # alternative is an installation waking up with no integrations and no error
-  # pointing at the cause.
   # Column first, guard second: the guard counts pending secrets across two
-  # tables, and asking it before there is anything to gate charged every
-  # dispatch — including bots with no inline key at all.
+  # tables, and asking it before there is anything to gate charges every dispatch.
   def inline_key(bot)
     inline = bot.api_key.presence
     return nil if inline.nil?
@@ -77,9 +62,8 @@ module AgentBots::CredentialResolution
     envelope = JSON.parse(value)
 
     # ⚠️ A scalar secret parses FINE: `JSON.parse("12345")` returns an Integer,
-    # and indexing it raised TypeError outside the rescue below, taking the n8n
-    # bot request down. A non-Hash is not an envelope — it is exactly what the
-    # colon convention handles (review of 2026-07-29, MÉDIO 12).
+    # and indexing it raises TypeError outside the rescue below. A non-Hash is
+    # not an envelope — it is what the colon convention handles.
     return inline_pair(value) unless envelope.is_a?(Hash)
 
     user = envelope['user'].presence

--- a/app/services/agent_bots/credential_resolution.rb
+++ b/app/services/agent_bots/credential_resolution.rb
@@ -50,10 +50,14 @@ module AgentBots::CredentialResolution
   # doubt (including a database error) keeps the fallback alive, because the
   # alternative is an installation waking up with no integrations and no error
   # pointing at the cause.
+  # Column first, guard second: the guard counts pending secrets across two
+  # tables, and asking it before there is anything to gate charged every
+  # dispatch — including bots with no inline key at all.
   def inline_key(bot)
-    return nil if Ai::IntegrationMigrationState.migrated?
+    inline = bot.api_key.presence
+    return nil if inline.nil?
 
-    bot.api_key.presence
+    Ai::IntegrationMigrationState.migrated? ? nil : inline
   end
 
   def vault_value(bot)

--- a/app/services/agent_bots/http_request_service.rb
+++ b/app/services/agent_bots/http_request_service.rb
@@ -111,7 +111,7 @@ class AgentBots::HttpRequestService
     # This should be a valid API key from evo-core-service
     if @agent_bot.api_key.present?
       Rails.logger.debug "[AgentBot HTTP] Using API Key: #{@agent_bot.api_key[0..10]}...#{@agent_bot.api_key[-10..-1]} (length: #{@agent_bot.api_key.length})"
-      request['X-API-Key'] = @agent_bot.api_key
+      request['X-API-Key'] = AgentBots::CredentialResolution.api_key_for(@agent_bot)
     else
       Rails.logger.warn "[AgentBot HTTP] No API key found for agent bot #{@agent_bot.id}"
     end

--- a/app/services/agent_bots/http_request_service.rb
+++ b/app/services/agent_bots/http_request_service.rb
@@ -109,13 +109,9 @@ class AgentBots::HttpRequestService
     request = Net::HTTP::Post.new(uri)
     request['Content-Type'] = 'application/json'
 
-    # The credential comes from the resolver, never from the inline column
-    # directly: gating on `api_key.present?` left a bot that references the vault
-    # and holds no inline key sending NO X-API-Key at all (review of 2026-07-29).
-    #
-    # No fragment of the key is logged: for a key under ~21 characters the old
-    # first-11-plus-last-10 preview printed the whole secret. The length alone
-    # carries the diagnostic value.
+    # From the resolver, never the inline column: gating on `api_key.present?`
+    # leaves a vault-only bot sending no X-API-Key at all. And no fragment of the
+    # key is logged — under ~21 characters a preview prints the whole secret.
     api_key = AgentBots::CredentialResolution.api_key_for(@agent_bot)
     if api_key.present?
       Rails.logger.debug "[AgentBot HTTP] Using API Key (length: #{api_key.length})"

--- a/app/services/agent_bots/http_request_service.rb
+++ b/app/services/agent_bots/http_request_service.rb
@@ -29,8 +29,10 @@ class AgentBots::HttpRequestService
 
     Rails.logger.info "[AgentBot HTTP] Starting request to bot: #{@agent_bot.name}"
     Rails.logger.info "[AgentBot HTTP] Outgoing URL: #{@agent_bot.outgoing_url}"
-    Rails.logger.info "[AgentBot HTTP] API Key present: #{@agent_bot.api_key.present?}"
-    Rails.logger.info "[AgentBot HTTP] API Key length: #{@agent_bot.api_key&.length || 0}"
+    # Reports the credential the request will ACTUALLY use, not the inline column:
+    # for a bot that references the vault, the old lines said "no key" while the
+    # request went out authenticated (and vice versa after retirement).
+    Rails.logger.info "[AgentBot HTTP] Vault reference: #{@agent_bot.credential_id.present?}"
 
     begin
       response = make_http_request
@@ -107,13 +109,19 @@ class AgentBots::HttpRequestService
     request = Net::HTTP::Post.new(uri)
     request['Content-Type'] = 'application/json'
 
-    # Use api_key for evo-ai-processor authentication
-    # This should be a valid API key from evo-core-service
-    if @agent_bot.api_key.present?
-      Rails.logger.debug "[AgentBot HTTP] Using API Key: #{@agent_bot.api_key[0..10]}...#{@agent_bot.api_key[-10..-1]} (length: #{@agent_bot.api_key.length})"
-      request['X-API-Key'] = AgentBots::CredentialResolution.api_key_for(@agent_bot)
+    # The credential comes from the resolver, never from the inline column
+    # directly: gating on `api_key.present?` left a bot that references the vault
+    # and holds no inline key sending NO X-API-Key at all (review of 2026-07-29).
+    #
+    # No fragment of the key is logged: for a key under ~21 characters the old
+    # first-11-plus-last-10 preview printed the whole secret. The length alone
+    # carries the diagnostic value.
+    api_key = AgentBots::CredentialResolution.api_key_for(@agent_bot)
+    if api_key.present?
+      Rails.logger.debug "[AgentBot HTTP] Using API Key (length: #{api_key.length})"
+      request['X-API-Key'] = api_key
     else
-      Rails.logger.warn "[AgentBot HTTP] No API key found for agent bot #{@agent_bot.id}"
+      Rails.logger.warn "[AgentBot HTTP] No API key resolved for agent bot #{@agent_bot.id}"
     end
 
     request.body = build_jsonrpc_payload.to_json

--- a/app/services/agent_bots/n8n_request_service.rb
+++ b/app/services/agent_bots/n8n_request_service.rb
@@ -82,7 +82,6 @@ class AgentBots::N8nRequestService
 
     # Basic auth pair, from the vault when the bot references one and from the
     # colon-separated api_key otherwise. The header on the wire is unchanged.
-    basic_auth = AgentBots::CredentialResolution.basic_auth_for(@agent_bot)
     if basic_auth
       auth = Base64.strict_encode64("#{basic_auth[0]}:#{basic_auth[1]}")
       request['Authorization'] = "Basic #{auth}"
@@ -152,9 +151,17 @@ class AgentBots::N8nRequestService
   def extract_api_key
     # An api key, not a basic auth pair: a colon means the value carries
     # credentials and belongs in the Authorization header instead.
-    return nil if AgentBots::CredentialResolution.basic_auth_for(@agent_bot)
+    return nil if basic_auth
 
     AgentBots::CredentialResolution.api_key_for(@agent_bot)
+  end
+
+  # Once per dispatch: each call hits the vault, and this service asked three
+  # times per outgoing message.
+  def basic_auth
+    return @basic_auth if defined?(@basic_auth)
+
+    @basic_auth = AgentBots::CredentialResolution.basic_auth_for(@agent_bot)
   end
 
   def extract_contact_id

--- a/app/services/agent_bots/n8n_request_service.rb
+++ b/app/services/agent_bots/n8n_request_service.rb
@@ -80,13 +80,12 @@ class AgentBots::N8nRequestService
     request = Net::HTTP::Post.new(uri)
     request['Content-Type'] = 'application/json'
 
-    # Handle basic auth for N8n if api_key contains credentials
-    if @agent_bot.api_key.present? && @agent_bot.api_key.include?(':')
-      auth_credentials = @agent_bot.api_key.split(':', 2)
-      if auth_credentials.length == 2
-        auth = Base64.strict_encode64("#{auth_credentials[0]}:#{auth_credentials[1]}")
-        request['Authorization'] = "Basic #{auth}"
-      end
+    # Basic auth pair, from the vault when the bot references one and from the
+    # colon-separated api_key otherwise. The header on the wire is unchanged.
+    basic_auth = AgentBots::CredentialResolution.basic_auth_for(@agent_bot)
+    if basic_auth
+      auth = Base64.strict_encode64("#{basic_auth[0]}:#{basic_auth[1]}")
+      request['Authorization'] = "Basic #{auth}"
     end
 
     request.body = build_n8n_payload.to_json
@@ -151,8 +150,11 @@ class AgentBots::N8nRequestService
   end
 
   def extract_api_key
-    # Return the agent bot's API key if available
-    @agent_bot.api_key if @agent_bot.api_key.present? && !@agent_bot.api_key.include?(':')
+    # An api key, not a basic auth pair: a colon means the value carries
+    # credentials and belongs in the Authorization header instead.
+    return nil if AgentBots::CredentialResolution.basic_auth_for(@agent_bot)
+
+    AgentBots::CredentialResolution.api_key_for(@agent_bot)
   end
 
   def extract_contact_id

--- a/app/services/agent_bots/session_sync_service.rb
+++ b/app/services/agent_bots/session_sync_service.rb
@@ -305,7 +305,7 @@ module AgentBots
       {
         'Content-Type' => 'application/json',
         'Accept' => 'application/json',
-        'X-API-Key' => @agent_bot.api_key
+        'X-API-Key' => AgentBots::CredentialResolution.api_key_for(@agent_bot)
       }
     end
   end

--- a/app/services/ai/consumer_compatibility.rb
+++ b/app/services/ai/consumer_compatibility.rb
@@ -2,12 +2,11 @@
 
 # Which providers each AI feature can actually talk to (FR18).
 #
-# AI Agents reach every provider through the core service. The other consumers
-# build a `POST /chat/completions` call in `lib/integrations/openai_base_service.rb`,
-# so a non-OpenAI provider there is not a misconfiguration — it is a different
-# protocol, and calling it would fail at the wire.
+# AI Agents reach every provider through the core service. The others build a
+# `POST /chat/completions` call, so a non-OpenAI provider there is not a
+# misconfiguration but a different protocol, and it fails at the wire.
 #
-# Stories 1.3 and 1.4 register their consumers here; the resolver needs no change.
+# New consumers register here; the resolver needs no change.
 class Ai::ConsumerCompatibility
   ALL_PROVIDERS = :all
 

--- a/app/services/ai/consumer_compatibility.rb
+++ b/app/services/ai/consumer_compatibility.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Which providers each AI feature can actually talk to (FR18).
+#
+# AI Agents reach every provider through the core service. The other consumers
+# build a `POST /chat/completions` call in `lib/integrations/openai_base_service.rb`,
+# so a non-OpenAI provider there is not a misconfiguration — it is a different
+# protocol, and calling it would fail at the wire.
+#
+# Stories 1.3 and 1.4 register their consumers here; the resolver needs no change.
+class Ai::ConsumerCompatibility
+  ALL_PROVIDERS = :all
+
+  CONSUMERS = {
+    ai_agents: ALL_PROVIDERS,
+    inbox_assist: Ai::Credential::OPENAI_COMPATIBLE_PROVIDERS,
+    audio_transcription: Ai::Credential::OPENAI_COMPATIBLE_PROVIDERS,
+    label_suggestion: Ai::Credential::OPENAI_COMPATIBLE_PROVIDERS,
+    moderation: Ai::Credential::OPENAI_COMPATIBLE_PROVIDERS
+  }.freeze
+
+  class << self
+    def known?(consumer)
+      CONSUMERS.key?(consumer&.to_sym)
+    end
+
+    def accepted_providers(consumer)
+      CONSUMERS[consumer&.to_sym]
+    end
+
+    def accepts?(consumer, provider)
+      accepted = accepted_providers(consumer)
+      return false if accepted.nil?
+      return true if accepted == ALL_PROVIDERS
+
+      accepted.include?(provider)
+    end
+  end
+end

--- a/app/services/ai/credential_decryptor.rb
+++ b/app/services/ai/credential_decryptor.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-# Decrypts the credential values stored by evo-ai-core-service.
+# Decrypts the credential values evo-ai-core-service stores with Fernet. The CRM
+# is a third reader of EVO_AI_ENCRYPTION_KEY; it never re-derives or rotates it.
 #
-# The core encrypts with Fernet using EVO_AI_ENCRYPTION_KEY, the same key the
-# processor uses to decrypt. The CRM is a third reader of that value — the key
-# is never re-derived or rotated here.
+# ⚠️ NOT `ENV['ENCRYPTION_KEY']`, which belongs to InstallationConfig and holds
+# a different secret. Reusing it decrypts nothing and invites someone to "fix"
+# it by overwriting the installation key.
 #
-# ⚠️ NOT `ENV['ENCRYPTION_KEY']`: that one belongs to InstallationConfig and
-# holds a different secret. Reusing it would decrypt nothing and, worse, invite
-# someone to "fix" it by overwriting the installation key.
-#
-# ⚠️ `enforce_ttl = false` is required, not cosmetic. The Ruby gem defaults to a
-# 60-second TTL, while the Go side verifies with ttl=0 (no age check). Left on,
-# every credential older than a minute would fail to decrypt — and a test using
-# a freshly encrypted fixture would never catch it.
+# ⚠️ `enforce_ttl = false` is required: the Ruby gem defaults to a 60-second TTL
+# while Go verifies with ttl=0, so every credential older than a minute would
+# fail to decrypt — and a freshly encrypted fixture would never catch it.
 class Ai::CredentialDecryptor
   ENCRYPTION_KEY_ENV = 'EVO_AI_ENCRYPTION_KEY'
 

--- a/app/services/ai/credential_decryptor.rb
+++ b/app/services/ai/credential_decryptor.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Decrypts the credential values stored by evo-ai-core-service.
+#
+# The core encrypts with Fernet using EVO_AI_ENCRYPTION_KEY, the same key the
+# processor uses to decrypt. The CRM is a third reader of that value — the key
+# is never re-derived or rotated here.
+#
+# ⚠️ NOT `ENV['ENCRYPTION_KEY']`: that one belongs to InstallationConfig and
+# holds a different secret. Reusing it would decrypt nothing and, worse, invite
+# someone to "fix" it by overwriting the installation key.
+#
+# ⚠️ `enforce_ttl = false` is required, not cosmetic. The Ruby gem defaults to a
+# 60-second TTL, while the Go side verifies with ttl=0 (no age check). Left on,
+# every credential older than a minute would fail to decrypt — and a test using
+# a freshly encrypted fixture would never catch it.
+class Ai::CredentialDecryptor
+  ENCRYPTION_KEY_ENV = 'EVO_AI_ENCRYPTION_KEY'
+
+  class MissingKeyError < StandardError; end
+
+  class << self
+    # Returns the plaintext key, or nil when it cannot be decrypted. Callers
+    # treat nil as "no usable credential" and fall through the chain.
+    def decrypt(ciphertext)
+      return nil if ciphertext.blank?
+
+      secret = encryption_key
+      if secret.blank?
+        Rails.logger.error("Ai::CredentialDecryptor: #{ENCRYPTION_KEY_ENV} is not set")
+        return nil
+      end
+
+      verifier = Fernet.verifier(secret, ciphertext)
+      verifier.enforce_ttl = false
+
+      unless verifier.valid?
+        Rails.logger.error('Ai::CredentialDecryptor: credential failed Fernet verification')
+        return nil
+      end
+
+      verifier.message
+    rescue StandardError => e
+      Rails.logger.error("Ai::CredentialDecryptor: #{e.class}: #{e.message}")
+      nil
+    end
+
+    def encryption_key
+      ENV.fetch(ENCRYPTION_KEY_ENV, nil)
+    end
+  end
+end

--- a/app/services/ai/credential_encryptor.rb
+++ b/app/services/ai/credential_encryptor.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Encrypts a credential so evo-ai-core-service and the processor can read it.
+#
+# Only the 1.5 migration writes credentials from Ruby: everything else goes
+# through the core's own endpoint, which encrypts server-side. That endpoint sits
+# behind a user-bearer permission check, which a rake task does not have — hence
+# encrypting here, with the same Fernet key the Go side uses.
+#
+# The Ruby → Go direction is proven by spec: the core decrypts with
+# `fernet.VerifyAndDecrypt(token, 0, keys)`, and a token this class produces must
+# survive it. See credential_encryptor_spec.rb.
+class Ai::CredentialEncryptor
+  KEY_HINT_LENGTH = 4
+
+  class << self
+    # Returns the ciphertext, or nil when the key is missing. Callers treat nil
+    # as "cannot write" and must abort rather than store something unreadable.
+    def encrypt(plaintext)
+      return nil if plaintext.blank?
+
+      secret = Ai::CredentialDecryptor.encryption_key
+      if secret.blank?
+        Rails.logger.error("Ai::CredentialEncryptor: #{Ai::CredentialDecryptor::ENCRYPTION_KEY_ENV} is not set")
+        return nil
+      end
+
+      Fernet.generate(secret, plaintext)
+    rescue StandardError => e
+      Rails.logger.error("Ai::CredentialEncryptor: #{e.class}: #{e.message}")
+      nil
+    end
+
+    # Mirrors DeriveKeyHint in the Go model: the last characters of the plaintext,
+    # so the screen renders a mask without the key ever reaching the browser.
+    def key_hint(plaintext)
+      return '' if plaintext.blank?
+
+      characters = plaintext.chars
+      return plaintext if characters.length <= KEY_HINT_LENGTH
+
+      characters.last(KEY_HINT_LENGTH).join
+    end
+  end
+end

--- a/app/services/ai/credential_encryptor.rb
+++ b/app/services/ai/credential_encryptor.rb
@@ -2,14 +2,10 @@
 
 # Encrypts a credential so evo-ai-core-service and the processor can read it.
 #
-# Only the 1.5 migration writes credentials from Ruby: everything else goes
-# through the core's own endpoint, which encrypts server-side. That endpoint sits
-# behind a user-bearer permission check, which a rake task does not have — hence
-# encrypting here, with the same Fernet key the Go side uses.
-#
-# The Ruby → Go direction is proven by spec: the core decrypts with
-# `fernet.VerifyAndDecrypt(token, 0, keys)`, and a token this class produces must
-# survive it. See credential_encryptor_spec.rb.
+# Only the migrations write credentials from Ruby: everything else goes through
+# the core's endpoint, which encrypts server-side but sits behind a user-bearer
+# check a rake task does not have. Same Fernet key as the Go side, and
+# credential_encryptor_spec proves a token from here survives its decrypt.
 class Ai::CredentialEncryptor
   KEY_HINT_LENGTH = 4
 

--- a/app/services/ai/credential_migration.rb
+++ b/app/services/ai/credential_migration.rb
@@ -15,8 +15,16 @@
 # Nothing is deleted here. `OPENAI_API_SECRET` and the hook settings stay put —
 # removing them is story 1.6, and the legacy fallback still reads them.
 class Ai::CredentialMigration
+  # ⚠️ These strings are the idempotency key AND they go into
+  # `imported_from VARCHAR(64)` (migration 000018). The hook prefix plus a uuid
+  # plus the ":original" suffix used to reach 71 chars, so on any install with
+  # both a global key and a hook the migration inserted the account row and then
+  # raised ValueTooLong on the inactive one, leaving a PARTIAL write that flips
+  # MigrationState to "migrated" and turns the legacy fallback off for everyone.
+  # Keep every source under 64 characters.
   INSTALLATION_SOURCE = 'installation_configs:OPENAI_API_SECRET'
-  HOOK_SOURCE_PREFIX = 'integrations_hooks:openai:'
+  HOOK_SOURCE_PREFIX = 'hook:openai:'
+  HOOK_ORIGINAL_SUFFIX = ':orig'
 
   INSTALLATION_NAME = 'Padrão da instalação (migrado)'
   ACCOUNT_NAME = 'Credencial da conta (migrado)'
@@ -158,9 +166,18 @@ class Ai::CredentialMigration
     @logger.info("[Ai::CredentialMigration] #{rows.count(&:ok?)}/#{rows.size} OK")
   end
 
+  # One transaction for the whole import.
+  #
+  # Without it, a failure midway (a too-long source, an encryption error, a
+  # unique-index race) leaves earlier rows committed. That partial state flips
+  # BOTH `registry_already_populated?` and `MigrationState.imported_credentials?`
+  # to true, so the next run short-circuits its own gate and the legacy fallback
+  # switches off globally — including for hooks that were never imported.
   def write(plan)
-    import_installation(plan)
-    plan[:hooks].each { |entry| import_hook(plan, entry) }
+    ActiveRecord::Base.transaction do
+      import_installation(plan)
+      plan[:hooks].each { |entry| import_hook(plan, entry) }
+    end
   end
 
   def import_installation(plan)
@@ -196,7 +213,7 @@ class Ai::CredentialMigration
       plaintext: hook_key,
       scope: Ai::Credential::SCOPE_ACCOUNT,
       provider: 'openai',
-      source: "#{HOOK_SOURCE_PREFIX}#{entry[:hook].id}:original",
+      source: "#{HOOK_SOURCE_PREFIX}#{entry[:hook].id}#{HOOK_ORIGINAL_SUFFIX}",
       active: false
     )
   end

--- a/app/services/ai/credential_migration.rb
+++ b/app/services/ai/credential_migration.rb
@@ -2,29 +2,19 @@
 
 # Imports the credentials configured before the registry existed.
 #
-# ⚠️ THE PRECEDENCE INVERTS. Before: the global `OPENAI_API_SECRET` wins and the
-# account hook is the fallback. After: the account credential wins and the
-# installation one is the default. So importing "each source to its own level"
-# would SWAP the key in use — the account would start using the hook key that is
-# ignored today.
+# ⚠️ THE PRECEDENCE INVERTS: the global key used to win over the account hook,
+# and now the account credential wins. Importing "each source to its own level"
+# would therefore SWAP the key in use, so where both exist the ACCOUNT
+# credential is created with the GLOBAL value. The hook key lands inactive
+# rather than being lost.
 #
-# The fix: where both exist, the ACCOUNT credential is created with the GLOBAL
-# value, so the resolver keeps returning the same key through the new path. The
-# hook key is not lost: it is imported inactive, visible, for a human to decide.
-#
-# Nothing is deleted here. `OPENAI_API_SECRET` and the hook settings stay put —
-# removing them is story 1.6, and the legacy fallback still reads them.
-# rubocop:disable Metrics/ClassLength -- the analytic DEPOIS calculation (the
-# gate fix of the 2026-07-29 review) is what pushed this over; splitting the
-# class would separate the projection from the rules it projects.
+# Nothing is deleted: the legacy fallback still reads those sources.
+# rubocop:disable Metrics/ClassLength -- splitting the class would separate the
+# analytic projection from the rules it projects.
 class Ai::CredentialMigration
-  # ⚠️ These strings are the idempotency key AND they go into
-  # `imported_from VARCHAR(64)` (migration 000018). The hook prefix plus a uuid
-  # plus the ":original" suffix used to reach 71 chars, so on any install with
-  # both a global key and a hook the migration inserted the account row and then
-  # raised ValueTooLong on the inactive one, leaving a PARTIAL write that flips
-  # MigrationState to "migrated" and turns the legacy fallback off for everyone.
-  # Keep every source under 64 characters.
+  # ⚠️ Idempotency keys, and they go into `imported_from VARCHAR(64)`. Keep every
+  # source under 64 characters: an overflow mid-import leaves a PARTIAL write
+  # that flips MigrationState to "migrated" and kills the fallback for everyone.
   INSTALLATION_SOURCE = 'installation_configs:OPENAI_API_SECRET'
   HOOK_SOURCE_PREFIX = 'hook:openai:'
   HOOK_ORIGINAL_SUFFIX = ':orig'
@@ -96,17 +86,14 @@ class Ai::CredentialMigration
   end
 
   # The effective credential today, and what it would be after the import.
-  #
-  # BEFORE comes from the resolver itself: on an unmigrated install the registry
-  # is empty, so it falls through to the legacy link — which IS the old
-  # precedence. Reimplementing it here would risk drifting from the real rule.
+  # BEFORE comes from the resolver itself, whose legacy link IS the old
+  # precedence: reimplementing it here would drift from the real rule.
   def build_report(plan)
     rows = []
 
-    # Only meaningful when there IS a global key: with none, `resolve_key`
-    # without a hook still reaches the account hook through the legacy link, and
-    # comparing that against an installation-level plan would report a phantom
-    # divergence for a level that has nothing to migrate.
+    # Only meaningful with a global key: without one, `resolve_key` still
+    # reaches the account hook through the legacy link, and comparing that
+    # against an installation-level plan reports a phantom divergence.
     if plan[:global_key].present?
       rows << Ai::CredentialMigrationRow.new(
         subject: 'instalação',
@@ -131,17 +118,11 @@ class Ai::CredentialMigration
 
   # Resolution AFTER the import, computed analytically — never by writing and
   # rolling back, because the report must run without side effects.
-  # ⚠️ This USED to short-circuit to `existing_registry_key` whenever any active
-  # credential existed — the same call `before_key` makes — so no row could ever
-  # report DIVERGE and the gate disarmed itself (review of 2026-07-29, ALTO 6).
   #
-  # Worse than a blind gate: the import inserts an `account` row, and the chain
-  # resolves account BEFORE installation, so an installation credential a human
-  # had already registered gets outranked. The effective key changed while the
-  # report said OK.
-  #
-  # Now the DEPOIS is computed analytically, through the same precedence the
-  # resolver uses, against the state the write would produce.
+  # ⚠️ It must project through the SAME precedence the resolver uses. Answering
+  # with the current resolution would make the gate unfalsifiable, and the
+  # import inserts an `account` row that outranks an installation credential a
+  # human already registered.
   def effective_after(plan, hook_key:)
     imported = plan[:global_key] || hook_key
 

--- a/app/services/ai/credential_migration.rb
+++ b/app/services/ai/credential_migration.rb
@@ -225,6 +225,7 @@ class Ai::CredentialMigration
       plaintext: plan[:global_key],
       scope: Ai::Credential::SCOPE_INSTALLATION,
       provider: provider_for(plan[:global_api_url]),
+      base_url: custom_base_url(plan[:global_api_url]),
       source: INSTALLATION_SOURCE
     )
   end
@@ -239,6 +240,7 @@ class Ai::CredentialMigration
       plaintext: promoted ? plan[:global_key] : hook_key,
       scope: Ai::Credential::SCOPE_ACCOUNT,
       provider: provider_for(plan[:global_api_url]),
+      base_url: custom_base_url(plan[:global_api_url]),
       source: "#{HOOK_SOURCE_PREFIX}#{entry[:hook].id}"
     )
 
@@ -255,6 +257,16 @@ class Ai::CredentialMigration
     )
   end
 
+  # Only a CUSTOM endpoint is stored: NULL already means "the provider default",
+  # which is what every credential registered before this column meant. Stamping
+  # the public URL on every install would be noise with no information in it.
+  def custom_base_url(api_url)
+    return nil if api_url.blank?
+    return nil if api_url.include?('api.openai.com')
+
+    api_url
+  end
+
   # A custom base URL means the provider is not stock OpenAI.
   def provider_for(api_url)
     return 'openai' if api_url.blank? || api_url.include?('api.openai.com')
@@ -263,7 +275,7 @@ class Ai::CredentialMigration
   end
 
   # Keyword-arg bundle for a credential the migration intends to create.
-  Planned = Struct.new(:name, :plaintext, :scope, :provider, :source, :active, keyword_init: true)
+  Planned = Struct.new(:name, :plaintext, :scope, :provider, :source, :active, :base_url, keyword_init: true)
 
   def create_credential(**attrs)
     planned = Planned.new(active: true, **attrs)
@@ -285,6 +297,7 @@ class Ai::CredentialMigration
       key: ciphertext,
       key_hint: Ai::CredentialEncryptor.key_hint(planned.plaintext),
       scope: planned.scope,
+      base_url: planned.base_url,
       is_active: planned.active,
       imported_from: planned.source,
       created_at: Time.current,

--- a/app/services/ai/credential_migration.rb
+++ b/app/services/ai/credential_migration.rb
@@ -14,6 +14,9 @@
 #
 # Nothing is deleted here. `OPENAI_API_SECRET` and the hook settings stay put —
 # removing them is story 1.6, and the legacy fallback still reads them.
+# rubocop:disable Metrics/ClassLength -- the analytic DEPOIS calculation (the
+# gate fix of the 2026-07-29 review) is what pushed this over; splitting the
+# class would separate the projection from the rules it projects.
 class Ai::CredentialMigration
   # ⚠️ These strings are the idempotency key AND they go into
   # `imported_from VARCHAR(64)` (migration 000018). The hook prefix plus a uuid
@@ -128,12 +131,46 @@ class Ai::CredentialMigration
 
   # Resolution AFTER the import, computed analytically — never by writing and
   # rolling back, because the report must run without side effects.
+  # ⚠️ This USED to short-circuit to `existing_registry_key` whenever any active
+  # credential existed — the same call `before_key` makes — so no row could ever
+  # report DIVERGE and the gate disarmed itself (review of 2026-07-29, ALTO 6).
+  #
+  # Worse than a blind gate: the import inserts an `account` row, and the chain
+  # resolves account BEFORE installation, so an installation credential a human
+  # had already registered gets outranked. The effective key changed while the
+  # report said OK.
+  #
+  # Now the DEPOIS is computed analytically, through the same precedence the
+  # resolver uses, against the state the write would produce.
   def effective_after(plan, hook_key:)
-    return existing_registry_key if registry_already_populated?
+    imported = plan[:global_key] || hook_key
 
-    # The account link is created with the global value when both exist, so the
-    # winner is unchanged. Otherwise whichever single source exists wins.
-    plan[:global_key] || hook_key
+    # What the import will place at each scope. The account link carries the
+    # global value when both exist (that is the promotion this class exists for).
+    projected = {
+      Ai::Credential::SCOPE_INSTALLATION => plan[:global_key],
+      Ai::Credential::SCOPE_ACCOUNT => (imported if hook_key.present? || plan[:global_key].present?)
+    }
+
+    # Most specific link wins, exactly like Ai::ScopeChain: an already-registered
+    # credential only survives where the import puts nothing.
+    Ai::ScopeChain::SCOPE_CHAIN.reverse_each do |scope|
+      projected_key = projected[scope.to_s]
+      return projected_key if projected_key.present?
+
+      existing = existing_key_at(scope.to_s)
+      return existing if existing.present?
+    end
+
+    nil
+  end
+
+  # The plaintext of the credential already stored at a scope, or nil.
+  def existing_key_at(scope)
+    credential = Ai::Credential.active.for_scope(scope).order(created_at: :asc).first
+    return nil unless credential
+
+    Ai::CredentialDecryptor.decrypt(credential.key)
   end
 
   def registry_already_populated?
@@ -265,3 +302,4 @@ class Ai::CredentialMigration
     "#{base} (#{suffix})"
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/ai/credential_migration.rb
+++ b/app/services/ai/credential_migration.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+# Imports the credentials configured before the registry existed.
+#
+# ⚠️ THE PRECEDENCE INVERTS. Before: the global `OPENAI_API_SECRET` wins and the
+# account hook is the fallback. After: the account credential wins and the
+# installation one is the default. So importing "each source to its own level"
+# would SWAP the key in use — the account would start using the hook key that is
+# ignored today.
+#
+# The fix: where both exist, the ACCOUNT credential is created with the GLOBAL
+# value, so the resolver keeps returning the same key through the new path. The
+# hook key is not lost: it is imported inactive, visible, for a human to decide.
+#
+# Nothing is deleted here. `OPENAI_API_SECRET` and the hook settings stay put —
+# removing them is story 1.6, and the legacy fallback still reads them.
+class Ai::CredentialMigration
+  INSTALLATION_SOURCE = 'installation_configs:OPENAI_API_SECRET'
+  HOOK_SOURCE_PREFIX = 'integrations_hooks:openai:'
+
+  INSTALLATION_NAME = 'Padrão da instalação (migrado)'
+  ACCOUNT_NAME = 'Credencial da conta (migrado)'
+  INACTIVE_HOOK_NAME = 'Chave do hook OpenAI (migrado, inativa)'
+
+  class AbortedError < StandardError; end
+
+  def self.call(apply: false, logger: Rails.logger)
+    new(apply: apply, logger: logger).call
+  end
+
+  def initialize(apply: false, logger: Rails.logger)
+    @apply = apply
+    @logger = logger
+  end
+
+  # Returns the report rows. In apply mode, writes only after every row is OK.
+  def call
+    ensure_encryption_key!
+
+    plan = build_plan
+    rows = build_report(plan)
+
+    emit_report(rows)
+
+    diverging = rows.reject(&:ok?)
+    if diverging.any?
+      raise AbortedError,
+            "migration aborted: #{diverging.size} account(s) would change effective credential"
+    end
+
+    return rows unless @apply
+
+    write(plan)
+    rows
+  end
+
+  private
+
+  def ensure_encryption_key!
+    return if Ai::CredentialDecryptor.encryption_key.present?
+
+    # Without the key every credential written here is unreadable by the core,
+    # the processor and the resolver — and the failure would only surface later,
+    # inside a job.
+    raise AbortedError,
+          "#{Ai::CredentialDecryptor::ENCRYPTION_KEY_ENV} is not set; refusing to write unreadable credentials"
+  end
+
+  # What the migration intends to create. Pure: touches nothing.
+  def build_plan
+    {
+      global_key: GlobalConfigService.load('OPENAI_API_SECRET', nil).presence,
+      global_api_url: GlobalConfigService.load('OPENAI_API_URL', nil).presence,
+      hooks: openai_hooks
+    }
+  end
+
+  def openai_hooks
+    Integrations::Hook.where(app_id: 'openai').filter_map do |hook|
+      key = hook.settings&.dig('api_key').presence
+      next if key.blank?
+
+      { hook: hook, key: key }
+    end
+  end
+
+  # The effective credential today, and what it would be after the import.
+  #
+  # BEFORE comes from the resolver itself: on an unmigrated install the registry
+  # is empty, so it falls through to the legacy link — which IS the old
+  # precedence. Reimplementing it here would risk drifting from the real rule.
+  def build_report(plan)
+    rows = []
+
+    # Only meaningful when there IS a global key: with none, `resolve_key`
+    # without a hook still reaches the account hook through the legacy link, and
+    # comparing that against an installation-level plan would report a phantom
+    # divergence for a level that has nothing to migrate.
+    if plan[:global_key].present?
+      rows << Ai::CredentialMigrationRow.new(
+        subject: 'instalação',
+        before_key: Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist),
+        after_key: effective_after(plan, hook_key: nil),
+        origin: installation_origin(plan)
+      )
+    end
+
+    plan[:hooks].each do |entry|
+      before = Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist, legacy_hook: entry[:hook])
+      rows << Ai::CredentialMigrationRow.new(
+        subject: "hook #{entry[:hook].id}",
+        before_key: before,
+        after_key: effective_after(plan, hook_key: entry[:key]),
+        origin: hook_origin(plan, entry[:key])
+      )
+    end
+
+    rows
+  end
+
+  # Resolution AFTER the import, computed analytically — never by writing and
+  # rolling back, because the report must run without side effects.
+  def effective_after(plan, hook_key:)
+    return existing_registry_key if registry_already_populated?
+
+    # The account link is created with the global value when both exist, so the
+    # winner is unchanged. Otherwise whichever single source exists wins.
+    plan[:global_key] || hook_key
+  end
+
+  def registry_already_populated?
+    Ai::Credential.active.exists?
+  end
+
+  def existing_registry_key
+    Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist)
+  end
+
+  def installation_origin(plan)
+    return 'nada a migrar' if plan[:global_key].blank?
+
+    'installation_configs → escopo instalação'
+  end
+
+  def hook_origin(plan, hook_key)
+    return 'nada a migrar' if hook_key.blank? && plan[:global_key].blank?
+
+    if plan[:global_key].present? && plan[:global_key] != hook_key
+      'chave GLOBAL promovida para o escopo conta (hook importado inativo)'
+    else
+      'hook → escopo conta'
+    end
+  end
+
+  def emit_report(rows)
+    @logger.info("[Ai::CredentialMigration] modo=#{@apply ? 'apply' : 'dry_run'}")
+    rows.each { |row| @logger.info("[Ai::CredentialMigration] #{row.to_line}") }
+    @logger.info("[Ai::CredentialMigration] #{rows.count(&:ok?)}/#{rows.size} OK")
+  end
+
+  def write(plan)
+    import_installation(plan)
+    plan[:hooks].each { |entry| import_hook(plan, entry) }
+  end
+
+  def import_installation(plan)
+    return if plan[:global_key].blank?
+
+    create_credential(
+      name: INSTALLATION_NAME,
+      plaintext: plan[:global_key],
+      scope: Ai::Credential::SCOPE_INSTALLATION,
+      provider: provider_for(plan[:global_api_url]),
+      source: INSTALLATION_SOURCE
+    )
+  end
+
+  def import_hook(plan, entry)
+    hook_key = entry[:key]
+    promoted = plan[:global_key].present? && plan[:global_key] != hook_key
+
+    # The account credential carries the value that wins TODAY.
+    create_credential(
+      name: ACCOUNT_NAME,
+      plaintext: promoted ? plan[:global_key] : hook_key,
+      scope: Ai::Credential::SCOPE_ACCOUNT,
+      provider: provider_for(plan[:global_api_url]),
+      source: "#{HOOK_SOURCE_PREFIX}#{entry[:hook].id}"
+    )
+
+    return unless promoted
+
+    # The hook key is not discarded: it lands inactive so a human can promote it.
+    create_credential(
+      name: INACTIVE_HOOK_NAME,
+      plaintext: hook_key,
+      scope: Ai::Credential::SCOPE_ACCOUNT,
+      provider: 'openai',
+      source: "#{HOOK_SOURCE_PREFIX}#{entry[:hook].id}:original",
+      active: false
+    )
+  end
+
+  # A custom base URL means the provider is not stock OpenAI.
+  def provider_for(api_url)
+    return 'openai' if api_url.blank? || api_url.include?('api.openai.com')
+
+    'custom_openai_compatible'
+  end
+
+  # Keyword-arg bundle for a credential the migration intends to create.
+  Planned = Struct.new(:name, :plaintext, :scope, :provider, :source, :active, keyword_init: true)
+
+  def create_credential(**attrs)
+    planned = Planned.new(active: true, **attrs)
+
+    # imported_from is the idempotency key, not the name: a human may rename or
+    # disable an imported credential, and a re-run must respect that.
+    return if Ai::Credential.exists?(imported_from: planned.source)
+
+    ciphertext = Ai::CredentialEncryptor.encrypt(planned.plaintext)
+    raise AbortedError, "failed to encrypt credential for #{planned.source}" if ciphertext.blank?
+
+    Ai::Credential.insert_all!([row_for(planned, ciphertext)]) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def row_for(planned, ciphertext)
+    {
+      name: unique_name(planned.name),
+      provider: planned.provider,
+      key: ciphertext,
+      key_hint: Ai::CredentialEncryptor.key_hint(planned.plaintext),
+      scope: planned.scope,
+      is_active: planned.active,
+      imported_from: planned.source,
+      created_at: Time.current,
+      updated_at: Time.current
+    }
+  end
+
+  # `name` carries a UNIQUE index, so a collision is a database error rather
+  # than a cosmetic detail.
+  def unique_name(base)
+    return base unless Ai::Credential.exists?(name: base)
+
+    suffix = 2
+    suffix += 1 while Ai::Credential.exists?(name: "#{base} (#{suffix})")
+    "#{base} (#{suffix})"
+  end
+end

--- a/app/services/ai/credential_migration_row.rb
+++ b/app/services/ai/credential_migration_row.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# One line of the migration report: which credential is in effect for a subject
+# before the import and which would be after it.
+#
+# The comparison is by KEY VALUE, not row id — the point is proving the key in
+# use did not change (NFR1).
+class Ai::CredentialMigrationRow
+  attr_reader :subject, :before_key, :after_key, :origin
+
+  def initialize(subject:, before_key:, after_key:, origin:)
+    @subject = subject
+    @before_key = before_key
+    @after_key = after_key
+    @origin = origin
+  end
+
+  def ok?
+    before_key == after_key
+  end
+
+  def verdict
+    ok? ? 'OK' : 'DIVERGE'
+  end
+
+  def to_line
+    format(
+      '%<subject>-28s ANTES=%<before>-12s DEPOIS=%<after>-12s %<verdict>-10s %<origin>s',
+      subject: subject, before: mask(before_key), after: mask(after_key),
+      verdict: verdict, origin: origin
+    )
+  end
+
+  # The report goes to the logs, so it carries the mask, never the key.
+  def mask(value)
+    return '(nenhuma)' if value.blank?
+
+    "••••#{value.chars.last(4).join}"
+  end
+end

--- a/app/services/ai/credential_resolver.rb
+++ b/app/services/ai/credential_resolver.rb
@@ -20,16 +20,25 @@
 class Ai::CredentialResolver
   SCOPE_CHAIN = %i[installation account].freeze
 
-  # Returns the credential in effect, or nil when no link in the chain offers a
-  # usable one. Never raises for "nothing configured" — that is an expected
-  # state, and callers fall back to their legacy sources until story 1.6.
+  # Returns the credential record in effect, or nil when no link in the chain
+  # offers a usable one. Never raises for "nothing configured" — that is an
+  # expected state.
   def self.resolve(for_consumer:, account: nil)
     new(consumer: for_consumer, account: account).resolve
   end
 
-  def initialize(consumer:, account: nil)
+  # Returns the plaintext key in effect, decrypting the registry value or
+  # falling back to the legacy sources. This is what consumers call.
+  # `legacy_hook` is the caller's own openai Hook when it has one, so the
+  # fallback reads the same record the consumer used before this story.
+  def self.resolve_key(for_consumer:, account: nil, legacy_hook: nil)
+    new(consumer: for_consumer, account: account, legacy_hook: legacy_hook).resolve_key
+  end
+
+  def initialize(consumer:, account: nil, legacy_hook: nil)
     @consumer = consumer&.to_sym
     @account = account
+    @legacy_hook = legacy_hook
   end
 
   def resolve
@@ -40,7 +49,43 @@ class Ai::CredentialResolver
     SCOPE_CHAIN.reverse.lazy.filter_map { |scope| credential_for(scope) }.first
   end
 
+  def resolve_key
+    credential = resolve
+    key = credential && Ai::CredentialDecryptor.decrypt(credential.key)
+    return key if key.present?
+
+    legacy_key
+  end
+
   private
+
+  # LEGACY FALLBACK — REMOVED BY STORY 1.6.
+  #
+  # The pre-registry precedence (global config wins, account hook is the
+  # fallback) does not disappear in this story: it drops one level and becomes
+  # the last, most generic link. Installations that have not migrated keep
+  # working, and a credential registered on the new screen is never shadowed by
+  # legacy configuration, because the chain above is tried first.
+  #
+  # It lives here, inside the resolver, and never spread across consumers.
+  def legacy_key
+    return nil unless Ai::ConsumerCompatibility.accepts?(@consumer, 'openai')
+
+    global_key = GlobalConfigService.load('OPENAI_API_SECRET', nil)
+    return global_key if global_key.present?
+
+    legacy_hook_key
+  rescue StandardError => e
+    Rails.logger.error("Ai::CredentialResolver legacy fallback: #{e.class}: #{e.message}")
+    nil
+  end
+
+  # Consumers holding a Hook pass it in, so the fallback reads the very record
+  # they read before. Without one, the account-level openai hook is used.
+  def legacy_hook_key
+    hook = @legacy_hook || Integrations::Hook.find_by(app_id: 'openai')
+    hook&.settings&.dig('api_key').presence
+  end
 
   def credential_for(scope)
     candidates(scope).find { |credential| accepted?(credential) }

--- a/app/services/ai/credential_resolver.rb
+++ b/app/services/ai/credential_resolver.rb
@@ -59,22 +59,29 @@ class Ai::CredentialResolver
 
   private
 
-  # LEGACY FALLBACK — REMOVED BY STORY 1.6.
+  # LEGACY FALLBACK — retired by story 1.6, but only for installations that
+  # already migrated.
   #
-  # The pre-registry precedence (global config wins, account hook is the
-  # fallback) does not disappear in this story: it drops one level and becomes
-  # the last, most generic link. Installations that have not migrated keep
-  # working, and a credential registered on the new screen is never shadowed by
-  # legacy configuration, because the chain above is tried first.
+  # Ai::MigrationState is the guard: while an install still keeps its key only
+  # in the old sources, this link stays alive so AI does not switch off in
+  # silence. Once the 1.5 task has run — or there was never anything to migrate
+  # — the registry is the single origin and this returns nothing.
   #
-  # It lives here, inside the resolver, and never spread across consumers.
+  # It lives here, inside the resolver, and was never spread across consumers.
+  # Deleting it outright is safe only after every install has migrated.
   def legacy_key
     return nil unless Ai::ConsumerCompatibility.accepts?(@consumer, 'openai')
+    return nil unless Ai::MigrationState.legacy_fallback_active?(legacy_hook: @legacy_hook)
 
     global_key = GlobalConfigService.load('OPENAI_API_SECRET', nil)
-    return global_key if global_key.present?
+    if global_key.present?
+      Ai::MigrationState.warn_pending_migration
+      return global_key
+    end
 
-    legacy_hook_key
+    hook_key = legacy_hook_key
+    Ai::MigrationState.warn_pending_migration if hook_key.present?
+    hook_key
   rescue StandardError => e
     Rails.logger.error("Ai::CredentialResolver legacy fallback: #{e.class}: #{e.message}")
     nil

--- a/app/services/ai/credential_resolver.rb
+++ b/app/services/ai/credential_resolver.rb
@@ -24,6 +24,11 @@ class Ai::CredentialResolver
   # SAME frozen array, not a copy, so there is still one place to change.
   SCOPE_CHAIN = Ai::ScopeChain::SCOPE_CHAIN
 
+  # Key and endpoint travel together: an OpenAI-compatible provider is the pair,
+  # so a key from one credential with a URL from elsewhere hits the wrong server.
+  # `base_url` nil means "use the consumer's default".
+  Endpoint = Struct.new(:key, :base_url, keyword_init: true)
+
   # Returns the credential record in effect, or nil when no link in the chain
   # offers a usable one. Never raises for "nothing configured" — that is an
   # expected state.
@@ -36,7 +41,13 @@ class Ai::CredentialResolver
   # `legacy_hook` is the caller's own openai Hook when it has one, so the
   # fallback reads the same record the consumer used before this story.
   def self.resolve_key(for_consumer:, account: nil, legacy_hook: nil)
-    new(consumer: for_consumer, account: account, legacy_hook: legacy_hook).resolve_key
+    resolve_endpoint(for_consumer: for_consumer, account: account, legacy_hook: legacy_hook).key
+  end
+
+  # Returns the Endpoint in effect. Callers that need both halves must use this
+  # rather than pairing `resolve_key` with a URL of their own.
+  def self.resolve_endpoint(for_consumer:, account: nil, legacy_hook: nil)
+    new(consumer: for_consumer, account: account, legacy_hook: legacy_hook).resolve_endpoint
   end
 
   def initialize(consumer:, account: nil, legacy_hook: nil)
@@ -54,11 +65,17 @@ class Ai::CredentialResolver
   end
 
   def resolve_key
+    resolve_endpoint.key
+  end
+
+  def resolve_endpoint
     credential = resolve
     key = credential && Ai::CredentialDecryptor.decrypt(credential.key)
-    return key if key.present?
+    return Endpoint.new(key: key, base_url: credential.base_url.presence) if key.present?
 
-    legacy_key
+    # The legacy sources hold a key and nothing else: the endpoint there has
+    # always been the consumer's own OPENAI_API_URL, and nil keeps it that way.
+    Endpoint.new(key: legacy_key, base_url: nil)
   end
 
   private

--- a/app/services/ai/credential_resolver.rb
+++ b/app/services/ai/credential_resolver.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Resolves which AI credential is in effect for a given feature.
+#
+# This is the ONLY owner of the precedence rule. The core service stores the
+# scope but does not resolve inheritance: duplicating the rule on both sides
+# guarantees divergence at the first bugfix.
+#
+# Scopes form an ORDERED CHAIN from the most generic to the most specific, and
+# the most specific link wins. It is deliberately a list, not a pair: the
+# enterprise roadmap adds an `agency` link between installation and account, and
+# it must be able to do that by inserting into the chain — never by rewriting
+# the resolution logic. There is no `if account then ... else installation` here
+# on purpose.
+#
+# `account:` is threaded through the chain rather than queried: the community
+# CRM is single-tenant and has no accounts table, so nothing filters on it. The
+# parameter exists so the enterprise overlay can scope a link without changing
+# this class.
+class Ai::CredentialResolver
+  SCOPE_CHAIN = %i[installation account].freeze
+
+  # Returns the credential in effect, or nil when no link in the chain offers a
+  # usable one. Never raises for "nothing configured" — that is an expected
+  # state, and callers fall back to their legacy sources until story 1.6.
+  def self.resolve(for_consumer:, account: nil)
+    new(consumer: for_consumer, account: account).resolve
+  end
+
+  def initialize(consumer:, account: nil)
+    @consumer = consumer&.to_sym
+    @account = account
+  end
+
+  def resolve
+    return nil unless Ai::ConsumerCompatibility.known?(@consumer)
+
+    # Most specific first: the chain is read backwards, so inserting a link
+    # changes precedence without touching this method.
+    SCOPE_CHAIN.reverse.lazy.filter_map { |scope| credential_for(scope) }.first
+  end
+
+  private
+
+  def credential_for(scope)
+    candidates(scope).find { |credential| accepted?(credential) }
+  end
+
+  def candidates(scope)
+    Ai::Credential
+      .active
+      .for_scope(scope.to_s)
+      .order(created_at: :asc)
+  end
+
+  # A credential the consumer cannot speak to is skipped, so resolution falls
+  # through to a more generic link instead of failing at the provider (FR18).
+  def accepted?(credential)
+    Ai::ConsumerCompatibility.accepts?(@consumer, credential.provider)
+  end
+end

--- a/app/services/ai/credential_resolver.rb
+++ b/app/services/ai/credential_resolver.rb
@@ -1,27 +1,18 @@
 # frozen_string_literal: true
 
-# Resolves which AI credential is in effect for a given feature.
+# Resolves which AI credential is in effect for a given feature. The ONLY owner
+# of the precedence rule: the core stores the scope but resolves no inheritance.
 #
-# This is the ONLY owner of the precedence rule. The core service stores the
-# scope but does not resolve inheritance: duplicating the rule on both sides
-# guarantees divergence at the first bugfix.
+# Scopes are an ordered chain, most specific wins. A list and not a pair on
+# purpose — the enterprise overlay inserts an `agency` link by adding to the
+# chain, never by rewriting resolution, so there is no `if account then ...
+# else installation` here.
 #
-# Scopes form an ORDERED CHAIN from the most generic to the most specific, and
-# the most specific link wins. It is deliberately a list, not a pair: the
-# enterprise roadmap adds an `agency` link between installation and account, and
-# it must be able to do that by inserting into the chain — never by rewriting
-# the resolution logic. There is no `if account then ... else installation` here
-# on purpose.
-#
-# `account:` is threaded through the chain rather than queried: the community
-# CRM is single-tenant and has no accounts table, so nothing filters on it. The
-# parameter exists so the enterprise overlay can scope a link without changing
-# this class.
+# `account:` is threaded rather than queried: this CRM is single-tenant and has
+# no accounts table. The parameter exists for that overlay to scope a link.
 class Ai::CredentialResolver
-  # The chain and its traversal live in Ai::ScopeChain, shared with the
-  # integration credential resolver (story 2.2). This constant is kept as an
-  # alias so callers and specs referring to it keep working — but it is the
-  # SAME frozen array, not a copy, so there is still one place to change.
+  # Alias of Ai::ScopeChain::SCOPE_CHAIN, kept for call sites. The SAME frozen
+  # array, not a copy, so there is still one place to change.
   SCOPE_CHAIN = Ai::ScopeChain::SCOPE_CHAIN
 
   # Key and endpoint travel together: an OpenAI-compatible provider is the pair,
@@ -80,16 +71,11 @@ class Ai::CredentialResolver
 
   private
 
-  # LEGACY FALLBACK — retired by story 1.6, but only for installations that
-  # already migrated.
+  # LEGACY FALLBACK, alive only while Ai::MigrationState says this installation
+  # still keeps its key in the old sources. Once the migration has run — or
+  # there was never anything to migrate — the registry is the single origin.
   #
-  # Ai::MigrationState is the guard: while an install still keeps its key only
-  # in the old sources, this link stays alive so AI does not switch off in
-  # silence. Once the 1.5 task has run — or there was never anything to migrate
-  # — the registry is the single origin and this returns nothing.
-  #
-  # It lives here, inside the resolver, and was never spread across consumers.
-  # Deleting it outright is safe only after every install has migrated.
+  # It lives inside the resolver and was never spread across consumers.
   def legacy_key
     return nil unless Ai::ConsumerCompatibility.accepts?(@consumer, 'openai')
     return nil unless Ai::MigrationState.legacy_fallback_active?(legacy_hook: @legacy_hook)

--- a/app/services/ai/credential_resolver.rb
+++ b/app/services/ai/credential_resolver.rb
@@ -18,7 +18,11 @@
 # parameter exists so the enterprise overlay can scope a link without changing
 # this class.
 class Ai::CredentialResolver
-  SCOPE_CHAIN = %i[installation account].freeze
+  # The chain and its traversal live in Ai::ScopeChain, shared with the
+  # integration credential resolver (story 2.2). This constant is kept as an
+  # alias so callers and specs referring to it keep working — but it is the
+  # SAME frozen array, not a copy, so there is still one place to change.
+  SCOPE_CHAIN = Ai::ScopeChain::SCOPE_CHAIN
 
   # Returns the credential record in effect, or nil when no link in the chain
   # offers a usable one. Never raises for "nothing configured" — that is an
@@ -44,9 +48,9 @@ class Ai::CredentialResolver
   def resolve
     return nil unless Ai::ConsumerCompatibility.known?(@consumer)
 
-    # Most specific first: the chain is read backwards, so inserting a link
-    # changes precedence without touching this method.
-    SCOPE_CHAIN.reverse.lazy.filter_map { |scope| credential_for(scope) }.first
+    # Most specific first: Ai::ScopeChain reads the chain backwards, so
+    # inserting a link changes precedence without touching this method.
+    Ai::ScopeChain.resolve { |scope| credential_for(scope) }
   end
 
   def resolve_key

--- a/app/services/ai/integration_credential_migration.rb
+++ b/app/services/ai/integration_credential_migration.rb
@@ -359,7 +359,21 @@ class Ai::IntegrationCredentialMigration
     source = import_source(entry[:plaintext])
 
     existing = Ai::IntegrationCredential.find_by(imported_from: source)
-    return existing.id if existing
+    if existing
+      # The digest match proves the secret was imported ONCE — not that the row
+      # still holds it. A human may have rotated the imported credential since;
+      # linking a new consumer to it would silently swap the secret on the
+      # wire, which is the exact change the ANTES=DEPOIS gate exists to forbid
+      # (found in the adversarial review of 2026-07-29). Fail loud instead.
+      stored = Ai::CredentialDecryptor.decrypt(existing.value)
+      unless stored == entry[:plaintext]
+        raise AbortedError,
+              "credencial importada #{existing.id} foi alterada depois da importação e não " \
+              "corresponde mais ao segredo de #{subject_for(entry)}; ligue o consumidor manualmente"
+      end
+
+      return existing.id
+    end
 
     ciphertext = Ai::CredentialEncryptor.encrypt(entry[:plaintext])
     raise AbortedError, "falha ao cifrar a credencial de #{subject_for(entry)}" if ciphertext.blank?

--- a/app/services/ai/integration_credential_migration.rb
+++ b/app/services/ai/integration_credential_migration.rb
@@ -12,6 +12,9 @@
 # inline. That makes any divergence suspicious rather than expected — if a row
 # reports DIVERGE it is a bug in this migration, not a business rule changing,
 # and the gate treats it as a hard failure.
+# rubocop:disable Metrics/ClassLength -- one plan_for_* per store is the shape
+# the story asks for; splitting it would hide the per-store rules the reviewer
+# has to check side by side.
 class Ai::IntegrationCredentialMigration
   BOT_NAME_PREFIX = 'Credencial do bot'
 
@@ -61,9 +64,129 @@ class Ai::IntegrationCredentialMigration
           "#{Ai::CredentialDecryptor::ENCRYPTION_KEY_ENV} não está setada; recusando gravar credencial ilegível"
   end
 
+  # Header names that are recognisably authentication. The heuristic errs on the
+  # side of NOT migrating: importing a header that is not a secret breaks the
+  # call, while leaving a secret behind only delays the gain. The two mistakes
+  # do not cost the same.
+  AUTH_HEADER_NAMES = %w[authorization x-api-key api-key apikey x-auth-token].freeze
+
+  # Where each static provider keeps its secret inside `config`. Only the secret
+  # travels: apiUrl, webhookUrl, space_id and friends are the address, and
+  # keeping them out is what lets one credential serve several consumers.
+  INTEGRATION_SECRET_FIELDS = {
+    'dify' => %w[apiKey],
+    'flowise' => %w[apiKey],
+    'openai' => %w[apiKey],
+    'elevenlabs' => %w[apiKey],
+    'knowledge_nexus' => %w[nexus_api_key apiKey],
+    'n8n' => %w[basicAuthUser basicAuthPass]
+  }.freeze
+
   # What the migration intends to do. Pure: touches nothing.
+  #
+  # Each store is scanned defensively: the core owns those tables and an
+  # installation may be running a core older than the migration that created
+  # them. A missing table means "nothing to migrate here", not a crash that
+  # would take the whole migration down with it.
   def build_plan
-    AgentBot.find_each.map { |bot| plan_for_bot(bot) }
+    scan(AgentBot) { |r| r == :relation ? AgentBot.all : [plan_for_bot(r)] } +
+      scan(Ai::CustomTool) { |r| r == :relation ? Ai::CustomTool.active : plan_for_headers(r, :custom_tool) } +
+      scan(Ai::CustomMcpServer) { |r| r == :relation ? Ai::CustomMcpServer.active : plan_for_headers(r, :custom_mcp_server) } +
+      scan(Ai::AgentIntegration) { |r| r == :relation ? Ai::AgentIntegration.all : [plan_for_integration(r)] }
+  end
+
+  # The table is checked BEFORE querying, not rescued after: a failed statement
+  # aborts the surrounding transaction in Postgres, so catching the error would
+  # leave every later query failing too.
+  def scan(model)
+    unless table_available?(model)
+      @logger.warn("[Ai::IntegrationCredentialMigration] store #{model.table_name} ausente, pulado")
+      return []
+    end
+
+    # rubocop:disable Style/ExplicitBlockArgument -- the block serves two roles
+    # (build the relation, then map each record), so an explicit &block would
+    # not simplify it.
+    yield(:relation).find_each.flat_map { |record| yield(record) }
+    # rubocop:enable Style/ExplicitBlockArgument
+  end
+
+  # The core owns these tables, and an installation may run a core older than
+  # the migration that created them. A missing table means "nothing to migrate
+  # here", not a crash that takes the whole migration down.
+  def table_available?(model)
+    model.connection.table_exists?(model.table_name)
+  end
+
+  # Tools and MCP servers keep a free-form header map, so the reference is a MAP
+  # (header name -> credential id): two auth headers are two credentials.
+  def plan_for_headers(record, kind)
+    headers = parse_json(record.headers)
+    existing_refs = parse_json(record.credential_refs)
+
+    auth_headers = headers.select { |name, value| auth_header?(name) && value.present? }
+    return [skip_record(record, kind, 'nenhum header de autenticação reconhecido')] if auth_headers.empty?
+
+    auth_headers.filter_map do |name, value|
+      next if existing_refs[name].present?
+
+      { record: record, kind: kind, header: name, plaintext: value, format: 'scalar', secret_component: value }
+    end.presence || [skip_record(record, kind, 'headers já apontam para o cofre')]
+  end
+
+  def plan_for_integration(integration)
+    provider = integration.provider
+    fields = INTEGRATION_SECRET_FIELDS[provider]
+
+    # ⚠️ Everything outside the static allowlist is a deliberate skip: OAuth
+    # connection rows and their `<provider>_credentials` satellites hold tokens
+    # the vault must never own (story 2.5 lists them by reference instead), and
+    # typebot authenticates with nothing at all.
+    return skip_record(integration, :agent_integration, "provedor #{provider} não guarda segredo estático") if fields.blank?
+
+    config = parse_json(integration.config)
+    return skip_record(integration, :agent_integration, 'já aponta para o cofre') if config['credential_id'].present?
+
+    build_integration_entry(integration, provider, fields, config)
+  end
+
+  def build_integration_entry(integration, provider, fields, config)
+    if provider == 'n8n'
+      user = config['basicAuthUser'].presence
+      password = config['basicAuthPass'].presence
+      return skip_record(integration, :agent_integration, 'sem par de basic auth') if user.blank? || password.blank?
+
+      return {
+        record: integration, kind: :agent_integration,
+        plaintext: { user: user, password: password }.to_json,
+        format: 'composite', secret_component: password, provider: provider
+      }
+    end
+
+    value = fields.filter_map { |field| config[field].presence }.first
+    return skip_record(integration, :agent_integration, 'sem segredo no config') if value.blank?
+
+    {
+      record: integration, kind: :agent_integration, plaintext: value,
+      format: 'scalar', secret_component: value, provider: provider
+    }
+  end
+
+  def auth_header?(name)
+    AUTH_HEADER_NAMES.include?(name.to_s.downcase)
+  end
+
+  def parse_json(value)
+    return value if value.is_a?(Hash)
+    return {} if value.blank?
+
+    JSON.parse(value)
+  rescue JSON::ParserError
+    {}
+  end
+
+  def skip_record(record, kind, reason)
+    { record: record, kind: kind, skipped: true, reason: reason }
   end
 
   def plan_for_bot(bot)
@@ -107,23 +230,39 @@ class Ai::IntegrationCredentialMigration
       next skipped_row(entry) if entry[:skipped]
 
       Ai::IntegrationMigrationRow.new(
-        subject: "bot #{entry[:bot].id}",
+        subject: subject_for(entry),
         before_value: effective_before(entry),
         after_value: effective_after(entry),
-        origin: "agent_bots.api_key → cofre (#{entry[:format]})"
+        origin: "#{origin_for(entry)} → cofre (#{entry[:format]})"
       )
     end
   end
 
   def skipped_row(entry)
-    Ai::IntegrationMigrationRow.new(
-      subject: "bot #{entry[:bot].id}", origin: entry[:reason], skipped: true
-    )
+    Ai::IntegrationMigrationRow.new(subject: subject_for(entry), origin: entry[:reason], skipped: true)
+  end
+
+  def subject_for(entry)
+    return "bot #{entry[:bot].id}" if entry[:bot]
+
+    header = entry[:header] ? " [#{entry[:header]}]" : ''
+    "#{entry[:kind]} #{entry[:record].id}#{header}"
+  end
+
+  def origin_for(entry)
+    return 'agent_bots.api_key' if entry[:bot]
+    return "#{entry[:kind]}.headers" if entry[:header]
+
+    "#{entry[:kind]}.config"
   end
 
   # What the consumer sends today, through its real resolution path.
   def effective_before(entry)
-    AgentBots::CredentialResolution.api_key_for(entry[:bot])
+    return AgentBots::CredentialResolution.api_key_for(entry[:bot]) if entry[:bot]
+
+    # For the stores whose runtime path lives in Python, the inline value IS
+    # what goes out today, so it is the honest left-hand side of the gate.
+    entry[:format] == 'composite' ? equivalent_inline_key(entry[:plaintext]) : entry[:plaintext]
   end
 
   # What it would send after the import: the plaintext we are about to encrypt,
@@ -158,7 +297,43 @@ class Ai::IntegrationCredentialMigration
   end
 
   def write(plan)
-    plan.reject { |entry| entry[:skipped] }.each { |entry| import_bot(entry) }
+    plan.reject { |entry| entry[:skipped] }.each do |entry|
+      entry[:bot] ? import_bot(entry) : import_record(entry)
+    end
+  end
+
+  # Tools, MCP servers and agent integrations. The reference is written back
+  # into the table the CORE owns, so it goes through `update_all` on the
+  # relation: those models are read-only by design, and an instance `update`
+  # would raise.
+  def import_record(entry)
+    credential_id = find_or_create_credential(entry)
+    return if credential_id.blank?
+
+    entry[:header] ? link_header_ref(entry, credential_id) : link_config_ref(entry, credential_id)
+  end
+
+  def link_header_ref(entry, credential_id)
+    record = entry[:record].reload
+    refs = parse_json(record.credential_refs)
+    # A human may have pointed this header elsewhere after the first run.
+    return if refs[entry[:header]].present?
+
+    refs[entry[:header]] = credential_id
+    record.class.where(id: record.id).update_all( # rubocop:disable Rails/SkipsModelValidations
+      credential_refs: refs, updated_at: Time.current
+    )
+  end
+
+  def link_config_ref(entry, credential_id)
+    record = entry[:record].reload
+    config = parse_json(record.config)
+    return if config['credential_id'].present?
+
+    config['credential_id'] = credential_id
+    record.class.where(id: record.id).update_all( # rubocop:disable Rails/SkipsModelValidations
+      config: config, updated_at: Time.current
+    )
   end
 
   def import_bot(entry)
@@ -187,16 +362,31 @@ class Ai::IntegrationCredentialMigration
     return existing.id if existing
 
     ciphertext = Ai::CredentialEncryptor.encrypt(entry[:plaintext])
-    raise AbortedError, "falha ao cifrar a credencial de #{entry[:bot].id}" if ciphertext.blank?
+    raise AbortedError, "falha ao cifrar a credencial de #{subject_for(entry)}" if ciphertext.blank?
 
     insert_credential(entry, source, ciphertext)
+  end
+
+  # Deterministic per origin, so a re-run never renames a row.
+  def credential_name_for(entry)
+    return "#{BOT_NAME_PREFIX} #{credential_provider_for(entry)}" if entry[:bot]
+    return "Header #{entry[:header]} (#{entry[:kind]})" if entry[:header]
+
+    "Credencial #{entry[:provider]}"
+  end
+
+  def credential_provider_for(entry)
+    return entry[:bot].bot_provider.to_s.delete_suffix('_provider') if entry[:bot]
+    return entry[:provider] if entry[:provider]
+
+    entry[:kind].to_s
   end
 
   def insert_credential(entry, source, ciphertext)
     Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
       [{
-        name: unique_name("#{BOT_NAME_PREFIX} #{entry[:bot].bot_provider.to_s.delete_suffix('_provider')}"),
-        provider: entry[:bot].bot_provider.to_s.delete_suffix('_provider'),
+        name: unique_name(credential_name_for(entry)),
+        provider: credential_provider_for(entry),
         kind: Ai::IntegrationCredential::KIND_STATIC,
         value: ciphertext,
         value_format: entry[:format],
@@ -232,3 +422,4 @@ class Ai::IntegrationCredentialMigration
     "#{base} (#{suffix})"
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/ai/integration_credential_migration.rb
+++ b/app/services/ai/integration_credential_migration.rb
@@ -309,9 +309,17 @@ class Ai::IntegrationCredentialMigration
     )
   end
 
+  # One transaction for the whole import, exactly like story 1.5.
+  #
+  # A partial write is worse than no write: it leaves `imported_from` present, so
+  # `Ai::IntegrationMigrationState` starts answering "migrated" and the 2.7 guard
+  # removes the inline fallback for EVERY consumer — including the ones whose
+  # credential never made it into the vault (review of 2026-07-29, ALTO 8).
   def write(plan)
-    plan.reject { |entry| entry[:skipped] }.each do |entry|
-      entry[:bot] ? import_bot(entry) : import_record(entry)
+    ActiveRecord::Base.transaction do
+      plan.reject { |entry| entry[:skipped] }.each do |entry|
+        entry[:bot] ? import_bot(entry) : import_record(entry)
+      end
     end
   end
 

--- a/app/services/ai/integration_credential_migration.rb
+++ b/app/services/ai/integration_credential_migration.rb
@@ -1,20 +1,13 @@
 # frozen_string_literal: true
 
-# Imports into the vault the integration secrets that were configured before it
-# existed (EVO-2250 story 2.6).
+# Imports into the vault the integration secrets configured before it existed.
+# Nothing is deleted: what changes is where each consumer LOOKS.
 #
-# Nothing is deleted: the inline values stay where they are, because the
-# consumers still fall back to them until story 2.7 retires that path. What
-# changes is where each consumer LOOKS.
-#
-# ⚠️ Unlike story 1.5, precedence did NOT invert here: a consumer points at one
-# credential by id, so the secret on the wire is literally the same one that was
-# inline. That makes any divergence suspicious rather than expected — if a row
-# reports DIVERGE it is a bug in this migration, not a business rule changing,
-# and the gate treats it as a hard failure.
-# rubocop:disable Metrics/ClassLength -- one plan_for_* per store is the shape
-# the story asks for; splitting it would hide the per-store rules the reviewer
-# has to check side by side.
+# ⚠️ Precedence does NOT invert here — a consumer points at one credential by id,
+# so the secret on the wire is literally the one that was inline. A DIVERGE row
+# is therefore a bug in this migration, and the gate treats it as a hard failure.
+# rubocop:disable Metrics/ClassLength -- splitting the plan_for_* methods would
+# hide the per-store rules a reviewer has to check side by side.
 class Ai::IntegrationCredentialMigration
   BOT_NAME_PREFIX = 'Credencial do bot'
 
@@ -64,15 +57,14 @@ class Ai::IntegrationCredentialMigration
           "#{Ai::CredentialDecryptor::ENCRYPTION_KEY_ENV} não está setada; recusando gravar credencial ilegível"
   end
 
-  # Header names that are recognisably authentication. The heuristic errs on the
-  # side of NOT migrating: importing a header that is not a secret breaks the
-  # call, while leaving a secret behind only delays the gain. The two mistakes
-  # do not cost the same.
+  # Recognisably authentication. The heuristic errs towards NOT migrating:
+  # importing a header that is not a secret breaks the call, while leaving one
+  # behind only delays the gain.
   AUTH_HEADER_NAMES = %w[authorization x-api-key api-key apikey x-auth-token].freeze
 
   # Where each static provider keeps its secret inside `config`. Only the secret
-  # travels: apiUrl, webhookUrl, space_id and friends are the address, and
-  # keeping them out is what lets one credential serve several consumers.
+  # travels — apiUrl, webhookUrl and space_id are the address, and keeping them
+  # out is what lets one credential serve several consumers.
   INTEGRATION_SECRET_FIELDS = {
     'dify' => %w[apiKey],
     'flowise' => %w[apiKey],
@@ -84,10 +76,8 @@ class Ai::IntegrationCredentialMigration
 
   # What the migration intends to do. Pure: touches nothing.
   #
-  # Each store is scanned defensively: the core owns those tables and an
-  # installation may be running a core older than the migration that created
-  # them. A missing table means "nothing to migrate here", not a crash that
-  # would take the whole migration down with it.
+  # Scanned defensively because an installation may run a core older than the
+  # migration that created these tables: missing means "nothing to migrate".
   def build_plan
     scan(AgentBot) { |r| r == :relation ? AgentBot.all : [plan_for_bot(r)] } +
       scan(Ai::CustomTool) { |r| r == :relation ? Ai::CustomTool.active : plan_for_headers(r, :custom_tool) } +
@@ -95,9 +85,8 @@ class Ai::IntegrationCredentialMigration
       scan(Ai::AgentIntegration) { |r| r == :relation ? Ai::AgentIntegration.all : [plan_for_integration(r)] }
   end
 
-  # The table is checked BEFORE querying, not rescued after: a failed statement
-  # aborts the surrounding transaction in Postgres, so catching the error would
-  # leave every later query failing too.
+  # Checked BEFORE querying, not rescued after: in Postgres a failed statement
+  # aborts the surrounding transaction, so every later query would fail too.
   def scan(model)
     unless table_available?(model)
       @logger.warn("[Ai::IntegrationCredentialMigration] store #{model.table_name} ausente, pulado")
@@ -216,15 +205,11 @@ class Ai::IntegrationCredentialMigration
   # The gate. For each consumer: does what we would write decrypt back to the
   # value in use today?
   #
-  # ⚠️ It is a ROUND-TRIP proof, not a replay of the old precedence. Story 1.5
-  # could call the resolver because the old rule lived in Ruby; here the runtime
-  # path for tools and MCPs is in Python and cannot be invoked from a rake task.
-  # Since precedence did not invert, proving the value survives encryption and
-  # decryption intact is what actually catches the failures possible here: a
-  # malformed composite, a dedup pointing at the wrong row, a broken key.
-  #
-  # The bot is the one consumer whose real runtime path IS in Ruby, so it is
-  # also checked through AgentBots::CredentialResolution.
+  # ⚠️ A ROUND-TRIP proof, not a replay of the old precedence: the runtime path
+  # for tools and MCPs is in Python and cannot be invoked from a rake task.
+  # Precedence did not invert, so surviving encryption and decryption intact is
+  # what catches the failures possible here — a malformed composite, a dedup
+  # pointing at the wrong row, a broken key.
   def build_report(plan)
     plan.map do |entry|
       next skipped_row(entry) if entry[:skipped]
@@ -258,11 +243,10 @@ class Ai::IntegrationCredentialMigration
 
   # What the consumer sends today.
   #
-  # ⚠️ It must NOT go through `AgentBots::CredentialResolution`: since story 2.7
-  # that resolver honours the retirement guard, and this migration is precisely
-  # the thing that READS the legacy source in order to import it. Asking the
-  # gated resolver would report "no secret" for every bot on the second run and
-  # abort with a phantom DIVERGE.
+  # ⚠️ NOT through `AgentBots::CredentialResolution`: that resolver honours the
+  # retirement guard, and this migration is the thing that reads the legacy
+  # source in order to import it. Gated, it would report "no secret" for every
+  # bot on the second run and abort with a phantom DIVERGE.
   #
   # The vault value wins when the bot already references one (a re-run must
   # compare against what is in effect), and the inline column is read directly
@@ -309,12 +293,9 @@ class Ai::IntegrationCredentialMigration
     )
   end
 
-  # One transaction for the whole import, exactly like story 1.5.
-  #
-  # A partial write is worse than no write: it leaves `imported_from` present, so
-  # `Ai::IntegrationMigrationState` starts answering "migrated" and the 2.7 guard
-  # removes the inline fallback for EVERY consumer — including the ones whose
-  # credential never made it into the vault (review of 2026-07-29, ALTO 8).
+  # One transaction for the whole import: a partial write leaves `imported_from`
+  # present, so the guard starts answering "migrated" and the inline fallback is
+  # removed for EVERY consumer, including those never imported.
   def write(plan)
     ActiveRecord::Base.transaction do
       plan.reject { |entry| entry[:skipped] }.each do |entry|
@@ -369,13 +350,9 @@ class Ai::IntegrationCredentialMigration
     )
   end
 
-  # Deduplication is by VALUE: the same secret in N consumers becomes ONE
-  # credential with N references.
-  #
-  # That is why `imported_from` is derived from the SECRET and not from the
-  # consumer. Keying it on the consumer would make the second consumer sharing a
-  # secret look "not yet imported" and create a duplicate, which is exactly what
-  # the idempotency requirement forbids.
+  # Deduplication is by VALUE, which is why `imported_from` derives from the
+  # SECRET and not from the consumer: keyed on the consumer, the second one
+  # sharing a secret would look "not yet imported" and create a duplicate.
   def find_or_create_credential(entry)
     source = import_source(entry[:plaintext])
 
@@ -385,7 +362,7 @@ class Ai::IntegrationCredentialMigration
       # still holds it. A human may have rotated the imported credential since;
       # linking a new consumer to it would silently swap the secret on the
       # wire, which is the exact change the ANTES=DEPOIS gate exists to forbid
-      # (found in the adversarial review of 2026-07-29). Fail loud instead.
+      #. Fail loud instead.
       stored = Ai::CredentialDecryptor.decrypt(existing.value)
       unless stored == entry[:plaintext]
         raise AbortedError,

--- a/app/services/ai/integration_credential_migration.rb
+++ b/app/services/ai/integration_credential_migration.rb
@@ -256,9 +256,22 @@ class Ai::IntegrationCredentialMigration
     "#{entry[:kind]}.config"
   end
 
-  # What the consumer sends today, through its real resolution path.
+  # What the consumer sends today.
+  #
+  # ⚠️ It must NOT go through `AgentBots::CredentialResolution`: since story 2.7
+  # that resolver honours the retirement guard, and this migration is precisely
+  # the thing that READS the legacy source in order to import it. Asking the
+  # gated resolver would report "no secret" for every bot on the second run and
+  # abort with a phantom DIVERGE.
+  #
+  # The vault value wins when the bot already references one (a re-run must
+  # compare against what is in effect), and the inline column is read directly
+  # otherwise.
   def effective_before(entry)
-    return AgentBots::CredentialResolution.api_key_for(entry[:bot]) if entry[:bot]
+    if entry[:bot]
+      from_vault = AgentBots::CredentialResolution.vault_value(entry[:bot])
+      return from_vault.presence || entry[:bot].api_key.presence
+    end
 
     # For the stores whose runtime path lives in Python, the inline value IS
     # what goes out today, so it is the honest left-hand side of the gate.

--- a/app/services/ai/integration_credential_migration.rb
+++ b/app/services/ai/integration_credential_migration.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+# Imports into the vault the integration secrets that were configured before it
+# existed (EVO-2250 story 2.6).
+#
+# Nothing is deleted: the inline values stay where they are, because the
+# consumers still fall back to them until story 2.7 retires that path. What
+# changes is where each consumer LOOKS.
+#
+# ⚠️ Unlike story 1.5, precedence did NOT invert here: a consumer points at one
+# credential by id, so the secret on the wire is literally the same one that was
+# inline. That makes any divergence suspicious rather than expected — if a row
+# reports DIVERGE it is a bug in this migration, not a business rule changing,
+# and the gate treats it as a hard failure.
+class Ai::IntegrationCredentialMigration
+  BOT_NAME_PREFIX = 'Credencial do bot'
+
+  # Bots whose provider sends no credential at all. Registered explicitly so
+  # their absence reads as a decision rather than as an oversight.
+  PROVIDERS_WITHOUT_CREDENTIAL = %w[webhook_provider].freeze
+
+  class AbortedError < StandardError; end
+
+  def self.call(apply: false, logger: Rails.logger)
+    new(apply: apply, logger: logger).call
+  end
+
+  def initialize(apply: false, logger: Rails.logger)
+    @apply = apply
+    @logger = logger
+  end
+
+  # Returns the report rows. In apply mode, writes only after every row is OK.
+  def call
+    ensure_encryption_key!
+
+    plan = build_plan
+    rows = build_report(plan)
+    emit_report(rows)
+
+    diverging = rows.reject(&:ok?)
+    if diverging.any?
+      raise AbortedError,
+            "migração abortada: #{diverging.size} consumidor(es) mudariam de segredo efetivo (DIVERGE)"
+    end
+
+    return rows unless @apply
+
+    write(plan)
+    rows
+  end
+
+  private
+
+  def ensure_encryption_key!
+    return if Ai::CredentialDecryptor.encryption_key.present?
+
+    # Without the key every credential written here is unreadable by the core,
+    # the processor and the resolver, and the failure would only surface later.
+    raise AbortedError,
+          "#{Ai::CredentialDecryptor::ENCRYPTION_KEY_ENV} não está setada; recusando gravar credencial ilegível"
+  end
+
+  # What the migration intends to do. Pure: touches nothing.
+  def build_plan
+    AgentBot.find_each.map { |bot| plan_for_bot(bot) }
+  end
+
+  def plan_for_bot(bot)
+    return skip(bot, 'provedor não usa credencial') if PROVIDERS_WITHOUT_CREDENTIAL.include?(bot.bot_provider)
+    return skip(bot, 'sem chave inline') if bot.api_key.blank?
+    return skip(bot, 'já aponta para o cofre') if bot.credential_id.present?
+
+    pair = AgentBots::CredentialResolution.inline_pair(bot.api_key)
+
+    if pair
+      # The n8n basic auth is ONE indivisible secret, stored as a composite
+      # envelope. The scalar overload of `api_key` is not replicated.
+      { bot: bot, plaintext: composite_envelope(pair), format: 'composite', secret_component: pair.last }
+    else
+      { bot: bot, plaintext: bot.api_key, format: 'scalar', secret_component: bot.api_key }
+    end
+  end
+
+  def skip(bot, reason)
+    { bot: bot, skipped: true, reason: reason }
+  end
+
+  def composite_envelope(pair)
+    { user: pair.first, password: pair.last }.to_json
+  end
+
+  # The gate. For each consumer: does what we would write decrypt back to the
+  # value in use today?
+  #
+  # ⚠️ It is a ROUND-TRIP proof, not a replay of the old precedence. Story 1.5
+  # could call the resolver because the old rule lived in Ruby; here the runtime
+  # path for tools and MCPs is in Python and cannot be invoked from a rake task.
+  # Since precedence did not invert, proving the value survives encryption and
+  # decryption intact is what actually catches the failures possible here: a
+  # malformed composite, a dedup pointing at the wrong row, a broken key.
+  #
+  # The bot is the one consumer whose real runtime path IS in Ruby, so it is
+  # also checked through AgentBots::CredentialResolution.
+  def build_report(plan)
+    plan.map do |entry|
+      next skipped_row(entry) if entry[:skipped]
+
+      Ai::IntegrationMigrationRow.new(
+        subject: "bot #{entry[:bot].id}",
+        before_value: effective_before(entry),
+        after_value: effective_after(entry),
+        origin: "agent_bots.api_key → cofre (#{entry[:format]})"
+      )
+    end
+  end
+
+  def skipped_row(entry)
+    Ai::IntegrationMigrationRow.new(
+      subject: "bot #{entry[:bot].id}", origin: entry[:reason], skipped: true
+    )
+  end
+
+  # What the consumer sends today, through its real resolution path.
+  def effective_before(entry)
+    AgentBots::CredentialResolution.api_key_for(entry[:bot])
+  end
+
+  # What it would send after the import: the plaintext we are about to encrypt,
+  # decrypted back. For a composite, the comparison is on the pair, because that
+  # is what the header is built from.
+  def effective_after(entry)
+    ciphertext = Ai::CredentialEncryptor.encrypt(entry[:plaintext])
+    return nil if ciphertext.blank?
+
+    decrypted = Ai::CredentialDecryptor.decrypt(ciphertext)
+    return nil if decrypted.blank?
+
+    entry[:format] == 'composite' ? equivalent_inline_key(decrypted) : decrypted
+  end
+
+  # A composite envelope has to rebuild the exact inline form it replaces, so
+  # the comparison against `effective_before` is apples to apples.
+  def equivalent_inline_key(envelope_json)
+    envelope = JSON.parse(envelope_json)
+    "#{envelope['user']}:#{envelope['password']}"
+  rescue JSON::ParserError
+    nil
+  end
+
+  def emit_report(rows)
+    @logger.info("[Ai::IntegrationCredentialMigration] modo=#{@apply ? 'apply' : 'dry_run'}")
+    rows.each { |row| @logger.info("[Ai::IntegrationCredentialMigration] #{row.to_line}") }
+    @logger.info(
+      "[Ai::IntegrationCredentialMigration] #{rows.count(&:ok?)}/#{rows.size} OK " \
+      "(#{rows.count(&:skipped?)} pulado(s))"
+    )
+  end
+
+  def write(plan)
+    plan.reject { |entry| entry[:skipped] }.each { |entry| import_bot(entry) }
+  end
+
+  def import_bot(entry)
+    credential_id = find_or_create_credential(entry)
+    return if credential_id.blank?
+
+    # `update_all` on the relation, not `update` on the record: AgentBot is a
+    # normal model here, but the same call shape is used for the core-owned
+    # tables, whose models are read-only by design.
+    AgentBot.where(id: entry[:bot].id, credential_id: nil).update_all( # rubocop:disable Rails/SkipsModelValidations
+      credential_id: credential_id, updated_at: Time.current
+    )
+  end
+
+  # Deduplication is by VALUE: the same secret in N consumers becomes ONE
+  # credential with N references.
+  #
+  # That is why `imported_from` is derived from the SECRET and not from the
+  # consumer. Keying it on the consumer would make the second consumer sharing a
+  # secret look "not yet imported" and create a duplicate, which is exactly what
+  # the idempotency requirement forbids.
+  def find_or_create_credential(entry)
+    source = import_source(entry[:plaintext])
+
+    existing = Ai::IntegrationCredential.find_by(imported_from: source)
+    return existing.id if existing
+
+    ciphertext = Ai::CredentialEncryptor.encrypt(entry[:plaintext])
+    raise AbortedError, "falha ao cifrar a credencial de #{entry[:bot].id}" if ciphertext.blank?
+
+    insert_credential(entry, source, ciphertext)
+  end
+
+  def insert_credential(entry, source, ciphertext)
+    Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: unique_name("#{BOT_NAME_PREFIX} #{entry[:bot].bot_provider.to_s.delete_suffix('_provider')}"),
+        provider: entry[:bot].bot_provider.to_s.delete_suffix('_provider'),
+        kind: Ai::IntegrationCredential::KIND_STATIC,
+        value: ciphertext,
+        value_format: entry[:format],
+        # The hint comes from the SECRET component: hinting on the envelope
+        # would render JSON syntax, and hinting on the user would mask the
+        # public half of the pair.
+        value_hint: Ai::CredentialEncryptor.key_hint(entry[:secret_component]),
+        scope: Ai::IntegrationCredential::SCOPE_ACCOUNT,
+        is_active: true,
+        imported_from: source,
+        created_at: Time.current,
+        updated_at: Time.current
+      }]
+    )
+    Ai::IntegrationCredential.find_by(imported_from: source)&.id
+  end
+
+  # Deterministic from the secret, so a re-run finds the row it created and two
+  # consumers sharing a secret land on the same one. The digest never exposes
+  # the secret itself.
+  def import_source(plaintext)
+    "integration:sha256:#{Digest::SHA256.hexdigest(plaintext)}"
+  end
+
+  # The unique index is (scope, name), so a collision inside the same scope is a
+  # database error rather than a cosmetic detail.
+  def unique_name(base)
+    scope = Ai::IntegrationCredential::SCOPE_ACCOUNT
+    return base unless Ai::IntegrationCredential.exists?(scope: scope, name: base)
+
+    suffix = 2
+    suffix += 1 while Ai::IntegrationCredential.exists?(scope: scope, name: "#{base} (#{suffix})")
+    "#{base} (#{suffix})"
+  end
+end

--- a/app/services/ai/integration_credential_resolver.rb
+++ b/app/services/ai/integration_credential_resolver.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# Resolves which integration credential is in effect: the Dify key, the n8n
+# basic auth, an MCP header, the Knowledge Nexus key.
+#
+# It reuses the chain mechanic of Ai::CredentialResolver through
+# Ai::ScopeChain rather than reimplementing precedence — two copies of the rule
+# diverge at the first bugfix, which is what story 1.2 exists to prevent.
+#
+# The deliberate difference from the AI credential resolver: here the normal
+# case is a REFERENCE. A Dify agent uses the key of that Dify, not "the default
+# key", so consumers point at one credential by id. The chain still exists, for
+# the narrower case of a scope default per provider (an installation-wide
+# ElevenLabs serving every account). Both live here so consumers never resolve
+# an id by hand and spread the rule again.
+class Ai::IntegrationCredentialResolver
+  # Alias of the shared chain, kept for readability at call sites. It is the
+  # SAME frozen array as Ai::ScopeChain::SCOPE_CHAIN, not a copy.
+  SCOPE_CHAIN = Ai::ScopeChain::SCOPE_CHAIN
+
+  # The outcome of resolving a VALUE. Three states that callers must be able to
+  # tell apart:
+  #
+  #   missing   — nothing usable is configured
+  #   reference — the credential is an oauth connection whose secret lives in
+  #               another store; the caller reads it there, and the vault never
+  #               owned it (a copy would go stale on the first refresh)
+  #   value     — a static secret, decrypted and ready to use
+  #
+  # Collapsing reference into missing would leave a consumer unable to tell
+  # "you have no credential" from "your credential lives somewhere else".
+  Resolution = Struct.new(:credential, :value, keyword_init: true) do
+    def missing?
+      credential.nil? || (credential.static? && value.blank?)
+    end
+
+    def reference?
+      credential.present? && credential.oauth?
+    end
+
+    def present_value?
+      credential.present? && credential.static? && value.present?
+    end
+
+    def owner_store
+      credential&.owner_store
+    end
+
+    def owner_ref
+      credential&.owner_ref
+    end
+  end
+
+  class << self
+    # Returns the referenced credential, or nil when the reference cannot be
+    # honoured. It NEVER falls through to the chain: a consumer configured with
+    # one credential must not silently authenticate with another.
+    def resolve_by_id(credential_id)
+      return nil if credential_id.blank?
+
+      Ai::IntegrationCredential.active.find_by(id: credential_id)
+    rescue ActiveRecord::StatementInvalid => e
+      # A malformed uuid is a bad reference, not an outage.
+      Rails.logger.error("Ai::IntegrationCredentialResolver: #{e.class}: #{e.message}")
+      nil
+    end
+
+    # Returns the credential that is the default for a provider, walking the
+    # chain from the most specific link to the most generic one, or nil when no
+    # link offers one.
+    #
+    # `account:` is threaded rather than queried, exactly as story 1.2 decided:
+    # the community CRM is single-tenant and has no accounts table. The
+    # parameter exists so the enterprise overlay can scope a link without
+    # rewriting this class.
+    def resolve_default(provider:, account: nil)
+      return nil if provider.blank?
+
+      new(provider: provider, account: account).resolve_default
+    end
+
+    # Returns a Resolution: the plaintext for a static credential, a reference
+    # marker for an oauth one, or a missing marker. Prefers an explicit
+    # reference when given, and only then falls back to the provider default.
+    def resolve_value(credential_id: nil, provider: nil, account: nil)
+      credential =
+        if credential_id.present?
+          resolve_by_id(credential_id)
+        else
+          resolve_default(provider: provider, account: account)
+        end
+
+      build_resolution(credential)
+    end
+
+    private
+
+    def build_resolution(credential)
+      # An oauth row carries no value (the column is NULL by database CHECK),
+      # so decrypting it would be both pointless and misleading.
+      return Resolution.new(credential: credential, value: nil) if credential.nil? || credential.oauth?
+
+      Resolution.new(credential: credential, value: Ai::CredentialDecryptor.decrypt(credential.value))
+    end
+  end
+
+  def initialize(provider:, account: nil)
+    @provider = provider
+    @account = account
+  end
+
+  def resolve_default
+    Ai::ScopeChain.resolve { |scope| credential_for(scope) }
+  end
+
+  private
+
+  def credential_for(scope)
+    Ai::IntegrationCredential
+      .active
+      .for_scope(scope.to_s)
+      .for_provider(@provider)
+      .order(created_at: :asc)
+      .first
+  end
+end

--- a/app/services/ai/integration_credential_resolver.rb
+++ b/app/services/ai/integration_credential_resolver.rb
@@ -1,31 +1,20 @@
 # frozen_string_literal: true
 
 # Resolves which integration credential is in effect: the Dify key, the n8n
-# basic auth, an MCP header, the Knowledge Nexus key.
+# basic auth, an MCP header, the Knowledge Nexus key. Precedence comes from the
+# shared Ai::ScopeChain, never reimplemented here.
 #
-# It reuses the chain mechanic of Ai::CredentialResolver through
-# Ai::ScopeChain rather than reimplementing precedence — two copies of the rule
-# diverge at the first bugfix, which is what story 1.2 exists to prevent.
-#
-# The deliberate difference from the AI credential resolver: here the normal
-# case is a REFERENCE. A Dify agent uses the key of that Dify, not "the default
-# key", so consumers point at one credential by id. The chain still exists, for
-# the narrower case of a scope default per provider (an installation-wide
-# ElevenLabs serving every account). Both live here so consumers never resolve
-# an id by hand and spread the rule again.
+# The difference from the AI resolver: the normal case is a REFERENCE, because a
+# Dify agent uses the key of that Dify and not "the default key". The chain
+# still serves the narrower case of a per-provider scope default. Both live here
+# so consumers never resolve an id by hand and spread the rule again.
 class Ai::IntegrationCredentialResolver
   # Alias of the shared chain, kept for readability at call sites. It is the
   # SAME frozen array as Ai::ScopeChain::SCOPE_CHAIN, not a copy.
   SCOPE_CHAIN = Ai::ScopeChain::SCOPE_CHAIN
 
-  # The outcome of resolving a VALUE. Three states that callers must be able to
-  # tell apart:
-  #
-  #   missing   — nothing usable is configured
-  #   reference — the credential is an oauth connection whose secret lives in
-  #               another store; the caller reads it there, and the vault never
-  #               owned it (a copy would go stale on the first refresh)
-  #   value     — a static secret, decrypted and ready to use
+  # Three outcomes callers must tell apart: missing, reference (an oauth
+  # connection whose secret lives in the store that owns it) and value.
   #
   # Collapsing reference into missing would leave a consumer unable to tell
   # "you have no credential" from "your credential lives somewhere else".
@@ -65,14 +54,9 @@ class Ai::IntegrationCredentialResolver
       nil
     end
 
-    # Returns the credential that is the default for a provider, walking the
-    # chain from the most specific link to the most generic one, or nil when no
-    # link offers one.
-    #
-    # `account:` is threaded rather than queried, exactly as story 1.2 decided:
-    # the community CRM is single-tenant and has no accounts table. The
-    # parameter exists so the enterprise overlay can scope a link without
-    # rewriting this class.
+    # The default credential for a provider, walking the chain most specific
+    # first. `account:` is threaded rather than queried: this CRM has no accounts
+    # table, and the parameter exists for the enterprise overlay to scope a link.
     def resolve_default(provider:, account: nil)
       return nil if provider.blank?
 

--- a/app/services/ai/integration_migration_row.rb
+++ b/app/services/ai/integration_migration_row.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# One line of the integration credential migration report: what secret a
+# consumer uses today and what it would use after the import.
+#
+# The comparison is by VALUE, not by row id: the point is proving that what goes
+# out on the wire does not change.
+class Ai::IntegrationMigrationRow
+  VERDICT_SKIPPED = 'PULADO'
+
+  attr_reader :subject, :before_value, :after_value, :origin, :skipped
+
+  def initialize(subject:, origin:, before_value: nil, after_value: nil, skipped: false)
+    @subject = subject
+    @before_value = before_value
+    @after_value = after_value
+    @origin = origin
+    @skipped = skipped
+  end
+
+  def skipped?
+    @skipped
+  end
+
+  # A skipped consumer is not a failure: it simply has nothing to migrate, and
+  # saying so keeps it from reading as a pending item nobody addressed.
+  def ok?
+    skipped? || before_value == after_value
+  end
+
+  def verdict
+    return VERDICT_SKIPPED if skipped?
+
+    ok? ? 'OK' : 'DIVERGE'
+  end
+
+  def to_line
+    format(
+      '%<subject>-34s ANTES=%<before>-12s DEPOIS=%<after>-12s %<verdict>-8s %<origin>s',
+      subject: subject, before: mask(before_value), after: mask(after_value),
+      verdict: verdict, origin: origin
+    )
+  end
+
+  # The report goes to the logs, so it carries the mask, never the secret.
+  def mask(value)
+    return '(nenhum)' if value.blank?
+
+    "••••#{value.chars.last(4).join}"
+  end
+end

--- a/app/services/ai/integration_migration_state.rb
+++ b/app/services/ai/integration_migration_state.rb
@@ -35,13 +35,38 @@ class Ai::IntegrationMigrationState
 
     # A bot still holding an inline key that no vault reference replaces is a
     # legacy secret waiting to be migrated.
+    # EVERY store the 2.6 migration touches, not just bots.
+    #
+    # ⚠️ Looking only at AgentBot was a fail-open: an installation whose inline
+    # secret lives in a Dify integration and has no bots answered "migrated",
+    # and retiring the inline read there leaves the agent authenticating with
+    # nothing (review of 2026-07-29, finding 10).
     def legacy_sources_empty?
-      !AgentBot.where(credential_id: nil)
-               .where.not(api_key: [nil, ''])
-               .exists?
+      pending_bots.zero? && pending_integrations.zero?
     rescue StandardError => e
+      # A database hiccup must not read as "migrated": that would remove the
+      # fallback on a broken install.
       Rails.logger.error("Ai::IntegrationMigrationState: #{e.class}: #{e.message}")
       false
+    end
+
+    def pending_bots
+      AgentBot.where(credential_id: nil)
+              .where.not(api_key: [nil, ''])
+              .count
+    end
+
+    # An integration still holding a static secret inline, with no vault
+    # reference replacing it. Tools and MCP servers live in tables the core owns
+    # and are counted by the Go endpoint; here we cover what Rails can see.
+    def pending_integrations
+      return 0 unless Ai::AgentIntegration.table_exists?
+
+      Ai::AgentIntegration
+        .static_providers
+        .where("config ->> 'credential_id' IS NULL")
+        .where("COALESCE(config ->> 'apiKey', config ->> 'nexus_api_key', config ->> 'basicAuthPass', '') <> ''")
+        .count
     end
   end
 end

--- a/app/services/ai/integration_migration_state.rb
+++ b/app/services/ai/integration_migration_state.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Answers whether this installation has moved its integration secrets into the
+# vault (EVO-2250 story 2.6).
+#
+# Story 2.7 removes the inline fallback, and this guard is what keeps that
+# removal from silently switching integrations off. An installation that never
+# ran the 2.6 task still has its secrets only in the old stores: cutting the
+# fallback there would leave every bot, tool and MCP resolving to nothing, with
+# no error pointing at the cause.
+#
+# Migrated means either of:
+#   - the task ran (a credential carries `imported_from`), or
+#   - there is nothing to migrate, which is the case for a fresh install that
+#     only ever used the vault screen.
+class Ai::IntegrationMigrationState
+  class << self
+    def migrated?
+      imported_credentials? || legacy_sources_empty?
+    end
+
+    # The fallback stays alive exactly while the guard says we are not migrated.
+    def legacy_fallback_active?
+      !migrated?
+    end
+
+    def imported_credentials?
+      Ai::IntegrationCredential.where.not(imported_from: nil).exists?
+    rescue StandardError => e
+      # A missing table or a database hiccup must not read as "migrated": that
+      # would remove the fallback on a broken install.
+      Rails.logger.error("Ai::IntegrationMigrationState: #{e.class}: #{e.message}")
+      false
+    end
+
+    # A bot still holding an inline key that no vault reference replaces is a
+    # legacy secret waiting to be migrated.
+    def legacy_sources_empty?
+      !AgentBot.where(credential_id: nil)
+               .where.not(api_key: [nil, ''])
+               .exists?
+    rescue StandardError => e
+      Rails.logger.error("Ai::IntegrationMigrationState: #{e.class}: #{e.message}")
+      false
+    end
+  end
+end

--- a/app/services/ai/integration_migration_state.rb
+++ b/app/services/ai/integration_migration_state.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
 # Answers whether this installation has moved its integration secrets into the
-# vault (EVO-2250 story 2.6).
+# vault, which is what keeps the inline fallback from being cut on an install
+# that never migrated — there, every bot, tool and MCP resolves to nothing.
 #
-# Story 2.7 removes the inline fallback, and this guard is what keeps that
-# removal from silently switching integrations off. An installation that never
-# ran the 2.6 task still has its secrets only in the old stores: cutting the
-# fallback there would leave every bot, tool and MCP resolving to nothing, with
-# no error pointing at the cause.
-#
-# Migrated means either of:
-#   - the task ran (a credential carries `imported_from`), or
-#   - there is nothing to migrate, which is the case for a fresh install that
-#     only ever used the vault screen.
+# Migrated means the task ran (a credential carries `imported_from`) OR there is
+# nothing left inline, the case for a fresh install.
 class Ai::IntegrationMigrationState
   class << self
     def migrated?
@@ -33,14 +26,9 @@ class Ai::IntegrationMigrationState
       false
     end
 
-    # A bot still holding an inline key that no vault reference replaces is a
-    # legacy secret waiting to be migrated.
-    # EVERY store the 2.6 migration touches, not just bots.
-    #
-    # ⚠️ Looking only at AgentBot was a fail-open: an installation whose inline
-    # secret lives in a Dify integration and has no bots answered "migrated",
-    # and retiring the inline read there leaves the agent authenticating with
-    # nothing (review of 2026-07-29, finding 10).
+    # EVERY store the migration touches, not just bots: an installation whose
+    # inline secret lives in a Dify integration and has no bots would otherwise
+    # answer "migrated" and lose the credential it still authenticates with.
     def legacy_sources_empty?
       pending_bots.zero? && pending_integrations.zero?
     rescue StandardError => e

--- a/app/services/ai/migration_state.rb
+++ b/app/services/ai/migration_state.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Answers whether this installation has moved to the credential registry.
+#
+# Story 1.6 removes the legacy fallback, and this guard is what keeps that
+# removal from silently switching off AI. An installation that never ran the 1.5
+# task still has its key only in the old sources: cutting the fallback there
+# would make the resolver return nothing and every feature behave as
+# "not configured", with no error pointing at the cause.
+#
+# Migrated means either of:
+#   - the 1.5 task ran (a credential carries `imported_from`), or
+#   - there is nothing to migrate (no key in any legacy source), which is the
+#     case for a fresh install that only ever used the new screen.
+class Ai::MigrationState
+  class << self
+    # `legacy_hook` is the caller's own openai Hook, when it has one. Without it
+    # a consumer holding a hook the global lookup cannot see would be judged
+    # "migrated" and lose the very key it was about to use.
+    def migrated?(legacy_hook: nil)
+      imported_credentials? || legacy_sources_empty?(legacy_hook: legacy_hook)
+    end
+
+    # The fallback stays alive exactly while the guard says we are not migrated.
+    def legacy_fallback_active?(legacy_hook: nil)
+      !migrated?(legacy_hook: legacy_hook)
+    end
+
+    def imported_credentials?
+      Ai::Credential.where.not(imported_from: nil).exists?
+    rescue StandardError => e
+      # A missing table or a DB hiccup must not be read as "migrated": that
+      # would remove the fallback on a broken install.
+      Rails.logger.error("Ai::MigrationState: #{e.class}: #{e.message}")
+      false
+    end
+
+    def legacy_sources_empty?(legacy_hook: nil)
+      GlobalConfigService.load('OPENAI_API_SECRET', nil).blank? &&
+        legacy_hook_key(legacy_hook).blank?
+    rescue StandardError => e
+      Rails.logger.error("Ai::MigrationState: #{e.class}: #{e.message}")
+      false
+    end
+
+    # Logged once per resolution that actually needed the fallback, so the
+    # operator learns what to run instead of guessing.
+    def warn_pending_migration
+      Rails.logger.warn(
+        '[Ai::MigrationState] usando credencial de fonte legada: rode ' \
+        '`bin/rails ai_credentials:migrate_dry_run` e depois `ai_credentials:migrate` ' \
+        'para migrar as credenciais para o registro'
+      )
+    end
+
+    private
+
+    def legacy_hook_key(legacy_hook = nil)
+      hook = legacy_hook || Integrations::Hook.find_by(app_id: 'openai')
+      hook&.settings&.dig('api_key').presence
+    end
+  end
+end

--- a/app/services/ai/migration_state.rb
+++ b/app/services/ai/migration_state.rb
@@ -1,22 +1,16 @@
 # frozen_string_literal: true
 
-# Answers whether this installation has moved to the credential registry.
+# Answers whether this installation has moved to the credential registry, which
+# is what keeps the legacy fallback from being cut on an install that never
+# migrated — there, AI would go silently "not configured".
 #
-# Story 1.6 removes the legacy fallback, and this guard is what keeps that
-# removal from silently switching off AI. An installation that never ran the 1.5
-# task still has its key only in the old sources: cutting the fallback there
-# would make the resolver return nothing and every feature behave as
-# "not configured", with no error pointing at the cause.
-#
-# Migrated means either of:
-#   - the 1.5 task ran (a credential carries `imported_from`), or
-#   - there is nothing to migrate (no key in any legacy source), which is the
-#     case for a fresh install that only ever used the new screen.
+# Migrated means the task ran (a credential carries `imported_from`) OR there is
+# no key in any legacy source, the case for a fresh install.
 class Ai::MigrationState
   class << self
-    # `legacy_hook` is the caller's own openai Hook, when it has one. Without it
-    # a consumer holding a hook the global lookup cannot see would be judged
-    # "migrated" and lose the very key it was about to use.
+    # `legacy_hook` is the caller's own openai Hook: without it, a consumer
+    # holding a hook the global lookup cannot see is judged "migrated" and loses
+    # the very key it was about to use.
     def migrated?(legacy_hook: nil)
       imported_credentials? || legacy_sources_empty?(legacy_hook: legacy_hook)
     end

--- a/app/services/ai/scope_chain.rb
+++ b/app/services/ai/scope_chain.rb
@@ -1,30 +1,21 @@
 # frozen_string_literal: true
 
-# The ordered scope chain, and the single owner of how it is walked.
+# The ordered scope chain and the single owner of how it is walked, shared by
+# both resolvers: two copies of the traversal would be two truths about
+# precedence, and the enterprise overlay's `agency` link would land in one and
+# be forgotten in the other.
 #
-# Extracted from Ai::CredentialResolver (story 1.2) when story 2.2 added a
-# second resolver for integration credentials. Copying the traversal instead
-# would have created two truths about precedence, and the enterprise overlay
-# inserts an `agency` link between installation and account: with two copies it
-# would land in one of them and be forgotten in the other, which is exactly the
-# divergence story 1.2 exists to prevent.
-#
-# Scopes run from the most GENERIC to the most SPECIFIC, and the most specific
-# link wins. It is deliberately a list, not a pair, so inserting a link changes
-# precedence without touching any resolution logic. There is no
-# `if account then ... else installation` anywhere on purpose.
+# Most GENERIC to most SPECIFIC, and the most specific wins. A list and not a
+# pair, so inserting a link changes precedence without touching any logic.
 module Ai::ScopeChain
   SCOPE_CHAIN = %i[installation account].freeze
 
   module_function
 
-  # Walks the chain from the most specific link to the most generic one and
-  # returns the first result the block yields, or nil when no link offers one.
-  #
-  # The caller supplies the per-scope lookup: the two resolvers filter by
-  # different things (consumer compatibility for AI credentials, provider for
-  # integration ones), and pushing that into here would make this module know
-  # about both.
+  # Walks from the most specific link to the most generic, returning the first
+  # result the block yields. The caller supplies the per-scope lookup: the two
+  # resolvers filter by different things, and knowing about both would couple
+  # this module to each.
   def resolve(&)
     SCOPE_CHAIN.reverse.lazy.filter_map(&).first
   end

--- a/app/services/ai/scope_chain.rb
+++ b/app/services/ai/scope_chain.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# The ordered scope chain, and the single owner of how it is walked.
+#
+# Extracted from Ai::CredentialResolver (story 1.2) when story 2.2 added a
+# second resolver for integration credentials. Copying the traversal instead
+# would have created two truths about precedence, and the enterprise overlay
+# inserts an `agency` link between installation and account: with two copies it
+# would land in one of them and be forgotten in the other, which is exactly the
+# divergence story 1.2 exists to prevent.
+#
+# Scopes run from the most GENERIC to the most SPECIFIC, and the most specific
+# link wins. It is deliberately a list, not a pair, so inserting a link changes
+# precedence without touching any resolution logic. There is no
+# `if account then ... else installation` anywhere on purpose.
+module Ai::ScopeChain
+  SCOPE_CHAIN = %i[installation account].freeze
+
+  module_function
+
+  # Walks the chain from the most specific link to the most generic one and
+  # returns the first result the block yields, or nil when no link offers one.
+  #
+  # The caller supplies the per-scope lookup: the two resolvers filter by
+  # different things (consumer compatibility for AI credentials, provider for
+  # integration ones), and pushing that into here would make this module know
+  # about both.
+  def resolve(&)
+    SCOPE_CHAIN.reverse.lazy.filter_map(&).first
+  end
+end

--- a/app/services/bot_runtime/delegation_service.rb
+++ b/app/services/bot_runtime/delegation_service.rb
@@ -34,7 +34,7 @@ module BotRuntime
         message_id: @message.id.to_s,
         message_content: @message.content.to_s,
         attachments: build_attachments,
-        api_key: @agent_bot.api_key.to_s,
+        api_key: AgentBots::CredentialResolution.api_key_for(@agent_bot).to_s,
         outgoing_url: @agent_bot.outgoing_url.to_s,
         bot_config: build_bot_config,
         postback_url: build_postback_url,

--- a/app/services/facebook/moderation/response_generator_service.rb
+++ b/app/services/facebook/moderation/response_generator_service.rb
@@ -118,7 +118,7 @@ class Facebook::Moderation::ResponseGeneratorService
 
     request = Net::HTTP::Post.new(uri)
     request['Content-Type'] = 'application/json'
-    request['Authorization'] = "Bearer #{agent_bot.api_key}" if agent_bot.api_key.present?
+    request['Authorization'] = "Bearer #{AgentBots::CredentialResolution.api_key_for(agent_bot)}" if agent_bot.api_key.present?
 
     # Build JSON-RPC payload (same format as HttpRequestService)
     jsonrpc_payload = {

--- a/app/services/facebook/moderation/response_generator_service.rb
+++ b/app/services/facebook/moderation/response_generator_service.rb
@@ -118,7 +118,10 @@ class Facebook::Moderation::ResponseGeneratorService
 
     request = Net::HTTP::Post.new(uri)
     request['Content-Type'] = 'application/json'
-    request['Authorization'] = "Bearer #{AgentBots::CredentialResolution.api_key_for(agent_bot)}" if agent_bot.api_key.present?
+    # Same reason as the HTTP request service: gating on the inline column left a
+    # vault-only bot with no Authorization header at all.
+    moderation_key = AgentBots::CredentialResolution.api_key_for(agent_bot)
+    request['Authorization'] = "Bearer #{moderation_key}" if moderation_key.present?
 
     # Build JSON-RPC payload (same format as HttpRequestService)
     jsonrpc_payload = {

--- a/app/services/hubspot/refresh_oauth_token_service.rb
+++ b/app/services/hubspot/refresh_oauth_token_service.rb
@@ -32,14 +32,10 @@ class Hubspot::RefreshOauthTokenService
 
     apply_refresh_response(make_refresh_request)
   rescue StandardError => e
-    # The stale token is still returned: the caller contract is "give me a
-    # token", and failing here would break the conversation in progress. What
-    # changed is that the failure stops being invisible.
-    #
-    # `authorization_error!` is the mechanism this codebase already has for
-    # "tell the human": it counts failures in Redis and, past the threshold,
-    # e-mails and deactivates the hook. Bypassing it is what let an integration
-    # stay dead for days with nothing but a log line (EVO-2250).
+    # The stale token is still returned — the caller contract is "give me a
+    # token" — but the failure is reported. `authorization_error!` counts
+    # failures in Redis and, past the threshold, e-mails and deactivates the
+    # hook; bypassing it leaves an integration dead with only a log line.
     Rails.logger.error("HubSpot token refresh failed for hook #{hook.id}: #{e.class}: #{e.message}")
     report_authorization_error
     hook.access_token

--- a/app/services/hubspot/refresh_oauth_token_service.rb
+++ b/app/services/hubspot/refresh_oauth_token_service.rb
@@ -28,21 +28,37 @@ class Hubspot::RefreshOauthTokenService
 
   # Refreshes the OAuth token using the refresh_token
   def refresh_token
-    return hook.access_token unless hook.settings['refresh_token'].present?
+    return hook.access_token if hook.settings['refresh_token'].blank?
 
-    response = make_refresh_request
-    parsed_response = JSON.parse(response.body)
-
-    if response.success?
-      update_hook_tokens(parsed_response)
-      hook.reload.access_token
-    else
-      Rails.logger.error("HubSpot token refresh failed: #{response.body}")
-      raise "HubSpot token refresh failed: #{parsed_response['message'] || response.body}"
-    end
+    apply_refresh_response(make_refresh_request)
   rescue StandardError => e
-    Rails.logger.error("Token refresh error: #{e.message}")
-    hook.access_token # Return existing token as fallback
+    # The stale token is still returned: the caller contract is "give me a
+    # token", and failing here would break the conversation in progress. What
+    # changed is that the failure stops being invisible.
+    #
+    # `authorization_error!` is the mechanism this codebase already has for
+    # "tell the human": it counts failures in Redis and, past the threshold,
+    # e-mails and deactivates the hook. Bypassing it is what let an integration
+    # stay dead for days with nothing but a log line (EVO-2250).
+    Rails.logger.error("HubSpot token refresh failed for hook #{hook.id}: #{e.class}: #{e.message}")
+    report_authorization_error
+    hook.access_token
+  end
+
+  def apply_refresh_response(response)
+    parsed_response = JSON.parse(response.body)
+    raise "HubSpot token refresh failed: #{parsed_response['message'] || response.body}" unless response.success?
+
+    update_hook_tokens(parsed_response)
+    hook.reload.access_token
+  end
+
+  # Never let the reporting itself take down the refresh: a Redis hiccup must
+  # not turn a recoverable stale-token path into an exception.
+  def report_authorization_error
+    hook.authorization_error!
+  rescue StandardError => e
+    Rails.logger.error("HubSpot token refresh could not report the failure: #{e.class}: #{e.message}")
   end
 
   def make_refresh_request

--- a/app/services/messages/audio_transcription_service.rb
+++ b/app/services/messages/audio_transcription_service.rb
@@ -131,7 +131,12 @@ class Messages::AudioTranscriptionService
   # the same one every AI feature resolves. The precedence used to be copied
   # here; it now lives in Ai::CredentialResolver, its single owner.
   def get_openai_api_key
-    Ai::CredentialResolver.resolve_key(for_consumer: :audio_transcription)
+    credential_endpoint.key
+  end
+
+  # Once per message: Whisper host and key come from the same credential.
+  def credential_endpoint
+    @credential_endpoint ||= Ai::CredentialResolver.resolve_endpoint(for_consumer: :audio_transcription)
   end
 
   def download_audio_file
@@ -179,8 +184,10 @@ class Messages::AudioTranscriptionService
     require 'net/http'
     require 'uri'
 
-    # Use GlobalConfigService for API URL (same pattern as OpenaiBaseService)
-    base_url = GlobalConfigService.load('OPENAI_API_URL', 'https://api.openai.com/v1')
+    # A key issued by a local gateway must not go to api.openai.com just because
+    # the installation setting still points there.
+    base_url = credential_endpoint.base_url.presence ||
+               GlobalConfigService.load('OPENAI_API_URL', 'https://api.openai.com/v1')
     transcription_url = "#{base_url}/audio/transcriptions"
 
     uri = URI(transcription_url)

--- a/app/services/messages/audio_transcription_service.rb
+++ b/app/services/messages/audio_transcription_service.rb
@@ -85,35 +85,31 @@ class Messages::AudioTranscriptionService
 
       Rails.logger.info "AudioTranscriptionService: Global config value: #{global_enabled.inspect} (#{global_enabled.class}), converted to: #{enabled.inspect}"
 
-      if enabled
-        Rails.logger.info "AudioTranscriptionService: Transcription enabled via global config"
-        # Still need to check if API key is configured
-        api_key = get_openai_api_key
-        unless api_key.present?
-          Rails.logger.warn "AudioTranscriptionService: Global config enabled but API key not configured"
-        end
-        return api_key.present?
-      else
-        Rails.logger.info "AudioTranscriptionService: Transcription disabled via global config"
-        return false
-      end
+      Rails.logger.info "AudioTranscriptionService: Transcription #{enabled ? 'enabled' : 'disabled'} via global config"
+      return enabled
     end
 
     # Priority 2: Check OpenAI integration hook settings
-    openai_hook = Hook.find_by(app_id: 'openai')
+    openai_hook = Integrations::Hook.find_by(app_id: 'openai')
     return false unless openai_hook&.enabled?
-    return false unless openai_hook.settings&.[]('enable_audio_transcription') == true
 
-    # Check if OpenAI API key is configured
-    openai_hook.settings&.[]('api_key').present?
+    openai_hook.settings&.[]('enable_audio_transcription') == true
   end
 
   def transcribe_audio
     return nil unless attachment.file.attached?
 
-    # Get OpenAI API key from integration hook or global config
     api_key = get_openai_api_key
-    return nil unless api_key.present?
+    if api_key.blank?
+      # The toggle is on but no credential resolves. Saying so explicitly beats
+      # behaving like the feature was switched off, which is what hid the
+      # missing credential from the user before.
+      Rails.logger.warn(
+        'AudioTranscriptionService: transcription is enabled but no AI credential resolved ' \
+        '(register one under Settings > AI Credentials)'
+      )
+      return nil
+    end
 
     # Download audio file
     audio_file = download_audio_file
@@ -131,28 +127,11 @@ class Messages::AudioTranscriptionService
     nil
   end
 
+  # Whisper is a different endpoint from chat/completions, but the credential is
+  # the same one every AI feature resolves. The precedence used to be copied
+  # here; it now lives in Ai::CredentialResolver, its single owner.
   def get_openai_api_key
-    # Priority 1: Try global configuration (same pattern as OpenaiBaseService)
-    global_api_key = GlobalConfigService.load('OPENAI_API_SECRET', nil)
-    if global_api_key.present?
-      Rails.logger.info "AudioTranscriptionService: Using global OpenAI API key"
-      return global_api_key
-    end
-
-    # Priority 2: Fallback to hook settings for backward compatibility
-    openai_hook = Hook.find_by(app_id: 'openai')
-    unless openai_hook&.enabled?
-      Rails.logger.warn "AudioTranscriptionService: OpenAI hook not found or not enabled"
-      return nil
-    end
-
-    api_key = openai_hook.settings&.[]('api_key')
-    if api_key.present?
-      Rails.logger.info "AudioTranscriptionService: Using hook OpenAI API key"
-    else
-      Rails.logger.warn "AudioTranscriptionService: OpenAI hook exists but API key is not configured"
-    end
-    api_key
+    Ai::CredentialResolver.resolve_key(for_consumer: :audio_transcription)
   end
 
   def download_audio_file

--- a/config/integration/apps.yml
+++ b/config/integration/apps.yml
@@ -39,7 +39,7 @@ openai:
   action: /openai
   hook_type: account
   allow_multiple_hooks: false
-  # The AI credential moved to Settings > AI Credentials (EVO-2250). `api_key`
+  # The AI credential moved to Settings > AI Credentials. `api_key`
   # stays in `properties` so hooks that still carry the migrated value remain
   # valid, but it left `required`, the form and `visible_properties`: this screen
   # no longer registers credentials, only the feature toggles.

--- a/config/integration/apps.yml
+++ b/config/integration/apps.yml
@@ -39,6 +39,10 @@ openai:
   action: /openai
   hook_type: account
   allow_multiple_hooks: false
+  # The AI credential moved to Settings > AI Credentials (EVO-2250). `api_key`
+  # stays in `properties` so hooks that still carry the migrated value remain
+  # valid, but it left `required`, the form and `visible_properties`: this screen
+  # no longer registers credentials, only the feature toggles.
   settings_json_schema:
     {
       "type": "object",
@@ -48,17 +52,10 @@ openai:
           "label_suggestion": { "type": "boolean" },
           "enable_audio_transcription": { "type": "boolean" }
         },
-      "required": ["api_key"],
       "additionalProperties": false
     }
   settings_form_schema:
     [
-      {
-        "label": "API Key",
-        "type": "text",
-        "name": "api_key",
-        "validation": "required",
-      },
       {
         "label": "Show label suggestions",
         "type": "checkbox",
@@ -73,7 +70,7 @@ openai:
         "help": "Automatically transcribe incoming audio messages using OpenAI Whisper API",
       },
     ]
-  visible_properties: ["api_key", "label_suggestion", "enable_audio_transcription"]
+  visible_properties: ["label_suggestion", "enable_audio_transcription"]
 
 linear:
   id: linear

--- a/db/migrate/20260729140000_add_credential_id_to_agent_bots.rb
+++ b/db/migrate/20260729140000_add_credential_id_to_agent_bots.rb
@@ -1,0 +1,10 @@
+class AddCredentialIdToAgentBots < ActiveRecord::Migration[7.1]
+  def change
+    # A bot references ONE secret, so a scalar column is enough here. Tools and
+    # MCPs need a map, because two auth headers are two credentials.
+    #
+    # No foreign key: the vault table belongs to evo-ai-core-service, which owns
+    # its own migrations, and Rails does not manage that schema.
+    add_column :agent_bots, :credential_id, :uuid, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_27_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_29_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -120,6 +120,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_27_120000) do
     t.integer "text_segmentation_min_size", default: 50
     t.decimal "delay_per_character", precision: 8, scale: 2, default: "50.0"
     t.integer "debounce_time", default: 5, null: false
+    t.uuid "credential_id"
   end
 
   create_table "ai_agent_products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/integrations/openai/global_processor_service.rb
+++ b/lib/integrations/openai/global_processor_service.rb
@@ -42,8 +42,10 @@ class Integrations::Openai::GlobalProcessorService
     @api_url ||= GlobalConfigService.load('OPENAI_API_URL', nil)
   end
 
+  # The registry is the single source; the pre-registry global/hook chain is the
+  # last link inside the resolver, so unmigrated installations keep working.
   def api_key
-    @api_key ||= GlobalConfigService.load('OPENAI_API_SECRET', nil)
+    @api_key ||= Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist)
   end
 
   def gpt_model

--- a/lib/integrations/openai/global_processor_service.rb
+++ b/lib/integrations/openai/global_processor_service.rb
@@ -38,14 +38,20 @@ class Integrations::Openai::GlobalProcessorService
     api_url.present? && api_key.present? && gpt_model.present?
   end
 
+  # Endpoint from the same credential as the key: mixing halves points a valid
+  # key at the wrong server.
   def api_url
-    @api_url ||= GlobalConfigService.load('OPENAI_API_URL', nil)
+    @api_url ||= credential_endpoint.base_url.presence || GlobalConfigService.load('OPENAI_API_URL', nil)
   end
 
   # The registry is the single source; the pre-registry global/hook chain is the
   # last link inside the resolver, so unmigrated installations keep working.
   def api_key
-    @api_key ||= Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist)
+    credential_endpoint.key
+  end
+
+  def credential_endpoint
+    @credential_endpoint ||= Ai::CredentialResolver.resolve_endpoint(for_consumer: :inbox_assist)
   end
 
   def gpt_model

--- a/lib/integrations/openai_base_service.rb
+++ b/lib/integrations/openai_base_service.rb
@@ -94,13 +94,12 @@ class Integrations::OpenaiBaseService
   end
 
   # Get API key from global configuration or hook settings (fallback)
+  # The registry is the single source. The old precedence (global config wins,
+  # account hook is the fallback) did not disappear — it dropped one level and
+  # now lives as the last link inside Ai::CredentialResolver, so nothing breaks
+  # before the migration and no consumer carries precedence logic of its own.
   def api_key
-    # Priority 1: Try global global configuration
-    global_api_key = GlobalConfigService.load('OPENAI_API_SECRET', nil)
-    return global_api_key if global_api_key.present?
-
-    # Priority 2: Fallback to hook settings for backward compatibility
-    hook.settings['api_key']
+    Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist, legacy_hook: hook)
   end
 
   # Get dynamic prompts from global configuration

--- a/lib/integrations/openai_base_service.rb
+++ b/lib/integrations/openai_base_service.rb
@@ -83,9 +83,10 @@ class Integrations::OpenaiBaseService
     self.class::CACHEABLE_EVENTS.include?(event_name)
   end
 
-  # Get OpenAI API URL from global configuration
+  # Endpoint from the same credential as the key; installation setting is the
+  # fallback for credentials that carry no URL of their own.
   def api_url
-    @api_url ||= "#{GlobalConfigService.load('OPENAI_API_URL', 'https://api.openai.com/v1')}/chat/completions"
+    @api_url ||= "#{credential_endpoint.base_url.presence || GlobalConfigService.load('OPENAI_API_URL', 'https://api.openai.com/v1')}/chat/completions"
   end
 
   # Get OpenAI model from global configuration
@@ -99,7 +100,12 @@ class Integrations::OpenaiBaseService
   # now lives as the last link inside Ai::CredentialResolver, so nothing breaks
   # before the migration and no consumer carries precedence logic of its own.
   def api_key
-    Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist, legacy_hook: hook)
+    credential_endpoint.key
+  end
+
+  # One resolution per event: key and URL cannot come from different credentials.
+  def credential_endpoint
+    @credential_endpoint ||= Ai::CredentialResolver.resolve_endpoint(for_consumer: :inbox_assist, legacy_hook: hook)
   end
 
   # Get dynamic prompts from global configuration

--- a/lib/tasks/ai_credentials.rake
+++ b/lib/tasks/ai_credentials.rake
@@ -1,0 +1,17 @@
+namespace :ai_credentials do
+  desc 'Simula a migração das credenciais de IA já cadastradas e imprime o relatório (não escreve nada)'
+  task migrate_dry_run: :environment do
+    Ai::CredentialMigration.call(apply: false)
+    puts 'Simulação concluída. Nada foi escrito. Rode ai_credentials:migrate para aplicar.'
+  rescue Ai::CredentialMigration::AbortedError => e
+    abort("Migração NÃO pode ser aplicada: #{e.message}")
+  end
+
+  desc 'Aplica a migração das credenciais de IA (aborta se alguma conta mudaria de credencial efetiva)'
+  task migrate: :environment do
+    rows = Ai::CredentialMigration.call(apply: true)
+    puts "Migração aplicada. #{rows.size} linha(s) conferida(s), todas mantendo a credencial em uso."
+  rescue Ai::CredentialMigration::AbortedError => e
+    abort("Migração abortada: #{e.message}")
+  end
+end

--- a/lib/tasks/integration_credentials.rake
+++ b/lib/tasks/integration_credentials.rake
@@ -1,0 +1,18 @@
+namespace :integration_credentials do
+  desc 'Simula a migração das credenciais de integração já cadastradas e imprime o relatório (não escreve nada)'
+  task migrate_dry_run: :environment do
+    rows = Ai::IntegrationCredentialMigration.call(apply: false)
+    puts "Simulação concluída. #{rows.size} consumidor(es) conferido(s), nada foi escrito."
+    puts 'Rode integration_credentials:migrate para aplicar.'
+  rescue Ai::IntegrationCredentialMigration::AbortedError => e
+    abort("Migração NÃO pode ser aplicada: #{e.message}")
+  end
+
+  desc 'Aplica a migração das credenciais de integração (aborta se algum consumidor mudaria de segredo efetivo)'
+  task migrate: :environment do
+    rows = Ai::IntegrationCredentialMigration.call(apply: true)
+    puts "Migração aplicada. #{rows.size} consumidor(es) conferido(s), todos mantendo o segredo em uso."
+  rescue Ai::IntegrationCredentialMigration::AbortedError => e
+    abort("Migração abortada: #{e.message}")
+  end
+end

--- a/spec/controllers/agent_bots_retirement_spec.rb
+++ b/spec/controllers/agent_bots_retirement_spec.rb
@@ -2,8 +2,6 @@
 
 require 'rails_helper'
 
-# EVO-2250, review of 2026-07-29 (blocker 3a and high 4).
-#
 # Source-level guards, because the defects are "a line that is still there":
 # a request spec would need the whole bot CRUD, which this branch does not have.
 # rubocop:disable RSpec/DescribeClass -- these assert on SOURCE lines: the defects are "a line still there", and a request spec would need the bot CRUD this branch does not have

--- a/spec/controllers/agent_bots_retirement_spec.rb
+++ b/spec/controllers/agent_bots_retirement_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250, review of 2026-07-29 (blocker 3a and high 4).
+#
+# Source-level guards, because the defects are "a line that is still there":
+# a request spec would need the whole bot CRUD, which this branch does not have.
+# rubocop:disable RSpec/DescribeClass -- these assert on SOURCE lines: the defects are "a line still there", and a request spec would need the bot CRUD this branch does not have
+RSpec.describe 'Agent bot retirement, source guards' do
+  it 'no longer accepts :api_key in the permitted params (2.7 AC1)' do
+    source = Rails.root.join('app/controllers/api/v1/agent_bots_controller.rb').read
+
+    permitted = source[/def permitted_params.*?\n  end/m]
+    expect(permitted).to be_present
+
+    expect(permitted).not_to include(':api_key'),
+                             'the inline key can still be registered through the API'
+    expect(permitted).to include(':credential_id'),
+                         'the vault reference must remain writable'
+  end
+
+  # High 4: two of the six consumption points kept `if api_key.present?` in front
+  # of the resolver, so a bot with a credential_id and no inline key went out with
+  # NO X-API-Key / NO Authorization at all.
+  {
+    'app/services/agent_bots/http_request_service.rb' => 'X-API-Key',
+    'app/services/facebook/moderation/response_generator_service.rb' => 'Authorization'
+  }.each do |path, header|
+    it "does not gate the #{header} header on the inline key (#{File.basename(path)})" do
+      source = Rails.root.join(path).read
+
+      # The defect is the BOT's inline column gating the header. A guard on the
+      # resolved local (`api_key.present?` after resolution) is correct and must
+      # not trip this.
+      offending = source.lines.each_with_index.select do |line, _|
+        line.match?(/(@?agent_bot|@agent_bot)\.api_key/) && !line.strip.start_with?('#')
+      end
+
+      expect(offending).to be_empty,
+                           "the inline-key gate is still there, so a vault-only bot sends no #{header}: " \
+                           "#{offending.map { |l, i| "line #{i + 1}: #{l.strip}" }}"
+    end
+  end
+
+  # High 14: a key shorter than ~21 chars was logged in full by the
+  # first-11-plus-last-10 fragment.
+  it 'never logs a fragment of the bot key' do
+    source = Rails.root.join('app/services/agent_bots/http_request_service.rb').read
+
+    offending = source.lines.grep(/logger.*api_key\[/)
+
+    expect(offending).to be_empty, "the key still reaches the log: #{offending.map(&:strip)}"
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/controllers/hubspot/callbacks_controller_secret_log_spec.rb
+++ b/spec/controllers/hubspot/callbacks_controller_secret_log_spec.rb
@@ -2,12 +2,9 @@
 
 require 'rails_helper'
 
-# EVO-2250, collateral of the credential survey.
-#
-# The callback logged `token_params.inspect` at INFO. That hash carries the
-# app's `client_secret` AND the one-time authorization `code`, so the
-# installation secret was written in cleartext to any log sink, on every OAuth
-# connection.
+# `token_params` carries the app's `client_secret` and the one-time
+# authorization `code`, so rendering the hash writes the installation secret in
+# cleartext to every log sink, on every OAuth connection.
 # rubocop:disable RSpec/DescribeClass -- this asserts on the SOURCE of a
 # controller, not on its behaviour: the leak is a log line, and rendering it
 # through a request spec would need the whole OAuth round trip.

--- a/spec/controllers/hubspot/callbacks_controller_secret_log_spec.rb
+++ b/spec/controllers/hubspot/callbacks_controller_secret_log_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250, collateral of the credential survey.
+#
+# The callback logged `token_params.inspect` at INFO. That hash carries the
+# app's `client_secret` AND the one-time authorization `code`, so the
+# installation secret was written in cleartext to any log sink, on every OAuth
+# connection.
+# rubocop:disable RSpec/DescribeClass -- this asserts on the SOURCE of a
+# controller, not on its behaviour: the leak is a log line, and rendering it
+# through a request spec would need the whole OAuth round trip.
+RSpec.describe 'Hubspot callback secret logging' do
+  let(:source) { Rails.root.join('app/controllers/hubspot/callbacks_controller.rb').read }
+
+  # Rendering the whole hash is the defect; reading one PUBLIC field out of it
+  # (the redirect_uri) is fine and is what keeps the log line useful.
+  it 'never renders the token exchange params hash into a log line' do
+    offending = source.lines.each_with_index.select do |line, _|
+      line.include?('logger') && line.match?(/token_params(\.inspect|\.to_json)/)
+    end
+
+    expect(offending).to be_empty,
+                         "the params hash reaches the log: #{offending.map { |l, i| "line #{i + 1}: #{l.strip}" }}"
+  end
+
+  it 'never logs the secret-bearing fields of the exchange' do
+    offending = source.lines.select do |line|
+      line.include?('logger') && line.match?(/token_params\[:(client_secret|code)\]/)
+    end
+
+    expect(offending).to be_empty, "a secret field reaches the log: #{offending.map(&:strip)}"
+  end
+
+  it 'does not interpolate the client secret into any log line' do
+    offending = source.lines.grep(/logger.*client_secret/i)
+
+    expect(offending).to be_empty, "client_secret reaches the log: #{offending.map(&:strip)}"
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/models/agent_bot_webhook_data_spec.rb
+++ b/spec/models/agent_bot_webhook_data_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250 story 2.4.
+RSpec.describe AgentBot do
+  describe '#webhook_data' do
+    # The hash reaches Message#webhook_data when a bot is the sender, and the
+    # webhook listener delivers that payload to URLs the CUSTOMER registered.
+    # The bot secret used to travel to third-party endpoints with it.
+    it 'never carries the bot secret' do
+      bot = described_class.new(
+        name: 'Bot',
+        outgoing_url: 'https://exemplo.test/webhook',
+        api_key: 'chave-secreta'
+      )
+
+      payload = bot.webhook_data
+
+      expect(payload).not_to have_key(:api_key)
+      expect(payload.values.map(&:to_s)).not_to include('chave-secreta')
+      expect(payload[:outgoing_url]).to eq('https://exemplo.test/webhook')
+    end
+  end
+end

--- a/spec/models/agent_bot_webhook_data_spec.rb
+++ b/spec/models/agent_bot_webhook_data_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rails_helper'
 
-# EVO-2250 story 2.4.
 RSpec.describe AgentBot do
   describe '#webhook_data' do
     # The hash reaches Message#webhook_data when a bot is the sender, and the

--- a/spec/models/ai/integration_credential_spec.rb
+++ b/spec/models/ai/integration_credential_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_integration_credentials_table')
+
+# EVO-2250 story 2.1 — the CRM-side read-only view over the vault.
+RSpec.describe Ai::IntegrationCredential do
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the
+  # per-example transaction.
+  before(:all) { EvoCoreIntegrationCredentialsTable.create! }
+  after(:all) { EvoCoreIntegrationCredentialsTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before { described_class.delete_all }
+
+  def register(name:, kind: 'static', scope: 'account', active: true, **extra)
+    described_class.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: name, provider: 'dify', kind: kind, scope: scope,
+        value: kind == 'static' ? 'ciphertext' : nil,
+        value_hint: kind == 'static' ? '4f2a' : nil,
+        is_active: active,
+        created_at: Time.current, updated_at: Time.current
+      }.merge(extra)]
+    )
+    described_class.find_by(name: name)
+  end
+
+  it 'is read-only — writes belong to the core service' do
+    credential = register(name: 'Dify prod')
+
+    expect(credential.readonly?).to be(true)
+    expect { credential.update!(name: 'Outro') }.to raise_error(ActiveRecord::ReadOnlyRecord)
+  end
+
+  it 'distinguishes static from oauth rows' do
+    static = register(name: 'Dify prod')
+    oauth = register(name: 'GitHub conn', kind: 'oauth',
+                     owner_store: 'agent_integration', owner_ref: 'abc')
+
+    expect(static).to be_static
+    expect(oauth).to be_oauth
+    expect(described_class.static_kind).to contain_exactly(static)
+    expect(described_class.oauth_kind).to contain_exactly(oauth)
+  end
+
+  it 'allows the same name in different scopes (UNIQUE is (scope, name))' do
+    register(name: 'Producao', scope: 'account')
+
+    expect { register(name: 'Producao', scope: 'installation') }.not_to raise_error
+    expect { register(name: 'Producao', scope: 'account') }
+      .to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it 'filters by activity and scope like the AI credential model' do
+    active = register(name: 'Ativa')
+    register(name: 'Inativa', active: false)
+
+    expect(described_class.active).to contain_exactly(active)
+    expect(described_class.for_scope('account')).to include(active)
+  end
+end

--- a/spec/models/ai/integration_credential_spec.rb
+++ b/spec/models/ai/integration_credential_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_integration_credentials_table')
 
-# EVO-2250 story 2.1 — the CRM-side read-only view over the vault.
+# the CRM-side read-only view over the vault.
 RSpec.describe Ai::IntegrationCredential do
   # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the
   # per-example transaction.
@@ -60,10 +60,9 @@ RSpec.describe Ai::IntegrationCredential do
     expect(described_class.for_scope('account')).to include(active)
   end
 
-  # EVO-2250 review (achado 11 do Guilherme, confirmado na auditoria do Gerente):
-  # o helper de spec criava a tabela SEM os CHECK das migrations Go, então a
-  # suíte rodava contra um schema onde a AC 2.1 "por construção" não existia.
-  # Estes exemplos falham se o helper voltar a omiti-los.
+  # The spec helper must mirror the CHECKs the Go migration creates, or the
+  # suite runs against a schema where "by construction" does not hold. These
+  # fail if the helper drops them again.
   describe 'the CHECK constraints the Go migration creates' do
     it 'rejects an unknown kind' do
       expect { register(name: 'Invalida', kind: 'nonsense') }

--- a/spec/models/ai/integration_credential_spec.rb
+++ b/spec/models/ai/integration_credential_spec.rb
@@ -59,4 +59,40 @@ RSpec.describe Ai::IntegrationCredential do
     expect(described_class.active).to contain_exactly(active)
     expect(described_class.for_scope('account')).to include(active)
   end
+
+  # EVO-2250 review (achado 11 do Guilherme, confirmado na auditoria do Gerente):
+  # o helper de spec criava a tabela SEM os CHECK das migrations Go, então a
+  # suíte rodava contra um schema onde a AC 2.1 "por construção" não existia.
+  # Estes exemplos falham se o helper voltar a omiti-los.
+  describe 'the CHECK constraints the Go migration creates' do
+    it 'rejects an unknown kind' do
+      expect { register(name: 'Invalida', kind: 'nonsense') }
+        .to raise_error(ActiveRecord::StatementInvalid, /kind_check/)
+    end
+
+    # NOT 'agency': that one is deliberately allowed in the test helper, because
+    # the FR2 guard specs insert it to prove the chain accepts a new link.
+    it 'rejects an unknown scope' do
+      expect { register(name: 'Invalida', scope: 'nonsense') }
+        .to raise_error(ActiveRecord::StatementInvalid, /scope_check/)
+    end
+
+    it 'rejects a static row without a value' do
+      expect { register(name: 'Sem valor', kind: 'static', value: nil) }
+        .to raise_error(ActiveRecord::StatementInvalid, /kind_content_check/)
+    end
+
+    # The whole point of the oauth kind: no token value ever lands in the vault.
+    it 'rejects an oauth row carrying a value' do
+      expect do
+        register(name: 'Com token', kind: 'oauth', value: 'ciphertext',
+                 owner_store: 'agent_integration', owner_ref: 'abc')
+      end.to raise_error(ActiveRecord::StatementInvalid, /kind_content_check/)
+    end
+
+    it 'rejects an oauth row without an owner reference' do
+      expect { register(name: 'Sem dono', kind: 'oauth') }
+        .to raise_error(ActiveRecord::StatementInvalid, /kind_content_check/)
+    end
+  end
 end

--- a/spec/services/agent_bots/credential_resolution_spec.rb
+++ b/spec/services/agent_bots/credential_resolution_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_integration_credentials_table')
 
-# EVO-2250 story 2.4.
-#
 # A channel bot may point at the integration credential vault instead of holding
 # its key inline. The inline `api_key` stays the fallback until story 2.7, so no
 # installation has to migrate for this to ship.
@@ -128,10 +126,9 @@ RSpec.describe AgentBots::CredentialResolution do
       expect(described_class.basic_auth_for(bot(credential_id: credential.id))).to be_nil
     end
 
-    # MÉDIO 12 of the review: `JSON.parse("12345")` returns an Integer, so
-    # `envelope['user']` raised TypeError OUTSIDE the JSON::ParserError rescue and
-    # took the n8n bot request down. A scalar secret is not an envelope — it is
-    # exactly what the colon convention handles.
+    # `JSON.parse("12345")` returns an Integer, so `envelope['user']` raises
+    # TypeError outside the JSON::ParserError rescue. A scalar secret is not an
+    # envelope — it is what the colon convention handles.
     it 'treats a scalar vault value as an inline key instead of raising' do
       credential = create_credential(value: 'ciphertext', value_format: 'composite')
 

--- a/spec/services/agent_bots/credential_resolution_spec.rb
+++ b/spec/services/agent_bots/credential_resolution_spec.rb
@@ -14,7 +14,15 @@ RSpec.describe AgentBots::CredentialResolution do
   after(:all) { EvoCoreIntegrationCredentialsTable.drop! }
   # rubocop:enable RSpec/BeforeAfterAll
 
-  before { Ai::IntegrationCredential.delete_all }
+  before do
+    Ai::IntegrationCredential.delete_all
+    # These examples exercise PRECEDENCE (vault vs inline), with the bot built in
+    # memory. The retirement gate is a separate axis, covered by
+    # spec/services/agent_bots/retirement_path_spec.rb: here the installation is
+    # declared NOT migrated so the inline fallback is reachable and the
+    # precedence assertions stay meaningful.
+    allow(Ai::IntegrationMigrationState).to receive(:migrated?).and_return(false)
+  end
 
   def create_credential(value:, kind: 'static', value_format: 'scalar', active: true)
     Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations

--- a/spec/services/agent_bots/credential_resolution_spec.rb
+++ b/spec/services/agent_bots/credential_resolution_spec.rb
@@ -127,5 +127,27 @@ RSpec.describe AgentBots::CredentialResolution do
 
       expect(described_class.basic_auth_for(bot(credential_id: credential.id))).to be_nil
     end
+
+    # MÉDIO 12 of the review: `JSON.parse("12345")` returns an Integer, so
+    # `envelope['user']` raised TypeError OUTSIDE the JSON::ParserError rescue and
+    # took the n8n bot request down. A scalar secret is not an envelope — it is
+    # exactly what the colon convention handles.
+    it 'treats a scalar vault value as an inline key instead of raising' do
+      credential = create_credential(value: 'ciphertext', value_format: 'composite')
+
+      ['12345', 'true', 'null', '"apenas-texto"'].each do |scalar|
+        allow(Ai::CredentialDecryptor).to receive(:decrypt).with('ciphertext').and_return(scalar)
+
+        expect { described_class.basic_auth_for(bot(credential_id: credential.id)) }
+          .not_to raise_error, "a scalar vault value (#{scalar}) crashed the bot request"
+      end
+    end
+
+    it 'still splits a scalar that carries the pair in the colon convention' do
+      credential = create_credential(value: 'ciphertext', value_format: 'composite')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).with('ciphertext').and_return('admin:s3nha')
+
+      expect(described_class.basic_auth_for(bot(credential_id: credential.id))).to eq(%w[admin s3nha])
+    end
   end
 end

--- a/spec/services/agent_bots/credential_resolution_spec.rb
+++ b/spec/services/agent_bots/credential_resolution_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_integration_credentials_table')
+
+# EVO-2250 story 2.4.
+#
+# A channel bot may point at the integration credential vault instead of holding
+# its key inline. The inline `api_key` stays the fallback until story 2.7, so no
+# installation has to migrate for this to ship.
+RSpec.describe AgentBots::CredentialResolution do
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
+  before(:all) { EvoCoreIntegrationCredentialsTable.create! }
+  after(:all) { EvoCoreIntegrationCredentialsTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before { Ai::IntegrationCredential.delete_all }
+
+  def create_credential(value:, kind: 'static', value_format: 'scalar', active: true)
+    Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: "cred-#{SecureRandom.hex(4)}",
+        provider: 'evo_ai',
+        kind: kind,
+        value: value,
+        value_format: value_format,
+        value_hint: 'abcd',
+        scope: 'account',
+        is_active: active,
+        owner_store: kind == 'oauth' ? 'agent_integration' : nil,
+        owner_ref: kind == 'oauth' ? SecureRandom.uuid : nil,
+        created_at: Time.current,
+        updated_at: Time.current
+      }]
+    )
+    Ai::IntegrationCredential.order(created_at: :desc).first
+  end
+
+  def bot(credential_id: nil, api_key: nil)
+    instance_double(AgentBot, credential_id: credential_id, api_key: api_key)
+  end
+
+  describe '.api_key_for' do
+    it 'returns the vault value when the bot references a credential' do
+      credential = create_credential(value: 'ciphertext')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).with('ciphertext').and_return('chave-do-cofre')
+
+      expect(described_class.api_key_for(bot(credential_id: credential.id))).to eq('chave-do-cofre')
+    end
+
+    it 'falls back to the inline key when there is no reference (AC2)' do
+      expect(Ai::CredentialDecryptor).not_to receive(:decrypt)
+
+      expect(described_class.api_key_for(bot(api_key: 'chave-inline'))).to eq('chave-inline')
+    end
+
+    it 'falls back to the inline key when the reference cannot be resolved (AC9)' do
+      expect(described_class.api_key_for(bot(credential_id: SecureRandom.uuid, api_key: 'chave-inline')))
+        .to eq('chave-inline')
+    end
+
+    it 'falls back when the referenced credential is inactive' do
+      credential = create_credential(value: 'ciphertext', active: false)
+
+      expect(described_class.api_key_for(bot(credential_id: credential.id, api_key: 'chave-inline')))
+        .to eq('chave-inline')
+    end
+
+    # An oauth credential holds no value: the vault points at the store that owns
+    # the token instead of copying it.
+    it 'falls back when the referenced credential is oauth' do
+      credential = create_credential(value: nil, kind: 'oauth')
+
+      expect(described_class.api_key_for(bot(credential_id: credential.id, api_key: 'chave-inline')))
+        .to eq('chave-inline')
+    end
+
+    it 'returns nil when neither the reference nor an inline key resolves' do
+      expect(described_class.api_key_for(bot(credential_id: SecureRandom.uuid))).to be_nil
+    end
+
+    it 'never falls through to another credential of the same provider' do
+      other = create_credential(value: 'ciphertext-de-outro')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).and_return('chave-de-outro')
+
+      # A reference that does not resolve must not silently pick a different
+      # credential: the bot was configured with one specific secret.
+      expect(described_class.api_key_for(bot(credential_id: SecureRandom.uuid))).to be_nil
+      expect(other).to be_present
+    end
+  end
+
+  describe '.basic_auth_for (n8n)' do
+    # The stored shape changed, the wire format did not: what has to stay
+    # identical is the byte that goes out in the Authorization header.
+    it 'builds the same pair a colon-separated inline key builds today' do
+      credential = create_credential(value: 'ciphertext', value_format: 'composite')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt)
+        .with('ciphertext').and_return('{"user":"admin","password":"s3nha"}')
+
+      from_vault = described_class.basic_auth_for(bot(credential_id: credential.id))
+      from_inline = described_class.basic_auth_for(bot(api_key: 'admin:s3nha'))
+
+      expect(from_vault).to eq(%w[admin s3nha])
+      expect(from_vault).to eq(from_inline)
+    end
+
+    it 'keeps the inline colon split when there is no reference' do
+      expect(described_class.basic_auth_for(bot(api_key: 'admin:s3nha'))).to eq(%w[admin s3nha])
+    end
+
+    it 'returns nil when the inline key has no colon (it is an api key, not basic auth)' do
+      expect(described_class.basic_auth_for(bot(api_key: 'chave-sem-dois-pontos'))).to be_nil
+    end
+
+    it 'returns nil for a composite envelope that has no usable pair' do
+      credential = create_credential(value: 'ciphertext', value_format: 'composite')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).with('ciphertext').and_return('nao-e-json')
+
+      expect(described_class.basic_auth_for(bot(credential_id: credential.id))).to be_nil
+    end
+  end
+end

--- a/spec/services/agent_bots/media_type_detector_spec.rb
+++ b/spec/services/agent_bots/media_type_detector_spec.rb
@@ -5,19 +5,19 @@ require 'rails_helper'
 RSpec.describe AgentBots::MediaTypeDetector do
   describe '.detect' do
     {
-      'https://x/v.mp4'           => 'video',
-      'https://x/v.MP4'           => 'video',
+      'https://x/v.mp4' => 'video',
+      'https://x/v.MP4' => 'video',
       'https://x/v.mp4?token=abc' => 'video', # querystring ignored
-      'https://x/v.mov#t=10'      => 'video',
-      'https://x/pic.jpg'         => 'image',
-      'https://x/pic.png'         => 'image',
-      'https://x/song.mp3'        => 'audio',
-      'https://x/doc.pdf'         => 'document',
-      'https://x/sheet.xlsx'      => 'document',
-      'https://site.com/page'     => 'text', # no extension
-      'https://site.com/p.html'   => 'text', # not media
-      ''                          => 'text',
-      nil                         => 'text'
+      'https://x/v.mov#t=10' => 'video',
+      'https://x/pic.jpg' => 'image',
+      'https://x/pic.png' => 'image',
+      'https://x/song.mp3' => 'audio',
+      'https://x/doc.pdf' => 'document',
+      'https://x/sheet.xlsx' => 'document',
+      'https://site.com/page' => 'text', # no extension
+      'https://site.com/p.html' => 'text', # not media
+      '' => 'text',
+      nil => 'text'
     }.each do |url, expected|
       it "classifies #{url.inspect} as #{expected}" do
         expect(described_class.detect(url)).to eq(expected)

--- a/spec/services/agent_bots/remote_media_attacher_spec.rb
+++ b/spec/services/agent_bots/remote_media_attacher_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe AgentBots::RemoteMediaAttacher do
 
       message = Message.new(inbox: inbox, conversation: conversation, message_type: 'outgoing', content: 'x')
       described_class.build_attachments(message, [
-                                         { url: 'https://x.com/bad.mp4', file_type: 'video' },
-                                         { url: 'https://x.com/pic.jpg', file_type: 'image' }
-                                       ])
+                                          { url: 'https://x.com/bad.mp4', file_type: 'video' },
+                                          { url: 'https://x.com/pic.jpg', file_type: 'image' }
+                                        ])
       message.save!
       # only the good one survived
       expect(message.reload.attachments.pluck(:file_type)).to eq(['image'])

--- a/spec/services/agent_bots/retirement_path_spec.rb
+++ b/spec/services/agent_bots/retirement_path_spec.rb
@@ -3,15 +3,9 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_integration_credentials_table')
 
-# EVO-2250, review of 2026-07-29 (blocker 3 + finding 10).
-#
-# The 2.7 retirement was cosmetic: the UI hid the field while the runtime kept
-# reading `agent_bots.api_key` unconditionally, and `Ai::IntegrationMigrationState`
-# — the guard ACs 3 and 4 require — had ZERO production callers.
-#
-# These are PATH tests: they go through `AgentBots::CredentialResolution`, the
-# function the six consumption points actually call, and assert on what comes out
-# for each guard state. A test over the guard alone is what let this ship.
+# PATH tests: they go through `AgentBots::CredentialResolution`, the function the
+# six consumption points actually call, and assert what comes out for each guard
+# state. Testing the guard alone proves nothing about the runtime reading it.
 # rubocop:disable RSpec/DescribeClass -- this covers a PATH across the guard and the resolver, not one class
 RSpec.describe 'Agent bot inline retirement path' do
   # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.

--- a/spec/services/agent_bots/retirement_path_spec.rb
+++ b/spec/services/agent_bots/retirement_path_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_integration_credentials_table')
+
+# EVO-2250, review of 2026-07-29 (blocker 3 + finding 10).
+#
+# The 2.7 retirement was cosmetic: the UI hid the field while the runtime kept
+# reading `agent_bots.api_key` unconditionally, and `Ai::IntegrationMigrationState`
+# — the guard ACs 3 and 4 require — had ZERO production callers.
+#
+# These are PATH tests: they go through `AgentBots::CredentialResolution`, the
+# function the six consumption points actually call, and assert on what comes out
+# for each guard state. A test over the guard alone is what let this ship.
+# rubocop:disable RSpec/DescribeClass -- this covers a PATH across the guard and the resolver, not one class
+RSpec.describe 'Agent bot inline retirement path' do
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
+  before(:all) { EvoCoreIntegrationCredentialsTable.create! }
+  after(:all) { EvoCoreIntegrationCredentialsTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before do
+    Ai::IntegrationCredential.delete_all
+    AgentBot.delete_all
+  end
+
+  let(:bot) do
+    AgentBot.create!(name: "bot-#{SecureRandom.hex(3)}", bot_provider: 'evo_ai_provider',
+                     api_key: 'chave-inline', outgoing_url: 'https://exemplo.test/hook')
+  end
+
+  describe 'while the installation has NOT migrated' do
+    it 'still uses the inline key, so nothing goes dark before the migration runs' do
+      bot # the bot must exist before the guard is asked: it IS the legacy source
+      expect(Ai::IntegrationMigrationState.migrated?).to be(false)
+
+      expect(AgentBots::CredentialResolution.api_key_for(bot)).to eq('chave-inline')
+    end
+  end
+
+  describe 'once the installation HAS migrated' do
+    before do
+      # The 2.6 task ran: a credential carries `imported_from`.
+      Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+        [{
+          name: 'Migrada', provider: 'evo_ai', kind: 'static', value: 'cipher',
+          value_format: 'scalar', value_hint: 'abcd', scope: 'account', is_active: true,
+          imported_from: 'integration:sha256:abc', created_at: Time.current, updated_at: Time.current
+        }]
+      )
+    end
+
+    # The whole point of AC2: the inline value stops being read.
+    it 'ignores the inline key even though the column still holds it' do
+      expect(Ai::IntegrationMigrationState.migrated?).to be(true)
+
+      expect(AgentBots::CredentialResolution.api_key_for(bot)).to be_nil
+    end
+
+    it 'uses the vault credential the bot references' do
+      credential = Ai::IntegrationCredential.first
+      AgentBot.where(id: bot.id).update_all(credential_id: credential.id) # rubocop:disable Rails/SkipsModelValidations
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).with('cipher').and_return('chave-do-cofre')
+
+      expect(AgentBots::CredentialResolution.api_key_for(bot.reload)).to eq('chave-do-cofre')
+    end
+  end
+
+  # Finding 10: the guard only inspected AgentBot, so an installation whose
+  # inline secret lives in a Dify integration and has no bots answered
+  # "migrated" — and retiring the inline read there is a fail-open that leaves
+  # the agent authenticating with nothing.
+  describe 'the guard sees every store the 2.6 migration touches' do
+    before { AgentBot.delete_all }
+
+    it 'is not migrated while an agent integration still holds an inline secret' do
+      require Rails.root.join('spec/support/evo_core_agent_integrations_table')
+      EvoCoreAgentIntegrationsTable.create!
+      Ai::AgentIntegration.delete_all
+      Ai::AgentIntegration.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+        [{
+          agent_id: SecureRandom.uuid, provider: 'dify',
+          config: { 'apiKey' => 'app-dify-inline' },
+          created_at: Time.current, updated_at: Time.current
+        }]
+      )
+
+      expect(Ai::IntegrationMigrationState.migrated?).to be(false),
+                                                         'an inline Dify secret was ignored: retiring here authenticates with nothing'
+    ensure
+      Ai::AgentIntegration.delete_all
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/services/agent_bots/retirement_path_spec.rb
+++ b/spec/services/agent_bots/retirement_path_spec.rb
@@ -15,8 +15,19 @@ require Rails.root.join('spec/support/evo_core_integration_credentials_table')
 # rubocop:disable RSpec/DescribeClass -- this covers a PATH across the guard and the resolver, not one class
 RSpec.describe 'Agent bot inline retirement path' do
   # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
-  before(:all) { EvoCoreIntegrationCredentialsTable.create! }
-  after(:all) { EvoCoreIntegrationCredentialsTable.drop! }
+  before(:all) do
+    EvoCoreIntegrationCredentialsTable.create!
+    require Rails.root.join('spec/support/evo_core_agent_integrations_table')
+    EvoCoreAgentIntegrationsTable.create!
+  end
+
+  # Dropped, not just emptied: leaving the table behind changed what
+  # Ai::IntegrationMigrationState saw in OTHER spec files, which is a test-order
+  # dependency and not a real defect of the guard.
+  after(:all) do
+    EvoCoreAgentIntegrationsTable.drop!
+    EvoCoreIntegrationCredentialsTable.drop!
+  end
   # rubocop:enable RSpec/BeforeAfterAll
 
   before do
@@ -74,8 +85,6 @@ RSpec.describe 'Agent bot inline retirement path' do
     before { AgentBot.delete_all }
 
     it 'is not migrated while an agent integration still holds an inline secret' do
-      require Rails.root.join('spec/support/evo_core_agent_integrations_table')
-      EvoCoreAgentIntegrationsTable.create!
       Ai::AgentIntegration.delete_all
       Ai::AgentIntegration.insert_all!( # rubocop:disable Rails/SkipsModelValidations
         [{

--- a/spec/services/ai/consumer_compatibility_spec.rb
+++ b/spec/services/ai/consumer_compatibility_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-# EVO-2250 stories 1.3 and 1.4 — every AI feature is registered here, and the
+# Every AI feature is registered here, and the
 # resolver reads this map instead of each consumer carrying its own rule.
 RSpec.describe Ai::ConsumerCompatibility do
   it 'registers the five AI features of the CRM' do

--- a/spec/services/ai/consumer_compatibility_spec.rb
+++ b/spec/services/ai/consumer_compatibility_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250 stories 1.3 and 1.4 — every AI feature is registered here, and the
+# resolver reads this map instead of each consumer carrying its own rule.
+RSpec.describe Ai::ConsumerCompatibility do
+  it 'registers the five AI features of the CRM' do
+    expect(described_class::CONSUMERS.keys).to contain_exactly(
+      :ai_agents, :inbox_assist, :audio_transcription, :label_suggestion, :moderation
+    )
+  end
+
+  it 'lets AI Agents use every provider' do
+    expect(described_class.accepted_providers(:ai_agents)).to eq(described_class::ALL_PROVIDERS)
+    expect(described_class.accepts?(:ai_agents, 'anthropic')).to be(true)
+    expect(described_class.accepts?(:ai_agents, 'gemini')).to be(true)
+  end
+
+  # These four build an OpenAI-shaped request (chat/completions, or Whisper for
+  # transcription). A non-OpenAI provider there is a different protocol, not a
+  # misconfiguration, so it must never reach the wire.
+  %i[inbox_assist audio_transcription label_suggestion moderation].each do |consumer|
+    it "restricts #{consumer} to OpenAI-compatible providers" do
+      expect(described_class.accepts?(consumer, 'openai')).to be(true)
+      expect(described_class.accepts?(consumer, 'azure')).to be(true)
+      expect(described_class.accepts?(consumer, 'custom')).to be(true)
+
+      expect(described_class.accepts?(consumer, 'anthropic')).to be(false)
+      expect(described_class.accepts?(consumer, 'gemini')).to be(false)
+      expect(described_class.accepts?(consumer, 'bedrock')).to be(false)
+    end
+  end
+
+  it 'rejects an unknown consumer instead of guessing' do
+    expect(described_class.known?(:not_a_feature)).to be(false)
+    expect(described_class.accepts?(:not_a_feature, 'openai')).to be(false)
+  end
+
+  it 'accepts string or symbol consumers' do
+    expect(described_class.known?('inbox_assist')).to be(true)
+    expect(described_class.accepts?('inbox_assist', 'openai')).to be(true)
+  end
+end

--- a/spec/services/ai/credential_decryptor_spec.rb
+++ b/spec/services/ai/credential_decryptor_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250 story 1.3.
+#
+# These ciphertexts were produced by the GO side (github.com/fernet/fernet-go),
+# the service that owns the encryption, using the key below. They are frozen
+# fixtures on purpose: they prove cross-language compatibility, which a
+# Ruby-encrypted fixture could never do.
+RSpec.describe Ai::CredentialDecryptor do
+  # Same default as EVO_AI_ENCRYPTION_KEY in docker-compose.ecosystem.yml.
+  let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
+
+  # Encrypted by Go with the key above.
+  let(:go_ciphertext) do
+    'gAAAAABqagvYo5FEA9quumGpPOgNwZMRVyKb5uFhsibgflYMUC5vdSCbbEdvdV4etg3_' \
+      'CtQekqXPOtsIESs2aRluGJrCNy9rAxpiusgJdRoQ0EdVJIjsSdY='
+  end
+  let(:go_plaintext) { 'sk-proj-real-secret-4f2a' }
+
+  # Same, but with a timestamp 25 hours in the past. The Ruby gem enforces a
+  # 60-second TTL by default while Go verifies with ttl=0, so this token is the
+  # regression guard: without enforce_ttl=false every credential older than a
+  # minute stops decrypting, in a job, silently.
+  let(:go_old_ciphertext) do
+    'gAAAAABqaKxgdFGfOo82ClGYuQ6QNxXDFUEpYc7PuCyssn42tgUcPXg-ruxzyWrO4zgc' \
+      '6TNbUpo_1HcufS_dZQRU3aGCRuMOulnCh6fTCCcLRnj5B_RCK58='
+  end
+  let(:go_old_plaintext) { 'sk-proj-old-secret-91bc' }
+
+  around do |example|
+    original = ENV.fetch('EVO_AI_ENCRYPTION_KEY', nil)
+    ENV['EVO_AI_ENCRYPTION_KEY'] = fernet_key
+    example.run
+    ENV['EVO_AI_ENCRYPTION_KEY'] = original
+  end
+
+  it 'decrypts a credential encrypted by the Go service' do
+    expect(described_class.decrypt(go_ciphertext)).to eq(go_plaintext)
+  end
+
+  it 'decrypts a credential older than the gem default TTL' do
+    # Fails with the gem's default 60s TTL. Remove enforce_ttl=false and this
+    # is the example that catches it.
+    expect(described_class.decrypt(go_old_ciphertext)).to eq(go_old_plaintext)
+  end
+
+  it 'returns nil for a blank value instead of raising' do
+    expect(described_class.decrypt(nil)).to be_nil
+    expect(described_class.decrypt('')).to be_nil
+  end
+
+  it 'returns nil for a tampered token' do
+    expect(described_class.decrypt("#{go_ciphertext}tampered")).to be_nil
+  end
+
+  it 'returns nil for a token encrypted with another key' do
+    other_key = Base64.urlsafe_encode64(OpenSSL::Random.random_bytes(32))
+    token = Fernet.generate(other_key, 'sk-other')
+
+    expect(described_class.decrypt(token)).to be_nil
+  end
+
+  it 'returns nil, without raising, when the key is not configured' do
+    ENV['EVO_AI_ENCRYPTION_KEY'] = nil
+
+    expect { described_class.decrypt(go_ciphertext) }.not_to raise_error
+    expect(described_class.decrypt(go_ciphertext)).to be_nil
+  end
+
+  it 'does not read the InstallationConfig encryption key' do
+    # ENV['ENCRYPTION_KEY'] holds a different secret; reading it here would
+    # decrypt nothing and tempt someone to overwrite the installation key.
+    expect(described_class::ENCRYPTION_KEY_ENV).to eq('EVO_AI_ENCRYPTION_KEY')
+  end
+end

--- a/spec/services/ai/credential_decryptor_spec.rb
+++ b/spec/services/ai/credential_decryptor_spec.rb
@@ -2,8 +2,6 @@
 
 require 'rails_helper'
 
-# EVO-2250 story 1.3.
-#
 # These ciphertexts were produced by the GO side (github.com/fernet/fernet-go),
 # the service that owns the encryption, using the key below. They are frozen
 # fixtures on purpose: they prove cross-language compatibility, which a

--- a/spec/services/ai/credential_encryptor_spec.rb
+++ b/spec/services/ai/credential_encryptor_spec.rb
@@ -2,8 +2,6 @@
 
 require 'rails_helper'
 
-# EVO-2250 story 1.5.
-#
 # The migration writes credentials from Ruby that the Go core and the Python
 # processor must read. Story 1.3 proved Go → Ruby; this proves the direction the
 # migration actually depends on.

--- a/spec/services/ai/credential_encryptor_spec.rb
+++ b/spec/services/ai/credential_encryptor_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250 story 1.5.
+#
+# The migration writes credentials from Ruby that the Go core and the Python
+# processor must read. Story 1.3 proved Go → Ruby; this proves the direction the
+# migration actually depends on.
+RSpec.describe Ai::CredentialEncryptor do
+  let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
+
+  around do |example|
+    original = ENV.fetch('EVO_AI_ENCRYPTION_KEY', nil)
+    ENV['EVO_AI_ENCRYPTION_KEY'] = fernet_key
+    example.run
+    ENV['EVO_AI_ENCRYPTION_KEY'] = original
+  end
+
+  describe '.encrypt' do
+    it 'produces a token this codebase can read back' do
+      token = described_class.encrypt('sk-migrated-secret-7c3d')
+
+      expect(Ai::CredentialDecryptor.decrypt(token)).to eq('sk-migrated-secret-7c3d')
+    end
+
+    # The Go handler verifies with ttl=0 and the Fernet spec is byte-compatible
+    # across implementations. This asserts the token SHAPE the Go side requires:
+    # version byte 0x80, urlsafe base64. A token failing this would be written by
+    # the migration and rejected by every consumer.
+    it 'emits a spec-compliant Fernet token (version 0x80, urlsafe base64)' do
+      token = described_class.encrypt('sk-migrated-secret-7c3d')
+      raw = Base64.urlsafe_decode64(token)
+
+      expect(raw.bytes.first).to eq(0x80)
+      expect(token).to match(/\A[A-Za-z0-9_-]+=*\z/)
+      # 1 version + 8 timestamp + 16 IV + ciphertext + 32 HMAC
+      expect(raw.bytesize).to be > 57
+    end
+
+    it 'produces a different token each time for the same plaintext' do
+      # Fernet embeds a random IV; identical ciphertexts would signal a broken
+      # implementation, not a cache.
+      first = described_class.encrypt('sk-same-secret')
+      second = described_class.encrypt('sk-same-secret')
+
+      expect(first).not_to eq(second)
+      expect(Ai::CredentialDecryptor.decrypt(first)).to eq('sk-same-secret')
+      expect(Ai::CredentialDecryptor.decrypt(second)).to eq('sk-same-secret')
+    end
+
+    it 'returns nil for blank input' do
+      expect(described_class.encrypt(nil)).to be_nil
+      expect(described_class.encrypt('')).to be_nil
+    end
+
+    it 'returns nil, without raising, when the key is not configured' do
+      ENV['EVO_AI_ENCRYPTION_KEY'] = nil
+
+      expect { described_class.encrypt('sk-whatever') }.not_to raise_error
+      expect(described_class.encrypt('sk-whatever')).to be_nil
+    end
+  end
+
+  describe '.key_hint' do
+    it 'takes the last four characters, like the Go DeriveKeyHint' do
+      expect(described_class.key_hint('sk-proj-abcdef1234f2a')).to eq('4f2a')
+      expect(described_class.key_hint('ab12')).to eq('ab12')
+      expect(described_class.key_hint('ab')).to eq('ab')
+      expect(described_class.key_hint('')).to eq('')
+      expect(described_class.key_hint(nil)).to eq('')
+    end
+
+    it 'counts characters, not bytes' do
+      expect(described_class.key_hint('sk-chave-ção')).to eq('-ção')
+    end
+  end
+end

--- a/spec/services/ai/credential_migration_overflow_spec.rb
+++ b/spec/services/ai/credential_migration_overflow_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_api_keys_table')
+
+# Adversarial review of story 1.5 (EVO-2250).
+RSpec.describe Ai::CredentialMigration do
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
+  before(:all) { EvoCoreApiKeysTable.create! }
+  after(:all) { EvoCoreApiKeysTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before do
+    Ai::Credential.delete_all
+    Integrations::Hook.delete_all
+    InstallationConfig.find_by(name: 'OPENAI_API_SECRET')&.destroy!
+    GlobalConfig.clear_cache
+    allow(Ai::CredentialDecryptor).to receive(:encryption_key).and_return(fernet_key)
+  end
+
+  let(:fernet_key) { 'cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4=' }
+
+  # `imported_from` is VARCHAR(64) (migration 000018). A hook source built from a
+  # real uuid is 62 chars, and the ":original" variant is 71: on any install with
+  # BOTH a global key and a hook, the migration used to insert the account row and
+  # then blow up on the inactive one, leaving a partial write behind.
+  it 'keeps every import source within the column limit' do
+    hook = Integrations::Hook.create!(app_id: 'openai', status: 'enabled', settings: { 'api_key' => 'sk-do-hook' })
+
+    sources = [
+      described_class::INSTALLATION_SOURCE,
+      "#{described_class::HOOK_SOURCE_PREFIX}#{hook.id}",
+      "#{described_class::HOOK_SOURCE_PREFIX}#{hook.id}:original"
+    ]
+
+    sources.each do |source|
+      expect(source.length).to be <= 64, "import source #{source.inspect} has #{source.length} chars, column holds 64"
+    end
+  end
+
+  it 'imports a global key plus a hook without raising' do
+    InstallationConfig.create!(name: 'OPENAI_API_SECRET', value: 'sk-global', locked: false)
+    GlobalConfig.clear_cache
+    Integrations::Hook.create!(app_id: 'openai', status: 'enabled', settings: { 'api_key' => 'sk-do-hook' })
+
+    expect { described_class.call(apply: true) }.not_to raise_error
+
+    # Both the promoted account row and the preserved original must land.
+    expect(Ai::Credential.where.not(imported_from: nil).count).to eq(3)
+  end
+
+  # A partial write is worse than no write: it flips MigrationState to "migrated"
+  # and the 1.6 guard then removes the legacy fallback for consumers whose
+  # credential never made it into the registry.
+  it 'writes nothing when an import fails midway' do
+    InstallationConfig.create!(name: 'OPENAI_API_SECRET', value: 'sk-global', locked: false)
+    GlobalConfig.clear_cache
+    Integrations::Hook.create!(app_id: 'openai', status: 'enabled', settings: { 'api_key' => 'sk-do-hook' })
+
+    # The installation row imports fine; the hook import then blows up.
+    call_count = 0
+    allow(Ai::CredentialEncryptor).to receive(:encrypt).and_wrap_original do |original, *args|
+      call_count += 1
+      raise ActiveRecord::ValueTooLong, 'boom' if call_count > 1
+
+      original.call(*args)
+    end
+
+    expect { described_class.call(apply: true) }.to raise_error(ActiveRecord::ValueTooLong)
+    expect(Ai::Credential.count).to eq(0), 'a partial write survived and would flip the migration guard'
+  end
+end

--- a/spec/services/ai/credential_migration_overflow_spec.rb
+++ b/spec/services/ai/credential_migration_overflow_spec.rb
@@ -69,4 +69,44 @@ RSpec.describe Ai::CredentialMigration do
     expect { described_class.call(apply: true) }.to raise_error(ActiveRecord::ValueTooLong)
     expect(Ai::Credential.count).to eq(0), 'a partial write survived and would flip the migration guard'
   end
+
+  # ALTO 6 of the review: the gate disarmed itself.
+  #
+  # `effective_after` returned `existing_registry_key` whenever ANY active
+  # credential existed — literally the same call as `before_key` — so no row
+  # could ever report DIVERGE. And the migration still inserts an `account` row,
+  # which OUTRANKS an installation credential a human had registered: the
+  # effective key changes while the report says OK. That is exactly the NFR the
+  # gate exists to prove.
+  describe 'the gate with a pre-existing human credential' do
+    before do
+      EvoCoreApiKeysTable.create!
+      Ai::Credential.delete_all
+      Ai::Credential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+        [{
+          name: 'Cadastrada por humano', provider: 'openai',
+          key: Ai::CredentialEncryptor.encrypt('sk-do-humano'),
+          key_hint: 'mano', scope: 'installation', is_active: true,
+          created_at: Time.current, updated_at: Time.current
+        }]
+      )
+    end
+
+    it 'aborts instead of letting an imported account row outrank it' do
+      Integrations::Hook.create!(app_id: 'openai', status: 'enabled',
+                                 settings: { 'api_key' => 'sk-do-hook' })
+
+      expect { described_class.call(apply: true) }
+        .to raise_error(described_class::AbortedError)
+
+      expect(Ai::Credential.where.not(imported_from: nil).count).to eq(0),
+                                                                    'the import wrote despite changing the effective key'
+    end
+
+    # The complement: with nothing to import the gate must not invent a
+    # divergence and block a legitimate no-op run.
+    it 'does not abort when there is nothing to import' do
+      expect { described_class.call(apply: true) }.not_to raise_error
+    end
+  end
 end

--- a/spec/services/ai/credential_migration_overflow_spec.rb
+++ b/spec/services/ai/credential_migration_overflow_spec.rb
@@ -109,4 +109,44 @@ RSpec.describe Ai::CredentialMigration do
       expect { described_class.call(apply: true) }.not_to raise_error
     end
   end
+
+  # 1.5 AC1: the custom OPENAI_API_URL must be preserved ALONGSIDE the credential.
+  # There was nowhere to put it until the core added the column (ae28fcd), so the
+  # value the admin had configured was dropped on import.
+  describe 'the custom base URL travels with the credential (AC1)' do
+    before { Ai::Credential.delete_all }
+
+    it 'stores a custom endpoint on the imported credential' do
+      InstallationConfig.create!(name: 'OPENAI_API_SECRET', value: 'sk-global', locked: false)
+      InstallationConfig.create!(name: 'OPENAI_API_URL', value: 'https://llm.interno.test/v1', locked: false)
+      GlobalConfig.clear_cache
+
+      described_class.call(apply: true)
+
+      credential = Ai::Credential.find_by(scope: 'installation')
+      expect(credential.base_url).to eq('https://llm.interno.test/v1')
+    end
+
+    # Stamping the public default on every install would be noise: NULL already
+    # means "the provider default", which is what every pre-existing credential
+    # meant.
+    it 'leaves the column null when the endpoint is the public default' do
+      InstallationConfig.create!(name: 'OPENAI_API_SECRET', value: 'sk-global', locked: false)
+      InstallationConfig.create!(name: 'OPENAI_API_URL', value: 'https://api.openai.com/v1', locked: false)
+      GlobalConfig.clear_cache
+
+      described_class.call(apply: true)
+
+      expect(Ai::Credential.find_by(scope: 'installation').base_url).to be_nil
+    end
+
+    it 'leaves the column null when no custom endpoint is configured' do
+      InstallationConfig.create!(name: 'OPENAI_API_SECRET', value: 'sk-global', locked: false)
+      GlobalConfig.clear_cache
+
+      described_class.call(apply: true)
+
+      expect(Ai::Credential.find_by(scope: 'installation').base_url).to be_nil
+    end
+  end
 end

--- a/spec/services/ai/credential_migration_overflow_spec.rb
+++ b/spec/services/ai/credential_migration_overflow_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_api_keys_table')
 
-# Adversarial review of story 1.5 (EVO-2250).
 RSpec.describe Ai::CredentialMigration do
   # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
   before(:all) { EvoCoreApiKeysTable.create! }
@@ -70,7 +69,7 @@ RSpec.describe Ai::CredentialMigration do
     expect(Ai::Credential.count).to eq(0), 'a partial write survived and would flip the migration guard'
   end
 
-  # ALTO 6 of the review: the gate disarmed itself.
+  # the gate disarmed itself.
   #
   # `effective_after` returned `existing_registry_key` whenever ANY active
   # credential existed — literally the same call as `before_key` — so no row

--- a/spec/services/ai/credential_migration_spec.rb
+++ b/spec/services/ai/credential_migration_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_api_keys_table')
+
+# EVO-2250 story 1.5 — the migration exists to NOT change which key is in use.
+RSpec.describe Ai::CredentialMigration do
+  let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
+  let(:silent_logger) { Logger.new(File::NULL) }
+
+  # rubocop:disable RSpec/BeforeAfterAll -- creating the table is DDL, which
+  # cannot run inside the per-example transaction. Shared helper so every spec
+  # agrees on the column set.
+  before(:all) { EvoCoreApiKeysTable.create! }
+  after(:all) { EvoCoreApiKeysTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  around do |example|
+    original = ENV.fetch('EVO_AI_ENCRYPTION_KEY', nil)
+    ENV['EVO_AI_ENCRYPTION_KEY'] = fernet_key
+    example.run
+    ENV['EVO_AI_ENCRYPTION_KEY'] = original
+  end
+
+  before do
+    Ai::Credential.delete_all
+    allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return(nil)
+    allow(GlobalConfigService).to receive(:load).with('OPENAI_API_URL', nil).and_return(nil)
+    allow(Integrations::Hook).to receive(:where).with(app_id: 'openai').and_return([])
+    allow(Integrations::Hook).to receive(:find_by).with(app_id: 'openai').and_return(nil)
+  end
+
+  def with_global_key(key, api_url: nil)
+    allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return(key)
+    allow(GlobalConfigService).to receive(:load).with('OPENAI_API_URL', nil).and_return(api_url)
+  end
+
+  def with_hook(key, id: SecureRandom.uuid)
+    hook = instance_double(Integrations::Hook, id: id, enabled?: true,
+                                               settings: { 'api_key' => key })
+    allow(Integrations::Hook).to receive(:where).with(app_id: 'openai').and_return([hook])
+    allow(Integrations::Hook).to receive(:find_by).with(app_id: 'openai').and_return(hook)
+    hook
+  end
+
+  def run(apply: false)
+    described_class.call(apply: apply, logger: silent_logger)
+  end
+
+  describe 'dry run writes nothing (AC7)' do
+    it 'reports without creating credentials' do
+      with_global_key('sk-global-1111')
+
+      expect { run(apply: false) }.not_to change(Ai::Credential, :count).from(0)
+    end
+  end
+
+  describe 'installation level (AC1)' do
+    it 'imports the global key as an installation credential' do
+      with_global_key('sk-global-1111')
+      run(apply: true)
+
+      credential = Ai::Credential.find_by(scope: 'installation')
+      expect(credential).to be_present
+      expect(credential.name).to eq(described_class::INSTALLATION_NAME)
+      expect(Ai::CredentialDecryptor.decrypt(credential.key)).to eq('sk-global-1111')
+      expect(credential.key_hint).to eq('1111')
+    end
+
+    it 'marks a custom base URL as a non-stock provider' do
+      with_global_key('sk-global-1111', api_url: 'https://llm.interno.example/v1')
+      run(apply: true)
+
+      expect(Ai::Credential.find_by(scope: 'installation').provider).to eq('custom_openai_compatible')
+    end
+
+    it 'keeps stock OpenAI when the URL points at api.openai.com' do
+      with_global_key('sk-global-1111', api_url: 'https://api.openai.com/v1')
+      run(apply: true)
+
+      expect(Ai::Credential.find_by(scope: 'installation').provider).to eq('openai')
+    end
+  end
+
+  describe 'account level (AC2)' do
+    it 'imports the hook key as an account credential when there is no global key' do
+      with_hook('sk-hook-2222')
+      run(apply: true)
+
+      credential = Ai::Credential.find_by(scope: 'account')
+      expect(Ai::CredentialDecryptor.decrypt(credential.key)).to eq('sk-hook-2222')
+    end
+  end
+
+  # The heart of the story: the precedence inverts, so a naive per-level import
+  # would swap the key in use.
+  describe 'both sources present — the winner must not change (AC3, NFR1)' do
+    before { with_global_key('sk-global-1111') }
+
+    it 'gives the account credential the GLOBAL value, not the hook one' do
+      with_hook('sk-hook-2222')
+      run(apply: true)
+
+      account = Ai::Credential.active.find_by(scope: 'account')
+      # Naively importing hook → account would make 'sk-hook-2222' win, which is
+      # ignored today. That is the bug this story exists to prevent.
+      expect(Ai::CredentialDecryptor.decrypt(account.key)).to eq('sk-global-1111')
+    end
+
+    it 'keeps the hook key as an inactive credential instead of discarding it' do
+      with_hook('sk-hook-2222')
+      run(apply: true)
+
+      inactive = Ai::Credential.where(is_active: false).first
+      expect(inactive).to be_present
+      expect(Ai::CredentialDecryptor.decrypt(inactive.key)).to eq('sk-hook-2222')
+    end
+
+    it 'records the promotion in the report' do
+      with_hook('sk-hook-2222')
+      rows = run(apply: false)
+
+      expect(rows.map(&:origin)).to include(/promovida para o escopo conta/)
+    end
+
+    it 'resolves to the same key after the migration as before it' do
+      hook = with_hook('sk-hook-2222')
+      before_key = Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist, legacy_hook: hook)
+      run(apply: true)
+      after_key = Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist, legacy_hook: hook)
+
+      expect(after_key).to eq(before_key)
+      expect(after_key).to eq('sk-global-1111')
+    end
+
+    it 'does not create a redundant inactive row when both values are equal' do
+      with_hook('sk-global-1111')
+      run(apply: true)
+
+      expect(Ai::Credential.where(is_active: false).count).to eq(0)
+    end
+  end
+
+  describe 'nothing configured (AC5)' do
+    it 'finishes without writing and without raising' do
+      expect { run(apply: true) }.not_to raise_error
+      expect(Ai::Credential.count).to eq(0)
+    end
+  end
+
+  describe 'idempotency (AC4)' do
+    it 'creates nothing new on a second run' do
+      with_global_key('sk-global-1111')
+      with_hook('sk-hook-2222')
+      run(apply: true)
+      count_after_first = Ai::Credential.count
+
+      run(apply: true)
+
+      expect(Ai::Credential.count).to eq(count_after_first)
+    end
+
+    it 'does not revert a human rename or deactivation' do
+      with_global_key('sk-global-1111')
+      run(apply: true)
+      Ai::Credential.where(scope: 'installation')
+                    .update_all(name: 'Renomeada pelo admin', is_active: false) # rubocop:disable Rails/SkipsModelValidations
+
+      run(apply: true)
+
+      credential = Ai::Credential.find_by(imported_from: described_class::INSTALLATION_SOURCE)
+      expect(credential.name).to eq('Renomeada pelo admin')
+      expect(credential.is_active).to be(false)
+    end
+  end
+
+  describe 'the report is a gate, not a log (AC7)' do
+    it 'aborts instead of applying when a row would diverge' do
+      with_global_key('sk-global-1111')
+      # Artificial divergence: AFTER resolves to something else entirely.
+      allow_any_instance_of(described_class).to receive(:effective_after).and_return('sk-outra-9999') # rubocop:disable RSpec/AnyInstance
+
+      expect { run(apply: true) }.to raise_error(described_class::AbortedError, /would change effective credential/)
+      expect(Ai::Credential.count).to eq(0)
+    end
+
+    it 'refuses to run without the encryption key' do
+      ENV['EVO_AI_ENCRYPTION_KEY'] = nil
+      with_global_key('sk-global-1111')
+
+      # Writing unreadable credentials would only surface later, inside a job.
+      expect { run(apply: true) }.to raise_error(described_class::AbortedError, /is not set/)
+      expect(Ai::Credential.count).to eq(0)
+    end
+  end
+
+  describe 'deterministic naming (AC6)' do
+    it 'suffixes on collision instead of violating the UNIQUE index' do
+      Ai::Credential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+        [{ name: described_class::INSTALLATION_NAME, provider: 'openai', key: 'x',
+           key_hint: 'x', scope: 'account', is_active: false,
+           created_at: Time.current, updated_at: Time.current }]
+      )
+      with_global_key('sk-global-1111')
+
+      expect { run(apply: true) }.not_to raise_error
+      expect(Ai::Credential.exists?(name: "#{described_class::INSTALLATION_NAME} (2)")).to be(true)
+    end
+  end
+
+  describe 'legacy sources are preserved (story 1.6 removes them)' do
+    it 'never deletes the global config nor the hook settings' do
+      hook = with_hook('sk-hook-2222')
+      with_global_key('sk-global-1111')
+
+      expect(hook).not_to receive(:update)
+      expect(hook).not_to receive(:destroy)
+
+      run(apply: true)
+      expect(hook.settings['api_key']).to eq('sk-hook-2222')
+    end
+  end
+end

--- a/spec/services/ai/credential_migration_spec.rb
+++ b/spec/services/ai/credential_migration_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_api_keys_table')
 
-# EVO-2250 story 1.5 — the migration exists to NOT change which key is in use.
+# the migration exists to NOT change which key is in use.
 RSpec.describe Ai::CredentialMigration do
   let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
   let(:silent_logger) { Logger.new(File::NULL) }

--- a/spec/services/ai/credential_migration_spec.rb
+++ b/spec/services/ai/credential_migration_spec.rb
@@ -160,17 +160,28 @@ RSpec.describe Ai::CredentialMigration do
       expect(Ai::Credential.count).to eq(count_after_first)
     end
 
-    it 'does not revert a human rename or deactivation' do
+    it 'does not revert a human rename' do
       with_global_key('sk-global-1111')
       run(apply: true)
       Ai::Credential.where(scope: 'installation')
-                    .update_all(name: 'Renomeada pelo admin', is_active: false) # rubocop:disable Rails/SkipsModelValidations
+                    .update_all(name: 'Renomeada pelo admin') # rubocop:disable Rails/SkipsModelValidations
 
       run(apply: true)
 
       credential = Ai::Credential.find_by(imported_from: described_class::INSTALLATION_SOURCE)
       expect(credential.name).to eq('Renomeada pelo admin')
-      expect(credential.is_active).to be(false)
+    end
+
+    it 'refuses to re-run after a human disabled the imported credential' do
+      with_global_key('sk-global-1111')
+      run(apply: true)
+      Ai::Credential.where(scope: 'installation')
+                    .update_all(is_active: false) # rubocop:disable Rails/SkipsModelValidations
+
+      # Disabling it DID change the effective credential, so the gate is right
+      # to refuse: re-running must not quietly paper over a human decision.
+      expect { run(apply: true) }.to raise_error(described_class::AbortedError)
+      expect(Ai::Credential.find_by(imported_from: described_class::INSTALLATION_SOURCE).is_active).to be(false)
     end
   end
 

--- a/spec/services/ai/credential_resolver_endpoint_spec.rb
+++ b/spec/services/ai/credential_resolver_endpoint_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_api_keys_table')
+
+# EVO-2250 re-review, ALTO 4 (base_url): the column landed and the 1.5 migration
+# filled it, but no consumer read it. The key came from the credential and the
+# host from installation config, so two credentials pointing at different
+# gateways silently authenticated against whichever URL the install had set.
+RSpec.describe Ai::CredentialResolver, '.resolve_endpoint' do
+  let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
+  let(:go_ciphertext) do
+    'gAAAAABqagvYo5FEA9quumGpPOgNwZMRVyKb5uFhsibgflYMUC5vdSCbbEdvdV4etg3_' \
+      'CtQekqXPOtsIESs2aRluGJrCNy9rAxpiusgJdRoQ0EdVJIjsSdY='
+  end
+  let(:go_plaintext) { 'sk-proj-real-secret-4f2a' }
+
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example
+  # transaction; shared helper so every spec agrees on the column set.
+  before(:all) { EvoCoreApiKeysTable.create! }
+  after(:all) { EvoCoreApiKeysTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  around do |example|
+    original = ENV.fetch('EVO_AI_ENCRYPTION_KEY', nil)
+    ENV['EVO_AI_ENCRYPTION_KEY'] = fernet_key
+    example.run
+    ENV['EVO_AI_ENCRYPTION_KEY'] = original
+  end
+
+  before { Ai::Credential.delete_all }
+
+  def register(scope:, base_url: nil, provider: 'openai', active: true)
+    Ai::Credential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: "cred-#{scope}-#{provider}-#{SecureRandom.hex(2)}",
+        provider: provider,
+        key: go_ciphertext,
+        key_hint: '4f2a',
+        scope: scope,
+        base_url: base_url,
+        is_active: active,
+        created_at: Time.current,
+        updated_at: Time.current
+      }]
+    )
+  end
+
+  it 'returns the endpoint stored with the credential' do
+    register(scope: 'account', base_url: 'https://gateway.interno/v1')
+
+    endpoint = described_class.resolve_endpoint(for_consumer: :inbox_assist)
+
+    expect(endpoint.key).to eq(go_plaintext)
+    expect(endpoint.base_url).to eq('https://gateway.interno/v1')
+  end
+
+  it 'returns nil for a credential with no endpoint of its own' do
+    register(scope: 'account')
+
+    expect(described_class.resolve_endpoint(for_consumer: :inbox_assist).base_url).to be_nil
+  end
+
+  # The half that was broken: the winning credential decides BOTH halves. An
+  # account credential outranks the installation one, so its endpoint must come
+  # with it instead of the installation one's.
+  it 'takes the endpoint from the credential that won the chain' do
+    register(scope: 'installation', base_url: 'https://casa.interno/v1')
+    register(scope: 'account', base_url: 'https://conta.interno/v1')
+
+    expect(described_class.resolve_endpoint(for_consumer: :inbox_assist).base_url)
+      .to eq('https://conta.interno/v1')
+  end
+
+  it 'falls back to the installation endpoint when the account has none' do
+    register(scope: 'installation', base_url: 'https://casa.interno/v1')
+
+    expect(described_class.resolve_endpoint(for_consumer: :inbox_assist).base_url)
+      .to eq('https://casa.interno/v1')
+  end
+
+  # A provider the consumer cannot speak is skipped for the key, so its endpoint
+  # must not leak into the resolution either.
+  it 'skips the endpoint of a credential the consumer cannot use' do
+    register(scope: 'account', provider: 'anthropic', base_url: 'https://anthropic.interno')
+    register(scope: 'installation', base_url: 'https://casa.interno/v1')
+
+    expect(described_class.resolve_endpoint(for_consumer: :inbox_assist).base_url)
+      .to eq('https://casa.interno/v1')
+  end
+
+  # The legacy sources carry a key and nothing else: the consumer's own
+  # OPENAI_API_URL stays the endpoint there, as it always was.
+  it 'reports no endpoint when the key came from the legacy fallback' do
+    allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return('sk-legacy-global')
+
+    endpoint = described_class.resolve_endpoint(for_consumer: :inbox_assist)
+
+    expect(endpoint.key).to eq('sk-legacy-global')
+    expect(endpoint.base_url).to be_nil
+  end
+
+  it 'keeps resolve_key answering exactly what resolve_endpoint carries' do
+    register(scope: 'account', base_url: 'https://gateway.interno/v1')
+
+    expect(described_class.resolve_key(for_consumer: :inbox_assist))
+      .to eq(described_class.resolve_endpoint(for_consumer: :inbox_assist).key)
+  end
+end

--- a/spec/services/ai/credential_resolver_endpoint_spec.rb
+++ b/spec/services/ai/credential_resolver_endpoint_spec.rb
@@ -3,10 +3,9 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_api_keys_table')
 
-# EVO-2250 re-review, ALTO 4 (base_url): the column landed and the 1.5 migration
-# filled it, but no consumer read it. The key came from the credential and the
-# host from installation config, so two credentials pointing at different
-# gateways silently authenticated against whichever URL the install had set.
+# The endpoint travels with the key it belongs to: a credential carrying its own
+# base_url must decide both halves, or two credentials pointing at different
+# gateways authenticate against whichever URL the installation happens to set.
 RSpec.describe Ai::CredentialResolver, '.resolve_endpoint' do
   let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
   let(:go_ciphertext) do

--- a/spec/services/ai/credential_resolver_resolve_key_spec.rb
+++ b/spec/services/ai/credential_resolver_resolve_key_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_api_keys_table')
 
 # EVO-2250 story 1.3 — the legacy chain as the last link of the resolver.
 #
@@ -18,29 +19,11 @@ RSpec.describe Ai::CredentialResolver, '.resolve_key' do
   end
   let(:go_plaintext) { 'sk-proj-real-secret-4f2a' }
 
-  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example
-  # transaction; the table is emptied per example and dropped after the suite.
-  before(:all) do
-    connection = ActiveRecord::Base.connection
-    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
-
-    unless connection.table_exists?(:evo_core_api_keys)
-      connection.create_table :evo_core_api_keys, id: false do |t|
-        t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
-        t.string :name, null: false
-        t.string :provider, null: false
-        t.text :key, null: false
-        t.string :key_hint, null: false, default: ''
-        t.string :scope, null: false, default: 'account'
-        t.boolean :is_active, null: false, default: true
-        t.timestamps
-      end
-    end
-  end
-
-  after(:all) do
-    ActiveRecord::Base.connection.drop_table(:evo_core_api_keys, if_exists: true)
-  end
+  # rubocop:disable RSpec/BeforeAfterAll -- creating the table is DDL, which
+  # cannot run inside the per-example transaction. Shared helper so every spec
+  # agrees on the column set.
+  before(:all) { EvoCoreApiKeysTable.create! }
+  after(:all) { EvoCoreApiKeysTable.drop! }
   # rubocop:enable RSpec/BeforeAfterAll
 
   around do |example|

--- a/spec/services/ai/credential_resolver_resolve_key_spec.rb
+++ b/spec/services/ai/credential_resolver_resolve_key_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250 story 1.3 — the legacy chain as the last link of the resolver.
+#
+# The pre-registry precedence (global config wins, account hook is the fallback)
+# did not disappear: it dropped one level. What changes is that the registry is
+# tried first, so a credential registered on the new screen is never shadowed by
+# legacy configuration.
+RSpec.describe Ai::CredentialResolver, '.resolve_key' do
+  # Same frozen fixtures as credential_decryptor_spec: ciphertext produced by the
+  # Go service. `let` avoids redefining the constants that spec declares.
+  let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
+  let(:go_ciphertext) do
+    'gAAAAABqagvYo5FEA9quumGpPOgNwZMRVyKb5uFhsibgflYMUC5vdSCbbEdvdV4etg3_' \
+      'CtQekqXPOtsIESs2aRluGJrCNy9rAxpiusgJdRoQ0EdVJIjsSdY='
+  end
+  let(:go_plaintext) { 'sk-proj-real-secret-4f2a' }
+
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example
+  # transaction; the table is emptied per example and dropped after the suite.
+  before(:all) do
+    connection = ActiveRecord::Base.connection
+    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+
+    unless connection.table_exists?(:evo_core_api_keys)
+      connection.create_table :evo_core_api_keys, id: false do |t|
+        t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
+        t.string :name, null: false
+        t.string :provider, null: false
+        t.text :key, null: false
+        t.string :key_hint, null: false, default: ''
+        t.string :scope, null: false, default: 'account'
+        t.boolean :is_active, null: false, default: true
+        t.timestamps
+      end
+    end
+  end
+
+  after(:all) do
+    ActiveRecord::Base.connection.drop_table(:evo_core_api_keys, if_exists: true)
+  end
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  around do |example|
+    original = ENV.fetch('EVO_AI_ENCRYPTION_KEY', nil)
+    ENV['EVO_AI_ENCRYPTION_KEY'] = fernet_key
+    example.run
+    ENV['EVO_AI_ENCRYPTION_KEY'] = original
+  end
+
+  before { Ai::Credential.delete_all }
+
+  def register(scope:, ciphertext:, provider: 'openai', active: true)
+    Ai::Credential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: "cred-#{scope}-#{provider}",
+        provider: provider,
+        key: ciphertext,
+        key_hint: '4f2a',
+        scope: scope,
+        is_active: active,
+        created_at: Time.current,
+        updated_at: Time.current
+      }]
+    )
+  end
+
+  describe 'the registry wins over legacy sources (AC4)' do
+    it 'ignores the global config when the registry has a credential' do
+      register(scope: 'account', ciphertext: go_ciphertext)
+      allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return('sk-legacy-global')
+
+      expect(described_class.resolve_key(for_consumer: :inbox_assist)).to eq(go_plaintext)
+    end
+
+    it 'ignores the account hook when the registry has a credential' do
+      register(scope: 'installation', ciphertext: go_ciphertext)
+      hook = instance_double(Integrations::Hook, settings: { 'api_key' => 'sk-legacy-hook' })
+
+      expect(
+        described_class.resolve_key(for_consumer: :inbox_assist, legacy_hook: hook)
+      ).to eq(go_plaintext)
+    end
+  end
+
+  describe 'unmigrated installations keep working (AC3)' do
+    it 'falls back to the global config when the registry is empty' do
+      allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return('sk-legacy-global')
+
+      expect(described_class.resolve_key(for_consumer: :inbox_assist)).to eq('sk-legacy-global')
+    end
+
+    it 'falls back to the hook when neither registry nor global config has one' do
+      allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return(nil)
+      hook = instance_double(Integrations::Hook, settings: { 'api_key' => 'sk-legacy-hook' })
+
+      expect(
+        described_class.resolve_key(for_consumer: :inbox_assist, legacy_hook: hook)
+      ).to eq('sk-legacy-hook')
+    end
+
+    it 'preserves the legacy order between the two: global beats hook' do
+      allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return('sk-legacy-global')
+      hook = instance_double(Integrations::Hook, settings: { 'api_key' => 'sk-legacy-hook' })
+
+      expect(
+        described_class.resolve_key(for_consumer: :inbox_assist, legacy_hook: hook)
+      ).to eq('sk-legacy-global')
+    end
+
+    it 'falls back when the registry credential cannot be decrypted' do
+      register(scope: 'account', ciphertext: 'not-a-fernet-token')
+      allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return('sk-legacy-global')
+
+      expect(described_class.resolve_key(for_consumer: :inbox_assist)).to eq('sk-legacy-global')
+    end
+  end
+
+  describe 'incompatible providers never reach the wire (AC5)' do
+    it 'skips an Anthropic account credential and inherits the installation one' do
+      register(scope: 'account', provider: 'anthropic', ciphertext: go_ciphertext)
+      register(scope: 'installation', ciphertext: go_ciphertext)
+
+      expect(described_class.resolve_key(for_consumer: :inbox_assist)).to eq(go_plaintext)
+    end
+
+    it 'does not offer a non-OpenAI credential to the legacy chain either' do
+      register(scope: 'account', provider: 'anthropic', ciphertext: go_ciphertext)
+      allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return('sk-legacy-global')
+
+      # The assist speaks the OpenAI protocol, so it still gets a usable key
+      # from the legacy chain rather than the Anthropic one.
+      expect(described_class.resolve_key(for_consumer: :inbox_assist)).to eq('sk-legacy-global')
+    end
+  end
+
+  describe 'nothing configured anywhere (AC6)' do
+    it 'returns nil without raising' do
+      allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return(nil)
+
+      expect { described_class.resolve_key(for_consumer: :inbox_assist) }.not_to raise_error
+      expect(described_class.resolve_key(for_consumer: :inbox_assist)).to be_nil
+    end
+  end
+
+  describe 'AI Agents are not restricted to the legacy OpenAI chain' do
+    it 'resolves an Anthropic credential for agents' do
+      register(scope: 'account', provider: 'anthropic', ciphertext: go_ciphertext)
+
+      expect(described_class.resolve_key(for_consumer: :ai_agents)).to eq(go_plaintext)
+    end
+  end
+end

--- a/spec/services/ai/credential_resolver_resolve_key_spec.rb
+++ b/spec/services/ai/credential_resolver_resolve_key_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_api_keys_table')
 
-# EVO-2250 story 1.3 — the legacy chain as the last link of the resolver.
+# the legacy chain as the last link of the resolver.
 #
 # The pre-registry precedence (global config wins, account hook is the fallback)
 # did not disappear: it dropped one level. What changes is that the registry is

--- a/spec/services/ai/credential_resolver_spec.rb
+++ b/spec/services/ai/credential_resolver_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_api_keys_table')
 
-# EVO-2250 story 1.2.
-#
 # `evo_core_api_keys` is created by the Go migrations of evo-ai-core-service and
 # is deliberately absent from `db/schema.rb` (Rails does not own it), so the test
 # database has no such table. We create it here to exercise the resolver against

--- a/spec/services/ai/credential_resolver_spec.rb
+++ b/spec/services/ai/credential_resolver_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250 story 1.2.
+#
+# `evo_core_api_keys` is created by the Go migrations of evo-ai-core-service and
+# is deliberately absent from `db/schema.rb` (Rails does not own it), so the test
+# database has no such table. We create it here to exercise the resolver against
+# the real column set instead of stubbing the model away.
+RSpec.describe Ai::CredentialResolver do
+  # rubocop:disable RSpec/BeforeAfterAll -- creating the table is DDL, which
+  # cannot live inside the per-example transaction. No records leak: the table
+  # is emptied before every example and dropped after the suite.
+  before(:all) do
+    connection = ActiveRecord::Base.connection
+    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+
+    unless connection.table_exists?(:evo_core_api_keys)
+      connection.create_table :evo_core_api_keys, id: false do |t|
+        t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
+        t.string :name, null: false
+        t.string :provider, null: false
+        t.text :key, null: false
+        t.string :key_hint, null: false, default: ''
+        t.string :scope, null: false, default: 'account'
+        t.boolean :is_active, null: false, default: true
+        t.timestamps
+      end
+    end
+  end
+
+  after(:all) do
+    ActiveRecord::Base.connection.drop_table(:evo_core_api_keys, if_exists: true)
+  end
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before { Ai::Credential.delete_all }
+
+  def create_credential(name:, scope:, provider: 'openai', active: true)
+    # insert_all! is the point: the model is read-only, so the core service is
+    # simulated writing straight to its own table.
+    Ai::Credential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: name,
+        provider: provider,
+        key: "ciphertext-#{name}",
+        key_hint: '4f2a',
+        scope: scope,
+        is_active: active,
+        created_at: Time.current,
+        updated_at: Time.current
+      }]
+    )
+    Ai::Credential.find_by(name: name)
+  end
+
+  describe 'the ordered chain (AC3)' do
+    it 'declares scopes from the most generic to the most specific' do
+      expect(described_class::SCOPE_CHAIN).to eq(%i[installation account])
+    end
+
+    # FR2 guard: the enterprise overlay adds an `agency` link between
+    # installation and account. Inserting a link must change precedence WITHOUT
+    # editing the resolver — if this spec ever needs a resolver change to pass,
+    # the "if account else installation" shape has crept back in.
+    it 'resolves a link inserted into the chain without any resolver change' do
+      stub_const("#{described_class}::SCOPE_CHAIN", %i[installation agency account])
+      create_credential(name: 'Da instalacao', scope: 'installation')
+      agency = create_credential(name: 'Da agencia', scope: 'agency')
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to eq(agency)
+    end
+
+    it 'keeps honouring the most specific link when the new one is empty' do
+      stub_const("#{described_class}::SCOPE_CHAIN", %i[installation agency account])
+      create_credential(name: 'Da instalacao', scope: 'installation')
+      account = create_credential(name: 'Da conta', scope: 'account')
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to eq(account)
+    end
+  end
+
+  describe 'precedence (AC4, AC5, AC6, AC7)' do
+    it 'falls back to the installation credential when the account has none (AC4)' do
+      installation = create_credential(name: 'Chave da casa', scope: 'installation')
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to eq(installation)
+    end
+
+    it 'prefers the account credential over the installation one (AC5)' do
+      create_credential(name: 'Chave da casa', scope: 'installation')
+      account = create_credential(name: 'Producao', scope: 'account')
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to eq(account)
+    end
+
+    it 'ignores an inactive account credential and inherits the default (AC6)' do
+      installation = create_credential(name: 'Chave da casa', scope: 'installation')
+      create_credential(name: 'Desativada', scope: 'account', active: false)
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to eq(installation)
+    end
+
+    it 'returns nil, without raising, when no link has a credential (AC7)' do
+      expect { described_class.resolve(for_consumer: :ai_agents) }.not_to raise_error
+      expect(described_class.resolve(for_consumer: :ai_agents)).to be_nil
+    end
+
+    it 'returns nil when every credential is inactive (AC7)' do
+      create_credential(name: 'Desativada', scope: 'account', active: false)
+      create_credential(name: 'Tambem desativada', scope: 'installation', active: false)
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to be_nil
+    end
+  end
+
+  describe 'provider compatibility per consumer (AC8)' do
+    it 'skips an incompatible account credential and inherits the default' do
+      installation = create_credential(name: 'Chave da casa', scope: 'installation', provider: 'openai')
+      create_credential(name: 'Claude Prod', scope: 'account', provider: 'anthropic')
+
+      # The assist speaks the OpenAI protocol, so Anthropic is not "wrong
+      # config" — it is a different wire format, and it must be skipped.
+      expect(described_class.resolve(for_consumer: :inbox_assist)).to eq(installation)
+    end
+
+    it 'still serves the same credential to a consumer that accepts it' do
+      anthropic = create_credential(name: 'Claude Prod', scope: 'account', provider: 'anthropic')
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to eq(anthropic)
+    end
+
+    it 'returns nil when no link offers a compatible provider' do
+      create_credential(name: 'Claude Prod', scope: 'account', provider: 'anthropic')
+      create_credential(name: 'Gemini casa', scope: 'installation', provider: 'gemini')
+
+      expect(described_class.resolve(for_consumer: :inbox_assist)).to be_nil
+    end
+
+    it 'resolves independently per consumer from the same registry' do
+      create_credential(name: 'Chave da casa', scope: 'installation', provider: 'openai')
+      anthropic = create_credential(name: 'Claude Prod', scope: 'account', provider: 'anthropic')
+
+      expect(described_class.resolve(for_consumer: :ai_agents)).to eq(anthropic)
+      expect(described_class.resolve(for_consumer: :inbox_assist).name).to eq('Chave da casa')
+    end
+
+    it 'returns nil for an unknown consumer instead of guessing' do
+      create_credential(name: 'Producao', scope: 'account')
+
+      expect(described_class.resolve(for_consumer: :not_a_consumer)).to be_nil
+    end
+  end
+
+  describe 'the credential model' do
+    it 'is read-only — writes belong to the core service' do
+      credential = create_credential(name: 'Producao', scope: 'account')
+
+      expect(credential.readonly?).to be(true)
+      expect { credential.update!(name: 'Outro') }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+  end
+end

--- a/spec/services/ai/credential_resolver_spec.rb
+++ b/spec/services/ai/credential_resolver_spec.rb
@@ -46,8 +46,13 @@ RSpec.describe Ai::CredentialResolver do
     # installation and account. Inserting a link must change precedence WITHOUT
     # editing the resolver — if this spec ever needs a resolver change to pass,
     # the "if account else installation" shape has crept back in.
+    #
+    # The stub targets Ai::ScopeChain since story 2.2 moved the chain there to
+    # share it with the integration credential resolver. Stubbing the alias on
+    # this class instead would define a constant nothing reads any more, and
+    # this guard would go green while testing nothing.
     it 'resolves a link inserted into the chain without any resolver change' do
-      stub_const("#{described_class}::SCOPE_CHAIN", %i[installation agency account])
+      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
       create_credential(name: 'Da instalacao', scope: 'installation')
       agency = create_credential(name: 'Da agencia', scope: 'agency')
 
@@ -55,7 +60,7 @@ RSpec.describe Ai::CredentialResolver do
     end
 
     it 'keeps honouring the most specific link when the new one is empty' do
-      stub_const("#{described_class}::SCOPE_CHAIN", %i[installation agency account])
+      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
       create_credential(name: 'Da instalacao', scope: 'installation')
       account = create_credential(name: 'Da conta', scope: 'account')
 

--- a/spec/services/ai/credential_resolver_spec.rb
+++ b/spec/services/ai/credential_resolver_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_api_keys_table')
 
 # EVO-2250 story 1.2.
 #
@@ -10,29 +11,10 @@ require 'rails_helper'
 # the real column set instead of stubbing the model away.
 RSpec.describe Ai::CredentialResolver do
   # rubocop:disable RSpec/BeforeAfterAll -- creating the table is DDL, which
-  # cannot live inside the per-example transaction. No records leak: the table
-  # is emptied before every example and dropped after the suite.
-  before(:all) do
-    connection = ActiveRecord::Base.connection
-    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
-
-    unless connection.table_exists?(:evo_core_api_keys)
-      connection.create_table :evo_core_api_keys, id: false do |t|
-        t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
-        t.string :name, null: false
-        t.string :provider, null: false
-        t.text :key, null: false
-        t.string :key_hint, null: false, default: ''
-        t.string :scope, null: false, default: 'account'
-        t.boolean :is_active, null: false, default: true
-        t.timestamps
-      end
-    end
-  end
-
-  after(:all) do
-    ActiveRecord::Base.connection.drop_table(:evo_core_api_keys, if_exists: true)
-  end
+  # cannot run inside the per-example transaction. Shared helper so every spec
+  # agrees on the column set.
+  before(:all) { EvoCoreApiKeysTable.create! }
+  after(:all) { EvoCoreApiKeysTable.drop! }
   # rubocop:enable RSpec/BeforeAfterAll
 
   before { Ai::Credential.delete_all }

--- a/spec/services/ai/integration_credential_migration_spec.rb
+++ b/spec/services/ai/integration_credential_migration_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_integration_credentials_table')
 
-# EVO-2250 story 2.6.
 RSpec.describe Ai::IntegrationCredentialMigration do
   # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
   before(:all) { EvoCoreIntegrationCredentialsTable.create! }
@@ -245,7 +244,7 @@ RSpec.describe Ai::IntegrationCredentialMigration do
   # The digest in `imported_from` proves the secret was imported once, not that
   # the row still holds it. Linking a new consumer to a rotated credential would
   # swap the secret on the wire with no DIVERGE anywhere — the exact silent
-  # change the gate forbids (adversarial review, 2026-07-29).
+  # change the gate forbids.
   describe 'dedupe against a humanly rotated credential' do
     it 'aborts instead of linking a new consumer to a value that no longer matches' do
       create_bot(provider: 'evo_ai_provider', api_key: 'chave-compartilhada-9c1d')

--- a/spec/services/ai/integration_credential_migration_spec.rb
+++ b/spec/services/ai/integration_credential_migration_spec.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_integration_credentials_table')
+
+# EVO-2250 story 2.6.
+RSpec.describe Ai::IntegrationCredentialMigration do
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
+  before(:all) { EvoCoreIntegrationCredentialsTable.create! }
+  after(:all) { EvoCoreIntegrationCredentialsTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before do
+    Ai::IntegrationCredential.delete_all
+    AgentBot.delete_all
+    allow(Ai::CredentialDecryptor).to receive(:encryption_key).and_return(fernet_key)
+  end
+
+  # A real Fernet key, so the round-trip proof exercises the actual crypto
+  # rather than a stub: the gate is only meaningful if what it writes is
+  # readable back.
+  let(:fernet_key) { 'cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4=' }
+
+  def create_bot(provider:, api_key: nil, name: "bot-#{SecureRandom.hex(3)}")
+    AgentBot.create!(name: name, bot_provider: provider, api_key: api_key, outgoing_url: 'https://exemplo.test/hook')
+  end
+
+  def imported_credentials
+    Ai::IntegrationCredential.where.not(imported_from: nil)
+  end
+
+  def decrypt(credential)
+    Ai::CredentialDecryptor.decrypt(credential.value)
+  end
+
+  describe 'dry run (AC2)' do
+    it 'writes nothing and still reports' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      rows = described_class.call(apply: false)
+
+      expect(rows).not_to be_empty
+      expect(Ai::IntegrationCredential.count).to eq(0)
+    end
+
+    it 'is the default mode' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      described_class.call
+
+      expect(Ai::IntegrationCredential.count).to eq(0)
+    end
+  end
+
+  describe 'importing a channel bot (AC1)' do
+    it 'creates one encrypted credential and links the bot' do
+      bot = create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      described_class.call(apply: true)
+
+      credential = imported_credentials.first
+      expect(credential).to be_present
+      expect(credential.value).not_to eq('chave-do-bot-9c1d')
+      expect(decrypt(credential)).to eq('chave-do-bot-9c1d')
+      expect(credential.value_hint).to eq('9c1d')
+      expect(bot.reload.credential_id).to eq(credential.id)
+    end
+
+    it 'does not delete the inline value: the fallback still needs it' do
+      bot = create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      described_class.call(apply: true)
+
+      expect(bot.reload.api_key).to eq('chave-do-bot-9c1d')
+    end
+
+    # The bot is the one consumer whose real runtime path lives in Ruby, so the
+    # proof goes through it rather than through a round-trip.
+    it 'keeps the effective key the resolver returns' do
+      bot = create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+      before_key = AgentBots::CredentialResolution.api_key_for(bot)
+
+      described_class.call(apply: true)
+
+      expect(AgentBots::CredentialResolution.api_key_for(bot.reload)).to eq(before_key)
+    end
+  end
+
+  describe 'the n8n pair (AC5)' do
+    it 'stores the pair structured and keeps the wire format identical' do
+      bot = create_bot(provider: 'n8n_provider', api_key: 'admin:s3nha-f9b2')
+      before_pair = AgentBots::CredentialResolution.basic_auth_for(bot)
+
+      described_class.call(apply: true)
+
+      credential = imported_credentials.first
+      expect(credential.value_format).to eq('composite')
+      expect(JSON.parse(decrypt(credential))).to eq('user' => 'admin', 'password' => 's3nha-f9b2')
+      # The hint comes from the SECRET half, never from the envelope or the user.
+      expect(credential.value_hint).to eq('f9b2')
+      expect(AgentBots::CredentialResolution.basic_auth_for(bot.reload)).to eq(before_pair)
+    end
+  end
+
+  describe 'deliberate skips (AC4)' do
+    it 'skips a webhook bot, reporting it rather than failing' do
+      create_bot(provider: 'webhook_provider')
+
+      rows = described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(0)
+      expect(rows.map(&:verdict)).to include('PULADO')
+    end
+
+    it 'skips a bot with no key at all' do
+      create_bot(provider: 'n8n_provider', api_key: nil)
+
+      described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(0)
+    end
+  end
+
+  describe 'deduplication by value (AC6)' do
+    it 'creates one credential for a secret shared by several consumers' do
+      bots = Array.new(3) { create_bot(provider: 'evo_ai_provider', api_key: 'mesma-chave-1234') }
+
+      described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(1)
+      credential_id = imported_credentials.first.id
+      expect(bots.map { |bot| bot.reload.credential_id }).to all(eq(credential_id))
+    end
+
+    it 'keeps distinct secrets apart' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-a-1111')
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-b-2222')
+
+      described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(2)
+    end
+  end
+
+  describe 'idempotency (AC3)' do
+    it 'does not duplicate on a second run' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      described_class.call(apply: true)
+      described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(1)
+    end
+
+    it 'does not duplicate a shared secret on a second run' do
+      Array.new(3) { create_bot(provider: 'evo_ai_provider', api_key: 'mesma-chave-1234') }
+
+      described_class.call(apply: true)
+      described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(1)
+    end
+
+    it 'never reverts a human rename' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+      described_class.call(apply: true)
+      Ai::IntegrationCredential.where.not(imported_from: nil).update_all(name: 'Renomeada por humano') # rubocop:disable Rails/SkipsModelValidations
+
+      described_class.call(apply: true)
+
+      expect(imported_credentials.pluck(:name)).to eq(['Renomeada por humano'])
+    end
+
+    it 'never relinks a consumer a human pointed elsewhere' do
+      bot = create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+      described_class.call(apply: true)
+      human_choice = SecureRandom.uuid
+      AgentBot.where(id: bot.id).update_all(credential_id: human_choice) # rubocop:disable Rails/SkipsModelValidations
+
+      described_class.call(apply: true)
+
+      expect(bot.reload.credential_id).to eq(human_choice)
+    end
+  end
+
+  describe 'empty installation (AC7)' do
+    it 'finishes without writing and without error' do
+      expect { described_class.call(apply: true) }.not_to raise_error
+      expect(Ai::IntegrationCredential.count).to eq(0)
+    end
+  end
+
+  describe 'deterministic naming (AC8)' do
+    it 'suffixes a colliding name instead of violating the unique index' do
+      Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+        [{
+          name: "#{described_class::BOT_NAME_PREFIX} evo_ai", provider: 'evo_ai', kind: 'static',
+          value: 'x', value_format: 'scalar', value_hint: 'xxxx', scope: 'account',
+          is_active: true, created_at: Time.current, updated_at: Time.current
+        }]
+      )
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      expect { described_class.call(apply: true) }.not_to raise_error
+      expect(imported_credentials.first.name).to match(/\(\d+\)\z/)
+    end
+  end
+
+  describe 'the report is a gate, not a log (AC2)' do
+    it 'aborts apply when a consumer would change effective value' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+      # Simulate the migration writing a value that does not round-trip.
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).and_return('valor-diferente')
+
+      expect { described_class.call(apply: true) }.to raise_error(described_class::AbortedError, /DIVERGE|diverg/i)
+      expect(Ai::IntegrationCredential.count).to eq(0)
+    end
+
+    it 'refuses to write when the encryption key is missing' do
+      allow(Ai::CredentialDecryptor).to receive(:encryption_key).and_return(nil)
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      expect { described_class.call(apply: true) }.to raise_error(described_class::AbortedError, /EVO_AI_ENCRYPTION_KEY/)
+    end
+  end
+
+  describe 'oauth rows are never touched (AC9)' do
+    it 'copies no token and creates no credential for an oauth row' do
+      Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+        [{
+          name: 'GitHub conectado', provider: 'github', kind: 'oauth',
+          value: nil, value_format: 'scalar', value_hint: '', scope: 'account',
+          is_active: true, owner_store: 'agent_integration', owner_ref: SecureRandom.uuid,
+          created_at: Time.current, updated_at: Time.current
+        }]
+      )
+
+      described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(0)
+      expect(Ai::IntegrationCredential.where(kind: 'oauth').first.value).to be_nil
+    end
+  end
+
+  describe Ai::IntegrationMigrationState do
+    it 'reports not migrated while a secret still lives only in the old store' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+
+      expect(described_class.migrated?).to be(false)
+    end
+
+    it 'reports migrated once the task has run' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')
+      Ai::IntegrationCredentialMigration.call(apply: true)
+
+      expect(described_class.migrated?).to be(true)
+    end
+
+    it 'reports migrated on an installation that has nothing to migrate' do
+      expect(described_class.migrated?).to be(true)
+    end
+  end
+end

--- a/spec/services/ai/integration_credential_migration_spec.rb
+++ b/spec/services/ai/integration_credential_migration_spec.rb
@@ -242,6 +242,40 @@ RSpec.describe Ai::IntegrationCredentialMigration do
     end
   end
 
+  # The digest in `imported_from` proves the secret was imported once, not that
+  # the row still holds it. Linking a new consumer to a rotated credential would
+  # swap the secret on the wire with no DIVERGE anywhere — the exact silent
+  # change the gate forbids (adversarial review, 2026-07-29).
+  describe 'dedupe against a humanly rotated credential' do
+    it 'aborts instead of linking a new consumer to a value that no longer matches' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-compartilhada-9c1d')
+      described_class.call(apply: true)
+
+      # A human rotates the imported credential's value afterwards.
+      Ai::IntegrationCredential.where.not(imported_from: nil).update_all( # rubocop:disable Rails/SkipsModelValidations
+        value: Ai::CredentialEncryptor.encrypt('valor-rotacionado-f00d')
+      )
+
+      # A NEW consumer still carrying the OLD secret shows up on a later run.
+      late_bot = create_bot(provider: 'evo_ai_provider', api_key: 'chave-compartilhada-9c1d')
+
+      expect { described_class.call(apply: true) }
+        .to raise_error(described_class::AbortedError, /alterada depois da importação/)
+      expect(late_bot.reload.credential_id).to be_nil
+    end
+
+    it 'still links a new consumer when the imported value is untouched (idempotent path)' do
+      create_bot(provider: 'evo_ai_provider', api_key: 'chave-compartilhada-9c1d')
+      described_class.call(apply: true)
+
+      late_bot = create_bot(provider: 'evo_ai_provider', api_key: 'chave-compartilhada-9c1d')
+      described_class.call(apply: true)
+
+      expect(imported_credentials.count).to eq(1)
+      expect(late_bot.reload.credential_id).to eq(imported_credentials.first.id)
+    end
+  end
+
   describe Ai::IntegrationMigrationState do
     it 'reports not migrated while a secret still lives only in the old store' do
       create_bot(provider: 'evo_ai_provider', api_key: 'chave-do-bot-9c1d')

--- a/spec/services/ai/integration_credential_migration_stores_spec.rb
+++ b/spec/services/ai/integration_credential_migration_stores_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_integration_credentials_table')
+require Rails.root.join('spec/support/evo_core_custom_tools_table')
+require Rails.root.join('spec/support/evo_core_custom_mcp_servers_table')
+require Rails.root.join('spec/support/evo_core_agent_integrations_table')
+
+# EVO-2250 story 2.6, the stores beyond the channel bot.
+RSpec.describe Ai::IntegrationCredentialMigration do
+  # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
+  before(:all) do
+    EvoCoreIntegrationCredentialsTable.create!
+    EvoCoreCustomToolsTable.create!
+    EvoCoreCustomMcpServersTable.create!
+    EvoCoreAgentIntegrationsTable.create!
+  end
+
+  after(:all) do
+    EvoCoreAgentIntegrationsTable.drop!
+    EvoCoreCustomMcpServersTable.drop!
+    EvoCoreCustomToolsTable.drop!
+    EvoCoreIntegrationCredentialsTable.drop!
+  end
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before do
+    Ai::IntegrationCredential.delete_all
+    Ai::CustomTool.delete_all
+    Ai::CustomMcpServer.delete_all
+    Ai::AgentIntegration.delete_all
+    AgentBot.delete_all
+    allow(Ai::CredentialDecryptor).to receive(:encryption_key).and_return(fernet_key)
+  end
+
+  let(:fernet_key) { 'cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4=' }
+
+  def create_tool(headers:, name: "tool-#{SecureRandom.hex(3)}")
+    Ai::CustomTool.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: name, method: 'POST', endpoint: 'https://exemplo.test/api',
+        headers: headers.to_json, credential_refs: {},
+        path_params: '{}', query_params: '{}', body_params: '{}',
+        error_handling: '{}', values: '{}', is_active: true,
+        created_at: Time.current, updated_at: Time.current
+      }]
+    )
+    Ai::CustomTool.find_by(name: name)
+  end
+
+  def create_mcp(headers:, name: "mcp-#{SecureRandom.hex(3)}")
+    Ai::CustomMcpServer.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: name, url: 'https://mcp.exemplo.test', headers: headers.to_json,
+        credential_refs: {}, timeout: 30, retry_count: 0, is_active: true,
+        created_at: Time.current, updated_at: Time.current
+      }]
+    )
+    Ai::CustomMcpServer.find_by(name: name)
+  end
+
+  def create_integration(provider:, config:, agent_id: SecureRandom.uuid)
+    Ai::AgentIntegration.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        agent_id: agent_id, provider: provider, config: config,
+        created_at: Time.current, updated_at: Time.current
+      }]
+    )
+    Ai::AgentIntegration.find_by(agent_id: agent_id, provider: provider)
+  end
+
+  def imported
+    Ai::IntegrationCredential.where.not(imported_from: nil)
+  end
+
+  def decrypt(credential)
+    Ai::CredentialDecryptor.decrypt(credential.value)
+  end
+
+  describe 'custom tools' do
+    it 'imports a recognised auth header and links it by name' do
+      tool = create_tool(headers: { 'Authorization' => 'Bearer sk-secreto-9c1d', 'Content-Type' => 'application/json' })
+
+      described_class.call(apply: true)
+
+      credential = imported.first
+      expect(decrypt(credential)).to eq('Bearer sk-secreto-9c1d')
+      expect(tool.reload.credential_refs).to eq('Authorization' => credential.id)
+    end
+
+    it 'imports two auth headers as two distinct credentials (cardinality rule)' do
+      tool = create_tool(headers: { 'Authorization' => 'Bearer um-1111', 'X-Api-Key' => 'dois-2222' })
+
+      described_class.call(apply: true)
+
+      expect(imported.count).to eq(2)
+      expect(tool.reload.credential_refs.keys).to contain_exactly('Authorization', 'X-Api-Key')
+      expect(tool.credential_refs.values.uniq.size).to eq(2)
+    end
+
+    # The heuristic must err on the side of NOT migrating: importing a header
+    # that is not a secret breaks the call, while leaving one behind only delays
+    # the gain. The two mistakes do not cost the same.
+    it 'leaves headers that are not recognised auth headers alone' do
+      tool = create_tool(headers: { 'Content-Type' => 'application/json', 'X-Trace-Id' => 'abc' })
+
+      described_class.call(apply: true)
+
+      expect(imported.count).to eq(0)
+      expect(tool.reload.credential_refs).to eq({})
+    end
+
+    it 'does not delete the inline header: the fallback still needs it' do
+      tool = create_tool(headers: { 'Authorization' => 'Bearer sk-secreto-9c1d' })
+
+      described_class.call(apply: true)
+
+      expect(JSON.parse(tool.reload.headers)).to include('Authorization' => 'Bearer sk-secreto-9c1d')
+    end
+  end
+
+  describe 'custom MCP servers' do
+    it 'imports the auth header and links it' do
+      mcp = create_mcp(headers: { 'Authorization' => 'Bearer mcp-7a3c' })
+
+      described_class.call(apply: true)
+
+      credential = imported.first
+      expect(decrypt(credential)).to eq('Bearer mcp-7a3c')
+      expect(mcp.reload.credential_refs).to eq('Authorization' => credential.id)
+    end
+  end
+
+  describe 'agent integrations (static providers only)' do
+    it 'imports the dify apiKey' do
+      integration = create_integration(provider: 'dify', config: { 'apiUrl' => 'https://dify.test', 'apiKey' => 'app-dify-9c1d' })
+
+      described_class.call(apply: true)
+
+      credential = imported.first
+      expect(decrypt(credential)).to eq('app-dify-9c1d')
+      expect(integration.reload.config['credential_id']).to eq(credential.id)
+    end
+
+    it 'imports the knowledge nexus key and leaves the address fields alone' do
+      integration = create_integration(
+        provider: 'knowledge_nexus',
+        config: { 'nexus_base_url' => 'https://nexus.test', 'nexus_api_key' => 'evo_k_ab.cd9c1d', 'space_id' => 'sp-1' }
+      )
+
+      described_class.call(apply: true)
+
+      expect(decrypt(imported.first)).to eq('evo_k_ab.cd9c1d')
+      config = integration.reload.config
+      expect(config['nexus_base_url']).to eq('https://nexus.test')
+      expect(config['space_id']).to eq('sp-1')
+    end
+
+    it 'imports the n8n pair as a composite envelope' do
+      create_integration(provider: 'n8n', config: { 'webhookUrl' => 'https://n8n.test', 'basicAuthUser' => 'admin', 'basicAuthPass' => 's3nha-f9b2' })
+
+      described_class.call(apply: true)
+
+      credential = imported.first
+      expect(credential.value_format).to eq('composite')
+      expect(JSON.parse(decrypt(credential))).to eq('user' => 'admin', 'password' => 's3nha-f9b2')
+      expect(credential.value_hint).to eq('f9b2')
+    end
+
+    # ⚠️ The correction from the adversarial review: this key is GENERATED by the
+    # core (it is the agent's inbound key), never registered by the customer. It
+    # is a deliberate skip, not a credential to import.
+    it 'skips an OAuth connection row entirely (AC9)' do
+      create_integration(provider: 'github', config: { 'access_token' => 'gho_secreto', 'connected' => true })
+
+      rows = described_class.call(apply: true)
+
+      expect(imported.count).to eq(0)
+      expect(rows.select(&:skipped?)).not_to be_empty
+    end
+
+    it 'skips a satellite credentials row' do
+      create_integration(provider: 'google_calendar_credentials', config: { 'access_token' => 'ya29', 'refresh_token' => 'r' })
+
+      described_class.call(apply: true)
+
+      expect(imported.count).to eq(0)
+    end
+
+    it 'skips typebot, which authenticates with nothing' do
+      create_integration(provider: 'typebot', config: { 'url' => 'https://typebot.test', 'typebot' => 'fluxo' })
+
+      described_class.call(apply: true)
+
+      expect(imported.count).to eq(0)
+    end
+  end
+
+  describe 'deduplication across stores (AC6)' do
+    it 'creates one credential when a tool and an MCP share the same secret' do
+      tool = create_tool(headers: { 'Authorization' => 'Bearer compartilhado-1234' })
+      mcp = create_mcp(headers: { 'Authorization' => 'Bearer compartilhado-1234' })
+
+      described_class.call(apply: true)
+
+      expect(imported.count).to eq(1)
+      credential_id = imported.first.id
+      expect(tool.reload.credential_refs['Authorization']).to eq(credential_id)
+      expect(mcp.reload.credential_refs['Authorization']).to eq(credential_id)
+    end
+  end
+
+  describe 'idempotency across stores (AC3)' do
+    it 'does not duplicate nor relink on a second run' do
+      tool = create_tool(headers: { 'Authorization' => 'Bearer sk-secreto-9c1d' })
+      create_integration(provider: 'dify', config: { 'apiKey' => 'app-dify-9c1d' })
+
+      described_class.call(apply: true)
+      first_refs = tool.reload.credential_refs
+      described_class.call(apply: true)
+
+      expect(imported.count).to eq(2)
+      expect(tool.reload.credential_refs).to eq(first_refs)
+    end
+
+    it 'never overwrites a reference a human changed' do
+      tool = create_tool(headers: { 'Authorization' => 'Bearer sk-secreto-9c1d' })
+      described_class.call(apply: true)
+      human_choice = SecureRandom.uuid
+      Ai::CustomTool.where(id: tool.id).update_all(credential_refs: { 'Authorization' => human_choice }) # rubocop:disable Rails/SkipsModelValidations
+
+      described_class.call(apply: true)
+
+      expect(tool.reload.credential_refs).to eq('Authorization' => human_choice)
+    end
+  end
+
+  describe 'the gate covers every store (AC2)' do
+    it 'aborts without writing when a value would not round-trip' do
+      create_tool(headers: { 'Authorization' => 'Bearer sk-secreto-9c1d' })
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).and_return('valor-diferente')
+
+      expect { described_class.call(apply: true) }.to raise_error(described_class::AbortedError)
+      expect(Ai::IntegrationCredential.count).to eq(0)
+    end
+  end
+end

--- a/spec/services/ai/integration_credential_migration_stores_spec.rb
+++ b/spec/services/ai/integration_credential_migration_stores_spec.rb
@@ -6,7 +6,7 @@ require Rails.root.join('spec/support/evo_core_custom_tools_table')
 require Rails.root.join('spec/support/evo_core_custom_mcp_servers_table')
 require Rails.root.join('spec/support/evo_core_agent_integrations_table')
 
-# EVO-2250 story 2.6, the stores beyond the channel bot.
+# , the stores beyond the channel bot.
 RSpec.describe Ai::IntegrationCredentialMigration do
   # rubocop:disable RSpec/BeforeAfterAll -- DDL cannot run inside the per-example transaction.
   before(:all) do

--- a/spec/services/ai/integration_credential_resolver_spec.rb
+++ b/spec/services/ai/integration_credential_resolver_spec.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_integration_credentials_table')
+
+# EVO-2250 story 2.2.
+#
+# `evo_core_integration_credentials` is created by the Go migration 000019 of
+# evo-ai-core-service and is deliberately absent from `db/schema.rb`, so the
+# test database has no such table. It is built here to exercise the resolver
+# against the real column set instead of stubbing the model away.
+RSpec.describe Ai::IntegrationCredentialResolver do
+  # rubocop:disable RSpec/BeforeAfterAll -- creating the table is DDL, which
+  # cannot run inside the per-example transaction.
+  before(:all) { EvoCoreIntegrationCredentialsTable.create! }
+  after(:all) { EvoCoreIntegrationCredentialsTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  before { Ai::IntegrationCredential.delete_all }
+
+  def create_credential(name:, **options)
+    kind = options.fetch(:kind, 'static')
+    oauth = kind == Ai::IntegrationCredential::KIND_OAUTH
+
+    # insert_all! is the point: the model is read-only, so the core service is
+    # simulated writing straight to its own table.
+    Ai::IntegrationCredential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: name,
+        provider: options.fetch(:provider, 'dify'),
+        kind: kind,
+        value: options[:value] || (oauth ? nil : "ciphertext-#{name}"),
+        value_format: 'scalar',
+        value_hint: '9c1d',
+        scope: options.fetch(:scope, 'account'),
+        is_active: options.fetch(:active, true),
+        owner_store: oauth ? 'agent_integration' : nil,
+        owner_ref: oauth ? SecureRandom.uuid : nil,
+        created_at: Time.current,
+        updated_at: Time.current
+      }]
+    )
+    Ai::IntegrationCredential.find_by(name: name)
+  end
+
+  describe 'resolution by reference (AC2)' do
+    it 'returns exactly the referenced credential' do
+      wanted = create_credential(name: 'Dify do time')
+      create_credential(name: 'Outra qualquer', provider: 'n8n')
+
+      expect(described_class.resolve_by_id(wanted.id)).to eq(wanted)
+    end
+
+    # AC2 is explicit: a reference that cannot be honoured resolves to nothing.
+    # Falling through to the chain would silently authenticate against a
+    # different platform than the one the consumer was configured with.
+    it 'returns nothing for an inactive credential instead of falling through' do
+      inactive = create_credential(name: 'Desativada', active: false)
+      create_credential(name: 'Padrao da casa', scope: 'installation')
+
+      expect(described_class.resolve_by_id(inactive.id)).to be_nil
+    end
+
+    it 'returns nothing for an unknown id instead of falling through' do
+      create_credential(name: 'Padrao da casa', scope: 'installation')
+
+      expect(described_class.resolve_by_id(SecureRandom.uuid)).to be_nil
+    end
+
+    it 'returns nothing for a blank id' do
+      expect(described_class.resolve_by_id(nil)).to be_nil
+      expect(described_class.resolve_by_id('')).to be_nil
+    end
+  end
+
+  describe 'the ordered chain (AC1)' do
+    it 'declares scopes from the most generic to the most specific' do
+      expect(described_class::SCOPE_CHAIN).to eq(%i[installation account])
+    end
+
+    # FR2 guard, same shape as story 1.2: the enterprise overlay inserts an
+    # `agency` link between installation and account. Inserting a link must
+    # change precedence WITHOUT editing the resolver — if this spec ever needs
+    # a resolver change to pass, the "if account else installation" shape has
+    # crept back in.
+    it 'resolves a link inserted into the chain without any resolver change' do
+      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
+      create_credential(name: 'Da instalacao', scope: 'installation')
+      agency = create_credential(name: 'Da agencia', scope: 'agency')
+
+      expect(described_class.resolve_default(provider: 'dify')).to eq(agency)
+    end
+
+    it 'keeps honouring the most specific link when the new one is empty' do
+      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
+      create_credential(name: 'Da instalacao', scope: 'installation')
+      account = create_credential(name: 'Da conta', scope: 'account')
+
+      expect(described_class.resolve_default(provider: 'dify')).to eq(account)
+    end
+
+    # The story asks for ONE chain, not two copies: a change in one place must
+    # reach both resolvers. Two constants would diverge at the first bugfix,
+    # which is exactly what story 1.2 exists to prevent.
+    it 'shares the chain with the AI credential resolver' do
+      expect(described_class::SCOPE_CHAIN).to equal(Ai::CredentialResolver::SCOPE_CHAIN)
+      expect(described_class::SCOPE_CHAIN).to equal(Ai::ScopeChain::SCOPE_CHAIN)
+    end
+  end
+
+  describe 'resolution by scope default (AC3, AC4, AC5, AC6)' do
+    it 'falls back to the installation credential when the account has none (AC4)' do
+      installation = create_credential(name: 'ElevenLabs da casa', scope: 'installation', provider: 'elevenlabs')
+
+      expect(described_class.resolve_default(provider: 'elevenlabs')).to eq(installation)
+    end
+
+    it 'prefers the account credential over the installation one (AC5)' do
+      create_credential(name: 'Da casa', scope: 'installation')
+      account = create_credential(name: 'Da conta', scope: 'account')
+
+      expect(described_class.resolve_default(provider: 'dify')).to eq(account)
+    end
+
+    it 'skips an inactive account credential and uses the installation one' do
+      installation = create_credential(name: 'Da casa', scope: 'installation')
+      create_credential(name: 'Da conta', scope: 'account', active: false)
+
+      expect(described_class.resolve_default(provider: 'dify')).to eq(installation)
+    end
+
+    it 'only considers credentials of the requested provider' do
+      create_credential(name: 'Dify da conta', provider: 'dify')
+      n8n = create_credential(name: 'N8N da casa', scope: 'installation', provider: 'n8n')
+
+      expect(described_class.resolve_default(provider: 'n8n')).to eq(n8n)
+    end
+
+    it 'returns nothing when no link offers a credential (AC6)' do
+      expect(described_class.resolve_default(provider: 'dify')).to be_nil
+    end
+
+    it 'returns nothing for a blank provider rather than matching anything' do
+      create_credential(name: 'Qualquer', scope: 'installation')
+
+      expect(described_class.resolve_default(provider: nil)).to be_nil
+    end
+
+    # `account:` is threaded rather than queried, exactly as story 1.2 decided:
+    # the community CRM is single-tenant, and the parameter exists so the
+    # enterprise overlay can scope a link without rewriting this class.
+    it 'accepts an account argument without changing community behaviour' do
+      installation = create_credential(name: 'Da casa', scope: 'installation')
+
+      expect(described_class.resolve_default(provider: 'dify', account: 42)).to eq(installation)
+    end
+  end
+
+  describe 'oauth credentials are references, never values (AC7)' do
+    it 'never decrypts an oauth credential' do
+      create_credential(name: 'GitHub', provider: 'github', kind: 'oauth', scope: 'installation')
+
+      expect(Ai::CredentialDecryptor).not_to receive(:decrypt)
+
+      described_class.resolve_value(provider: 'github')
+    end
+
+    it 'reports an oauth credential as a reference instead of a value' do
+      credential = create_credential(name: 'GitHub', provider: 'github', kind: 'oauth', scope: 'installation')
+
+      result = described_class.resolve_value(provider: 'github')
+
+      expect(result).to be_reference
+      expect(result).not_to be_missing
+      expect(result.credential).to eq(credential)
+      expect(result.value).to be_nil
+      expect(result.owner_store).to eq('agent_integration')
+    end
+
+    # AC6 and AC7 are different states. Collapsing both into a bare nil would
+    # leave the caller unable to tell "nothing is configured" from "your
+    # credential lives in another store, go read it there".
+    it 'distinguishes a missing credential from an oauth reference' do
+      missing = described_class.resolve_value(provider: 'dify')
+
+      expect(missing).to be_missing
+      expect(missing).not_to be_reference
+      expect(missing.value).to be_nil
+    end
+
+    it 'still resolves the oauth row as a record' do
+      credential = create_credential(name: 'GitHub', provider: 'github', kind: 'oauth', scope: 'installation')
+
+      expect(described_class.resolve_default(provider: 'github')).to eq(credential)
+    end
+  end
+
+  describe 'decryption of static credentials' do
+    it 'returns the plaintext for the resolved credential' do
+      create_credential(name: 'Dify', value: 'ciphertext-dify')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).with('ciphertext-dify').and_return('app-dify-9c1d')
+
+      result = described_class.resolve_value(provider: 'dify')
+
+      expect(result).to be_present_value
+      expect(result.value).to eq('app-dify-9c1d')
+      expect(result.credential.name).to eq('Dify')
+    end
+
+    it 'resolves a value by reference too' do
+      credential = create_credential(name: 'Dify', value: 'ciphertext-dify')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).with('ciphertext-dify').and_return('app-dify-9c1d')
+
+      expect(described_class.resolve_value(credential_id: credential.id).value).to eq('app-dify-9c1d')
+    end
+
+    it 'reports an undecryptable credential as missing instead of raising' do
+      create_credential(name: 'Dify', value: 'lixo')
+      allow(Ai::CredentialDecryptor).to receive(:decrypt).and_return(nil)
+
+      result = described_class.resolve_value(provider: 'dify')
+
+      expect(result).to be_missing
+      expect(result.value).to be_nil
+    end
+
+    it 'reports missing when the reference cannot be honoured' do
+      expect(described_class.resolve_value(credential_id: SecureRandom.uuid)).to be_missing
+    end
+  end
+end

--- a/spec/services/ai/integration_credential_resolver_spec.rb
+++ b/spec/services/ai/integration_credential_resolver_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_integration_credentials_table')
 
-# EVO-2250 story 2.2.
-#
 # `evo_core_integration_credentials` is created by the Go migration 000019 of
 # evo-ai-core-service and is deliberately absent from `db/schema.rb`, so the
 # test database has no such table. It is built here to exercise the resolver

--- a/spec/services/ai/migration_state_spec.rb
+++ b/spec/services/ai/migration_state_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('spec/support/evo_core_api_keys_table')
+
+# EVO-2250 story 1.6 — the guard that keeps retiring the fallback from switching
+# AI off on an installation that never migrated.
+RSpec.describe Ai::MigrationState do
+  let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }
+
+  # rubocop:disable RSpec/BeforeAfterAll -- creating the table is DDL, which
+  # cannot run inside the per-example transaction.
+  before(:all) { EvoCoreApiKeysTable.create! }
+  after(:all) { EvoCoreApiKeysTable.drop! }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  around do |example|
+    original = ENV.fetch('EVO_AI_ENCRYPTION_KEY', nil)
+    ENV['EVO_AI_ENCRYPTION_KEY'] = fernet_key
+    example.run
+    ENV['EVO_AI_ENCRYPTION_KEY'] = original
+  end
+
+  before do
+    Ai::Credential.delete_all
+    allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return(nil)
+    allow(Integrations::Hook).to receive(:find_by).with(app_id: 'openai').and_return(nil)
+  end
+
+  def register(imported_from: nil)
+    Ai::Credential.insert_all!( # rubocop:disable Rails/SkipsModelValidations
+      [{
+        name: "cred-#{SecureRandom.hex(4)}", provider: 'openai',
+        key: Ai::CredentialEncryptor.encrypt('sk-registry-1111'), key_hint: '1111',
+        scope: 'account', is_active: true, imported_from: imported_from,
+        created_at: Time.current, updated_at: Time.current
+      }]
+    )
+  end
+
+  def with_legacy_global(key)
+    allow(GlobalConfigService).to receive(:load).with('OPENAI_API_SECRET', nil).and_return(key)
+  end
+
+  describe '.migrated?' do
+    it 'is true once the 1.5 task imported something' do
+      register(imported_from: Ai::CredentialMigration::INSTALLATION_SOURCE)
+      with_legacy_global('sk-legacy-9999')
+
+      expect(described_class).to be_migrated
+    end
+
+    it 'is true on a fresh install with nothing in the legacy sources' do
+      # Never had a key anywhere: there is nothing to migrate, so retiring the
+      # fallback takes nothing away.
+      expect(described_class).to be_migrated
+    end
+
+    it 'is FALSE when a legacy key exists and nothing was imported' do
+      with_legacy_global('sk-legacy-9999')
+
+      expect(described_class).not_to be_migrated
+    end
+
+    it 'is false when the legacy key lives in the hook' do
+      hook = instance_double(Integrations::Hook, settings: { 'api_key' => 'sk-hook-8888' })
+      allow(Integrations::Hook).to receive(:find_by).with(app_id: 'openai').and_return(hook)
+
+      expect(described_class).not_to be_migrated
+    end
+
+    it 'does not count a hand-registered credential as a migration' do
+      # A human registering a credential on the new screen does not prove the
+      # legacy key was carried over — the fallback must stay.
+      register(imported_from: nil)
+      with_legacy_global('sk-legacy-9999')
+
+      expect(described_class).not_to be_migrated
+    end
+
+    it 'treats a database failure as NOT migrated' do
+      allow(Ai::Credential).to receive(:where).and_raise(ActiveRecord::StatementInvalid, 'boom')
+      with_legacy_global('sk-legacy-9999')
+
+      # Reading an error as "migrated" would remove the fallback on a broken
+      # install, which is the one thing this guard exists to prevent.
+      expect(described_class).not_to be_migrated
+    end
+  end
+
+  describe 'the resolver honours the guard (AC3, AC4)' do
+    it 'still serves the legacy key while the install has not migrated' do
+      with_legacy_global('sk-legacy-9999')
+
+      expect(Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist)).to eq('sk-legacy-9999')
+    end
+
+    it 'warns, so the operator knows which task to run' do
+      with_legacy_global('sk-legacy-9999')
+      allow(Rails.logger).to receive(:warn)
+
+      Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist)
+
+      expect(Rails.logger).to have_received(:warn).with(/ai_credentials:migrate/)
+    end
+
+    it 'stops reading the legacy source once the install migrated' do
+      register(imported_from: Ai::CredentialMigration::INSTALLATION_SOURCE)
+      Ai::Credential.update_all(is_active: false) # rubocop:disable Rails/SkipsModelValidations
+      with_legacy_global('sk-legacy-9999')
+
+      # Migrated: the registry is the only origin, so an inactive registry
+      # credential means "nothing configured", not "fall back to the old key".
+      expect(Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist)).to be_nil
+    end
+
+    it 'serves the registry credential after migrating' do
+      register(imported_from: Ai::CredentialMigration::INSTALLATION_SOURCE)
+      with_legacy_global('sk-legacy-9999')
+
+      expect(Ai::CredentialResolver.resolve_key(for_consumer: :inbox_assist)).to eq('sk-registry-1111')
+    end
+  end
+end

--- a/spec/services/ai/migration_state_spec.rb
+++ b/spec/services/ai/migration_state_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require Rails.root.join('spec/support/evo_core_api_keys_table')
 
-# EVO-2250 story 1.6 — the guard that keeps retiring the fallback from switching
+# the guard that keeps retiring the fallback from switching
 # AI off on an installation that never migrated.
 RSpec.describe Ai::MigrationState do
   let(:fernet_key) { 'XoQPOBw2FrzjQS11utERG9qO2MsAnXFxlhIns_uUxRk=' }

--- a/spec/services/bot_runtime/delegation_service_spec.rb
+++ b/spec/services/bot_runtime/delegation_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BotRuntime::DelegationService do
   subject(:service) { described_class.new(agent_bot, message, conversation) }
 
   let(:agent_bot) do
-    instance_double(AgentBot, id: 'bot-1', name: 'Agente', api_key: 'api-key',
+    instance_double(AgentBot, id: 'bot-1', name: 'Agente', api_key: 'api-key', credential_id: nil,
                               outgoing_url: 'https://agent.example/webhook', debounce_time: 5,
                               message_signature: '', text_segmentation_enabled: false,
                               text_segmentation_limit: 300, text_segmentation_min_size: 50,

--- a/spec/services/hubspot/refresh_oauth_token_service_silence_spec.rb
+++ b/spec/services/hubspot/refresh_oauth_token_service_silence_spec.rb
@@ -2,8 +2,6 @@
 
 require 'rails_helper'
 
-# EVO-2250, collateral of the credential survey.
-#
 # The refresh returns the STALE token when renewal fails. That fallback is
 # deliberate and stays: the caller contract is "give me a token", and failing
 # hard there would break every consumer mid-conversation. What was wrong is that

--- a/spec/services/hubspot/refresh_oauth_token_service_silence_spec.rb
+++ b/spec/services/hubspot/refresh_oauth_token_service_silence_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250, collateral of the credential survey.
+#
+# The refresh returns the STALE token when renewal fails. That fallback is
+# deliberate and stays: the caller contract is "give me a token", and failing
+# hard there would break every consumer mid-conversation. What was wrong is that
+# the failure was invisible — an integration could be dead for days with nothing
+# but a debug-level line to show for it.
+RSpec.describe Hubspot::RefreshOauthTokenService do
+  let(:hook) do
+    Integrations::Hook.create!(
+      app_id: 'hubspot',
+      status: 'enabled',
+      access_token: 'token-velho',
+      settings: { 'refresh_token' => 'r-1', 'expires_at' => 1.hour.ago.to_s }
+    )
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load).and_return('valor')
+  end
+
+  describe 'when the renewal fails' do
+    before do
+      allow(HTTParty).to receive(:post).and_raise(Errno::ECONNREFUSED)
+    end
+
+    it 'still returns the stale token, keeping the caller contract' do
+      expect(described_class.new(hook: hook).access_token).to eq('token-velho')
+    end
+
+    # The silence is what dies: an operator has to be able to see this in the
+    # logs at the level failures are actually read at.
+    it 'logs the failure as an error, not as debug noise' do
+      expect(Rails.logger).to receive(:error).with(/hubspot/i).at_least(:once)
+
+      described_class.new(hook: hook).access_token
+    end
+
+    # Reauthorizable is the mechanism this codebase already has for "tell the
+    # human": it counts failures in Redis and, past the threshold, e-mails and
+    # deactivates. Bypassing it is what made the failure silent.
+    it 'counts the failure through Reauthorizable so the existing escalation fires' do
+      expect(hook).to receive(:authorization_error!).at_least(:once)
+
+      described_class.new(hook: hook).access_token
+    end
+  end
+
+  describe 'when the renewal succeeds' do
+    before do
+      response = instance_double(HTTParty::Response, success?: true,
+                                                     body: { access_token: 'token-novo', refresh_token: 'r-2',
+                                                             expires_in: 3600 }.to_json)
+      allow(HTTParty).to receive(:post).and_return(response)
+    end
+
+    it 'returns the fresh token and never reports an auth error' do
+      expect(hook).not_to receive(:authorization_error!)
+
+      expect(described_class.new(hook: hook).access_token).to eq('token-novo')
+    end
+  end
+
+  describe 'when there is no refresh token' do
+    let(:hook) do
+      Integrations::Hook.create!(app_id: 'hubspot', status: 'enabled', access_token: 'token-velho',
+                                 settings: { 'expires_at' => 1.hour.ago.to_s })
+    end
+
+    it 'returns the stored token without pretending a refresh happened' do
+      expect(HTTParty).not_to receive(:post)
+
+      expect(described_class.new(hook: hook).access_token).to eq('token-velho')
+    end
+  end
+end

--- a/spec/services/messages/audio_transcription_service_credential_spec.rb
+++ b/spec/services/messages/audio_transcription_service_credential_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-# EVO-2250 story 1.4 — transcription resolves its credential from the registry,
+# transcription resolves its credential from the registry,
 # and the toggle stops meaning "has a key".
 RSpec.describe Messages::AudioTranscriptionService do
   let(:attached_file) { instance_double(ActiveStorage::Attached::One, attached?: true) }

--- a/spec/services/messages/audio_transcription_service_credential_spec.rb
+++ b/spec/services/messages/audio_transcription_service_credential_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# EVO-2250 story 1.4 — transcription resolves its credential from the registry,
+# and the toggle stops meaning "has a key".
+RSpec.describe Messages::AudioTranscriptionService do
+  let(:attached_file) { instance_double(ActiveStorage::Attached::One, attached?: true) }
+  let(:attachment) { instance_double(Attachment, file: attached_file) }
+  let(:service) { described_class.new(attachment: attachment) }
+
+  describe '#transcription_enabled? separates the toggle from the credential (AC4)' do
+    it 'stays enabled with the global toggle on even when no credential resolves' do
+      allow(GlobalConfigService).to receive(:load)
+        .with('OPENAI_ENABLE_AUDIO_TRANSCRIPTION', nil).and_return(true)
+      # No credential anywhere: the feature is still ON, it just cannot run.
+      allow(Ai::CredentialResolver).to receive(:resolve_key).and_return(nil)
+
+      expect(service.send(:transcription_enabled?)).to be(true)
+    end
+
+    it 'is disabled when the global toggle is off, credential or not' do
+      allow(GlobalConfigService).to receive(:load)
+        .with('OPENAI_ENABLE_AUDIO_TRANSCRIPTION', nil).and_return(false)
+      allow(Ai::CredentialResolver).to receive(:resolve_key).and_return('sk-usable')
+
+      expect(service.send(:transcription_enabled?)).to be(false)
+    end
+
+    it 'accepts string values for the global toggle' do
+      %w[true 1 yes on].each do |truthy|
+        allow(GlobalConfigService).to receive(:load)
+          .with('OPENAI_ENABLE_AUDIO_TRANSCRIPTION', nil).and_return(truthy)
+
+        expect(service.send(:transcription_enabled?)).to be(true)
+      end
+
+      %w[false 0 no off].each do |falsy|
+        allow(GlobalConfigService).to receive(:load)
+          .with('OPENAI_ENABLE_AUDIO_TRANSCRIPTION', nil).and_return(falsy)
+
+        expect(service.send(:transcription_enabled?)).to be(false)
+      end
+    end
+
+    context 'when the global toggle is unset and the hook decides' do
+      before do
+        allow(GlobalConfigService).to receive(:load)
+          .with('OPENAI_ENABLE_AUDIO_TRANSCRIPTION', nil).and_return(nil)
+      end
+
+      it 'is enabled by the hook toggle alone, with no api_key in settings' do
+        hook = instance_double(Integrations::Hook, enabled?: true,
+                                                   settings: { 'enable_audio_transcription' => true })
+        allow(Integrations::Hook).to receive(:find_by).with(app_id: 'openai').and_return(hook)
+
+        # Before this story the same settings without 'api_key' returned false,
+        # so a missing credential looked exactly like a disabled feature.
+        expect(service.send(:transcription_enabled?)).to be(true)
+      end
+
+      it 'is disabled when the hook toggle is off' do
+        hook = instance_double(Integrations::Hook, enabled?: true,
+                                                   settings: { 'enable_audio_transcription' => false })
+        allow(Integrations::Hook).to receive(:find_by).with(app_id: 'openai').and_return(hook)
+
+        expect(service.send(:transcription_enabled?)).to be(false)
+      end
+
+      it 'is disabled when there is no hook at all' do
+        allow(Integrations::Hook).to receive(:find_by).with(app_id: 'openai').and_return(nil)
+
+        expect(service.send(:transcription_enabled?)).to be(false)
+      end
+    end
+  end
+
+  describe '#get_openai_api_key delegates to the resolver (AC1)' do
+    it 'asks the resolver for the audio_transcription consumer' do
+      expect(Ai::CredentialResolver).to receive(:resolve_key)
+        .with(for_consumer: :audio_transcription).and_return('sk-from-registry')
+
+      expect(service.send(:get_openai_api_key)).to eq('sk-from-registry')
+    end
+
+    it 'does not read GlobalConfigService directly any more' do
+      # The duplicated precedence chain was deleted, not adapted: it lives in
+      # Ai::CredentialResolver, and reading it here would fork the rule again.
+      allow(Ai::CredentialResolver).to receive(:resolve_key).and_return('sk-from-registry')
+      expect(GlobalConfigService).not_to receive(:load).with('OPENAI_API_SECRET', nil)
+
+      service.send(:get_openai_api_key)
+    end
+  end
+
+  describe '#transcribe_audio without a credential (AC5)' do
+    it 'does not call Whisper and records the reason' do
+      allow(Ai::CredentialResolver).to receive(:resolve_key).and_return(nil)
+      allow(Rails.logger).to receive(:warn)
+
+      expect(service).not_to receive(:call_openai_whisper_api)
+      expect(service.send(:transcribe_audio)).to be_nil
+      expect(Rails.logger).to have_received(:warn).with(/no AI credential resolved/)
+    end
+  end
+end

--- a/spec/support/evo_core_agent_integrations_table.rb
+++ b/spec/support/evo_core_agent_integrations_table.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# `evo_core_agent_integrations`, from the Go migration 000014. See
+# EvoCoreCustomToolsTable. The unique (agent_id, provider) mirrors the real
+# constraint: two agents may hold the same provider, one row each.
+module EvoCoreAgentIntegrationsTable
+  module_function
+
+  def create!
+    connection = ActiveRecord::Base.connection
+    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+    return if connection.table_exists?(:evo_core_agent_integrations)
+
+    connection.create_table :evo_core_agent_integrations, id: false do |t|
+      t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
+      t.column :agent_id, :uuid, null: false
+      t.string :provider, null: false
+      t.jsonb :config, default: {}
+      t.timestamps
+    end
+
+    connection.execute('ALTER TABLE evo_core_agent_integrations ADD PRIMARY KEY (id)')
+    connection.add_index :evo_core_agent_integrations, %i[agent_id provider], unique: true
+  end
+
+  def drop!
+    ActiveRecord::Base.connection.drop_table(:evo_core_agent_integrations, if_exists: true)
+  end
+end

--- a/spec/support/evo_core_api_keys_table.rb
+++ b/spec/support/evo_core_api_keys_table.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# `evo_core_api_keys` is created by the Go migrations of evo-ai-core-service and
+# is deliberately absent from `db/schema.rb` — Rails does not own it. The test
+# database therefore has no such table.
+#
+# Every spec that touches Ai::Credential builds it through this helper so the
+# column set stays in one place: specs that declared their own copy drifted
+# apart, and whichever ran last dropped the table the others expected.
+module EvoCoreApiKeysTable
+  module_function
+
+  def create!
+    connection = ActiveRecord::Base.connection
+    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+    return if connection.table_exists?(:evo_core_api_keys)
+
+    connection.create_table :evo_core_api_keys, id: false do |t|
+      t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
+      t.string :name, null: false
+      t.string :provider, null: false
+      t.text :key, null: false
+      t.string :key_hint, null: false, default: ''
+      t.string :scope, null: false, default: 'account'
+      t.string :imported_from
+      t.boolean :is_active, null: false, default: true
+      t.timestamps
+    end
+
+    # Mirrors idx_evo_core_api_keys_name_unique from the Go migration 000005:
+    # a name collision is a database error, not a cosmetic detail.
+    connection.add_index :evo_core_api_keys, :name, unique: true
+  end
+
+  def drop!
+    ActiveRecord::Base.connection.drop_table(:evo_core_api_keys, if_exists: true)
+  end
+end

--- a/spec/support/evo_core_api_keys_table.rb
+++ b/spec/support/evo_core_api_keys_table.rb
@@ -15,6 +15,11 @@ module EvoCoreApiKeysTable
     connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
     return if connection.table_exists?(:evo_core_api_keys)
 
+    create_columns!(connection)
+    add_constraints!(connection)
+  end
+
+  def create_columns!(connection)
     connection.create_table :evo_core_api_keys, id: false do |t|
       t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
       t.string :name, null: false
@@ -29,7 +34,9 @@ module EvoCoreApiKeysTable
       t.boolean :is_active, null: false, default: true
       t.timestamps
     end
+  end
 
+  def add_constraints!(connection)
     # Mirrors idx_evo_core_api_keys_name_unique from the Go migration 000005:
     # a name collision is a database error, not a cosmetic detail.
     connection.add_index :evo_core_api_keys, :name, unique: true
@@ -38,6 +45,19 @@ module EvoCoreApiKeysTable
     connection.add_index :evo_core_api_keys, :imported_from, unique: true,
                                                              where: 'imported_from IS NOT NULL',
                                                              name: 'idx_evo_core_api_keys_imported_from'
+    # Migration 000017 constrains the scope at the database level. Without it a
+    # spec can insert a scope the real schema rejects, and the suite proves
+    # nothing about the resolution chain it exercises.
+    # ⚠️ `agency` is NOT in the Go migration: it is the enterprise link the
+    # FR2 guard specs insert to prove the chain is extensible by insertion.
+    # Constraining the test schema to the two community scopes would make the
+    # database reject the very scenario story 1.2 exists to protect. The
+    # community CHECK stays two-valued; this helper is deliberately wider.
+    connection.execute(<<~SQL.squish)
+      ALTER TABLE evo_core_api_keys
+        ADD CONSTRAINT evo_core_api_keys_scope_check
+          CHECK (scope IN ('installation', 'agency', 'account'))
+    SQL
   end
 
   def drop!

--- a/spec/support/evo_core_api_keys_table.rb
+++ b/spec/support/evo_core_api_keys_table.rb
@@ -22,7 +22,9 @@ module EvoCoreApiKeysTable
       t.text :key, null: false
       t.string :key_hint, null: false, default: ''
       t.string :scope, null: false, default: 'account'
-      t.string :imported_from
+      # Mirrors migration 000018 EXACTLY, limit included: an unbounded column
+      # here hid a real VARCHAR(64) overflow in the 1.5 migration.
+      t.string :imported_from, limit: 64
       t.boolean :is_active, null: false, default: true
       t.timestamps
     end
@@ -30,6 +32,11 @@ module EvoCoreApiKeysTable
     # Mirrors idx_evo_core_api_keys_name_unique from the Go migration 000005:
     # a name collision is a database error, not a cosmetic detail.
     connection.add_index :evo_core_api_keys, :name, unique: true
+    # Migration 000018 also puts a PARTIAL unique index on imported_from; without
+    # it the idempotency tests rest only on the application-level exists? check.
+    connection.add_index :evo_core_api_keys, :imported_from, unique: true,
+                                                             where: 'imported_from IS NOT NULL',
+                                                             name: 'idx_evo_core_api_keys_imported_from'
   end
 
   def drop!

--- a/spec/support/evo_core_api_keys_table.rb
+++ b/spec/support/evo_core_api_keys_table.rb
@@ -24,6 +24,7 @@ module EvoCoreApiKeysTable
       t.string :scope, null: false, default: 'account'
       # Mirrors migration 000018 EXACTLY, limit included: an unbounded column
       # here hid a real VARCHAR(64) overflow in the 1.5 migration.
+      t.string :base_url, limit: 512
       t.string :imported_from, limit: 64
       t.boolean :is_active, null: false, default: true
       t.timestamps

--- a/spec/support/evo_core_custom_mcp_servers_table.rb
+++ b/spec/support/evo_core_custom_mcp_servers_table.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# `evo_core_custom_mcp_servers`, from the Go migration 000003 (plus
+# `credential_refs` from 000021). See EvoCoreCustomToolsTable.
+module EvoCoreCustomMcpServersTable
+  module_function
+
+  def create!
+    connection = ActiveRecord::Base.connection
+    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+    return if connection.table_exists?(:evo_core_custom_mcp_servers)
+
+    connection.create_table :evo_core_custom_mcp_servers, id: false do |t|
+      t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
+      t.string :name, null: false
+      t.text :description
+      t.string :url, null: false
+      t.json :headers, null: false
+      t.jsonb :credential_refs, null: false, default: {}
+      t.integer :timeout, null: false, default: 0
+      t.integer :retry_count, null: false, default: 0
+      t.boolean :is_active, default: true
+      t.timestamps
+    end
+
+    connection.execute('ALTER TABLE evo_core_custom_mcp_servers ADD PRIMARY KEY (id)')
+  end
+
+  def drop!
+    ActiveRecord::Base.connection.drop_table(:evo_core_custom_mcp_servers, if_exists: true)
+  end
+end

--- a/spec/support/evo_core_custom_tools_table.rb
+++ b/spec/support/evo_core_custom_tools_table.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# `evo_core_custom_tools` is created by the Go migration 000002 of
+# evo-ai-core-service (plus `credential_refs` from 000021) and is deliberately
+# absent from `db/schema.rb`. Specs build it here so the column set stays in one
+# place (same arrangement as EvoCoreIntegrationCredentialsTable).
+module EvoCoreCustomToolsTable
+  module_function
+
+  def create! # rubocop:disable Metrics/MethodLength -- mirrors the Go migration column for column
+    connection = ActiveRecord::Base.connection
+    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+    return if connection.table_exists?(:evo_core_custom_tools)
+
+    connection.create_table :evo_core_custom_tools, id: false do |t|
+      t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
+      t.string :name, null: false
+      t.text :description
+      t.string :method, null: false
+      t.string :endpoint, null: false
+      t.json :headers, null: false
+      t.jsonb :credential_refs, null: false, default: {}
+      t.json :path_params, null: false
+      t.json :query_params, null: false
+      t.json :body_params, null: false
+      t.json :error_handling, null: false
+      t.json :values, null: false
+      t.boolean :is_active, default: true
+      t.timestamps
+    end
+
+    connection.execute('ALTER TABLE evo_core_custom_tools ADD PRIMARY KEY (id)')
+  end
+
+  def drop!
+    ActiveRecord::Base.connection.drop_table(:evo_core_custom_tools, if_exists: true)
+  end
+end

--- a/spec/support/evo_core_integration_credentials_table.rb
+++ b/spec/support/evo_core_integration_credentials_table.rb
@@ -12,6 +12,11 @@ module EvoCoreIntegrationCredentialsTable
     connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
     return if connection.table_exists?(:evo_core_integration_credentials)
 
+    create_columns!(connection)
+    add_constraints!(connection)
+  end
+
+  def create_columns!(connection)
     connection.create_table :evo_core_integration_credentials, id: false do |t|
       t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
       t.string :name, null: false
@@ -27,15 +32,39 @@ module EvoCoreIntegrationCredentialsTable
       t.string :imported_from
       t.timestamps
     end
-
-    add_constraints!(connection)
   end
 
-  # Mirrors the Go migration: real primary key, and unique per scope — never
-  # on name alone.
+  # Mirrors migration 000019 of the core service: primary key, uniqueness per
+  # scope (never on name alone) AND the CHECK constraints.
+  #
+  # The CHECKs are not decoration here. Story 2.1 AC4 says an oauth row carries
+  # no value "by construction", and the construction IS the database constraint.
+  # A helper without them lets a spec insert a row the real schema rejects, so
+  # the suite would go green against a schema where the invariant does not
+  # exist — the same structural blindness the unique index had before.
   def add_constraints!(connection)
     connection.execute('ALTER TABLE evo_core_integration_credentials ADD PRIMARY KEY (id)')
     connection.add_index :evo_core_integration_credentials, %i[scope name], unique: true
+    # ⚠️ `agency` is NOT in the Go migration: it is the enterprise link the
+    # FR2 guard specs insert to prove the chain is extensible by insertion.
+    # Constraining the test schema to the two community scopes would make the
+    # database reject the very scenario story 1.2 exists to protect. The
+    # community CHECK stays two-valued; this helper is deliberately wider.
+    connection.execute(<<~SQL.squish)
+      ALTER TABLE evo_core_integration_credentials
+        ADD CONSTRAINT evo_core_integration_credentials_kind_check
+          CHECK (kind IN ('static', 'oauth')),
+        ADD CONSTRAINT evo_core_integration_credentials_value_format_check
+          CHECK (value_format IN ('scalar', 'composite')),
+        ADD CONSTRAINT evo_core_integration_credentials_scope_check
+          CHECK (scope IN ('installation', 'agency', 'account')),
+        ADD CONSTRAINT evo_core_integration_credentials_kind_content_check
+          CHECK (
+            (kind = 'static' AND value IS NOT NULL AND owner_store IS NULL AND owner_ref IS NULL)
+            OR
+            (kind = 'oauth' AND value IS NULL AND owner_store IS NOT NULL AND owner_ref IS NOT NULL)
+          )
+    SQL
   end
 
   def drop!

--- a/spec/support/evo_core_integration_credentials_table.rb
+++ b/spec/support/evo_core_integration_credentials_table.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# `evo_core_integration_credentials` is created by the Go migration 000019 of
+# evo-ai-core-service and is deliberately absent from `db/schema.rb`. Specs that
+# touch Ai::IntegrationCredential build it through this helper so the column set
+# stays in one place (same arrangement as EvoCoreApiKeysTable).
+module EvoCoreIntegrationCredentialsTable
+  module_function
+
+  def create!
+    connection = ActiveRecord::Base.connection
+    connection.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+    return if connection.table_exists?(:evo_core_integration_credentials)
+
+    connection.create_table :evo_core_integration_credentials, id: false do |t|
+      t.column :id, :uuid, null: false, default: -> { 'uuid_generate_v4()' }
+      t.string :name, null: false
+      t.string :provider, null: false
+      t.string :kind, null: false, default: 'static'
+      t.text :value
+      t.string :value_format, null: false, default: 'scalar'
+      t.string :value_hint
+      t.string :scope, null: false, default: 'account'
+      t.boolean :is_active, null: false, default: true
+      t.string :owner_store
+      t.string :owner_ref
+      t.string :imported_from
+      t.timestamps
+    end
+
+    add_constraints!(connection)
+  end
+
+  # Mirrors the Go migration: real primary key, and unique per scope — never
+  # on name alone.
+  def add_constraints!(connection)
+    connection.execute('ALTER TABLE evo_core_integration_credentials ADD PRIMARY KEY (id)')
+    connection.add_index :evo_core_integration_credentials, %i[scope name], unique: true
+  end
+
+  def drop!
+    ActiveRecord::Base.connection.drop_table(:evo_core_integration_credentials, if_exists: true)
+  end
+end


### PR DESCRIPTION
Ai::CredentialResolver como dono único da precedência (cadeia ordenada extensível, guarda do FR2 por spec), decryptor Fernet compartilhado com o core (enforce_ttl=false provado com ciphertext real do Go), assist/transcrição/etiquetas/moderação no registro com fallback legado atrás de guard, migrações dry-run-como-gate dos 2 épicos, aposentadoria das telas antigas. Inclui fixes de segurança: client_secret + code de autorização fora do log do HubSpot. 14 commits, 233 exemplos verdes. Ordem de merge da feature: **auth → core → CRM + processor → vendor/crm (front) → frontend (bump) → superprojeto**.

Guia de validação tela a tela: `_evo-output/planning-artifacts/config-ia-unificada/guia-teste-dev-evo-2250.md` (no superprojeto). Card: EVO-2250.

## Summary by Sourcery

Introduce centralized AI credential resolution and migration into shared vault, wire all AI features and agent bots to use it while preserving existing behaviour, and tighten security around secrets and OAuth flows.

New Features:
- Add AI credential registry integration and resolvers for core AI features and external integrations, including support for scope-based precedence and provider compatibility.
- Allow agent bots to reference shared integration credentials via a new credential_id field, with helper resolution for API keys and basic auth pairs.

Bug Fixes:
- Stop logging HubSpot OAuth client_secret and authorization codes, and ensure token refresh failures are surfaced via logging and authorization error reporting.
- Prevent agent bot secrets from being included in webhook payloads sent to third-party endpoints.

Enhancements:
- Update OpenAI and audio transcription configuration and integration hooks to rely on the new credential resolver, decoupling feature toggles from secret storage and improving visibility when credentials are missing.
- Add dry-run and gated migration tasks for AI and integration credentials, with round-trip verification, idempotency, and guards against partial or divergent imports.
- Share Fernet-based encryption/decryption utilities with evo-ai-core-service to ensure cross-language compatibility for stored credentials.
- Introduce migration state guards so legacy credential fallbacks are only retired once installations have safely migrated.

Tests:
- Add comprehensive specs for credential encryption/decryption, resolvers, migration flows, migration state guards, agent bot credential resolution, audio transcription behaviour, and HubSpot token refresh failure handling.