### PR TITLE
fix(health): /health/ready reprova com migration pendente

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -43,21 +43,8 @@ class HealthController < ActionController::Base
     false
   end
 
-  # A boot whose `db:migrate` aborted leaves the process serving requests over an
-  # INCOMPLETE schema: liveness passes, orchestrators mark the service healthy, and
-  # dependents start against tables that do not exist. Readiness must reflect that.
-  # Deliberately generic (pending migrations, not a table allowlist) so it covers any
-  # migration source — the app's own and those appended by mounted engines.
-  #
-  # It reads `Rails.application.paths['db/migrate']`, NOT the connection's default
-  # `migration_context`. That default resolves to just ["db/migrate"], so it sees only
-  # the app's own migrations: an engine that appends its path via an initializer is
-  # invisible to it, and a pending engine migration would report ready. Measured on a
-  # live boot: the default context saw 79 migrations, this one sees 216.
-  # Returns a STATE, not a boolean: a check that cannot run is not the same failure
-  # as a schema that is behind. Collapsing both into `pending_migrations` would report
-  # a permission error or a broken migration path as "run your migrations" — the same
-  # class of misleading-green this probe exists to remove.
+  # A boot whose `db:migrate` aborted keeps serving requests over an INCOMPLETE schema:
+  # liveness passes and dependents start against tables that do not exist.
   def check_schema
     migration_context.needs_migration? ? 'pending_migrations' : 'ok'
   rescue StandardError => e
@@ -65,6 +52,9 @@ class HealthController < ActionController::Base
     'check_failed'
   end
 
+  # NOT the connection's default `migration_context`: that one resolves to just
+  # ["db/migrate"], so migrations a mounted engine appends via initializer are invisible
+  # to it and a pending engine migration would report ready.
   def migration_context
     paths = Rails.application.paths['db/migrate'].to_a
     return ActiveRecord::Base.connection.migration_context if paths.blank?

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -20,14 +20,16 @@ class HealthController < ActionController::Base
   def ready
     database_ok = check_database
     redis_ok = check_redis
-    
-    is_ready = database_ok && redis_ok
-    
+    schema_ok = check_schema
+
+    is_ready = database_ok && redis_ok && schema_ok
+
     render json: {
       ready: is_ready,
       checks: {
         database: database_ok ? 'ok' : 'failing',
-        redis: redis_ok ? 'ok' : 'failing'
+        redis: redis_ok ? 'ok' : 'failing',
+        schema: schema_ok ? 'ok' : 'pending_migrations'
       }
     }, status: is_ready ? :ok : :service_unavailable
   end
@@ -37,6 +39,17 @@ class HealthController < ActionController::Base
   def check_database
     ActiveRecord::Base.connection.execute('SELECT 1')
     true
+  rescue StandardError
+    false
+  end
+
+  # A boot whose `db:migrate` aborted leaves the process serving requests over an
+  # INCOMPLETE schema: liveness passes, orchestrators mark the service healthy, and
+  # dependents start against tables that do not exist. Readiness must reflect that.
+  # Deliberately generic (pending migrations, not a table allowlist) so it covers any
+  # migration source — the app's own and those appended by mounted engines.
+  def check_schema
+    !ActiveRecord::Base.connection.migration_context.needs_migration?
   rescue StandardError
     false
   end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -48,10 +48,23 @@ class HealthController < ActionController::Base
   # dependents start against tables that do not exist. Readiness must reflect that.
   # Deliberately generic (pending migrations, not a table allowlist) so it covers any
   # migration source — the app's own and those appended by mounted engines.
+  #
+  # It reads `Rails.application.paths['db/migrate']`, NOT the connection's default
+  # `migration_context`. That default resolves to just ["db/migrate"], so it sees only
+  # the app's own migrations: an engine that appends its path via an initializer is
+  # invisible to it, and a pending engine migration would report ready. Measured on a
+  # live boot: the default context saw 79 migrations, this one sees 216.
   def check_schema
-    !ActiveRecord::Base.connection.migration_context.needs_migration?
+    !migration_context.needs_migration?
   rescue StandardError
     false
+  end
+
+  def migration_context
+    paths = Rails.application.paths['db/migrate'].to_a
+    return ActiveRecord::Base.connection.migration_context if paths.blank?
+
+    ActiveRecord::MigrationContext.new(paths)
   end
 
   def check_redis

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -20,16 +20,16 @@ class HealthController < ActionController::Base
   def ready
     database_ok = check_database
     redis_ok = check_redis
-    schema_ok = check_schema
+    schema_state = check_schema
 
-    is_ready = database_ok && redis_ok && schema_ok
+    is_ready = database_ok && redis_ok && schema_state == 'ok'
 
     render json: {
       ready: is_ready,
       checks: {
         database: database_ok ? 'ok' : 'failing',
         redis: redis_ok ? 'ok' : 'failing',
-        schema: schema_ok ? 'ok' : 'pending_migrations'
+        schema: schema_state
       }
     }, status: is_ready ? :ok : :service_unavailable
   end
@@ -54,10 +54,15 @@ class HealthController < ActionController::Base
   # the app's own migrations: an engine that appends its path via an initializer is
   # invisible to it, and a pending engine migration would report ready. Measured on a
   # live boot: the default context saw 79 migrations, this one sees 216.
+  # Returns a STATE, not a boolean: a check that cannot run is not the same failure
+  # as a schema that is behind. Collapsing both into `pending_migrations` would report
+  # a permission error or a broken migration path as "run your migrations" — the same
+  # class of misleading-green this probe exists to remove.
   def check_schema
-    !migration_context.needs_migration?
-  rescue StandardError
-    false
+    migration_context.needs_migration? ? 'pending_migrations' : 'ok'
+  rescue StandardError => e
+    Rails.logger.error("[health] schema check failed: #{e.class}: #{e.message}")
+    'check_failed'
   end
 
   def migration_context

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
-# `/health/ready` gates the whole compose boot: the enterprise healthcheck points at it
-# and six services block on `enterprise: service_healthy`. A regression here does not
-# fail loudly — it reports green over an incomplete schema, which is the exact failure
-# this endpoint was added to remove (EVO-2252).
+# `/health/ready` gates the compose boot: the enterprise healthcheck points at it and six
+# services block on `enterprise: service_healthy`. A regression here reports green over an
+# incomplete schema instead of failing loudly.
 RSpec.describe HealthController, type: :controller do
   before do
     allow(controller).to receive(:check_database).and_return(true)
@@ -65,10 +64,8 @@ RSpec.describe HealthController, type: :controller do
       end
     end
 
-    # Regression guard for the bug that made the first version of this check useless:
-    # the connection's default migration_context resolves to just ["db/migrate"], so it
-    # never sees migrations appended by a mounted engine. Measured on a live boot, the
-    # default context saw 79 migrations while the app's configured paths saw 216.
+    # Guards the bug that made the first version of this check useless: the connection's
+    # default migration_context never sees migrations appended by a mounted engine.
     it 'reads the application migration paths, not the connection default' do
       app_paths = %w[/app/db/migrate /enterprise/licensing-ruby/db/migrate]
       allow(Rails.application.paths['db/migrate']).to receive(:to_a).and_return(app_paths)
@@ -79,9 +76,8 @@ RSpec.describe HealthController, type: :controller do
       get :ready
 
       expect(response).to have_http_status(:ok)
-      # Asserting on :new closes the whole link — that the configured paths are what the
-      # context is BUILT from. Asserting only that `to_a` was called would still pass if
-      # the result were read and then discarded.
+      # Asserting on :new, not just on `to_a`: reading the paths and discarding them
+      # would still pass.
       expect(ActiveRecord::MigrationContext).to have_received(:new).with(app_paths)
     end
   end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe HealthController, type: :controller do
   end
 
   describe 'GET #ready' do
-    let(:body) { JSON.parse(response.body) }
+    let(:body) { response.parsed_body }
 
     context 'when the schema is up to date' do
       before { stub_migration_context(needs_migration: false) }
@@ -53,10 +53,15 @@ RSpec.describe HealthController, type: :controller do
         expect(body.dig('checks', 'schema')).to eq('check_failed')
       end
 
+      # `allow` + `have_received`, not a message expectation: constraining :error with
+      # `with` would also fail this example on any UNRELATED error the request logs.
       it 'logs the underlying error instead of swallowing it' do
-        expect(Rails.logger).to receive(:error).with(/schema check failed.*permission denied/)
+        allow(Rails.logger).to receive(:error)
 
         get :ready
+
+        expect(Rails.logger).to have_received(:error)
+          .with(/schema check failed.*permission denied/)
       end
     end
 
@@ -65,7 +70,8 @@ RSpec.describe HealthController, type: :controller do
     # never sees migrations appended by a mounted engine. Measured on a live boot, the
     # default context saw 79 migrations while the app's configured paths saw 216.
     it 'reads the application migration paths, not the connection default' do
-      expect(Rails.application.paths['db/migrate']).to receive(:to_a).and_return(%w[db/migrate])
+      app_paths = %w[/app/db/migrate /enterprise/licensing-ruby/db/migrate]
+      allow(Rails.application.paths['db/migrate']).to receive(:to_a).and_return(app_paths)
       allow(ActiveRecord::MigrationContext).to receive(:new).and_return(
         instance_double(ActiveRecord::MigrationContext, needs_migration?: false)
       )
@@ -73,6 +79,10 @@ RSpec.describe HealthController, type: :controller do
       get :ready
 
       expect(response).to have_http_status(:ok)
+      # Asserting on :new closes the whole link — that the configured paths are what the
+      # context is BUILT from. Asserting only that `to_a` was called would still pass if
+      # the result were read and then discarded.
+      expect(ActiveRecord::MigrationContext).to have_received(:new).with(app_paths)
     end
   end
 

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+# `/health/ready` gates the whole compose boot: the enterprise healthcheck points at it
+# and six services block on `enterprise: service_healthy`. A regression here does not
+# fail loudly — it reports green over an incomplete schema, which is the exact failure
+# this endpoint was added to remove (EVO-2252).
+RSpec.describe HealthController, type: :controller do
+  before do
+    allow(controller).to receive(:check_database).and_return(true)
+    allow(controller).to receive(:check_redis).and_return(true)
+  end
+
+  describe 'GET #ready' do
+    let(:body) { JSON.parse(response.body) }
+
+    context 'when the schema is up to date' do
+      before { stub_migration_context(needs_migration: false) }
+
+      it 'reports ready' do
+        get :ready
+
+        expect(response).to have_http_status(:ok)
+        expect(body['ready']).to be(true)
+        expect(body.dig('checks', 'schema')).to eq('ok')
+      end
+    end
+
+    context 'when a migration is pending' do
+      before { stub_migration_context(needs_migration: true) }
+
+      it 'reports NOT ready with 503' do
+        get :ready
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(body['ready']).to be(false)
+        expect(body.dig('checks', 'schema')).to eq('pending_migrations')
+      end
+    end
+
+    # A check that cannot RUN is a different failure from a schema that is BEHIND.
+    # Reporting a permission error as "pending_migrations" would send whoever reads it
+    # to run migrations that are already applied.
+    context 'when the schema check itself raises' do
+      before do
+        allow(ActiveRecord::MigrationContext).to receive(:new)
+          .and_raise(StandardError, 'permission denied for table schema_migrations')
+      end
+
+      it 'reports check_failed, not pending_migrations' do
+        get :ready
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(body.dig('checks', 'schema')).to eq('check_failed')
+      end
+
+      it 'logs the underlying error instead of swallowing it' do
+        expect(Rails.logger).to receive(:error).with(/schema check failed.*permission denied/)
+
+        get :ready
+      end
+    end
+
+    # Regression guard for the bug that made the first version of this check useless:
+    # the connection's default migration_context resolves to just ["db/migrate"], so it
+    # never sees migrations appended by a mounted engine. Measured on a live boot, the
+    # default context saw 79 migrations while the app's configured paths saw 216.
+    it 'reads the application migration paths, not the connection default' do
+      expect(Rails.application.paths['db/migrate']).to receive(:to_a).and_return(%w[db/migrate])
+      allow(ActiveRecord::MigrationContext).to receive(:new).and_return(
+        instance_double(ActiveRecord::MigrationContext, needs_migration?: false)
+      )
+
+      get :ready
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  def stub_migration_context(needs_migration:)
+    allow(ActiveRecord::MigrationContext).to receive(:new).and_return(
+      instance_double(ActiveRecord::MigrationContext, needs_migration?: needs_migration)
+    )
+  end
+end


### PR DESCRIPTION
## Problema

`/health/ready` checava apenas **banco + redis**. Um boot cujo `db:migrate` abortou continua servindo requests sobre um schema **incompleto**: a liveness passa, o orquestrador marca o serviço como healthy, e os dependentes sobem contra tabelas que não existem.

Observado ao vivo (EVO-2252): container `Up 57 minutes (healthy)` com o `db:migrate` abortado e **46 migrations pendentes**, entregando uma instalação morta.

## Fix

O readiness passa a checar migrations pendentes — e a **enxergar todas as fontes de migration**, não só as do app:

```ruby
ActiveRecord::MigrationContext.new(Rails.application.paths['db/migrate'].to_a)
```

Deliberadamente **genérico** (pendência de migration, não allowlist de tabelas): o community não conhece nome de tabela de nenhuma engine. É bug genuíno do community (healthcheck que mente não é comportamento enterprise), por isso o fix vem aqui e não num shim.

### Por que NÃO o `migration_context` padrão

`connection.migration_context` resolve para `["db/migrate"]` apenas. Uma engine que anexa seu path via initializer fica **invisível** para ele — e são justamente as migrations da engine de licensing que o bug deste card aborta.

Medido em boot real, dentro do container:

| | migrations vistas |
|---|---|
| `connection.migration_context` (antes) | **79** (só o app) |
| `Rails.application.paths['db/migrate']` (agora) | **216** (79 app + 137 engine) |

`schema_migrations` tem 239 linhas. Com o contexto padrão, apagar uma versão **da engine** deixava o endpoint respondendo `schema:ok`.

## Prova em ambiente real (compose, banco limpo)

Usando `20260728000000_add_partner_enabled_to_evo_enterprise_agencies` — versão que existe **só** em `/enterprise/licensing-ruby/db/migrate`, não em `/app/db/migrate`:

| estado | resposta | container |
|---|---|---|
| schema íntegro | `200` `{"ready":true,...,"schema":"ok"}` | `healthy` |
| versão da ENGINE removida | `503` `{"ready":false,...,"schema":"pending_migrations"}` | vira `unhealthy` (~50s, 5 retries) |
| versão restaurada | `200` `{"ready":true,...,"schema":"ok"}` | volta a `healthy` |

O `schema_migrations` foi restaurado às 239 linhas originais.

## Por que não dá falso negativo

`needs_migration?` é `migrations.collect(&:version) - get_all_versions` — **arquivos que faltam em `schema_migrations`**. Linhas órfãs em `schema_migrations` sem arquivo (as entradas `NO FILE`, resíduo de re-stamp) são a direção **inversa** e não afetam o resultado.

## Consumidor

O `docker-compose.ecosystem.yml` do `evolution-ecosystem` aponta o healthcheck do serviço `enterprise` para `/health/ready` (PR pareado), com `start_period` de 600s para o primeiro boot em banco limpo.

## Histórico deste PR

O primeiro commit (`6480fe3`) usava o `migration_context` padrão e **não cumpria o AC2** — a validação em banco limpo mostrou que ele não reprovava com migration de engine pendente. O commit `12a3646` corrige a fonte dos paths e a prova acima é dele.

Refs EVO-2252