### PR TITLE
fix: Propagate transcribed_text and attachments to BotRuntime

### DIFF
--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -528,7 +528,7 @@ class AgentBotListener < BaseListener
     return unless conversation
 
     message = create_message_from_payload(payload, conversation)
-    BotRuntime::DelegationService.new(agent_bot, message, conversation).delegate
+    BotRuntime::DelegationService.new(agent_bot, message, conversation, payload).delegate
 
     Rails.logger.info "[BotRuntime] Delegated message to Bot Runtime: " \
                       "conversation=#{conversation.display_id} bot=#{agent_bot.name}"

--- a/app/services/bot_runtime/delegation_service.rb
+++ b/app/services/bot_runtime/delegation_service.rb
@@ -2,10 +2,11 @@
 
 module BotRuntime
   class DelegationService
-    def initialize(agent_bot, message, conversation)
+    def initialize(agent_bot, message, conversation, payload = {})
       @agent_bot = agent_bot
       @message = message
       @conversation = conversation
+      @payload = payload
     end
 
     def delegate
@@ -25,6 +26,8 @@ module BotRuntime
         contact_id: stable_contact_id,
         message_id: @message.id.to_s,
         message_content: @message.content.to_s,
+        attachments: @payload[:attachments] || @payload['attachments'] || [],
+        transcribed_text: extract_transcribed_text,
         api_key: @agent_bot.api_key.to_s,
         outgoing_url: @agent_bot.outgoing_url.to_s,
         bot_config: build_bot_config,
@@ -92,6 +95,12 @@ module BotRuntime
     def stable_contact_id
       digest = Digest::SHA256.digest(@conversation.contact_id.to_s)
       digest.unpack1('Q>') & 0x7FFFFFFFFFFFFFFF
+    end
+
+    def extract_transcribed_text
+      attrs = @payload[:content_attributes] || @payload['content_attributes'] || {}
+      attrs[:transcribed_text] || attrs['transcribed_text'] ||
+        @payload[:transcribed_text] || @payload['transcribed_text']
     end
   end
 end


### PR DESCRIPTION
This PR fixes the issue where transcription and attachments were dropped when delegating the message event to BotRuntime. It modifies AgentBotListener to pass the original payload to the DelegationService so the data is sent to the AI processor pipeline.

## Summary by Sourcery

Propagate message payload data, including transcription and attachments, when delegating events to BotRuntime.

Bug Fixes:
- Ensure transcribed text from content attributes or payload is included in BotRuntime message events.
- Ensure message attachments from the original payload are forwarded to BotRuntime instead of being dropped.