### PR TITLE
refactor(ai): cadeia de escopos extensível via insert_link (EVO-1794)

### DIFF
--- a/app/services/ai/credential_migration.rb
+++ b/app/services/ai/credential_migration.rb
@@ -135,7 +135,7 @@ class Ai::CredentialMigration
 
     # Most specific link wins, exactly like Ai::ScopeChain: an already-registered
     # credential only survives where the import puts nothing.
-    Ai::ScopeChain::SCOPE_CHAIN.reverse_each do |scope|
+    Ai::ScopeChain.chain.reverse_each do |scope|
       projected_key = projected[scope.to_s]
       return projected_key if projected_key.present?
 

--- a/app/services/ai/credential_resolver.rb
+++ b/app/services/ai/credential_resolver.rb
@@ -11,10 +11,6 @@
 # `account:` is threaded rather than queried: this CRM is single-tenant and has
 # no accounts table. The parameter exists for that overlay to scope a link.
 class Ai::CredentialResolver
-  # Alias of Ai::ScopeChain::SCOPE_CHAIN, kept for call sites. The SAME frozen
-  # array, not a copy, so there is still one place to change.
-  SCOPE_CHAIN = Ai::ScopeChain::SCOPE_CHAIN
-
   # Key and endpoint travel together: an OpenAI-compatible provider is the pair,
   # so a key from one credential with a URL from elsewhere hits the wrong server.
   # `base_url` nil means "use the consumer's default".

--- a/app/services/ai/integration_credential_resolver.rb
+++ b/app/services/ai/integration_credential_resolver.rb
@@ -9,10 +9,6 @@
 # still serves the narrower case of a per-provider scope default. Both live here
 # so consumers never resolve an id by hand and spread the rule again.
 class Ai::IntegrationCredentialResolver
-  # Alias of the shared chain, kept for readability at call sites. It is the
-  # SAME frozen array as Ai::ScopeChain::SCOPE_CHAIN, not a copy.
-  SCOPE_CHAIN = Ai::ScopeChain::SCOPE_CHAIN
-
   # Three outcomes callers must tell apart: missing, reference (an oauth
   # connection whose secret lives in the store that owns it) and value.
   #

--- a/app/services/ai/scope_chain.rb
+++ b/app/services/ai/scope_chain.rb
@@ -2,21 +2,52 @@
 
 # The ordered scope chain and the single owner of how it is walked, shared by
 # both resolvers: two copies of the traversal would be two truths about
-# precedence, and the enterprise overlay's `agency` link would land in one and
-# be forgotten in the other.
+# precedence, and an overlay's inserted link would land in one and be forgotten
+# in the other.
 #
 # Most GENERIC to most SPECIFIC, and the most specific wins. A list and not a
 # pair, so inserting a link changes precedence without touching any logic.
+#
+# The chain is a base seed (`BASE_CHAIN`) plus links added at boot via
+# `insert_link`. An overlay reaches precedence it does not own by inserting into
+# the list — never by reopening a resolver.
 module Ai::ScopeChain
-  SCOPE_CHAIN = %i[installation account].freeze
+  BASE_CHAIN = %i[installation account].freeze
+
+  # Built from the seed; only `insert_link` (at boot) and `reset!` (tests) mutate
+  # it, so runtime reads need no lock.
+  @chain = BASE_CHAIN.dup
 
   module_function
+
+  # A defensive copy: the chain is mutated only through `insert_link`, never by a
+  # caller holding the array.
+  def chain
+    @chain.dup.freeze
+  end
+
+  # The extension port. Inserts `scope` immediately before `before`, or does
+  # nothing if it is already present. Idempotency is not cosmetic: a reloading
+  # boot hook would otherwise grow the chain `agency, agency, agency` unnoticed.
+  def insert_link(scope, before:)
+    return @chain if @chain.include?(scope)
+
+    index = @chain.index(before)
+    raise ArgumentError, "unknown chain link: #{before.inspect}" unless index
+
+    @chain.insert(index, scope)
+  end
+
+  # Restores the seed. For test isolation only — production never resets.
+  def reset!
+    @chain = BASE_CHAIN.dup
+  end
 
   # Walks from the most specific link to the most generic, returning the first
   # result the block yields. The caller supplies the per-scope lookup: the two
   # resolvers filter by different things, and knowing about both would couple
   # this module to each.
   def resolve(&)
-    SCOPE_CHAIN.reverse.lazy.filter_map(&).first
+    @chain.reverse.lazy.filter_map(&).first
   end
 end

--- a/spec/services/ai/credential_resolver_spec.rb
+++ b/spec/services/ai/credential_resolver_spec.rb
@@ -36,21 +36,23 @@ RSpec.describe Ai::CredentialResolver do
   end
 
   describe 'the ordered chain (AC3)' do
+    # insert_link mutates module state; restore the seed so a 3-link chain does
+    # not leak into the rest of the suite.
+    after { Ai::ScopeChain.reset! }
+
     it 'declares scopes from the most generic to the most specific' do
-      expect(described_class::SCOPE_CHAIN).to eq(%i[installation account])
+      expect(Ai::ScopeChain.chain).to eq(%i[installation account])
     end
 
-    # FR2 guard: the enterprise overlay adds an `agency` link between
-    # installation and account. Inserting a link must change precedence WITHOUT
-    # editing the resolver — if this spec ever needs a resolver change to pass,
-    # the "if account else installation" shape has crept back in.
+    # FR2 guard: an overlay adds a link between installation and account.
+    # Inserting a link must change precedence WITHOUT editing the resolver — if
+    # this spec ever needs a resolver change to pass, the "if account else
+    # installation" shape has crept back in.
     #
-    # The stub targets Ai::ScopeChain since story 2.2 moved the chain there to
-    # share it with the integration credential resolver. Stubbing the alias on
-    # this class instead would define a constant nothing reads any more, and
-    # this guard would go green while testing nothing.
+    # It uses the real insert_link port, so the guard exercises the very path an
+    # overlay takes.
     it 'resolves a link inserted into the chain without any resolver change' do
-      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
+      Ai::ScopeChain.insert_link(:agency, before: :account)
       create_credential(name: 'Da instalacao', scope: 'installation')
       agency = create_credential(name: 'Da agencia', scope: 'agency')
 
@@ -58,7 +60,7 @@ RSpec.describe Ai::CredentialResolver do
     end
 
     it 'keeps honouring the most specific link when the new one is empty' do
-      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
+      Ai::ScopeChain.insert_link(:agency, before: :account)
       create_credential(name: 'Da instalacao', scope: 'installation')
       account = create_credential(name: 'Da conta', scope: 'account')
 

--- a/spec/services/ai/integration_credential_resolver_spec.rb
+++ b/spec/services/ai/integration_credential_resolver_spec.rb
@@ -72,17 +72,19 @@ RSpec.describe Ai::IntegrationCredentialResolver do
   end
 
   describe 'the ordered chain (AC1)' do
+    after { Ai::ScopeChain.reset! }
+
     it 'declares scopes from the most generic to the most specific' do
-      expect(described_class::SCOPE_CHAIN).to eq(%i[installation account])
+      expect(Ai::ScopeChain.chain).to eq(%i[installation account])
     end
 
-    # FR2 guard, same shape as story 1.2: the enterprise overlay inserts an
-    # `agency` link between installation and account. Inserting a link must
-    # change precedence WITHOUT editing the resolver — if this spec ever needs
-    # a resolver change to pass, the "if account else installation" shape has
-    # crept back in.
+    # FR2 guard, same shape as story 1.2: an overlay inserts a link between
+    # installation and account. Inserting a link must change precedence WITHOUT
+    # editing the resolver — via the real insert_link port. Both resolvers walk
+    # the one shared Ai::ScopeChain, so this reaching the integration resolver
+    # proves the chain is not copied per class.
     it 'resolves a link inserted into the chain without any resolver change' do
-      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
+      Ai::ScopeChain.insert_link(:agency, before: :account)
       create_credential(name: 'Da instalacao', scope: 'installation')
       agency = create_credential(name: 'Da agencia', scope: 'agency')
 
@@ -90,19 +92,11 @@ RSpec.describe Ai::IntegrationCredentialResolver do
     end
 
     it 'keeps honouring the most specific link when the new one is empty' do
-      stub_const('Ai::ScopeChain::SCOPE_CHAIN', %i[installation agency account])
+      Ai::ScopeChain.insert_link(:agency, before: :account)
       create_credential(name: 'Da instalacao', scope: 'installation')
       account = create_credential(name: 'Da conta', scope: 'account')
 
       expect(described_class.resolve_default(provider: 'dify')).to eq(account)
-    end
-
-    # The story asks for ONE chain, not two copies: a change in one place must
-    # reach both resolvers. Two constants would diverge at the first bugfix,
-    # which is exactly what story 1.2 exists to prevent.
-    it 'shares the chain with the AI credential resolver' do
-      expect(described_class::SCOPE_CHAIN).to equal(Ai::CredentialResolver::SCOPE_CHAIN)
-      expect(described_class::SCOPE_CHAIN).to equal(Ai::ScopeChain::SCOPE_CHAIN)
     end
   end
 

--- a/spec/services/ai/scope_chain_spec.rb
+++ b/spec/services/ai/scope_chain_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ai::ScopeChain do
+  # insert_link mutates module state; restore the seed after every example so a
+  # 3-link chain does not leak into another test.
+  after { described_class.reset! }
+
+  describe '.chain' do
+    it 'is the base seed by default' do
+      expect(described_class.chain).to eq(%i[installation account])
+    end
+
+    it 'returns a frozen copy so a caller cannot mutate the chain' do
+      expect(described_class.chain).to be_frozen
+      expect { described_class.chain << :agency }.to raise_error(FrozenError)
+      expect(described_class.chain).to eq(%i[installation account])
+    end
+  end
+
+  describe '.insert_link' do
+    it 'inserts a link immediately before the named one' do
+      described_class.insert_link(:agency, before: :account)
+      expect(described_class.chain).to eq(%i[installation agency account])
+    end
+
+    # A reloading boot hook re-runs the insert; without idempotency the chain
+    # would grow agency, agency, agency unnoticed.
+    it 'is idempotent — inserting the same link twice does not duplicate it' do
+      described_class.insert_link(:agency, before: :account)
+      described_class.insert_link(:agency, before: :account)
+      expect(described_class.chain).to eq(%i[installation agency account])
+    end
+
+    it 'raises when the anchor link is unknown, never inserting silently' do
+      expect { described_class.insert_link(:agency, before: :nope) }
+        .to raise_error(ArgumentError, /unknown chain link/)
+      expect(described_class.chain).to eq(%i[installation account])
+    end
+  end
+
+  describe '.resolve' do
+    it 'walks from the most specific link to the most generic' do
+      seen = []
+      described_class.resolve do |scope|
+        seen << scope
+        nil
+      end
+      expect(seen).to eq(%i[account installation])
+    end
+
+    it 'returns the first non-nil the block yields and stops there' do
+      seen = []
+      result = described_class.resolve do |scope|
+        seen << scope
+        scope == :account ? :hit : nil
+      end
+      expect(result).to eq(:hit)
+      expect(seen).to eq(%i[account])
+    end
+
+    it 'walks an inserted link in precedence order' do
+      described_class.insert_link(:agency, before: :account)
+      seen = []
+      described_class.resolve do |scope|
+        seen << scope
+        nil
+      end
+      expect(seen).to eq(%i[account agency installation])
+    end
+  end
+
+  describe '.reset!' do
+    it 'restores the base seed' do
+      described_class.insert_link(:agency, before: :account)
+      described_class.reset!
+      expect(described_class.chain).to eq(%i[installation account])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Torna a cadeia de escopos de credencial de IA (`Ai::ScopeChain`) **extensível**: um `insert_link(scope, before:)` idempotente permite inserir um elo na precedência sem reescrever os resolvers. Antes a cadeia era uma constante congelada de dois elos e os comentários já previam o elo intermediário do FR2, mas **sem mecanismo** — os specs falsificavam com `stub_const`.

- `BASE_CHAIN` (semente) + `chain` (montada no boot) + **`insert_link` idempotente** + `reset!` (isolamento de teste)
- mata os aliases `SCOPE_CHAIN` dos dois resolvers (passam a usar `Ai::ScopeChain.chain`/`.resolve`)
- `credential_migration` percorre `chain` (o terceiro leitor)
- specs migram de `stub_const` para `insert_link` — o teste passa a exercitar o caminho real de inserção

**Comportamento idêntico numa instalação sem overlay:** dois elos, mesma precedência, sem migração e sem config nova.

## Security

Nenhuma superfície nova. É mecanismo interno de resolução — sem endpoint, payload ou schema. `insert_link` é idempotente (um gancho de boot que recarrega não faz a cadeia crescer).

## Test plan

- `bundle exec rspec spec/services/ai/` → **63 examples, 0 failures**
- `rubocop` → limpo

## Changed Files

- `app/services/ai/scope_chain.rb`
- `app/services/ai/credential_resolver.rb`, `app/services/ai/integration_credential_resolver.rb`
- `app/services/ai/credential_migration.rb`
- `spec/services/ai/scope_chain_spec.rb` (novo), `credential_resolver_spec.rb`, `integration_credential_resolver_spec.rb`

## Linked Issue

EVO-1794 (rastreamento interno)

## Summary by Sourcery

Make the AI credential scope chain extensible and centrally managed to support inserting new precedence links without changing resolvers.

Enhancements:
- Refactor Ai::ScopeChain to build the scope list from a base seed with a public chain accessor and an insert_link API for inserting scopes before a given link.
- Remove per-resolver scope chain aliases so all resolvers and migrations read from the single shared Ai::ScopeChain.
- Update the AI credential migration to walk the shared scope chain via the new chain accessor, aligning its precedence with the resolvers.

Tests:
- Add dedicated specs for Ai::ScopeChain covering chain exposure, insert_link idempotency and ordering, resolve traversal, and reset! behavior.
- Update resolver specs to exercise scope insertion through insert_link and ensure test isolation via reset!, replacing direct constant stubbing and shared-chain assertions.