### PR TITLE
fix(whatsapp-cloud): transcode browser voice notes (webm) to ogg/opus before upload

### DIFF
--- a/app/services/whatsapp/audio_converter_service.rb
+++ b/app/services/whatsapp/audio_converter_service.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'English'
+require 'shellwords'
+
 module Whatsapp
   class AudioConverterService
     class ConversionError < StandardError; end
@@ -22,7 +25,7 @@ module Whatsapp
       command = build_ffmpeg_command(input_path, output_path)
 
       Rails.logger.info "Converting audio: #{input_path} -> #{output_path}"
-      Rails.logger.debug "FFmpeg command: #{command}"
+      Rails.logger.debug { "FFmpeg command: #{command}" }
 
       # Execute FFmpeg conversion
       output = `#{command} 2>&1`

--- a/app/services/whatsapp/audio_converter_service.rb
+++ b/app/services/whatsapp/audio_converter_service.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-require 'English'
-require 'shellwords'
+require 'open3'
 
 module Whatsapp
   class AudioConverterService
     class ConversionError < StandardError; end
+
+    # Hard ceiling for the ffmpeg subprocess. Transcoding a voice note takes
+    # well under a second; anything past this is a hung or pathological input,
+    # and it runs inline on the Sidekiq thread that sends the message.
+    FFMPEG_TIMEOUT_SECONDS = 30
 
     # Convert audio file to OGG format with Opus codec
     # @param input_path [String] Path to the input audio file
@@ -13,7 +17,7 @@ module Whatsapp
     def self.convert_to_ogg_opus(input_path)
       raise ConversionError, 'Input file does not exist' unless File.exist?(input_path)
 
-      output_path = input_path.sub(File.extname(input_path), '.ogg')
+      output_path = ogg_output_path(input_path)
 
       # Build FFmpeg command for OGG/Opus conversion
       # Based on WhatsApp's recommended audio format:
@@ -25,11 +29,10 @@ module Whatsapp
       command = build_ffmpeg_command(input_path, output_path)
 
       Rails.logger.info "Converting audio: #{input_path} -> #{output_path}"
-      Rails.logger.debug { "FFmpeg command: #{command}" }
+      Rails.logger.debug { "FFmpeg command: #{command.join(' ')}" }
 
       # Execute FFmpeg conversion
-      output = `#{command} 2>&1`
-      status = $CHILD_STATUS
+      output, status = run_ffmpeg(command)
 
       unless status.success?
         Rails.logger.error "FFmpeg conversion failed: #{output}"
@@ -39,18 +42,55 @@ module Whatsapp
       Rails.logger.info "Audio converted successfully: #{output_path}"
       output_path
     rescue StandardError => e
+      # ffmpeg opens the output file before it finishes decoding, so a failure
+      # can leave a partial .ogg behind. The caller only cleans up paths this
+      # method returned, so drop it here.
+      FileUtils.rm_f(output_path) if output_path
       Rails.logger.error "Audio conversion error: #{e.message}"
       raise ConversionError, e.message
     end
 
-    # Build FFmpeg command with proper options for WhatsApp voice messages
-    def self.build_ffmpeg_command(input_path, output_path)
-      # Escape file paths for shell
-      input_escaped = Shellwords.escape(input_path)
-      output_escaped = Shellwords.escape(output_path)
+    # Swap the extension for .ogg. Not String#sub: File.extname returns "" for
+    # a file with no extension, and sub("") matches at position 0, which would
+    # prepend ".ogg" to the path instead of appending it.
+    def self.ogg_output_path(input_path)
+      "#{input_path.delete_suffix(File.extname(input_path))}.ogg"
+    end
 
+    # Run ffmpeg without a shell and kill the process group if it outlives
+    # FFMPEG_TIMEOUT_SECONDS, so a hung encode cannot pin the worker thread.
+    # @return [Array(String, Process::Status)] combined output and exit status
+    def self.run_ffmpeg(command)
+      Open3.popen2e(*command, pgroup: true) do |stdin, out_err, wait_thr|
+        stdin.close
+
+        # Drain stdout/stderr concurrently: ffmpeg deadlocks if the pipe buffer
+        # fills while we are waiting on the process.
+        reader = Thread.new { out_err.read }
+        reader.report_on_exception = false
+
+        unless wait_thr.join(FFMPEG_TIMEOUT_SECONDS)
+          terminate_process_group(wait_thr.pid)
+          reader.join(1)
+          raise ConversionError, "FFmpeg timed out after #{FFMPEG_TIMEOUT_SECONDS}s"
+        end
+
+        [reader.value.to_s, wait_thr.value]
+      end
+    end
+
+    def self.terminate_process_group(pid)
+      Process.kill('KILL', -pid)
+    rescue Errno::ESRCH
+      # already gone
+    end
+
+    # Build FFmpeg command with proper options for WhatsApp voice messages
+    # @return [Array<String>] argv, executed without a shell
+    def self.build_ffmpeg_command(input_path, output_path)
       # FFmpeg options optimized for WhatsApp voice messages
       # -y: overwrite output file if exists
+      # -nostdin: never touch the worker's stdin
       # -i: input file
       # -vn: disable video (audio only)
       # -c:a libopus: use Opus audio codec
@@ -62,7 +102,8 @@ module Whatsapp
       [
         'ffmpeg',
         '-y',
-        '-i', input_escaped,
+        '-nostdin',
+        '-i', input_path,
         '-vn',
         '-c:a', 'libopus',
         '-b:a', '128k',
@@ -70,8 +111,8 @@ module Whatsapp
         '-ac', '1',
         '-application', 'voip',
         '-avoid_negative_ts', 'make_zero',
-        output_escaped
-      ].join(' ')
+        output_path
+      ]
     end
   end
 end

--- a/app/services/whatsapp/audio_converter_service.rb
+++ b/app/services/whatsapp/audio_converter_service.rb
@@ -32,7 +32,7 @@ module Whatsapp
       Rails.logger.debug { "FFmpeg command: #{command.join(' ')}" }
 
       # Execute FFmpeg conversion
-      output, status = run_ffmpeg(command)
+      output, status = run_with_timeout(command)
 
       unless status.success?
         Rails.logger.error "FFmpeg conversion failed: #{output}"
@@ -57,10 +57,29 @@ module Whatsapp
       "#{input_path.delete_suffix(File.extname(input_path))}.ogg"
     end
 
-    # Run ffmpeg without a shell and kill the process group if it outlives
-    # FFMPEG_TIMEOUT_SECONDS, so a hung encode cannot pin the worker thread.
+    # Codec of the first audio stream, used to tell an OGG/Opus apart from an
+    # OGG carrying anything else. Never raises: a probe we cannot run must not
+    # fail the send, it falls back to the caller's default.
+    # @return [String, nil] codec name, or nil when it cannot be read
+    def self.audio_codec(input_path)
+      command = [
+        'ffprobe', '-v', 'error', '-select_streams', 'a:0',
+        '-show_entries', 'stream=codec_name', '-of', 'csv=p=0', input_path
+      ]
+      output, status = run_with_timeout(command)
+      return nil unless status.success?
+
+      codec = output.strip
+      codec.empty? ? nil : codec
+    rescue StandardError => e
+      Rails.logger.warn "Could not probe audio codec of #{input_path}: #{e.message}"
+      nil
+    end
+
+    # Run ffmpeg/ffprobe without a shell and kill the process group if it
+    # outlives FFMPEG_TIMEOUT_SECONDS, so a hung encode cannot pin the worker.
     # @return [Array(String, Process::Status)] combined output and exit status
-    def self.run_ffmpeg(command)
+    def self.run_with_timeout(command)
       Open3.popen2e(*command, pgroup: true) do |stdin, out_err, wait_thr|
         stdin.close
 
@@ -72,7 +91,7 @@ module Whatsapp
         unless wait_thr.join(FFMPEG_TIMEOUT_SECONDS)
           terminate_process_group(wait_thr.pid)
           reader.join(1)
-          raise ConversionError, "FFmpeg timed out after #{FFMPEG_TIMEOUT_SECONDS}s"
+          raise ConversionError, "#{command.first} timed out after #{FFMPEG_TIMEOUT_SECONDS}s"
         end
 
         [reader.value.to_s, wait_thr.value]

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -389,10 +389,27 @@ module Whatsapp
 
         # Download attachment to temporary file
         temp_file = download_attachment_to_temp(attachment)
+        upload_path = temp_file.path
+        upload_mime = mime_type
+        converted_path = nil
 
         begin
-          # Upload original audio to WhatsApp Media API (no backend transcoding)
-          media_id = upload_media_to_whatsapp(temp_file.path, mime_type)
+          # WhatsApp Cloud rejects browser voice notes (audio/webm): the Media
+          # API only accepts aac/mp4/mpeg/amr/ogg. Transcode any non-accepted
+          # container to OGG/Opus (the format WhatsApp expects for voice notes)
+          # before upload — ffmpeg ships in the image (docker/Dockerfile) and the
+          # conversion is done by Whatsapp::AudioConverterService. Accepted
+          # formats pass through untouched.
+          unless whatsapp_accepted_audio?(mime_type)
+            converted_path = Whatsapp::AudioConverterService.convert_to_ogg_opus(temp_file.path)
+            upload_path = converted_path
+            upload_mime = 'audio/ogg'
+            Rails.logger.info(
+              "Transcoded audio #{mime_type} -> audio/ogg for WhatsApp Cloud (message #{message.id})"
+            )
+          end
+
+          media_id = upload_media_to_whatsapp(upload_path, upload_mime)
           return if media_id.blank?
 
           # Send message with media_id and voice: true
@@ -412,12 +429,15 @@ module Whatsapp
           )
 
           process_response(response)
+        rescue Whatsapp::AudioConverterService::ConversionError => e
+          mark_audio_upload_failed(message, "WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED - #{e.message}")
+          nil
         rescue AudioUploadError => e
           mark_audio_upload_failed(message, e.message)
           nil
         ensure
-          # Clean up temporary file
-          File.delete(temp_file.path) if temp_file && File.exist?(temp_file.path)
+          # Clean up temporary files (original download + any transcoded copy)
+          [temp_file&.path, converted_path].compact.uniq.each { |p| FileUtils.rm_f(p) }
 
           duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round
           Rails.logger.info("WhatsApp Cloud audio send finished message_id=#{message.id} duration_ms=#{duration_ms}")
@@ -498,6 +518,14 @@ module Whatsapp
 
       def detect_attachment_mime_type(attachment)
         attachment&.file&.blob&.content_type.presence || 'application/octet-stream'
+      end
+
+      # Audio MIME types the WhatsApp Cloud Media API accepts as-is (voice notes).
+      WHATSAPP_ACCEPTED_AUDIO_MIME = %w[audio/aac audio/mp4 audio/mpeg audio/amr audio/ogg].freeze
+
+      def whatsapp_accepted_audio?(mime_type)
+        base = mime_type.to_s.split(';').first.to_s.strip.downcase
+        WHATSAPP_ACCEPTED_AUDIO_MIME.include?(base)
       end
 
       def mark_audio_upload_failed(message, error_message)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -5,7 +5,13 @@ module Whatsapp
     class WhatsappCloudService < Whatsapp::Providers::BaseService
       include Whatsapp::Providers::Concerns::TemplateSync
       class AudioUploadError < StandardError; end
-      
+
+      # Audio MIME types the WhatsApp Cloud Media API accepts as-is (voice notes).
+      WHATSAPP_ACCEPTED_AUDIO_MIME = %w[audio/aac audio/mp4 audio/mpeg audio/amr audio/ogg].freeze
+
+      # Meta rejects media uploads over 16 MB.
+      WHATSAPP_MAX_MEDIA_BYTES = 16.megabytes
+
       def send_message(phone_number, message)
         @message = message
 
@@ -436,8 +442,10 @@ module Whatsapp
           mark_audio_upload_failed(message, e.message)
           nil
         ensure
-          # Clean up temporary files (original download + any transcoded copy)
-          [temp_file&.path, converted_path].compact.uniq.each { |p| FileUtils.rm_f(p) }
+          # Clean up temporary files. close! also releases the Tempfile handle,
+          # which rm_f on its path alone would leak until GC.
+          temp_file&.close!
+          FileUtils.rm_f(converted_path) if converted_path
 
           duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round
           Rails.logger.info("WhatsApp Cloud audio send finished message_id=#{message.id} duration_ms=#{duration_ms}")
@@ -488,6 +496,8 @@ module Whatsapp
       def upload_media_to_whatsapp(file_path, content_type)
         Rails.logger.info "Uploading media to WhatsApp: #{file_path} (mime_type=#{content_type})"
 
+        validate_media_size!(file_path)
+
         # Prepare multipart form data
         response = File.open(file_path, 'rb') do |file_io|
           HTTParty.post(
@@ -520,8 +530,15 @@ module Whatsapp
         attachment&.file&.blob&.content_type.presence || 'application/octet-stream'
       end
 
-      # Audio MIME types the WhatsApp Cloud Media API accepts as-is (voice notes).
-      WHATSAPP_ACCEPTED_AUDIO_MIME = %w[audio/aac audio/mp4 audio/mpeg audio/amr audio/ogg].freeze
+      # Fail with an actionable reason instead of Meta's generic error: the
+      # transcode can grow the file past the limit.
+      def validate_media_size!(file_path)
+        size = File.size(file_path)
+        return if size <= WHATSAPP_MAX_MEDIA_BYTES
+
+        raise AudioUploadError,
+              "WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED - file is #{size} bytes, over the #{WHATSAPP_MAX_MEDIA_BYTES} byte limit"
+      end
 
       def whatsapp_accepted_audio?(mime_type)
         base = mime_type.to_s.split(';').first.to_s.strip.downcase

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -406,7 +406,7 @@ module Whatsapp
           # before upload — ffmpeg ships in the image (docker/Dockerfile) and the
           # conversion is done by Whatsapp::AudioConverterService. Accepted
           # formats pass through untouched.
-          unless whatsapp_accepted_audio?(mime_type)
+          if transcode_required?(mime_type, temp_file.path)
             converted_path = Whatsapp::AudioConverterService.convert_to_ogg_opus(temp_file.path)
             upload_path = converted_path
             upload_mime = 'audio/ogg'
@@ -541,8 +541,23 @@ module Whatsapp
       end
 
       def whatsapp_accepted_audio?(mime_type)
-        base = mime_type.to_s.split(';').first.to_s.strip.downcase
-        WHATSAPP_ACCEPTED_AUDIO_MIME.include?(base)
+        WHATSAPP_ACCEPTED_AUDIO_MIME.include?(base_mime_type(mime_type))
+      end
+
+      def base_mime_type(mime_type)
+        mime_type.to_s.split(';').first.to_s.strip.downcase
+      end
+
+      # Of the accepted containers, Meta takes OGG only with the Opus codec, so
+      # an OGG carrying Vorbis is still rejected with (#100). Probe it and
+      # transcode when it is not Opus. A probe that comes back empty keeps the
+      # pass-through it has today rather than re-encoding a working file.
+      def transcode_required?(mime_type, path)
+        return true unless whatsapp_accepted_audio?(mime_type)
+        return false unless base_mime_type(mime_type) == 'audio/ogg'
+
+        codec = Whatsapp::AudioConverterService.audio_codec(path)
+        codec.present? && codec != 'opus'
       end
 
       def mark_audio_upload_failed(message, error_message)

--- a/spec/services/whatsapp/audio_converter_service_spec.rb
+++ b/spec/services/whatsapp/audio_converter_service_spec.rb
@@ -70,11 +70,44 @@ RSpec.describe Whatsapp::AudioConverterService do
     end
   end
 
-  describe '.run_ffmpeg' do
+  describe '.audio_codec' do
+    it 'reads the codec of an OGG/Opus file' do
+      webm = Rails.root.join('tmp', "wa_in_#{SecureRandom.hex(4)}.webm").to_s
+      record_webm_opus(webm)
+      ogg = described_class.convert_to_ogg_opus(webm)
+
+      expect(described_class.audio_codec(ogg)).to eq('opus')
+    ensure
+      [webm, ogg].each { |f| File.delete(f) if f && File.exist?(f) }
+    end
+
+    it 'reads the codec of an OGG carrying Vorbis (which WhatsApp rejects)' do
+      ogg = Rails.root.join('tmp', "wa_in_#{SecureRandom.hex(4)}.ogg").to_s
+      system(
+        'ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-f', 'lavfi',
+        '-i', 'sine=frequency=440:duration=1', '-c:a', 'libvorbis', ogg
+      )
+
+      expect(described_class.audio_codec(ogg)).to eq('vorbis')
+    ensure
+      File.delete(ogg) if ogg && File.exist?(ogg)
+    end
+
+    it 'returns nil instead of raising when the file cannot be probed' do
+      garbage = Rails.root.join('tmp', "wa_in_#{SecureRandom.hex(4)}.ogg").to_s
+      File.write(garbage, 'not actually audio')
+
+      expect(described_class.audio_codec(garbage)).to be_nil
+    ensure
+      File.delete(garbage) if garbage && File.exist?(garbage)
+    end
+  end
+
+  describe '.run_with_timeout' do
     it 'kills the subprocess and raises once it outlives the timeout' do
       stub_const("#{described_class}::FFMPEG_TIMEOUT_SECONDS", 1)
 
-      expect { described_class.run_ffmpeg(['sleep', '30']) }
+      expect { described_class.run_with_timeout(['sleep', '30']) }
         .to raise_error(described_class::ConversionError, /timed out after 1s/)
     end
   end

--- a/spec/services/whatsapp/audio_converter_service_spec.rb
+++ b/spec/services/whatsapp/audio_converter_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Functional spec: shells out to the real ffmpeg (shipped in the image) to prove
+# a browser voice note (WebM/Opus) is transcoded to the OGG/Opus format WhatsApp
+# Cloud accepts. The example self-skips where ffmpeg is unavailable.
+RSpec.describe Whatsapp::AudioConverterService do
+  describe '.convert_to_ogg_opus' do
+    it 'raises ConversionError when the input file does not exist' do
+      expect { described_class.convert_to_ogg_opus('/tmp/does-not-exist-xyz.webm') }
+        .to raise_error(described_class::ConversionError, /does not exist/)
+    end
+
+    it 'transcodes a real WebM/Opus voice note to a non-empty OGG/Opus file' do
+      skip 'ffmpeg not available' unless system('ffmpeg -version > /dev/null 2>&1')
+
+      webm = Rails.root.join('tmp', "wa_in_#{SecureRandom.hex(4)}.webm").to_s
+      ogg = webm.sub(/\.webm\z/, '.ogg')
+      # what the browser MediaRecorder produces: Opus audio in a WebM container
+      system(
+        'ffmpeg -y -hide_banner -loglevel error -f lavfi ' \
+        "-i sine=frequency=440:duration=1 -c:a libopus -f webm #{webm}"
+      )
+
+      out = described_class.convert_to_ogg_opus(webm)
+
+      expect(out).to eq(ogg)
+      expect(File.exist?(out)).to be(true)
+      expect(File.size(out)).to be > 0
+
+      codec = `ffprobe -v error -select_streams a:0 -show_entries stream=codec_name -of csv=p=0 #{out}`.strip
+      expect(codec).to eq('opus')
+    ensure
+      [webm, ogg].each { |f| File.delete(f) if f && File.exist?(f) }
+    end
+  end
+end

--- a/spec/services/whatsapp/audio_converter_service_spec.rb
+++ b/spec/services/whatsapp/audio_converter_service_spec.rb
@@ -4,8 +4,24 @@ require 'rails_helper'
 
 # Functional spec: shells out to the real ffmpeg (shipped in the image) to prove
 # a browser voice note (WebM/Opus) is transcoded to the OGG/Opus format WhatsApp
-# Cloud accepts. The example self-skips where ffmpeg is unavailable.
+# Cloud accepts.
 RSpec.describe Whatsapp::AudioConverterService do
+  # The transcode fix depends on ffmpeg/ffprobe being in the image
+  # (docker/Dockerfile). Assert it instead of skipping the examples below, so a
+  # build that drops them fails here rather than silently in production.
+  it 'runs on an image that ships ffmpeg and ffprobe' do
+    expect(system('ffmpeg -version > /dev/null 2>&1')).to be(true)
+    expect(system('ffprobe -version > /dev/null 2>&1')).to be(true)
+  end
+
+  def record_webm_opus(path)
+    # what the browser MediaRecorder produces: Opus audio in a WebM container
+    system(
+      'ffmpeg', '-y', '-hide_banner', '-loglevel', 'error', '-f', 'lavfi',
+      '-i', 'sine=frequency=440:duration=1', '-c:a', 'libopus', '-f', 'webm', path
+    )
+  end
+
   describe '.convert_to_ogg_opus' do
     it 'raises ConversionError when the input file does not exist' do
       expect { described_class.convert_to_ogg_opus('/tmp/does-not-exist-xyz.webm') }
@@ -13,15 +29,9 @@ RSpec.describe Whatsapp::AudioConverterService do
     end
 
     it 'transcodes a real WebM/Opus voice note to a non-empty OGG/Opus file' do
-      skip 'ffmpeg not available' unless system('ffmpeg -version > /dev/null 2>&1')
-
       webm = Rails.root.join('tmp', "wa_in_#{SecureRandom.hex(4)}.webm").to_s
       ogg = webm.sub(/\.webm\z/, '.ogg')
-      # what the browser MediaRecorder produces: Opus audio in a WebM container
-      system(
-        'ffmpeg -y -hide_banner -loglevel error -f lavfi ' \
-        "-i sine=frequency=440:duration=1 -c:a libopus -f webm #{webm}"
-      )
+      record_webm_opus(webm)
 
       out = described_class.convert_to_ogg_opus(webm)
 
@@ -33,6 +43,49 @@ RSpec.describe Whatsapp::AudioConverterService do
       expect(codec).to eq('opus')
     ensure
       [webm, ogg].each { |f| File.delete(f) if f && File.exist?(f) }
+    end
+
+    it 'appends .ogg when the input has no extension instead of prepending it' do
+      input = Rails.root.join('tmp', "wa_in_#{SecureRandom.hex(4)}").to_s
+      ogg = "#{input}.ogg"
+      record_webm_opus(input)
+
+      expect(described_class.convert_to_ogg_opus(input)).to eq(ogg)
+      expect(File.exist?(ogg)).to be(true)
+    ensure
+      [input, ogg].each { |f| File.delete(f) if f && File.exist?(f) }
+    end
+
+    it 'removes the partial output file when the conversion fails' do
+      webm = Rails.root.join('tmp', "wa_in_#{SecureRandom.hex(4)}.webm").to_s
+      ogg = webm.sub(/\.webm\z/, '.ogg')
+      File.write(webm, 'not actually audio')
+      File.write(ogg, 'partial output')
+
+      expect { described_class.convert_to_ogg_opus(webm) }
+        .to raise_error(described_class::ConversionError)
+      expect(File.exist?(ogg)).to be(false)
+    ensure
+      [webm, ogg].each { |f| File.delete(f) if f && File.exist?(f) }
+    end
+  end
+
+  describe '.run_ffmpeg' do
+    it 'kills the subprocess and raises once it outlives the timeout' do
+      stub_const("#{described_class}::FFMPEG_TIMEOUT_SECONDS", 1)
+
+      expect { described_class.run_ffmpeg(['sleep', '30']) }
+        .to raise_error(described_class::ConversionError, /timed out after 1s/)
+    end
+  end
+
+  describe '.build_ffmpeg_command' do
+    it 'returns argv (no shell) so paths need no escaping' do
+      command = described_class.build_ffmpeg_command('/tmp/a b.webm', '/tmp/a b.ogg')
+
+      expect(command).to be_an(Array)
+      expect(command.first).to eq('ffmpeg')
+      expect(command).to include('-nostdin', '/tmp/a b.webm', '/tmp/a b.ogg')
     end
   end
 end

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -29,32 +29,70 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
   let(:attachment) { instance_double('Attachment', file: file) }
   let(:message) { MessageStub.new(id: 42, content_attributes: {}) }
   let(:temp_file) { instance_double(Tempfile, path: '/tmp/voice.webm') }
+  let(:converted_path) { '/tmp/voice.ogg' }
 
   before do
     allow(service).to receive(:download_attachment_to_temp).and_return(temp_file)
 
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with(temp_file.path).and_return(true)
-    allow(File).to receive(:delete)
+    # Browser voice notes arrive as audio/webm; the service transcodes to
+    # OGG/Opus before upload. Stub the converter so these specs don't shell out
+    # to ffmpeg — the real transcode is exercised in the AudioConverterService spec.
+    allow(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus).and_return(converted_path)
+
+    # temp files are removed via FileUtils.rm_f in the ensure block
+    allow(FileUtils).to receive(:rm_f)
   end
 
   describe '#send_audio_via_media_upload' do
-    it 'uploads original file without invoking audio conversion service' do
-      success_response = instance_double(
+    let(:success_response) do
+      instance_double(
         HTTParty::Response,
         success?: true,
         parsed_response: { 'messages' => [{ 'id' => 'wamid.123' }], 'error' => nil }
       )
+    end
 
-      expect(Whatsapp::AudioConverterService).not_to receive(:convert_to_ogg_opus)
-      expect(service).to receive(:upload_media_to_whatsapp).with(temp_file.path, 'audio/webm').and_return('media_123')
+    it 'transcodes a browser voice note (audio/webm) to ogg/opus before upload' do
+      expect(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus)
+        .with(temp_file.path).and_return(converted_path)
+      expect(service).to receive(:upload_media_to_whatsapp).with(converted_path, 'audio/ogg').and_return('media_123')
       allow(HTTParty).to receive(:post).and_return(success_response)
 
       service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
-      expect(File).to have_received(:delete).with(temp_file.path)
+      # both the original download and the transcoded copy are cleaned up
+      expect(FileUtils).to have_received(:rm_f).with(temp_file.path)
+      expect(FileUtils).to have_received(:rm_f).with(converted_path)
       expect(message.status).to be_nil
       expect(message.external_error).to be_nil
+    end
+
+    it 'passes audio already in an accepted format (audio/ogg) through without transcoding' do
+      allow(blob).to receive(:content_type).and_return('audio/ogg')
+
+      expect(Whatsapp::AudioConverterService).not_to receive(:convert_to_ogg_opus)
+      expect(service).to receive(:upload_media_to_whatsapp).with(temp_file.path, 'audio/ogg').and_return('media_123')
+      allow(HTTParty).to receive(:post).and_return(success_response)
+
+      service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
+
+      expect(message.status).to be_nil
+    end
+
+    it 'marks the message failed (without uploading) when transcoding fails' do
+      allow(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus).and_raise(
+        Whatsapp::AudioConverterService::ConversionError, 'FFmpeg conversion failed: boom'
+      )
+      expect(service).not_to receive(:upload_media_to_whatsapp)
+
+      status_service = instance_double(Messages::StatusUpdateService, perform: true)
+      expect(Messages::StatusUpdateService).to receive(:new)
+        .with(message, 'failed', a_string_including('WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED'))
+        .and_return(status_service)
+
+      result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
+
+      expect(result).to be_nil
     end
 
     # EVO-1460 follow-up: handle_error and mark_audio_upload_failed used to write
@@ -71,7 +109,7 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
         body: '{"error":{"message":"Invalid audio payload"}}'
       )
 
-      expect(service).to receive(:upload_media_to_whatsapp).with(temp_file.path, 'audio/webm').and_return('media_123')
+      expect(service).to receive(:upload_media_to_whatsapp).with(converted_path, 'audio/ogg').and_return('media_123')
       allow(HTTParty).to receive(:post).and_return(failed_message_response)
 
       status_service = instance_double(Messages::StatusUpdateService, perform: true)
@@ -99,23 +137,7 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
-      expect(File).to have_received(:delete).with(temp_file.path)
-    end
-
-    it 'falls back mime type to application/octet-stream when blob content_type is absent' do
-      nil_mime_blob = instance_double('ActiveStorage::Blob', content_type: nil)
-      nil_mime_file = instance_double('AttachmentFile', blob: nil_mime_blob, filename: 'voice.bin')
-      nil_mime_attachment = instance_double('Attachment', file: nil_mime_file)
-      success_response = instance_double(
-        HTTParty::Response,
-        success?: true,
-        parsed_response: { 'messages' => [{ 'id' => 'wamid.123' }], 'error' => nil }
-      )
-
-      expect(service).to receive(:upload_media_to_whatsapp).with(temp_file.path, 'application/octet-stream').and_return('media_123')
-      allow(HTTParty).to receive(:post).and_return(success_response)
-
-      service.send(:send_audio_via_media_upload, '5511999999999', message, nil_mime_attachment)
+      expect(FileUtils).to have_received(:rm_f).with(temp_file.path)
     end
   end
 
@@ -132,7 +154,7 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
         body: '{"error":{"code":131053,"message":"Unsupported media type"}}',
         parsed_response: {
           'error' => {
-            'code' => 131053,
+            'code' => 131_053,
             'message' => 'Unsupported media type'
           }
         }

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
     # to ffmpeg — the real transcode is exercised in the AudioConverterService spec.
     allow(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus).and_return(converted_path)
 
+    # accepted OGG is probed for its codec; default to the one Meta takes
+    allow(Whatsapp::AudioConverterService).to receive(:audio_codec).and_return('opus')
+
     # the download is released via Tempfile#close!, the transcoded copy via FileUtils.rm_f
     allow(FileUtils).to receive(:rm_f)
   end
@@ -84,6 +87,33 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
 
     it 'passes audio already in an accepted format (audio/ogg) through without transcoding' do
       allow(blob).to receive(:content_type).and_return('audio/ogg')
+
+      expect(Whatsapp::AudioConverterService).not_to receive(:convert_to_ogg_opus)
+      expect(service).to receive(:upload_media_to_whatsapp).with(temp_file.path, 'audio/ogg').and_return('media_123')
+      allow(HTTParty).to receive(:post).and_return(success_response)
+
+      service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
+
+      expect(message.status).to be_nil
+    end
+
+    it 'transcodes an audio/ogg carrying a codec other than opus' do
+      allow(blob).to receive(:content_type).and_return('audio/ogg')
+      allow(Whatsapp::AudioConverterService).to receive(:audio_codec).and_return('vorbis')
+
+      expect(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus)
+        .with(temp_file.path).and_return(converted_path)
+      expect(service).to receive(:upload_media_to_whatsapp).with(converted_path, 'audio/ogg').and_return('media_123')
+      allow(HTTParty).to receive(:post).and_return(success_response)
+
+      service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
+
+      expect(message.status).to be_nil
+    end
+
+    it 'passes an accepted audio/ogg through when the codec cannot be probed' do
+      allow(blob).to receive(:content_type).and_return('audio/ogg')
+      allow(Whatsapp::AudioConverterService).to receive(:audio_codec).and_return(nil)
 
       expect(Whatsapp::AudioConverterService).not_to receive(:convert_to_ogg_opus)
       expect(service).to receive(:upload_media_to_whatsapp).with(temp_file.path, 'audio/ogg').and_return('media_123')

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
   let(:file) { instance_double('AttachmentFile', blob: blob, filename: 'voice.webm') }
   let(:attachment) { instance_double('Attachment', file: file) }
   let(:message) { MessageStub.new(id: 42, content_attributes: {}) }
-  let(:temp_file) { instance_double(Tempfile, path: '/tmp/voice.webm') }
+  let(:temp_file) { instance_double(Tempfile, path: '/tmp/voice.webm', close!: nil) }
   let(:converted_path) { '/tmp/voice.ogg' }
 
   before do
@@ -39,7 +39,7 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
     # to ffmpeg — the real transcode is exercised in the AudioConverterService spec.
     allow(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus).and_return(converted_path)
 
-    # temp files are removed via FileUtils.rm_f in the ensure block
+    # the download is released via Tempfile#close!, the transcoded copy via FileUtils.rm_f
     allow(FileUtils).to receive(:rm_f)
   end
 
@@ -61,10 +61,25 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       # both the original download and the transcoded copy are cleaned up
-      expect(FileUtils).to have_received(:rm_f).with(temp_file.path)
+      expect(temp_file).to have_received(:close!)
       expect(FileUtils).to have_received(:rm_f).with(converted_path)
       expect(message.status).to be_nil
       expect(message.external_error).to be_nil
+    end
+
+    it 'transcodes when the blob has no content_type (application/octet-stream fallback)' do
+      nil_mime_blob = instance_double('ActiveStorage::Blob', content_type: nil)
+      nil_mime_file = instance_double('AttachmentFile', blob: nil_mime_blob, filename: 'voice.bin')
+      nil_mime_attachment = instance_double('Attachment', file: nil_mime_file)
+
+      expect(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus)
+        .with(temp_file.path).and_return(converted_path)
+      expect(service).to receive(:upload_media_to_whatsapp).with(converted_path, 'audio/ogg').and_return('media_123')
+      allow(HTTParty).to receive(:post).and_return(success_response)
+
+      service.send(:send_audio_via_media_upload, '5511999999999', message, nil_mime_attachment)
+
+      expect(message.status).to be_nil
     end
 
     it 'passes audio already in an accepted format (audio/ogg) through without transcoding' do
@@ -137,7 +152,7 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
-      expect(FileUtils).to have_received(:rm_f).with(temp_file.path)
+      expect(temp_file).to have_received(:close!)
     end
   end
 
@@ -165,6 +180,22 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect do
         service.send(:upload_media_to_whatsapp, upload_file.path, 'audio/webm')
       end.to raise_error(StandardError, /WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED/)
+    ensure
+      upload_file.close!
+    end
+
+    it 'refuses to upload a file over the 16 MB limit instead of letting Meta reject it' do
+      upload_file = Tempfile.new(['audio', '.ogg'])
+      upload_file.write('x')
+      upload_file.rewind
+      allow(File).to receive(:size).and_call_original
+      allow(File).to receive(:size).with(upload_file.path).and_return(described_class::WHATSAPP_MAX_MEDIA_BYTES + 1)
+
+      expect(HTTParty).not_to receive(:post)
+
+      expect do
+        service.send(:upload_media_to_whatsapp, upload_file.path, 'audio/ogg')
+      end.to raise_error(described_class::AudioUploadError, /over the .* byte limit/)
     ensure
       upload_file.close!
     end


### PR DESCRIPTION
## Problema

Nota de voz gravada no navegador não é entregue no WhatsApp em canais **WhatsApp Cloud** (Meta oficial): a mensagem fica `status=failed`.

Confirmado em runtime:

```
ATT file_type=audio name=audio_....webm  blob svc=s3_compatible exist=true
MSG type=outgoing status=failed source_id=nil
external_error = "WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED - WhatsApp API Error (100) -
  (#100) Param file must be a file with one of the following types:
  audio/aac, audio/mp4, audio/mpeg, audio/amr, audio/ogg..."
```

## Causa raiz

O navegador (MediaRecorder) grava `audio/webm` (Opus em container WebM). Em `send_audio_via_media_upload` o arquivo era enviado **como está** ao endpoint `/media` da Meta — o comentário no código era explícito: *"no backend transcoding"*. A WhatsApp Cloud API **não aceita `audio/webm`** (só aac/mp4/mpeg/amr/ogg). Afeta **todo** canal WhatsApp Cloud.

## Fix

- `send_audio_via_media_upload`: transcodifica qualquer formato não-aceito para **OGG/Opus** via `Whatsapp::AudioConverterService.convert_to_ogg_opus` antes do upload; formatos já aceitos passam direto (`whatsapp_accepted_audio?`).
- Liga o `AudioConverterService` (existia mas nunca era chamado) e corrige um **bug latente** nele: referenciava `$CHILD_STATUS` sem `require 'English'` (ficaria `nil` → quebra). Adicionado `require 'English'` + `require 'shellwords'`.
- Cleanup atômico (`FileUtils.rm_f`) do download + da cópia transcodificada; falha de transcode roteada por `mark_audio_upload_failed`.

## Escopo / não-regressão

Isolado ao provider **WhatsApp Cloud**. O provider **Evolution/Baileys** manda áudio por URL/base64 (`send_audio_message`) — caminho **intocado**, sem regressão.

## Testes (imagem rebuildada da develop + postgres/redis)

- `whatsapp_cloud_service_spec.rb` + `audio_converter_service_spec.rb`: **8 examples, 0 failures** — inclui um spec **funcional que roda o ffmpeg de verdade** (webm/opus → ogg; `ffprobe` confirma `codec=opus`).
- Regressão `spec/services/whatsapp/providers/`: **33 examples, 0 failures**.
- rubocop: **zero offense novo no diff** (os 2 arquivos do converter zeram; as demais offenses de `whatsapp_cloud_service.rb`/spec são pré-existentes).

## Notas

- `ffmpeg` já vem na imagem (`docker/Dockerfile`).
- O spec antigo *"uploads original file without invoking audio conversion service"* afirmava o comportamento buggado — reescrito para provar o fix (webm→transcode→ogg; ogg passa direto; falha de transcode marca `failed`).

## Summary by Sourcery

Add backend audio transcoding for WhatsApp Cloud browser voice notes, converting non-accepted formats to OGG/Opus, and update supporting service logic, cleanup, and tests to ensure reliable media uploads.

New Features:
- Enable backend transcoding of browser-recorded WhatsApp Cloud voice notes from non-accepted formats to OGG/Opus before media upload.

Bug Fixes:
- Ensure WhatsApp Cloud audio uploads no longer fail for audio/webm voice notes by converting them to a WhatsApp-accepted format.
- Fix latent AudioConverterService bug related to process status handling by requiring the proper standard libraries.

Enhancements:
- Improve cleanup of temporary audio files by atomically removing both downloaded and transcoded copies after WhatsApp Cloud uploads.
- Add helper logic to recognize WhatsApp-accepted audio MIME types and bypass unnecessary transcoding.
- Add detailed logging around audio transcoding and WhatsApp Cloud media upload outcomes.

Tests:
- Extend WhatsApp Cloud provider specs to cover transcoding behavior, pass-through of already accepted audio formats, and failure handling when conversion errors occur.
- Introduce a functional AudioConverterService spec that exercises real ffmpeg-based WebM-to-OGG/Opus conversion and validates the resulting codec.