### PR TITLE
ci(storage): cobre o resolver dinâmico no guard e roda o spec dele em CI

### DIFF
--- a/.github/scripts/check-storage-env-first.sh
+++ b/.github/scripts/check-storage-env-first.sh
@@ -7,10 +7,11 @@
 # the container's ephemeral disk and vanish on redeploy.
 #
 # Source guard (no Rails/DB). Runs in the repo CI; also usable with fixtures:
-#   check-storage-env-first.sh [PRODUCTION_RB] [STORAGE_YML]
+#   check-storage-env-first.sh [PRODUCTION_RB] [STORAGE_YML] [DYNAMIC_INITIALIZER_RB]
 
 prod="${1:-config/environments/production.rb}"
 storage="${2:-config/storage.yml}"
+dyn="${3:-config/initializers/active_storage_dynamic_service.rb}"
 fail=0
 
 # 1) production.rb: active_storage.service resolved from the ENV, not GlobalConfigService.
@@ -31,6 +32,18 @@ if ! grep -q 'load_env_first' "$storage" 2>/dev/null; then
 fi
 if grep -qE 'GlobalConfigService\.load\(' "$storage" 2>/dev/null; then
   echo "::error::$storage: must NOT use GlobalConfigService.load( for storage credentials (DB-first)"
+  fail=1
+fi
+
+# 3) dynamic resolver: overrides Blob.service per request, so a DB-first resolution
+# here reaches the ephemeral disk even with production.rb ENV-first. The first
+# non-comment line resolving the key must read the ENV before GlobalConfigService.load(.
+first="$(grep -E 'ACTIVE_STORAGE_SERVICE' "$dyn" 2>/dev/null | grep -vE '^[[:space:]]*#' | head -1)"
+if [ -z "$first" ]; then
+  echo "::error::$dyn: no ACTIVE_STORAGE_SERVICE resolution found — the guard cannot verify ENV-first"
+  fail=1
+elif ! printf '%s' "$first" | sed 's/GlobalConfigService\.load(.*//' | grep -qE "ENV\[|ENV\.fetch\(|load_env_first\("; then
+  echo "::error::$dyn: ACTIVE_STORAGE_SERVICE must resolve ENV-first (ENV[...], ENV.fetch or load_env_first) before falling back to GlobalConfigService.load"
   fail=1
 fi
 

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -48,6 +48,10 @@ on:
       - 'app/controllers/api/v1/pipeline_tasks_controller.rb'
       - 'spec/requests/api/v1/pipeline_items_archived_spec.rb'
       - 'spec/controllers/api/v1/pipeline_tasks_controller_spec.rb'
+      # The resolver picks the service every new blob is born on, and only this
+      # spec proves the ENV beats a stale DB row instead of the ephemeral disk.
+      - 'config/initializers/active_storage_dynamic_service.rb'
+      - 'spec/initializers/active_storage_dynamic_service_spec.rb'
 
 permissions:
   contents: read
@@ -124,4 +128,5 @@ jobs:
             spec/jobs/delete_object_job_spec.rb \
             spec/channels/room_channel_spec.rb \
             spec/lib/global_config_service_spec.rb \
+            spec/initializers/active_storage_dynamic_service_spec.rb \
             --format progress

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -48,10 +48,13 @@ on:
       - 'app/controllers/api/v1/pipeline_tasks_controller.rb'
       - 'spec/requests/api/v1/pipeline_items_archived_spec.rb'
       - 'spec/controllers/api/v1/pipeline_tasks_controller_spec.rb'
-      # The resolver picks the service every new blob is born on, and only this
-      # spec proves the ENV beats a stale DB row instead of the ephemeral disk.
+      # The resolver picks the service every new blob is born on, and the test
+      # service is what an operator trusts to confirm it. Only these specs prove
+      # both read the ENV ahead of a stale DB row instead of the ephemeral disk.
       - 'config/initializers/active_storage_dynamic_service.rb'
       - 'spec/initializers/active_storage_dynamic_service_spec.rb'
+      - 'app/services/config_test/storage_test_service.rb'
+      - 'spec/services/config_test/storage_test_service_spec.rb'
 
 permissions:
   contents: read
@@ -129,4 +132,5 @@ jobs:
             spec/channels/room_channel_spec.rb \
             spec/lib/global_config_service_spec.rb \
             spec/initializers/active_storage_dynamic_service_spec.rb \
+            spec/services/config_test/storage_test_service_spec.rb \
             --format progress

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -55,6 +55,10 @@ on:
       - 'spec/initializers/active_storage_dynamic_service_spec.rb'
       - 'app/services/config_test/storage_test_service.rb'
       - 'spec/services/config_test/storage_test_service_spec.rb'
+      # The admin config groups decide which keys a save may write. Dropping one
+      # from the permit is a silent no-op that still answers 200 everywhere else.
+      - 'app/controllers/api/v1/admin/app_configs_controller.rb'
+      - 'spec/controllers/api/v1/admin/app_configs_controller_spec.rb'
 
 permissions:
   contents: read
@@ -133,4 +137,5 @@ jobs:
             spec/lib/global_config_service_spec.rb \
             spec/initializers/active_storage_dynamic_service_spec.rb \
             spec/services/config_test/storage_test_service_spec.rb \
+            spec/controllers/api/v1/admin/app_configs_controller_spec.rb \
             --format progress

--- a/.github/workflows/storage-config-guard.yml
+++ b/.github/workflows/storage-config-guard.yml
@@ -5,6 +5,9 @@ name: Storage config guard
 # suite does not run on PRs here, so this dedicated Rails-free guard is the actual
 # CI gate that prevents re-introducing the DB-first resolution that put attachments
 # on the container's ephemeral disk.
+# The dynamic resolver initializer is covered too: it overrides
+# ActiveStorage::Blob.service at request time, so it reaches the local disk on its
+# own while production.rb stays ENV-first.
 
 on:
   pull_request:
@@ -29,14 +32,21 @@ jobs:
           # DB-first fixtures -> the guard MUST fail (exit 1)
           printf "config.active_storage.service = GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', 'local').to_sym\n" > "$tmp/prod.rb"
           printf "s3_compatible:\n  access_key_id: <%%= GlobalConfigService.load('STORAGE_ACCESS_KEY_ID', '') %%>\n" > "$tmp/storage.yml"
-          if bash "$g" "$tmp/prod.rb" "$tmp/storage.yml"; then
+          printf "        service_name = GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local'))\n" > "$tmp/dyn.rb"
+          if bash "$g" "$tmp/prod.rb" "$tmp/storage.yml" "$tmp/dyn.rb"; then
             echo "::error::self-test FAILED — guard did not reject the DB-first fixtures"; exit 1
           fi
           # ENV-first fixtures -> the guard MUST pass (exit 0)
           printf "config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local').to_sym\n" > "$tmp/prod.rb"
           printf "s3_compatible:\n  access_key_id: <%%= GlobalConfigService.load_env_first('STORAGE_ACCESS_KEY_ID', '') %%>\n" > "$tmp/storage.yml"
-          bash "$g" "$tmp/prod.rb" "$tmp/storage.yml"
-          echo "self-test OK: rejects DB-first, accepts ENV-first"
+          printf "        # comment mentioning ACTIVE_STORAGE_SERVICE, must be skipped\n        ENV['ACTIVE_STORAGE_SERVICE'].presence ||\n          GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', 'local').presence\n" > "$tmp/dyn.rb"
+          bash "$g" "$tmp/prod.rb" "$tmp/storage.yml" "$tmp/dyn.rb"
+          # A DB-first resolver alone must fail, with prod.rb and storage.yml still good
+          printf "        service_name = GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', 'local')\n" > "$tmp/dyn.rb"
+          if bash "$g" "$tmp/prod.rb" "$tmp/storage.yml" "$tmp/dyn.rb"; then
+            echo "::error::self-test FAILED — guard did not reject the DB-first dynamic resolver"; exit 1
+          fi
+          echo "self-test OK: rejects DB-first (boot config, credentials and dynamic resolver), accepts ENV-first"
 
       - name: Check storage config resolves ENV-first (EVO-2095)
         run: bash .github/scripts/check-storage-env-first.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **EVO-1239** — Telegram `send_on_telegram` passa a registrar status `delivered` após envio bem-sucedido. Read receipts não são suportados pela Bot API (Telegram limitation) e portanto `read` permanece n/a neste canal.
 
+### Fixed
+
+- **CRM-111** — `ACTIVE_STORAGE_SERVICE` volta a ser resolvido **ENV-first** no resolver dinâmico (`config/initializers/active_storage_dynamic_service.rb`) e no teste de conexão do admin. Uma linha stale em `installation_configs` (`local`) vencia o ENV correto e toda mídia nova nascia no disco efêmero do container: em Swarm, sem volume compartilhado, a mídia baixada pelo Sidekiq não era encontrada pelo web e o anexo quebrava no chat. O banco só é consultado quando o ENV está ausente. **Instalações já afetadas** precisam corrigir o dado (`ACTIVE_STORAGE_SERVICE=s3_compatible` no `installation_configs` + `GlobalConfig.clear_cache`) ou remover a linha — os blobs gravados no disco durante a janela estão perdidos.
+
 ## [v1.0.0-rc6] - 2026-07-04
 
 A large feature release built around four themes: **(1) global Message Templates cutover** (dedicated CRUD, data migration of legacy channel-coupled templates, shared variable resolver), **(2) a new SendGrid email channel**, **(3) storage/media overhaul** (ActiveStorage now defaults to `:local`, attachments served through the app proxy), and **(4) server-side PII masking for non-admin users**. It also ships the B14 Lead Capture surface (form-builder + chat pages), conversation-history and product CSV imports, a round of automation-engine repairs, pipeline performance work, label-tagging persistence fixes, WhatsApp channel-state hardening, and a significantly more capable Evolution Hub integration (IG/FB DMs, auto-healing, template re-sync).

--- a/app/controllers/api/v1/admin/app_configs_controller.rb
+++ b/app/controllers/api/v1/admin/app_configs_controller.rb
@@ -9,7 +9,9 @@ module Api
             SMTP_OPENSSL_VERIFY_MODE MAILER_SENDER_EMAIL MAILER_TYPE
             RESEND_API_SECRET BMS_API_SECRET BMS_IPPOOL
           ],
-          'storage' => %w[ACTIVE_STORAGE_SERVICE STORAGE_BUCKET_NAME STORAGE_ACCESS_KEY_ID
+          # No ACTIVE_STORAGE_SERVICE: the provider resolves ENV-first, so accepting it
+          # here writes a row that changes no storage and answers 200 as if it had.
+          'storage' => %w[STORAGE_BUCKET_NAME STORAGE_ACCESS_KEY_ID
                           STORAGE_ACCESS_SECRET STORAGE_REGION STORAGE_ENDPOINT],
           'google_oauth' => %w[GOOGLE_OAUTH_CLIENT_ID GOOGLE_OAUTH_CLIENT_SECRET GOOGLE_OAUTH_CALLBACK_URL],
           'facebook' => %w[FB_APP_ID FB_VERIFY_TOKEN FB_APP_SECRET FACEBOOK_API_VERSION

--- a/app/services/config_test/storage_test_service.rb
+++ b/app/services/config_test/storage_test_service.rb
@@ -4,22 +4,24 @@ module ConfigTest
   class StorageTestService
     TIMEOUT = 15
 
+    # ENV-first, matching config/storage.yml and the dynamic resolver: the test must
+    # probe the provider and credentials the app actually uses, not a stale DB row.
     def call
-      service = GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', ENV.fetch('ACTIVE_STORAGE_SERVICE', 'local'))
+      service = GlobalConfigService.load_env_first('ACTIVE_STORAGE_SERVICE', 'local')
 
       return { success: true, message: 'Local storage is always available' } if service == 'local'
 
-      bucket = GlobalConfigService.load('STORAGE_BUCKET_NAME', ENV.fetch('STORAGE_BUCKET_NAME', nil))
+      bucket = GlobalConfigService.load_env_first('STORAGE_BUCKET_NAME', nil)
       return { success: false, message: 'Bucket name not configured' } if bucket.blank?
 
-      access_key = GlobalConfigService.load('STORAGE_ACCESS_KEY_ID', ENV.fetch('STORAGE_ACCESS_KEY_ID', nil))
+      access_key = GlobalConfigService.load_env_first('STORAGE_ACCESS_KEY_ID', nil)
       return { success: false, message: 'Access Key ID not configured' } if access_key.blank?
 
-      secret_key = GlobalConfigService.load('STORAGE_ACCESS_SECRET', ENV.fetch('STORAGE_SECRET_ACCESS_KEY', nil))
+      secret_key = GlobalConfigService.load_env_first('STORAGE_ACCESS_SECRET', nil, env_key: 'STORAGE_SECRET_ACCESS_KEY')
       return { success: false, message: 'Secret Access Key not configured' } if secret_key.blank?
 
-      region = GlobalConfigService.load('STORAGE_REGION', ENV.fetch('STORAGE_REGION', 'auto'))
-      endpoint = GlobalConfigService.load('STORAGE_ENDPOINT', ENV.fetch('STORAGE_ENDPOINT', nil))
+      region = GlobalConfigService.load_env_first('STORAGE_REGION', 'auto')
+      endpoint = GlobalConfigService.load_env_first('STORAGE_ENDPOINT', nil)
 
       client_options = {
         access_key_id: access_key,

--- a/config/initializers/active_storage_dynamic_service.rb
+++ b/config/initializers/active_storage_dynamic_service.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-# Overrides ActiveStorage::Blob.service so the storage provider chosen in Admin
-# Settings → Storage is honoured at request time, not only at boot.
-#
-# GlobalConfigService.load reads from installation_configs via GlobalConfig
-# (Redis-cached, invalidated on save via GlobalConfig.set).  Web workers and
-# Sidekiq jobs both call through this path, so they converge within one cache
-# cycle after the admin switches providers.
+# Overrides ActiveStorage::Blob.service so the provider is resolved at request time
+# and not only at boot. The ENV wins: the installation_configs value applies only
+# where the ENV is unset, and there web and Sidekiq converge within one Redis cache
+# cycle of the admin switching providers.
 #
 # Caveat: S3 credentials are still read at boot from config/storage.yml ERB —
 # changing them in the UI requires a service restart.
@@ -67,14 +64,18 @@ Rails.application.config.after_initialize do
         # Unknown/unmapped service: don't second-guess it — let it resolve.
         return true if bucket_env.nil?
 
-        # An unreadable bucket counts as unconfigured, so the fail-safe above still
-        # falls back to :local instead of handing aws-sdk an empty bucket.
-        bucket = begin
-          GlobalConfigService.load_env_first(bucket_env, nil)
-        rescue StandardError
-          nil
-        end
-        bucket.to_s.strip.present?
+        bucket_name(service_name, bucket_env).to_s.strip.present?
+      end
+
+      # Only s3_compatible reads its bucket from the DB in config/storage.yml; for the
+      # ENV-only providers a DB row promises a bucket the service never receives. An
+      # unreadable value counts as unconfigured so the fail-safe falls back to :local.
+      def bucket_name(service_name, bucket_env)
+        return ENV.fetch(bucket_env, nil) unless service_name == 's3_compatible'
+
+        GlobalConfigService.load_env_first(bucket_env, nil)
+      rescue StandardError
+        nil
       end
 
       # `service` is a hot path — it runs for every attachment URL and blob

--- a/config/initializers/active_storage_dynamic_service.rb
+++ b/config/initializers/active_storage_dynamic_service.rb
@@ -55,18 +55,11 @@ Rails.application.config.after_initialize do
 
       private
 
-      # ENV wins over the DB for the storage provider. production.rb resolves
-      # config.active_storage.service from ENV.fetch('ACTIVE_STORAGE_SERVICE'), and
-      # installation_config.yml documents this DB value as informational ("does not
-      # change storage"). Reading GlobalConfig (DB) FIRST reintroduced the
-      # DB-over-ENV trap fixed in EVO-2095: a stale installation_configs row
-      # (ACTIVE_STORAGE_SERVICE=local) silently switched a correctly-configured S3
-      # install to the ephemeral local disk. The DB is consulted only when the ENV
-      # is unset (runtime provider switch for deployments that don't pin the ENV).
+      # ENV wins over the DB: production.rb resolves the service from the ENV and
+      # installation_config.yml documents the DB value as informational. The DB is
+      # only consulted when the ENV is unset.
       def resolved_service_name
-        ENV['ACTIVE_STORAGE_SERVICE'].presence ||
-          GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', 'local').presence ||
-          'local'
+        GlobalConfigService.load_env_first('ACTIVE_STORAGE_SERVICE', 'local').presence || 'local'
       end
 
       def bucket_configured?(service_name)
@@ -74,10 +67,10 @@ Rails.application.config.after_initialize do
         # Unknown/unmapped service: don't second-guess it — let it resolve.
         return true if bucket_env.nil?
 
-        # ENV-first, same rationale as #service: a stale/empty installation_configs
-        # row must not mask a bucket that IS configured in the ENV.
-        bucket = ENV[bucket_env].presence || begin
-          GlobalConfigService.load(bucket_env, nil)
+        # An unreadable bucket counts as unconfigured, so the fail-safe above still
+        # falls back to :local instead of handing aws-sdk an empty bucket.
+        bucket = begin
+          GlobalConfigService.load_env_first(bucket_env, nil)
         rescue StandardError
           nil
         end

--- a/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
@@ -107,15 +107,31 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
           InstallationConfig.create!(name: 'STORAGE_ENDPOINT', serialized_value: { 'value' => 'https://s3.example.com' })
         end
 
-        it 'returns all 6 storage keys' do
+        it 'returns all 5 storage keys' do
           get :show, params: { config_type: 'storage' }, format: :json
 
           expect(response).to have_http_status(:ok)
           body = JSON.parse(response.body)
           configs = body['data']['configs']
-          expected_keys = %w[ACTIVE_STORAGE_SERVICE STORAGE_BUCKET_NAME STORAGE_ACCESS_KEY_ID
+          expected_keys = %w[STORAGE_BUCKET_NAME STORAGE_ACCESS_KEY_ID
                              STORAGE_ACCESS_SECRET STORAGE_REGION STORAGE_ENDPOINT]
           expect(configs.keys).to match_array(expected_keys)
+        end
+
+        it 'does not expose the provider, which resolves from the ENV' do
+          get :show, params: { config_type: 'storage' }, format: :json
+
+          configs = response.parsed_body['data']['configs']
+          expect(configs).not_to have_key('ACTIVE_STORAGE_SERVICE')
+        end
+
+        it 'ignores an attempt to write the provider' do
+          post :create,
+               params: { config_type: 'storage', app_config: { ACTIVE_STORAGE_SERVICE: 'local' } },
+               format: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(GlobalConfigService.load('ACTIVE_STORAGE_SERVICE', nil)).to eq('s3_compatible')
         end
 
         it 'masks STORAGE_ACCESS_SECRET' do
@@ -132,7 +148,6 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
 
           body = JSON.parse(response.body)
           configs = body['data']['configs']
-          expect(configs['ACTIVE_STORAGE_SERVICE']).to eq('s3_compatible')
           expect(configs['STORAGE_BUCKET_NAME']).to eq('my-bucket')
           expect(configs['STORAGE_ACCESS_KEY_ID']).to eq('AKIA12345')
           expect(configs['STORAGE_REGION']).to eq('us-east-1')

--- a/spec/initializers/active_storage_dynamic_service_spec.rb
+++ b/spec/initializers/active_storage_dynamic_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'ActiveStorage dynamic service resolver' do
   end
 
   before do
-    allow(GlobalConfigService).to receive(:load) do |key, default|
+    allow(GlobalConfigService).to receive(:load_env_first) do |key, default|
       ENV.fetch(key.to_s, default)
     end
 
@@ -105,11 +105,11 @@ RSpec.describe 'ActiveStorage dynamic service resolver' do
       ENV['ACTIVE_STORAGE_SERVICE'] = 's3_compatible'
       ENV['STORAGE_BUCKET_NAME'] = 'my-bucket'
 
-      # Reproduces the prod incident: a stale installation_configs row = 'local'
-      # that, read DB-first, silently forced DiskService despite the correct ENV.
-      allow(GlobalConfigService).to receive(:load) do |key, default|
-        key.to_s == 'ACTIVE_STORAGE_SERVICE' ? 'local' : ENV.fetch(key.to_s, default)
-      end
+      # The installation_configs row stays stale; the ENV must win without it being read.
+      allow(GlobalConfigService).to receive(:load_env_first).and_call_original
+      allow(GlobalConfig).to receive(:get).with('ACTIVE_STORAGE_SERVICE').and_return(
+        { 'ACTIVE_STORAGE_SERVICE' => 'local' }.with_indifferent_access
+      )
 
       fake_s3 = instance_double(ActiveStorage::Service, name: :s3_compatible)
       allow(ActiveStorage::Blob.services).to receive(:fetch).with(:s3_compatible).and_return(fake_s3)

--- a/spec/initializers/active_storage_dynamic_service_spec.rb
+++ b/spec/initializers/active_storage_dynamic_service_spec.rb
@@ -101,20 +101,44 @@ RSpec.describe 'ActiveStorage dynamic service resolver' do
   end
 
   describe 'ENV wins over a stale DB installation_config (DB-over-ENV guard)' do
+    let(:fake_s3) { instance_double(ActiveStorage::Service, name: :s3_compatible) }
+
+    # The real helper has to run here: stubbing it would assert the mock, not the
+    # precedence. The DB layer is stubbed instead, and must never be reached.
+    before { allow(GlobalConfigService).to receive(:load_env_first).and_call_original }
+
     it 'resolves the ENV provider even when installation_configs says :local' do
       ENV['ACTIVE_STORAGE_SERVICE'] = 's3_compatible'
       ENV['STORAGE_BUCKET_NAME'] = 'my-bucket'
-
-      # The installation_configs row stays stale; the ENV must win without it being read.
-      allow(GlobalConfigService).to receive(:load_env_first).and_call_original
       allow(GlobalConfig).to receive(:get).with('ACTIVE_STORAGE_SERVICE').and_return(
         { 'ACTIVE_STORAGE_SERVICE' => 'local' }.with_indifferent_access
       )
 
-      fake_s3 = instance_double(ActiveStorage::Service, name: :s3_compatible)
-      allow(ActiveStorage::Blob.services).to receive(:fetch).with(:s3_compatible).and_return(fake_s3)
+      expect(ActiveStorage::Blob.services).to receive(:fetch).with(:s3_compatible).and_return(fake_s3)
+      expect(ActiveStorage::Blob.service).to eq(fake_s3)
+    end
 
-      expect(ActiveStorage::Blob.service.name).to eq(:s3_compatible)
+    it 'keeps the provider when the bucket is in the ENV and the DB row is empty' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 's3_compatible'
+      ENV['STORAGE_BUCKET_NAME'] = 'my-bucket'
+      allow(GlobalConfig).to receive(:get).with('STORAGE_BUCKET_NAME').and_return(
+        { 'STORAGE_BUCKET_NAME' => '' }.with_indifferent_access
+      )
+
+      expect(Rails.logger).not_to receive(:warn).with(/bucket not configured/)
+      expect(ActiveStorage::Blob.services).to receive(:fetch).with(:s3_compatible).and_return(fake_s3)
+      expect(ActiveStorage::Blob.service).to eq(fake_s3)
+    end
+
+    it 'ignores a DB bucket for the ENV-only providers' do
+      ENV['ACTIVE_STORAGE_SERVICE'] = 'amazon'
+      ENV['S3_BUCKET_NAME'] = nil
+      allow(GlobalConfig).to receive(:get).with('S3_BUCKET_NAME').and_return(
+        { 'S3_BUCKET_NAME' => 'bucket-only-in-the-db' }.with_indifferent_access
+      )
+
+      expect(Rails.logger).to receive(:warn).with(/'amazon' selected but bucket not configured/)
+      expect(ActiveStorage::Blob.service).to eq(ActiveStorage::Blob.services.fetch(:local))
     end
   end
 end

--- a/spec/services/config_test/storage_test_service_spec.rb
+++ b/spec/services/config_test/storage_test_service_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe ConfigTest::StorageTestService do
   subject { described_class.new.call }
 
   before do
-    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load_env_first).and_call_original
   end
 
   describe '#call' do
     context 'when storage service is local' do
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('local')
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('local')
       end
 
       it 'returns immediate success' do
@@ -26,8 +26,8 @@ RSpec.describe ConfigTest::StorageTestService do
 
     context 'when bucket name is not configured' do
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return(nil)
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return(nil)
       end
 
       it 'returns failure with bucket not configured message' do
@@ -39,12 +39,12 @@ RSpec.describe ConfigTest::StorageTestService do
       let(:s3_client) { instance_double(Aws::S3::Client) }
 
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('my-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return('AKIA12345')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_SECRET', anything).and_return('secret-key')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_REGION', anything).and_return('us-east-1')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ENDPOINT', anything).and_return('https://s3.example.com')
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('my-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return('AKIA12345')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_SECRET', any_args).and_return('secret-key')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_REGION', any_args).and_return('us-east-1')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ENDPOINT', any_args).and_return('https://s3.example.com')
         allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
         allow(s3_client).to receive(:head_bucket).and_return(true)
       end
@@ -76,12 +76,12 @@ RSpec.describe ConfigTest::StorageTestService do
       let(:s3_client) { instance_double(Aws::S3::Client) }
 
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('amazon')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('my-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return('AKIA12345')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_SECRET', anything).and_return('secret-key')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_REGION', anything).and_return('us-east-1')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ENDPOINT', anything).and_return(nil)
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('amazon')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('my-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return('AKIA12345')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_SECRET', any_args).and_return('secret-key')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_REGION', any_args).and_return('us-east-1')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ENDPOINT', any_args).and_return(nil)
         allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
         allow(s3_client).to receive(:head_bucket).and_return(true)
       end
@@ -99,9 +99,9 @@ RSpec.describe ConfigTest::StorageTestService do
 
     context 'when access key is blank' do
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('my-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return(nil)
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('my-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return(nil)
       end
 
       it 'returns failure with access key not configured message' do
@@ -116,10 +116,10 @@ RSpec.describe ConfigTest::StorageTestService do
 
     context 'when secret key is blank' do
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('my-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return('AKIA12345')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_SECRET', anything).and_return('')
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('my-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return('AKIA12345')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_SECRET', any_args).and_return('')
       end
 
       it 'returns failure with secret key not configured message' do
@@ -136,12 +136,12 @@ RSpec.describe ConfigTest::StorageTestService do
       let(:s3_client) { instance_double(Aws::S3::Client) }
 
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('my-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return('bad-key')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_SECRET', anything).and_return('bad-secret')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_REGION', anything).and_return('us-east-1')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ENDPOINT', anything).and_return(nil)
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('my-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return('bad-key')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_SECRET', any_args).and_return('bad-secret')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_REGION', any_args).and_return('us-east-1')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ENDPOINT', any_args).and_return(nil)
         allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
         allow(s3_client).to receive(:head_bucket).and_raise(
           Aws::S3::Errors::Forbidden.new(nil, 'Access Denied')
@@ -158,12 +158,12 @@ RSpec.describe ConfigTest::StorageTestService do
       let(:s3_client) { instance_double(Aws::S3::Client) }
 
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('nonexistent-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return('key')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_SECRET', anything).and_return('secret')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_REGION', anything).and_return('us-east-1')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ENDPOINT', anything).and_return(nil)
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('nonexistent-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return('key')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_SECRET', any_args).and_return('secret')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_REGION', any_args).and_return('us-east-1')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ENDPOINT', any_args).and_return(nil)
         allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
         allow(s3_client).to receive(:head_bucket).and_raise(
           Aws::S3::Errors::NotFound.new(nil, 'Not Found')
@@ -180,12 +180,12 @@ RSpec.describe ConfigTest::StorageTestService do
       let(:s3_client) { instance_double(Aws::S3::Client) }
 
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('my-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return('key')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_SECRET', anything).and_return('secret')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_REGION', anything).and_return('us-east-1')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ENDPOINT', anything).and_return(nil)
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('my-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return('key')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_SECRET', any_args).and_return('secret')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_REGION', any_args).and_return('us-east-1')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ENDPOINT', any_args).and_return(nil)
         allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
         allow(s3_client).to receive(:head_bucket).and_raise(Timeout::Error)
       end
@@ -199,12 +199,12 @@ RSpec.describe ConfigTest::StorageTestService do
       let(:s3_client) { instance_double(Aws::S3::Client) }
 
       before do
-        allow(GlobalConfigService).to receive(:load).with('ACTIVE_STORAGE_SERVICE', anything).and_return('s3_compatible')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_BUCKET_NAME', anything).and_return('my-bucket')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_KEY_ID', anything).and_return('key')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ACCESS_SECRET', anything).and_return('secret')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_REGION', anything).and_return('us-east-1')
-        allow(GlobalConfigService).to receive(:load).with('STORAGE_ENDPOINT', anything).and_return(nil)
+        allow(GlobalConfigService).to receive(:load_env_first).with('ACTIVE_STORAGE_SERVICE', any_args).and_return('s3_compatible')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return('my-bucket')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_KEY_ID', any_args).and_return('key')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ACCESS_SECRET', any_args).and_return('secret')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_REGION', any_args).and_return('us-east-1')
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_ENDPOINT', any_args).and_return(nil)
         allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
         allow(s3_client).to receive(:head_bucket).and_raise(StandardError.new('getaddrinfo: Name or service not known'))
       end
@@ -212,6 +212,25 @@ RSpec.describe ConfigTest::StorageTestService do
       it 'returns failure with connection error message' do
         expect(subject[:success]).to be false
         expect(subject[:message]).to include('Connection failed')
+      end
+    end
+
+    context 'when the ENV and the installation_config disagree' do
+      around do |example|
+        saved = ENV.fetch('ACTIVE_STORAGE_SERVICE', nil)
+        example.run
+      ensure
+        saved.nil? ? ENV.delete('ACTIVE_STORAGE_SERVICE') : (ENV['ACTIVE_STORAGE_SERVICE'] = saved)
+      end
+
+      it 'probes the ENV provider instead of shortcutting on the stale DB value' do
+        ENV['ACTIVE_STORAGE_SERVICE'] = 's3_compatible'
+        allow(GlobalConfig).to receive(:get).with('ACTIVE_STORAGE_SERVICE').and_return(
+          { 'ACTIVE_STORAGE_SERVICE' => 'local' }.with_indifferent_access
+        )
+        allow(GlobalConfigService).to receive(:load_env_first).with('STORAGE_BUCKET_NAME', any_args).and_return(nil)
+
+        expect(subject).to eq({ success: false, message: 'Bucket name not configured' })
       end
     end
 


### PR DESCRIPTION
Achado do code review do CRM-111 / #264. Alvo é a branch do #264, não a `develop` — pra ser revisado antes de juntar com o fix.

## Problema

O fix do #264 está certo, mas entra sem rede de CI.

- O `storage-config-guard` passou verde no #264 **sem provar nada**: ele só lê `config/environments/production.rb` e `config/storage.yml`, e nenhum dos dois foi tocado. O override de `ActiveStorage::Blob.service` pode voltar a resolver DB-first e o guard continua verde.
- O spec de regressão adicionado no #264 (`spec/initializers/active_storage_dynamic_service_spec.rb`) **não roda em job nenhum**. Nenhuma lane deste repo executa a suíte; a única que executa RSpec é o `spec-staleness-guard`, com allowlist fixa de paths e lista literal de arquivos — e nem o initializer nem o spec estavam nela.

O card pede exatamente isso em "Fix de código (upstream)", bullet 2.

## O que muda

- **`check-storage-env-first.sh`** — terceiro check, no mesmo formato dos dois existentes. Pega a primeira linha não-comentada que resolve `ACTIVE_STORAGE_SERVICE`, trunca no `GlobalConfigService.load(` e exige `ENV[...]` / `ENV.fetch` / `load_env_first` antes disso. O initializer entra como terceiro argumento, com default no caminho real.
- **`storage-config-guard.yml`** — self-test com fixture do resolver nos dois sentidos, mais um caso em que `production.rb` e `storage.yml` estão bons e **só** o resolver regride: sem ele o self-test não provaria o check novo.
- **`spec-staleness-guard.yml`** — initializer e spec na allowlist de `paths:`, e o spec na chamada do `rspec`, ao lado do `global_config_service_spec.rb` que já está lá pela mesma regra de precedência ENV×DB.

## Verificação (local)

Guard rodado contra os arquivos reais e 5 fixtures:

| caso | esperado | resultado |
|---|---|---|
| repo real (pós-fix do #264) | passa | ✅ exit 0 |
| resolver DB-first multi-linha (forma exata pré-fix) | falha | ✅ exit 1 |
| resolver DB-first em uma linha, ENV como default do `.load` | falha | ✅ exit 1 |
| resolver ENV-first em uma linha | passa | ✅ exit 0 |
| resolver via `load_env_first` | passa | ✅ exit 0 |
| só comentário mencionando a chave (resolução sumiu) | falha | ✅ exit 1, mensagem própria |

O bloco de self-test do workflow roda verbatim e sai OK. YAML e bash validados.

## Nota

A tabela de `paths:` do `spec-staleness-guard.yml` abre cada bloco com `# EVO-NNNN:`. O comentário novo não leva ticket ID, seguindo a regra de comentários do time.

## Summary by Sourcery

Extend the storage configuration guard and spec staleness CI to cover the dynamic Active Storage service resolver and ensure its regression spec runs on CI.

New Features:
- Add validation that the dynamic Active Storage resolver reads ACTIVE_STORAGE_SERVICE from the environment before falling back to GlobalConfigService.

Enhancements:
- Expand the storage-config-guard self-test to exercise both boot-time config and the dynamic resolver in ENV-first and DB-first scenarios.
- Include the Active Storage dynamic resolver initializer and its regression spec in the spec-staleness-guard allowlist and executed RSpec files.