### PR TITLE
fix(spec): destrava o app_configs_controller_spec e põe ele no CI

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -48,6 +48,10 @@ on:
       - 'app/controllers/api/v1/pipeline_tasks_controller.rb'
       - 'spec/requests/api/v1/pipeline_items_archived_spec.rb'
       - 'spec/controllers/api/v1/pipeline_tasks_controller_spec.rb'
+      # The admin config groups decide which keys a save may write, and the masking
+      # keeps credentials out of the response. Neither shows up in another lane.
+      - 'app/controllers/api/v1/admin/app_configs_controller.rb'
+      - 'spec/controllers/api/v1/admin/app_configs_controller_spec.rb'
 
 permissions:
   contents: read
@@ -124,4 +128,5 @@ jobs:
             spec/jobs/delete_object_job_spec.rb \
             spec/channels/room_channel_spec.rb \
             spec/lib/global_config_service_spec.rb \
+            spec/controllers/api/v1/admin/app_configs_controller_spec.rb \
             --format progress

--- a/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
   before do
     ENV['ENCRYPTION_KEY'] = 'test-encryption-key-for-fernet!!'
     InstallationConfig.reset_encryption_key_cache!
+    # The model invalidates the GlobalConfig cache from after_commit, which never
+    # fires under transactional fixtures. Without this, values cached by one example
+    # answer the reads of the next one.
+    GlobalConfig.clear_cache
   end
 
   after do
@@ -75,7 +79,7 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
           configs = body['data']['configs']
           expect(configs['SMTP_ADDRESS']).to eq('smtp.example.com')
           expect(configs['SMTP_PORT']).to eq(587)
-          expect(configs['SMTP_PASSWORD_SECRET']).to start_with('••••••••')
+          expect(configs['SMTP_PASSWORD_SECRET']).to start_with(described_class::MASK_PREFIX)
         end
 
         it 'returns all keys for the config type including nil for missing ones' do
@@ -123,7 +127,7 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
 
           body = JSON.parse(response.body)
           configs = body['data']['configs']
-          expect(configs['STORAGE_ACCESS_SECRET']).to start_with('••••••••')
+          expect(configs['STORAGE_ACCESS_SECRET']).to start_with(described_class::MASK_PREFIX)
           expect(configs['STORAGE_ACCESS_SECRET']).not_to eq('super-secret-key')
         end
 
@@ -152,7 +156,7 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
 
           body = JSON.parse(response.body)
           configs = body['data']['configs']
-          expect(configs['EVOLUTION_HUB_API_KEY']).to start_with('••••••••')
+          expect(configs['EVOLUTION_HUB_API_KEY']).to start_with(described_class::MASK_PREFIX)
           expect(configs['EVOLUTION_HUB_API_KEY']).not_to eq('hub-bearer-token-1234')
           expect(configs['EVOLUTION_HUB_API_KEY']).to end_with('1234')
         end

--- a/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
@@ -246,14 +246,16 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
         it 'preserves existing value when sensitive key is null' do
           InstallationConfig.create!(name: 'SMTP_PASSWORD_SECRET', serialized_value: { 'value' => 'existing-secret' })
 
+          # as: :json, not format: :json — the urlencoded default serializes nil as an
+          # empty string, and a blank value is not what the preserve path reacts to.
           post :create, params: {
             config_type: 'smtp',
             app_config: { SMTP_PASSWORD_SECRET: nil, SMTP_ADDRESS: 'new.smtp.com' }
-          }, format: :json
+          }, as: :json
 
           expect(response).to have_http_status(:ok)
           config = InstallationConfig.find_by(name: 'SMTP_PASSWORD_SECRET')
-          expect(config.value).not_to be_nil
+          expect(config.value).to eq('existing-secret')
         end
 
         it 'encrypts EVOLUTION_HUB_API_KEY at rest' do
@@ -297,7 +299,7 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
           post :create, params: {
             config_type: 'evolution_hub',
             app_config: { EVOLUTION_HUB_API_KEY: nil, EVOLUTION_HUB_ENABLED: 'true' }
-          }, format: :json
+          }, as: :json
 
           expect(response).to have_http_status(:ok)
           config = InstallationConfig.find_by(name: 'EVOLUTION_HUB_API_KEY')


### PR DESCRIPTION
Hotfix a partir da `develop`. **Nada aqui é regressão** — os quatro exemplos falham na `develop` como ela está hoje. Apareceram porque o CRM-111 (#264/#265) colocou o `app_configs_controller_spec.rb` na allowlist do `spec-staleness-guard`, e a primeira execução do arquivo em CI mostrou o que estava lá.

Separado do CRM-111 de propósito: o conserto é da `develop`, não do fix de storage. Depois de mergeado aqui, a `develop` volta pra branch do #264.

## Por que ninguém tinha visto

Nenhuma lane deste repo roda a suíte. A única que executa RSpec é o `spec-staleness-guard`, com allowlist fixa — e este arquivo não estava nela. Quatro exemplos apodreceram em silêncio.

## As quatro falhas

**Três: asserção de máscara com o número errado de bullets.**

```
expected "••••word" to start with "••••••••"
```

`AppConfigsController::MASK_PREFIX` é `"•" * 4`, então o `mask_secret` devolve quatro bullets mais os quatro últimos caracteres. As asserções esperavam oito, hard-coded. Atinge `SMTP_PASSWORD_SECRET`, `STORAGE_ACCESS_SECRET` e `EVOLUTION_HUB_API_KEY`. O código está certo; as asserções passam a apontar para `described_class::MASK_PREFIX`, que é o que o controller promete e não envelhece de novo.

**Uma: vazamento de cache entre exemplos.**

`POST /api/v1/admin/app_configs` com `config_type=evolution_hub` e `EVOLUTION_HUB_API_KEY: nil` respondia **400 "Missing required configuration"** com as duas linhas obrigatórias criadas no próprio exemplo.

O `InstallationConfig` invalida o cache do `GlobalConfig` num `after_commit`, que **não dispara** com `use_transactional_fixtures = true`. O cache do Redis é do processo e sobrevive ao rollback: valor cacheado por um exemplo responde a leitura do seguinte, e o `missing_required_keys` — que para chave sensível enviada como `nil` cai no `GlobalConfigService.load` — enxergava a chave como ausente. O `before` do arquivo passa a limpar o cache.

Só afeta teste: em produção o `after_commit` dispara normalmente. Não há bug de admin aqui.

## Guard

`app_configs_controller.rb` e o spec entram na allowlist do `spec-staleness-guard`, senão o arquivo volta a não rodar e a rot recomeça.

## Divergência que fica registrada, sem ação

Existem duas implementações de máscara com contagens diferentes: `AppConfigsController::MASK_PREFIX` (4 bullets) e `InstallationConfig#masked_value` (8, hard-coded). O `masked_value` não tem nenhum chamador em `app/` ou `lib/` — só o próprio spec do model. Não mexi: unificar ou remover é decisão separada.

## Verificação

Sintaxe OK e rubocop sem offense nova em relação à `develop`. Os specs em si quem roda é o `spec-staleness-guard` deste PR — que existe justamente porque não dá pra rodar essa suíte fora do CI.

## Summary by Sourcery

Fix failing admin app config controller specs by aligning credential masking expectations with the controller’s mask prefix and preventing GlobalConfig cache leakage between examples.

Bug Fixes:
- Ensure admin app config controller specs expect masked secrets using the controller’s defined mask prefix instead of a hard‑coded bullet count.
- Clear GlobalConfig cache before each example in app_configs_controller specs to avoid stale values persisting across transactional fixture runs.

CI:
- Include admin app configs controller and its spec in the spec-staleness-guard workflow allowlist so they are exercised in CI.