### PR TITLE
fix(macros): parâmetro não resolvível deixa de reportar sucesso (CRM-54)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -59,8 +59,8 @@ on:
       # keeps credentials out of the response. Neither shows up in another lane.
       - 'app/controllers/api/v1/admin/app_configs_controller.rb'
       - 'spec/controllers/api/v1/admin/app_configs_controller_spec.rb'
-      # CRM-54: a macro only reports `failed` because ActionParamGuards validates
-      # the param before delegating to the shared handler. Loosening that guard
+      # A macro only reports `failed` because ActionParamGuards validates the
+      # param before delegating to the shared handler. Loosening that guard
       # brings back the silent success — and the junk label — invisibly to every
       # other lane.
       - 'app/services/macros/**'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -59,9 +59,10 @@ on:
       # keeps credentials out of the response. Neither shows up in another lane.
       - 'app/controllers/api/v1/admin/app_configs_controller.rb'
       - 'spec/controllers/api/v1/admin/app_configs_controller_spec.rb'
-      # CRM-54: a macro só marca `failed` porque ActionParamGuards valida o param
-      # antes de delegar ao handler compartilhado. Afrouxar essa guarda devolve o
-      # sucesso silencioso — e a etiqueta lixo — sem quebrar nenhuma outra lane.
+      # CRM-54: a macro only reports `failed` because ActionParamGuards validates
+      # the param before delegating to the shared handler. Loosening that guard
+      # brings back the silent success — and the junk label — invisibly to every
+      # other lane.
       - 'app/services/macros/**'
       - 'spec/services/macros/**'
       - 'spec/requests/api/v1/macros_spec.rb'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -59,6 +59,12 @@ on:
       # keeps credentials out of the response. Neither shows up in another lane.
       - 'app/controllers/api/v1/admin/app_configs_controller.rb'
       - 'spec/controllers/api/v1/admin/app_configs_controller_spec.rb'
+      # CRM-54: a macro só marca `failed` porque ActionParamGuards valida o param
+      # antes de delegar ao handler compartilhado. Afrouxar essa guarda devolve o
+      # sucesso silencioso — e a etiqueta lixo — sem quebrar nenhuma outra lane.
+      - 'app/services/macros/**'
+      - 'spec/services/macros/**'
+      - 'spec/requests/api/v1/macros_spec.rb'
 
 permissions:
   contents: read
@@ -138,4 +144,6 @@ jobs:
             spec/initializers/active_storage_dynamic_service_spec.rb \
             spec/services/config_test/storage_test_service_spec.rb \
             spec/controllers/api/v1/admin/app_configs_controller_spec.rb \
+            spec/services/macros/execution_service_spec.rb \
+            spec/requests/api/v1/macros_spec.rb \
             --format progress

--- a/app/services/macros/action_param_guards.rb
+++ b/app/services/macros/action_param_guards.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Guard rails for the id params carried by a macro action.
+#
+# A macro's action_params always come from a picker in the form — never free
+# text — so a value that does not resolve means the macro is stale or was saved
+# corrupted (CRM-54). Until then those params went straight to
+# AutomationRules::ConversationActionHandlers, which returns silently for the
+# assignments and treats a non-uuid label as a title; either way the execution
+# was reported as a success and the user got a green toast.
+#
+# The validation lives here and NOT in the shared handler on purpose: that
+# handler is also the implementation behind automation rules, journeys and
+# pipelines, where applying a label by NAME is intentional (EVO-1932).
+module Macros::ActionParamGuards
+  UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
+  class InvalidActionParam < StandardError; end
+
+  private
+
+  def assign_agent(agent_ids)
+    agent_ids = Array(agent_ids).map { |id| id == 'self' ? @user.id : id }
+    return super(agent_ids) if agent_ids.first.to_s == 'nil'
+
+    agent_id = agent_ids.first
+    raise_invalid_param('assign_agent', agent_id, 'not found') unless User.exists?(id: agent_id)
+    return super(agent_ids) if agent_belongs_to_inbox?(agent_ids)
+
+    raise_invalid_param('assign_agent', agent_id, "is not a member of inbox #{@conversation.inbox_id}")
+  end
+
+  def assign_team(team_ids)
+    team_ids = Array(team_ids)
+    return super(team_ids) if unassign_team?(team_ids)
+
+    team_id = team_ids.first
+    raise_invalid_param('assign_team', team_id, 'not found') unless Team.exists?(id: team_id)
+
+    super(team_ids)
+  end
+
+  def add_label(labels)
+    super(validated_label_ids(labels, 'add_label'))
+  end
+
+  def remove_label(labels)
+    super(validated_label_ids(labels, 'remove_label'))
+  end
+
+  # Mirrors the unassign branch of the shared handler so the "clear the team"
+  # macro keeps working — only a real assignment is validated.
+  def unassign_team?(team_ids)
+    team_ids.blank? || %w[nil 0].include?(team_ids[0].to_s)
+  end
+
+  # Inside a macro a label is always an id, so a non-uuid is corruption rather
+  # than a title — passing it through would tag the conversation with a junk
+  # label that exists nowhere in the account's label list.
+  def validated_label_ids(labels, action_name)
+    values = Array(labels).map(&:to_s).reject(&:empty?)
+    return values if values.empty?
+
+    malformed = values.grep_v(UUID_FORMAT)
+    raise_invalid_param(action_name, malformed, 'is not a label id') if malformed.any?
+
+    missing = values - Label.where(id: values).pluck(:id).map(&:to_s)
+    raise_invalid_param(action_name, missing, 'not found') if missing.any?
+
+    values
+  end
+
+  def raise_invalid_param(action_name, values, reason)
+    raise InvalidActionParam, "#{action_name}: #{Array(values).map(&:inspect).join(', ')} #{reason}"
+  end
+end

--- a/app/services/macros/action_param_guards.rb
+++ b/app/services/macros/action_param_guards.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 # Validates the id params of a macro action before delegating to the shared
-# conversation handlers, which return silently on an unresolved id (CRM-54).
+# conversation handlers, which return silently on an unresolved id.
 #
 # Deliberately NOT in AutomationRules::ConversationActionHandlers: that handler
 # also backs automation rules, journeys and pipelines, where applying a label by
-# NAME is intentional (EVO-1932).
+# NAME is intentional.
 module Macros::ActionParamGuards
   UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
 

--- a/app/services/macros/action_param_guards.rb
+++ b/app/services/macros/action_param_guards.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-# Guard rails for the id params carried by a macro action.
+# Validates the id params of a macro action before delegating to the shared
+# conversation handlers, which return silently on an unresolved id (CRM-54).
 #
-# A macro's action_params always come from a picker in the form — never free
-# text — so a value that does not resolve means the macro is stale or was saved
-# corrupted (CRM-54). Until then those params went straight to
-# AutomationRules::ConversationActionHandlers, which returns silently for the
-# assignments and treats a non-uuid label as a title; either way the execution
-# was reported as a success and the user got a green toast.
-#
-# The validation lives here and NOT in the shared handler on purpose: that
-# handler is also the implementation behind automation rules, journeys and
-# pipelines, where applying a label by NAME is intentional (EVO-1932).
+# Deliberately NOT in AutomationRules::ConversationActionHandlers: that handler
+# also backs automation rules, journeys and pipelines, where applying a label by
+# NAME is intentional (EVO-1932).
 module Macros::ActionParamGuards
   UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
 
@@ -48,15 +42,15 @@ module Macros::ActionParamGuards
     super(validated_label_ids(labels, 'remove_label'))
   end
 
-  # Mirrors the unassign branch of the shared handler so the "clear the team"
-  # macro keeps working — only a real assignment is validated.
+  # Mirrors the unassign branch of the shared handler: only a real assignment
+  # is validated, so the "clear the team" macro keeps working.
   def unassign_team?(team_ids)
     team_ids.blank? || %w[nil 0].include?(team_ids[0].to_s)
   end
 
-  # Inside a macro a label is always an id, so a non-uuid is corruption rather
-  # than a title — passing it through would tag the conversation with a junk
-  # label that exists nowhere in the account's label list.
+  # The macro form only offers a picker over registered labels, so a non-uuid
+  # here is corruption, not a title: passing it through tags the conversation
+  # with a label that exists nowhere in the account.
   def validated_label_ids(labels, action_name)
     values = Array(labels).map(&:to_s).reject(&:empty?)
     return values if values.empty?

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class Macros::ExecutionService < ActionService
+  # Validates the id params of assign_agent / assign_team / add_label /
+  # remove_label before delegating to the shared conversation handlers, so an
+  # unresolvable param fails the action instead of passing silently (CRM-54).
+  include Macros::ActionParamGuards
+
   def initialize(macro, conversation, user)
     super(conversation)
     @macro = macro
@@ -53,6 +58,11 @@ class Macros::ExecutionService < ActionService
     else
       @actions_result << { action: action_name, status: 'success' }
     end
+  rescue InvalidActionParam => e
+    # Bad data in the macro, not a runtime fault — fail the action without
+    # noising up the exception tracker.
+    @has_failure = true
+    @actions_result << { action: action_name, status: 'failed', error: e.message }
   rescue StandardError => e
     @has_failure = true
     @actions_result << { action: action_name, status: 'failed', error: e.message }
@@ -93,11 +103,6 @@ class Macros::ExecutionService < ActionService
       Time.zone.now,
       macro_execution: @execution
     )
-  end
-
-  def assign_agent(agent_ids)
-    agent_ids = agent_ids.map { |id| id == 'self' ? @user.id : id }
-    super(agent_ids)
   end
 
   def add_private_note(message)

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -147,17 +147,17 @@ class Macros::ExecutionService < ActionService
   def send_attachment(attachment_params)
     return if conversation_a_tweet?
 
-    # Suporte para formato antigo (array de IDs) e novo formato (hash com opções)
+    # Accepts both the old format (array of ids) and the new one (hash with options)
     if attachment_params.is_a?(Array)
-      # Formato legado: apenas array de blob_ids
+      # Legacy format: a bare array of blob_ids
       blob_ids = attachment_params
       inbox_id = nil
     elsif attachment_params.is_a?(Hash)
-      # Novo formato: hash com attachment_ids e inbox_id opcional
+      # New format: hash with attachment_ids and an optional inbox_id
       blob_ids = attachment_params[:attachment_ids] || attachment_params['attachment_ids']
       inbox_id = attachment_params[:inbox_id] || attachment_params['inbox_id']
     else
-      # Formato único: assumir que é um array de IDs
+      # Anything else: assume it is an array of ids
       blob_ids = [attachment_params].flatten
       inbox_id = nil
     end
@@ -168,15 +168,15 @@ class Macros::ExecutionService < ActionService
 
     return if blobs.blank?
 
-    # Preparar parâmetros da mensagem
+    # Build the message params
     params = { content: nil, private: false, attachments: blobs }
 
-    # Se um inbox específico foi fornecido, validar se a conversa pertence a esse inbox
+    # When a specific inbox was given, check the conversation belongs to it
     if inbox_id
       inbox = Inbox.find_by(id: inbox_id)
       if inbox && @conversation.inbox != inbox
         Rails.logger.warn "Macro #{@macro.id}: Inbox mismatch. Conversation inbox: #{@conversation.inbox.id}, Requested inbox: #{inbox_id}"
-        # Por ora, vamos logar e continuar com o inbox da conversa
+        # For now, log it and carry on with the conversation's own inbox
       end
     end
 

--- a/app/services/macros/execution_service.rb
+++ b/app/services/macros/execution_service.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class Macros::ExecutionService < ActionService
-  # Validates the id params of assign_agent / assign_team / add_label /
-  # remove_label before delegating to the shared conversation handlers, so an
-  # unresolvable param fails the action instead of passing silently (CRM-54).
   include Macros::ActionParamGuards
 
   def initialize(macro, conversation, user)
@@ -59,8 +56,7 @@ class Macros::ExecutionService < ActionService
       @actions_result << { action: action_name, status: 'success' }
     end
   rescue InvalidActionParam => e
-    # Bad data in the macro, not a runtime fault — fail the action without
-    # noising up the exception tracker.
+    # Bad data in the macro, not a runtime fault: no exception tracking.
     @has_failure = true
     @actions_result << { action: action_name, status: 'failed', error: e.message }
   rescue StandardError => e

--- a/spec/requests/api/v1/macros_spec.rb
+++ b/spec/requests/api/v1/macros_spec.rb
@@ -64,5 +64,36 @@ RSpec.describe 'Api::V1::MacrosController', type: :request do
       parsed = JSON.parse(response.body)
       expect(parsed['data']['name']).to eq('Test Macro')
     end
+
+    # CRM-54: the form used to save `parseInt(uuid) || uuid`, so every uuid
+    # starting with a hex digit 1-9 was truncated to a number before it ever
+    # reached this endpoint. Ids starting with 0 or a letter passed by accident.
+    # Cover the whole first-digit range so a reintroduced coercion — on either
+    # side of the wire — is caught here.
+    %w[0 1 2 3 4 5 6 7 8 9 a b c d e f].each do |first_digit|
+      it "persists an action param uuid starting with #{first_digit} verbatim" do
+        team_id = "#{first_digit}#{SecureRandom.uuid[1..]}"
+
+        post '/api/v1/macros',
+             params: {
+               name: "Macro #{first_digit}",
+               actions: [{ action_name: 'assign_team', action_params: [team_id] }],
+               visibility: 'global'
+             },
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:success)
+        created = response.parsed_body['data']
+        expect(created['actions'].first['action_params']).to eq([team_id])
+
+        # Reopening the macro must show the very same selection back.
+        get "/api/v1/macros/#{created['id']}", headers: headers, as: :json
+
+        expect(response).to have_http_status(:success)
+        reopened = response.parsed_body['data']
+        expect(reopened['actions'].first['action_params']).to eq([team_id])
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/macros_spec.rb
+++ b/spec/requests/api/v1/macros_spec.rb
@@ -65,9 +65,12 @@ RSpec.describe 'Api::V1::MacrosController', type: :request do
       expect(parsed['data']['name']).to eq('Test Macro')
     end
 
-    # CRM-54: the form used to save `parseInt(uuid) || uuid`, truncating every
-    # uuid that starts with a hex digit 1-9 before it reached this endpoint.
-    # The whole range is covered so a reintroduced coercion is caught here.
+    # CRM-54: pins the round-trip the form relies on — an action param comes
+    # back from create and from show byte for byte, for any first hex digit.
+    #
+    # It does NOT guard the bug itself. The `parseInt(uuid) || uuid` coercion
+    # lived in the form and never in Ruby, so nothing here can fail if it comes
+    # back; MacroActionRow.spec.tsx is what catches that.
     %w[0 1 2 3 4 5 6 7 8 9 a b c d e f].each do |first_digit|
       it "persists an action param uuid starting with #{first_digit} verbatim" do
         team_id = "#{first_digit}#{SecureRandom.uuid[1..]}"

--- a/spec/requests/api/v1/macros_spec.rb
+++ b/spec/requests/api/v1/macros_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe 'Api::V1::MacrosController', type: :request do
       expect(parsed['data']['name']).to eq('Test Macro')
     end
 
-    # CRM-54: pins the round-trip the form relies on — an action param comes
-    # back from create and from show byte for byte, for any first hex digit.
+    # Pins the round-trip the form relies on — an action param comes back from
+    # create and from show byte for byte, for any first hex digit.
     #
     # It does NOT guard the bug itself. The `parseInt(uuid) || uuid` coercion
     # lived in the form and never in Ruby, so nothing here can fail if it comes

--- a/spec/requests/api/v1/macros_spec.rb
+++ b/spec/requests/api/v1/macros_spec.rb
@@ -65,11 +65,9 @@ RSpec.describe 'Api::V1::MacrosController', type: :request do
       expect(parsed['data']['name']).to eq('Test Macro')
     end
 
-    # CRM-54: the form used to save `parseInt(uuid) || uuid`, so every uuid
-    # starting with a hex digit 1-9 was truncated to a number before it ever
-    # reached this endpoint. Ids starting with 0 or a letter passed by accident.
-    # Cover the whole first-digit range so a reintroduced coercion — on either
-    # side of the wire — is caught here.
+    # CRM-54: the form used to save `parseInt(uuid) || uuid`, truncating every
+    # uuid that starts with a hex digit 1-9 before it reached this endpoint.
+    # The whole range is covered so a reintroduced coercion is caught here.
     %w[0 1 2 3 4 5 6 7 8 9 a b c d e f].each do |first_digit|
       it "persists an action param uuid starting with #{first_digit} verbatim" do
         team_id = "#{first_digit}#{SecureRandom.uuid[1..]}"

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -251,8 +251,11 @@ RSpec.describe Macros::ExecutionService do
       end
     end
 
-    # Only uuids starting with a hex digit 1-9 were truncated by the old
-    # `parseInt(uuid) || uuid`; leading 0 and leading letter passed by accident.
+    # The guard resolves by `Team.exists?`, which has no digit sensitivity, so
+    # the sweep is documentation of the blast radius rather than a trap: the old
+    # `parseInt(uuid) || uuid` truncated a leading hex digit 1-9 and let 0 and a
+    # leading letter through by accident. What a truncated id does here is
+    # covered by the `[8]` example above.
     describe 'ids across the whole first-hex-digit range' do
       %w[0 1 2 3 4 5 6 7 8 9 a b c d e f].each do |first_digit|
         it "resolves a team whose uuid starts with #{first_digit}" do

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -24,27 +24,25 @@ RSpec.describe Macros::ExecutionService do
 
     before { service.instance_variable_set(:@execution, execution) }
 
-    it 'enqueues WebhookJob with stripped URL, payload, :macro_webhook and the execution id' do
-      expect(WebhookJob).to receive(:perform_later).with(
-        'https://webhook.site/abc',
-        hash_including(event: 'macro.executed'),
-        :macro_webhook,
-        execution.id
-      )
+    # O método não enfileira nada: devolve um descritor para #perform enfileirar
+    # DEPOIS de persistir o marcador 'enqueued' em actions_result. O enqueue de
+    # verdade é coberto no #perform, abaixo.
+    it 'returns a job descriptor carrying the stripped URL and the payload' do
+      result = service.send(:send_webhook_event, ["  https://webhook.site/abc  \t"])
 
-      service.send(:send_webhook_event, ["  https://webhook.site/abc  \t"])
+      expect(result[:status]).to eq(:pending_enqueue)
+      expect(result[:url]).to eq('https://webhook.site/abc')
+      expect(result[:payload]).to include(event: 'macro.executed')
     end
 
-    it 'skips enqueue and warns when the URL is blank' do
-      expect(WebhookJob).not_to receive(:perform_later)
+    it 'returns no descriptor and warns when the URL is blank' do
       expect(Rails.logger).to receive(:warn).with(/skipping send_webhook_event/)
 
-      service.send(:send_webhook_event, ['   '])
+      expect(service.send(:send_webhook_event, ['   '])).to be_nil
     end
 
-    it 'skips enqueue when params is nil' do
-      expect(WebhookJob).not_to receive(:perform_later)
-      service.send(:send_webhook_event, nil)
+    it 'returns no descriptor when params is nil' do
+      expect(service.send(:send_webhook_event, nil)).to be_nil
     end
   end
 
@@ -70,6 +68,21 @@ RSpec.describe Macros::ExecutionService do
           .with(Events::Types::MACRO_EXECUTION_COMPLETED, anything, anything)
 
         service.perform
+      end
+
+      it 'enqueues WebhookJob with the stripped URL, payload, :macro_webhook and the execution id' do
+        macro.update!(
+          actions: [{ 'action_name' => 'send_webhook_event', 'action_params' => ["  https://webhook.site/abc  \t"] }]
+        )
+        enqueued = nil
+        allow(WebhookJob).to receive(:perform_later) { |*args| enqueued = args }
+
+        execution = service.perform
+
+        expect(enqueued[0]).to eq('https://webhook.site/abc')
+        expect(enqueued[1]).to include(event: 'macro.executed')
+        expect(enqueued[2]).to eq(:macro_webhook)
+        expect(enqueued[3]).to eq(execution.id)
       end
     end
 

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Macros::ExecutionService do
     end
   end
 
-  # CRM-54: the shared handler returns silently on an unresolved assignment, and
+  # The shared handler returns silently on an unresolved assignment, and
   # treats a non-uuid label as a title — tagging the conversation with junk.
   # Both used to end as `success`.
   describe 'unresolvable action params' do
@@ -274,7 +274,7 @@ RSpec.describe Macros::ExecutionService do
   end
 
   # The uuid-only rule is scoped to macros: journeys, automation rules and
-  # pipelines apply labels by NAME on purpose (EVO-1932).
+  # pipelines apply labels by NAME on purpose.
   describe 'title passthrough of the shared handler (non-regression)' do
     let(:rule) do
       automation_rule = AutomationRule.new(

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -24,9 +24,8 @@ RSpec.describe Macros::ExecutionService do
 
     before { service.instance_variable_set(:@execution, execution) }
 
-    # O método não enfileira nada: devolve um descritor para #perform enfileirar
-    # DEPOIS de persistir o marcador 'enqueued' em actions_result. O enqueue de
-    # verdade é coberto no #perform, abaixo.
+    # The method does not enqueue: it returns a descriptor for #perform to
+    # enqueue after persisting the 'enqueued' marker. Enqueue is covered below.
     it 'returns a job descriptor carrying the stripped URL and the payload' do
       result = service.send(:send_webhook_event, ["  https://webhook.site/abc  \t"])
 
@@ -115,11 +114,9 @@ RSpec.describe Macros::ExecutionService do
     end
   end
 
-  # CRM-54: an unresolvable action param used to end in a green toast. For
-  # assign_team / assign_agent the shared handler returns silently; for
-  # add_label / remove_label it is worse — a non-uuid is treated as a label
-  # title and a junk label is created on the conversation. Both paths must end
-  # as `failed`, and the validation must live here, never in the shared handler.
+  # CRM-54: the shared handler returns silently on an unresolved assignment, and
+  # treats a non-uuid label as a title — tagging the conversation with junk.
+  # Both used to end as `success`.
   describe 'unresolvable action params' do
     let(:service) { described_class.new(macro, conversation, user) }
 
@@ -254,9 +251,8 @@ RSpec.describe Macros::ExecutionService do
       end
     end
 
-    # The frontend used to save `parseInt(uuid) || uuid`, which truncated every
-    # uuid starting with a hex digit 1-9. Ids starting with 0 or a letter passed
-    # by accident. All 16 must round-trip through an execution unchanged.
+    # Only uuids starting with a hex digit 1-9 were truncated by the old
+    # `parseInt(uuid) || uuid`; leading 0 and leading letter passed by accident.
     describe 'ids across the whole first-hex-digit range' do
       %w[0 1 2 3 4 5 6 7 8 9 a b c d e f].each do |first_digit|
         it "resolves a team whose uuid starts with #{first_digit}" do
@@ -274,9 +270,8 @@ RSpec.describe Macros::ExecutionService do
     end
   end
 
-  # Guard-rail: the uuid-only rule is scoped to macros. Journeys, automation
-  # rules and pipelines legitimately apply labels by NAME through
-  # resolve_label_titles (EVO-1932) and must keep working.
+  # The uuid-only rule is scoped to macros: journeys, automation rules and
+  # pipelines apply labels by NAME on purpose (EVO-1932).
   describe 'title passthrough of the shared handler (non-regression)' do
     let(:rule) do
       automation_rule = AutomationRule.new(

--- a/spec/services/macros/execution_service_spec.rb
+++ b/spec/services/macros/execution_service_spec.rb
@@ -102,6 +102,189 @@ RSpec.describe Macros::ExecutionService do
     end
   end
 
+  # CRM-54: an unresolvable action param used to end in a green toast. For
+  # assign_team / assign_agent the shared handler returns silently; for
+  # add_label / remove_label it is worse — a non-uuid is treated as a label
+  # title and a junk label is created on the conversation. Both paths must end
+  # as `failed`, and the validation must live here, never in the shared handler.
+  describe 'unresolvable action params' do
+    let(:service) { described_class.new(macro, conversation, user) }
+
+    before { allow(Rails.configuration.dispatcher).to receive(:dispatch) }
+
+    def macro_with(action_name, action_params)
+      Macro.create!(
+        name: "macro-#{SecureRandom.hex(4)}",
+        created_by: user,
+        updated_by: user,
+        actions: [{ 'action_name' => action_name, 'action_params' => action_params }]
+      )
+    end
+
+    def failed_result(action_name, action_params)
+      execution = described_class.new(macro_with(action_name, action_params), conversation, user).perform
+
+      expect(execution.status).to eq('failed')
+      result = execution.actions_result.first
+      expect(result['action']).to eq(action_name)
+      expect(result['status']).to eq('failed')
+      result
+    end
+
+    describe '#assign_team' do
+      it 'fails the action when the team does not exist' do
+        result = failed_result('assign_team', [SecureRandom.uuid])
+
+        expect(result['error']).to match(/assign_team.*not found/)
+        expect(conversation.reload.team_id).to be_nil
+      end
+
+      it 'fails the action when the id was truncated to a number' do
+        failed_result('assign_team', [8])
+
+        expect(conversation.reload.team_id).to be_nil
+      end
+
+      it 'assigns the team and reports success for a real team id' do
+        team = Team.create!(name: "team-#{SecureRandom.hex(4)}")
+        execution = described_class.new(macro_with('assign_team', [team.id]), conversation, user).perform
+
+        expect(execution.status).to eq('success')
+        expect(execution.actions_result.first['status']).to eq('success')
+        expect(conversation.reload.team_id).to eq(team.id)
+      end
+
+      it 'still unassigns the team when the param is the explicit unassign value' do
+        team = Team.create!(name: "team-#{SecureRandom.hex(4)}")
+        conversation.update!(team_id: team.id)
+
+        execution = described_class.new(macro_with('assign_team', ['nil']), conversation, user).perform
+
+        expect(execution.status).to eq('success')
+        expect(conversation.reload.team_id).to be_nil
+      end
+    end
+
+    describe '#assign_agent' do
+      it 'fails the action when the agent does not exist' do
+        result = failed_result('assign_agent', [SecureRandom.uuid])
+
+        expect(result['error']).to match(/assign_agent.*not found/)
+        expect(conversation.reload.assignee_id).to be_nil
+      end
+
+      it 'fails the action when the agent is not a member of the inbox' do
+        outsider = User.create!(name: 'Outsider', email: "outsider-#{SecureRandom.hex(4)}@test.com")
+
+        result = failed_result('assign_agent', [outsider.id])
+
+        expect(result['error']).to match(/not a member of inbox/)
+        expect(conversation.reload.assignee_id).to be_nil
+      end
+
+      it 'assigns the agent and reports success when they belong to the inbox' do
+        InboxMember.create!(inbox: inbox, user: user)
+
+        execution = described_class.new(macro_with('assign_agent', [user.id]), conversation, user).perform
+
+        expect(execution.status).to eq('success')
+        expect(conversation.reload.assignee_id).to eq(user.id)
+      end
+    end
+
+    describe '#add_label' do
+      it 'fails the action and tags nothing when the value is not a uuid' do
+        result = failed_result('add_label', ['8'])
+
+        expect(result['error']).to match(/add_label.*is not a label id/)
+        expect(conversation.reload.label_list).to be_empty
+      end
+
+      it 'does not report a bad param to the exception tracker' do
+        expect(EvolutionExceptionTracker).not_to receive(:new)
+
+        failed_result('add_label', ['8'])
+      end
+
+      it 'fails the action when the label uuid does not exist' do
+        result = failed_result('add_label', [SecureRandom.uuid])
+
+        expect(result['error']).to match(/add_label.*not found/)
+        expect(conversation.reload.label_list).to be_empty
+      end
+
+      it 'applies a registered label and reports success' do
+        label = Label.create!(title: "urgente-#{SecureRandom.hex(4)}")
+
+        execution = described_class.new(macro_with('add_label', [label.id]), conversation, user).perform
+
+        expect(execution.status).to eq('success')
+        expect(conversation.reload.label_list).to include(label.title)
+      end
+    end
+
+    describe '#remove_label' do
+      it 'fails the action when the value is not a uuid' do
+        result = failed_result('remove_label', ['8'])
+
+        expect(result['error']).to match(/remove_label.*is not a label id/)
+      end
+
+      it 'removes a registered label and reports success' do
+        label = Label.create!(title: "vip-#{SecureRandom.hex(4)}")
+        conversation.update!(label_list: [label.title])
+
+        execution = described_class.new(macro_with('remove_label', [label.id]), conversation, user).perform
+
+        expect(execution.status).to eq('success')
+        expect(conversation.reload.label_list).not_to include(label.title)
+      end
+    end
+
+    # The frontend used to save `parseInt(uuid) || uuid`, which truncated every
+    # uuid starting with a hex digit 1-9. Ids starting with 0 or a letter passed
+    # by accident. All 16 must round-trip through an execution unchanged.
+    describe 'ids across the whole first-hex-digit range' do
+      %w[0 1 2 3 4 5 6 7 8 9 a b c d e f].each do |first_digit|
+        it "resolves a team whose uuid starts with #{first_digit}" do
+          team = Team.create!(
+            id: "#{first_digit}#{SecureRandom.uuid[1..]}",
+            name: "team-#{first_digit}-#{SecureRandom.hex(4)}"
+          )
+
+          execution = described_class.new(macro_with('assign_team', [team.id]), conversation, user).perform
+
+          expect(execution.status).to eq('success')
+          expect(conversation.reload.team_id).to eq(team.id)
+        end
+      end
+    end
+  end
+
+  # Guard-rail: the uuid-only rule is scoped to macros. Journeys, automation
+  # rules and pipelines legitimately apply labels by NAME through
+  # resolve_label_titles (EVO-1932) and must keep working.
+  describe 'title passthrough of the shared handler (non-regression)' do
+    let(:rule) do
+      automation_rule = AutomationRule.new(
+        name: "rule-#{SecureRandom.hex(4)}",
+        event_name: 'conversation_updated',
+        active: true,
+        mode: 'simple',
+        conditions: [],
+        actions: [{ 'action_name' => 'add_label', 'action_params' => ['promocao'] }]
+      )
+      automation_rule.save!(validate: false)
+      automation_rule
+    end
+
+    it 'still applies a label by title from an automation rule' do
+      AutomationRules::ActionService.new(rule, nil, conversation).perform
+
+      expect(conversation.reload.label_list).to include('promocao')
+    end
+  end
+
   describe '#send_message with a template (EVO-1235)' do
     let(:template) { MessageTemplate.create!(name: 'macro_tpl', content: 'Hi {{first_name}}', channel: nil) }
     let(:service) { described_class.new(macro, conversation, user) }


### PR DESCRIPTION
Card: [CRM-54](https://plane.evosetup.com/evolution/browse/CRM-54/) — metade **backend**. A metade frontend é a [PR #292 do `evo-ai-frontend-community`](https://github.com/evolution-foundation/evo-ai-frontend-community/pull/292); as duas são independentes, sem ordem de merge.

## O bug

`Macros::ExecutionService#execute_action` só marca `failed` quando a ação levanta exceção — e nenhum dos quatro caminhos de id levantava:

- **`assign_team` / `assign_agent`:** o handler compartilhado dá `return` silencioso quando o id não resolve. A execução terminava `success` com a conversa intacta.
- **`add_label` / `remove_label`:** pior. `resolve_label_titles` particiona por uuid e trata o não-uuid como **título literal**, então um id truncado virava uma **etiqueta lixo chamada `"8"`** na conversa — tagging órfã, que não existe no cadastro de etiquetas. O backend marcava `success` com razão: ele fez exatamente o que foi pedido.

Nos dois casos o usuário via toast verde.

## Onde a validação foi (e por que não no handler)

Em `Macros::ActionParamGuards`, incluído pelo `ExecutionService` — **não** em `AutomationRules::ConversationActionHandlers`. Aquele handler é a implementação compartilhada por automation rules, jornadas e pipelines, onde aplicar etiqueta **por NOME** é intencional (EVO-1932, `labelable.rb:13-24`). Apertar ele mudaria o comportamento de três produtos.

Dentro da macro o formulário só oferece picker de etiqueta cadastrada, nunca texto livre — então ali um não-uuid é corrupção. A regra **uuid-only fica escopada à macro** e o passthrough de título segue intacto para os outros callers.

Param inválido levanta `InvalidActionParam`, que vira `failed` em `macro_executions.status` e na ação dentro de `actions_result`, **sem** passar pelo `EvolutionExceptionTracker` (é dado ruim, não falha de runtime). O front do chat (`MacrosButton.tsx:88-108`) já lê `status`/`actions_result` e já nomeia a ação que falhou — não precisa de trabalho novo lá.

## Testes

Os dois specs já existiam; foram **estendidos**, não criados. Nenhuma assertion anterior travava o comportamento buggado, então nada que passava quebrou.

- `execution_service_spec.rb` — os três caminhos de silent-success, a ausência de etiqueta lixo, o caminho feliz de cada ação, o unassign explícito (`'nil'`), o uuid de team em **cada um dos 16 dígitos hex iniciais**, e a não-regressão do passthrough de título via `AutomationRules::ActionService`.
- `macros_spec.rb` — round-trip do `action_params` pela API (criar + reabrir) para os 16 dígitos iniciais.

**Os specs de macro não rodavam em lugar nenhum — corrigido nesta PR.** Nenhuma lane da CI incluía `spec/services/macros/` nem `spec/requests/api/v1/macros_spec.rb`, então a cobertura existia como arquivo e nunca era executada. Eles entraram no `spec-staleness-guard`, que é a lane feita exatamente para isso (mesmo padrão dos precedentes EVO-2186 / EVO-2122 / EVO-2222 já listados lá). **Agora rodam e passam** — `Spec staleness guard` verde, 314 exemplos.

Ao entrar na lane, o bloco `#send_webhook_event` — que já existia e não faz parte deste card — acusou: os três exemplos assumiam que o método enfileira o `WebhookJob`, mas desde a correção da race do EVO-1041 ele só devolve um descritor e quem enfileira é o `#perform`. Um falhava e os outros dois passavam por vacuidade (o `not_to receive(:perform_later)` era trivialmente verdadeiro justamente porque o método nunca enfileira). Corrigido em commit próprio: cada asserção foi para o nível certo e o enqueue com os quatro argumentos passou a ser exercido via `#perform`.

Rspec **não** roda no ambiente de dev local (Windows: Ruby 3.4.9 vs 3.4.4 do Gemfile; o container enterprise é imagem de produção, sem as gems de teste), então o comportamento também foi provado em runtime via `rails runner` no container, com seed dentro de transação + rollback — baseline primeiro, depois o patch:

| caso | baseline | com o fix |
|---|---|---|
| `add_label ['8']` | `success`, `label_list=["8"]` | `failed`, `label_list=[]` |
| `assign_team [8]` | `success`, `team_id=nil` | `failed`, `team_id=nil` |
| `assign_team [uuid inexistente]` | `success`, `team_id=nil` | `failed` |
| `assign_agent [uuid inexistente]` | `success`, `assignee_id=nil` | `failed` |
| `assign_agent [fora do inbox]` | `success`, `assignee_id=nil` | `failed` |
| caminho feliz (uuid real começando em 8) | ok | ok |
| etiqueta por NOME via automation rule | ok | **ok** (não-regressão) |

`rubocop` nos arquivos tocados: **zero ofensas novas**.

## Item condicional do card

`SELECT count(*) FROM macros WHERE actions::text ~ '"action_params":\[[0-9]+\]';` → **0** no ambiente local, então a migration de limpeza não entra nesta PR. **Falta rodar em staging/prod** por quem tem acesso; se voltar > 0, entra como trabalho à parte (re-resolver é impossível — `8` não identifica de volta qual uuid era), junto com a decisão sobre as taggings lixo já aplicadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Mark macro executions as failed when id-based action parameters are invalid or unresolvable instead of silently succeeding.

Bug Fixes:
- Treat invalid or non-existent team, agent, and label ids in macro actions as failures, avoiding silent no-ops and junk labels on conversations.
- Ensure invalid macro parameters produce failed action results without going through the runtime exception tracker.

Enhancements:
- Introduce macro-specific parameter guards to validate id-based action params while preserving title-based label application for automation rules, journeys, and pipelines.

Tests:
- Extend macro execution and API request specs to cover invalid id scenarios, non-regression of shared handler behavior, and uuid round-trip across all first-hex-digit values.

