### PR TITLE
fix(api): para de mascarar a excecao real com DoubleRenderError (CRM-161)

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -87,7 +87,10 @@ class Api::BaseController < ApplicationController
   # it in, so without this the exception disappears entirely. handle_internal_error
   # has always logged; the specific handlers now do the same.
   def log_rescued_exception(exception)
-    Rails.logger.error("[api] #{exception.class}: #{exception.message}")
+    Rails.logger.error(
+      "[api] #{exception.class}: #{exception.message} " \
+      "(#{controller_name}##{action_name} #{request.method} #{request.original_fullpath})"
+    )
     Rails.logger.error(exception.backtrace.first(5).join("\n")) if exception.backtrace
   end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -81,8 +81,19 @@ class Api::BaseController < ApplicationController
     paginate_instance_variables(page, page_size)
   end
 
+  # Every rescue_from below turns an exception into a response body, which is the
+  # only place it would otherwise be visible. When the action already rendered —
+  # a callback raising after the response was sent — there is no body left to put
+  # it in, so without this the exception disappears entirely. handle_internal_error
+  # has always logged; the specific handlers now do the same.
+  def log_rescued_exception(exception)
+    Rails.logger.error("[api] #{exception.class}: #{exception.message}")
+    Rails.logger.error(exception.backtrace.first(5).join("\n")) if exception.backtrace
+  end
+
   # Handle ActiveRecord::RecordNotFound
   def handle_record_not_found(exception)
+    log_rescued_exception(exception)
     resource_name = exception.model.to_s.underscore.upcase
     error_code = "#{resource_name}_NOT_FOUND"
 
@@ -99,6 +110,7 @@ class Api::BaseController < ApplicationController
 
   # Handle ActiveRecord::RecordInvalid (validation errors)
   def handle_record_invalid(exception)
+    log_rescued_exception(exception)
     error_response(
       ApiErrorCodes::VALIDATION_ERROR,
       'Validation failed',
@@ -109,6 +121,7 @@ class Api::BaseController < ApplicationController
 
   # Handle ActiveRecord::RecordNotUnique (duplicate entries)
   def handle_record_not_unique(exception)
+    log_rescued_exception(exception)
     error_response(
       ApiErrorCodes::RESOURCE_ALREADY_EXISTS,
       'Resource already exists',
@@ -119,6 +132,7 @@ class Api::BaseController < ApplicationController
 
   # Handle Pundit::NotAuthorizedError (authorization failures)
   def handle_not_authorized(exception)
+    log_rescued_exception(exception)
     error_response(
       ApiErrorCodes::FORBIDDEN,
       'You are not authorized to perform this action',
@@ -132,6 +146,7 @@ class Api::BaseController < ApplicationController
 
   # Handle ActionController::ParameterMissing
   def handle_parameter_missing(exception)
+    log_rescued_exception(exception)
     error_response(
       ApiErrorCodes::MISSING_REQUIRED_FIELD,
       "Required parameter missing: #{exception.param}",

--- a/app/controllers/concerns/api_response_helper.rb
+++ b/app/controllers/concerns/api_response_helper.rb
@@ -80,6 +80,19 @@ module ApiResponseHelper
   #   )
   #
   def error_response(code, message, details: nil, status: :bad_request)
+    # An exception raised after the action already rendered lands here through
+    # rescue_from. Rendering again raises DoubleRenderError, which replaces the
+    # real error with a generic 500 and hides it from the response AND the log.
+    # The rendered response is already on its way, so the error can only be
+    # logged.
+    if performed?
+      Rails.logger.error(
+        "[api] #{code}: #{message} could not be rendered — response already sent " \
+        "for #{request.method} #{request.path}"
+      )
+      return
+    end
+
     response_body = {
       success: false,
       error: {

--- a/app/controllers/concerns/api_response_helper.rb
+++ b/app/controllers/concerns/api_response_helper.rb
@@ -88,7 +88,7 @@ module ApiResponseHelper
     if performed?
       Rails.logger.error(
         "[api] #{code}: #{message} could not be rendered — response already sent " \
-        "for #{request.method} #{request.path}"
+        "for #{request.method} #{request.original_fullpath}"
       )
       return
     end

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -23,11 +23,12 @@ class SendReplyJob < ApplicationJob
       services[channel_name].new(message: message).perform if services[channel_name].present?
     end
   rescue ActiveRecord::RecordNotFound
-    # The message is not there to send yet or not there at all — either way this
-    # is not a delivery failure, and swallowing it would mark the job done with
-    # the row still unsent, no source_id and no external_error. Re-raise so the
-    # retry decides, since the enqueue can land before the row is visible to this
-    # connection.
+    # Not a delivery failure: the row is either not visible to this connection yet
+    # or gone for good. This clause exists to keep the `rescue StandardError` below
+    # from swallowing it — that would mark the job done with the message still
+    # unsent, no source_id and no external_error. Re-raise and let the retry decide,
+    # logging first so a retry for this reason is not silent.
+    Rails.logger.warn "[SendReplyJob] Message #{message_id} not found — leaving it to the retry"
     raise
   rescue StandardError => e
     Rails.logger.error "[SendReplyJob] Delivery failed for message #{message_id}: #{e.message}"

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -22,6 +22,13 @@ class SendReplyJob < ApplicationJob
     else
       services[channel_name].new(message: message).perform if services[channel_name].present?
     end
+  rescue ActiveRecord::RecordNotFound
+    # The message is not there to send yet or not there at all — either way this
+    # is not a delivery failure, and swallowing it would mark the job done with
+    # the row still unsent, no source_id and no external_error. Re-raise so the
+    # retry decides, since the enqueue can land before the row is visible to this
+    # connection.
+    raise
   rescue StandardError => e
     Rails.logger.error "[SendReplyJob] Delivery failed for message #{message_id}: #{e.message}"
     message&.update(status: :failed, external_error: e.message.to_s.truncate(1000))

--- a/spec/controllers/api/v1/conversations/messages_controller_spec.rb
+++ b/spec/controllers/api/v1/conversations/messages_controller_spec.rb
@@ -84,4 +84,47 @@ RSpec.describe Api::V1::Conversations::MessagesController, type: :controller do
       controller.send(:retry)
     end
   end
+
+  # A callback raising after the action rendered used to reach error_response,
+  # which rendered a second time: DoubleRenderError, a generic 500, and the real
+  # exception nowhere — not in the response, not in the log.
+  describe 'error handling once the action has already responded' do
+    let(:exception) { ActiveRecord::RecordInvalid.new(Message.new) }
+
+    it 'renders the validation error when nothing has been rendered yet' do
+      allow(controller).to receive(:performed?).and_return(false)
+      allow(controller).to receive(:format_validation_errors).and_return([])
+
+      expect(controller).to receive(:render).with(
+        hash_including(status: :unprocessable_entity)
+      )
+
+      controller.send(:handle_record_invalid, exception)
+    end
+
+    it 'does not render a second time, and logs the error it could not deliver' do
+      allow(controller).to receive(:performed?).and_return(true)
+
+      expect(controller).not_to receive(:render)
+      expect(Rails.logger).to receive(:error).at_least(:once)
+
+      controller.send(
+        :error_response,
+        ApiErrorCodes::VALIDATION_ERROR,
+        'Validation failed',
+        status: :unprocessable_entity
+      )
+    end
+
+    it 'logs the rescued exception so it survives even when the response is gone' do
+      allow(controller).to receive(:performed?).and_return(true)
+      allow(controller).to receive(:format_validation_errors).and_return([])
+      logged = []
+      allow(Rails.logger).to receive(:error) { |message| logged << message.to_s }
+
+      controller.send(:handle_record_invalid, exception)
+
+      expect(logged.join("\n")).to include('ActiveRecord::RecordInvalid')
+    end
+  end
 end


### PR DESCRIPTION
## O problema

`ApiResponseHelper#error_response` renderiza sem checar `performed?`. Uma exceção levantada **depois** que a ação já respondeu — um callback pós-commit, por exemplo — cai no `rescue_from`, tenta renderizar de novo e vira `AbstractController::DoubleRenderError`: o cliente recebe um 500 genérico e o erro de origem some da resposta **e** do log.

Foi assim que o CRM-161 apareceu no staging: responder uma conversa de Telegram devolvia `{"status":500,"error":"Internal Server Error"}` e o log só mostrava um `BEGIN ... ROLLBACK` de 12ms sem uma única query entre os dois. A exceção real era um `ActiveRecord::RecordInvalid` levantado num callback, e ninguém conseguia vê-la.

## O fix

1. `error_response` retorna cedo quando a resposta já saiu, registrando no log o erro que não conseguiu entregar.
2. Os cinco handlers de `rescue_from` que não logavam (`handle_record_invalid`, `handle_record_not_found`, `handle_record_not_unique`, `handle_not_authorized`, `handle_parameter_missing`) passam a logar a exceção por um helper único. O `handle_internal_error` já fazia isso — só não era central.
3. `SendReplyJob` deixa de engolir `RecordNotFound`. O `rescue StandardError` cego pegava o `Message.find` que falha quando o job roda antes da linha commitar: `message` fica nil, o `message&.update` não faz nada e o Sidekiq marca o job como **sucesso** — a mensagem parada em `status=sent`, sem `source_id` e sem `external_error`, que é exatamente o sintoma reportado. Re-levantando, quem decide é o retry (o `ApplicationJob` só declara `discard_on ActiveJob::DeserializationError`, então o retry acontece).

## Por que é bug do community

Nada aqui é enterprise: é um helper de resposta que renderiza duas vezes, e um job que engole a exceção que deveria fazê-lo repetir. A causa-raiz do CRM-161 (o tenant desarmado no `after_commit`) é enterprise e está no PR da gem de licensing — este PR é o que faz o erro real aparecer, com ou sem aquele.

## Testes

`spec/controllers/api/v1/conversations/messages_controller_spec.rb`: 6 exemplos, 0 falhas — três novos cobrindo o 422 dentro da ação, o não-renderizar duas vezes e o log da exceção resgatada.

No conjunto de specs que tocam `error_response` e `SendReplyJob`: 70 exemplos, 1 falha — `spec/services/data_import/conversation_manager_spec.rb:212`, que **já falha numa worktree limpa da develop** (`undefined method 'channel_type' for nil`), então não vem daqui.

## Summary by Sourcery

Improve API error handling to avoid masking original exceptions and ensure background message delivery errors surface correctly.

Bug Fixes:
- Prevent double rendering in API error responses when an exception occurs after a response has already been sent.
- Log rescued exceptions for common API error handlers so underlying errors remain visible even without a response body.
- Ensure SendReplyJob no longer swallows ActiveRecord::RecordNotFound so retry logic can correctly reattempt message delivery.

Tests:
- Extend API conversations messages controller specs to cover validation error responses, double-render avoidance, and logging of rescued exceptions.