### PR TITLE
fix(events): manda a etiqueta completa em labels_data (CRM-155)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -66,11 +66,10 @@ on:
       - 'app/services/macros/**'
       - 'spec/services/macros/**'
       - 'spec/requests/api/v1/macros_spec.rb'
-      # CRM-155: the webhook body and the realtime payload are the same hash, told
-      # apart only by `include_labels_data:`. Pointing `webhook_data` back at the
-      # default ships `labels_data` to every customer integration, and dropping the
-      # field brings back the label that only appears after F5. Neither failure is
-      # visible to any other lane.
+      # The webhook body and the realtime payload are the same hash, told apart only
+      # by `include_labels_data:`. Wiring `webhook_data` back to the default ships
+      # `labels_data` to every customer integration; dropping the field leaves the
+      # label invisible until a reload. Neither shows up in another lane.
       - 'app/presenters/conversations/event_data_presenter.rb'
       - 'app/models/concerns/push_data_helper.rb'
       - 'spec/presenters/conversations/event_data_presenter_spec.rb'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -66,6 +66,15 @@ on:
       - 'app/services/macros/**'
       - 'spec/services/macros/**'
       - 'spec/requests/api/v1/macros_spec.rb'
+      # CRM-155: the webhook body and the realtime payload are the same hash, told
+      # apart only by `include_labels_data:`. Pointing `webhook_data` back at the
+      # default ships `labels_data` to every customer integration, and dropping the
+      # field brings back the label that only appears after F5. Neither failure is
+      # visible to any other lane.
+      - 'app/presenters/conversations/event_data_presenter.rb'
+      - 'app/models/concerns/push_data_helper.rb'
+      - 'spec/presenters/conversations/event_data_presenter_spec.rb'
+      - 'spec/models/concerns/push_data_helper_spec.rb'
 
 permissions:
   contents: read
@@ -147,4 +156,6 @@ jobs:
             spec/controllers/api/v1/admin/app_configs_controller_spec.rb \
             spec/services/macros/execution_service_spec.rb \
             spec/requests/api/v1/macros_spec.rb \
+            spec/presenters/conversations/event_data_presenter_spec.rb \
+            spec/models/concerns/push_data_helper_spec.rb \
             --format progress

--- a/app/models/concerns/push_data_helper.rb
+++ b/app/models/concerns/push_data_helper.rb
@@ -9,11 +9,9 @@ module PushDataHelper
     Conversations::EventDataPresenter.new(self).lock_data
   end
 
-  # CRM-155: `labels_data` is for the realtime consumers only. Keeping it out of
-  # the webhook body leaves customer integrations byte-for-byte unchanged, and
-  # spares the labels query on every message webhook (Message#webhook_data
-  # embeds this hash, and it is built before the "any webhook configured?"
-  # check).
+  # `labels_data` is realtime-only: leaving it out keeps customer integrations
+  # byte-for-byte unchanged and spares the labels query on every message webhook
+  # (Message#webhook_data embeds this hash, built before the "any webhook?" check).
   def webhook_data
     Conversations::EventDataPresenter.new(self).push_data(include_labels_data: false)
   end

--- a/app/models/concerns/push_data_helper.rb
+++ b/app/models/concerns/push_data_helper.rb
@@ -9,7 +9,12 @@ module PushDataHelper
     Conversations::EventDataPresenter.new(self).lock_data
   end
 
+  # CRM-155: `labels_data` is for the realtime consumers only. Keeping it out of
+  # the webhook body leaves customer integrations byte-for-byte unchanged, and
+  # spares the labels query on every message webhook (Message#webhook_data
+  # embeds this hash, and it is built before the "any webhook configured?"
+  # check).
   def webhook_data
-    Conversations::EventDataPresenter.new(self).push_data
+    Conversations::EventDataPresenter.new(self).push_data(include_labels_data: false)
   end
 end

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -1,7 +1,9 @@
 class Conversations::EventDataPresenter < SimpleDelegator
   UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
-  def push_data
+  # `include_labels_data: false` is the webhook egress: the body delivered to
+  # customer integrations stays byte-for-byte what it was before CRM-155.
+  def push_data(include_labels_data: true)
     {
       additional_attributes: additional_attributes,
       can_reply: can_reply?,
@@ -12,7 +14,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
       inbox_id: inbox_id,
       messages: push_messages,
       labels: label_list,
-      labels_data: push_labels_data,
+      **(include_labels_data ? { labels_data: push_labels_data } : {}),
       meta: push_meta,
       status: status,
       custom_attributes: custom_attributes,
@@ -28,11 +30,15 @@ class Conversations::EventDataPresenter < SimpleDelegator
 
   private
 
-  # CRM-155: `labels` stays a list of titles because `push_data` is also the
+  # CRM-155: `labels` stays a list of titles because the same hash is also the
   # webhook body delivered to customer integrations — changing its type is a
   # silent breaking change. `labels_data` is additive and carries what the
   # realtime consumers need (id + title + color), so a label arriving over the
   # WebSocket no longer lands on the screen colourless.
+  #
+  # A tag that resolves to no Label row is dropped, matching what the REST
+  # source of truth already does (ConversationSerializer#serialize), so both
+  # paths agree on which chips exist.
   def push_labels_data
     tags = label_list.map { |tag| tag.to_s.strip }.reject(&:blank?)
     return [] if tags.empty?
@@ -40,22 +46,24 @@ class Conversations::EventDataPresenter < SimpleDelegator
     by_title, by_id = label_indexes_for(tags)
 
     tags.filter_map do |tag|
-      label = by_title[tag.downcase] || by_id[tag]
+      label = by_title[tag.downcase] || by_id[tag.downcase]
       next if label.nil?
 
       { id: label.id, title: label.title, color: label.color }
-    end
+    end.uniq { |label| label[:id] }
   end
 
-  # One query per broadcast, never one per label. Legacy rows may still hold the
-  # Label PK instead of the title, so both are resolved in the same round trip.
+  # One query per broadcast, never one per label. Two things are resolved in the
+  # same round trip: legacy rows still holding the Label PK instead of the
+  # title, and titles whose casing predates the downcase hook on Label — the
+  # REST path tolerates both, so this one has to as well.
   def label_indexes_for(tags)
-    ids = tags.grep(UUID_FORMAT)
-    scope = Label.where(title: tags.map(&:downcase))
+    scope = Label.where('LOWER(labels.title) IN (?)', tags.map(&:downcase))
+    ids = tags.grep(UUID_FORMAT).map(&:downcase)
     scope = scope.or(Label.where(id: ids)) if ids.any?
     records = scope.to_a
 
-    [records.index_by { |label| label.title.to_s.downcase }, records.index_by { |label| label.id.to_s }]
+    [records.index_by { |label| label.title.to_s.downcase }, records.index_by { |label| label.id.to_s.downcase }]
   end
 
   # EVO-1551 round 3 / CB-4: `contact_inbox: contact_inbox` previously dumped

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -1,5 +1,9 @@
 class Conversations::EventDataPresenter < SimpleDelegator
-  UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+  # Case-sensitive on purpose. Postgres renders uuid lower-case, so ConversationSerializer
+  # — which indexes by `label.id.to_s` and looks the raw tag up — only ever resolves a
+  # lower-case id tag. Matching it here keeps a chip from lighting up over the WebSocket
+  # and vanishing on the next REST load, which is this card's bug with the sign flipped.
+  UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
 
   # `include_labels_data: false` is the webhook egress — see PushDataHelper.
   def push_data(include_labels_data: true)
@@ -39,7 +43,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
     by_title, by_id = label_indexes_for(tags)
 
     tags.filter_map do |tag|
-      label = by_title[tag.downcase] || by_id[tag.downcase]
+      label = by_title[tag.downcase] || by_id[tag]
       next if label.nil?
 
       { id: label.id, title: label.title, color: label.color }
@@ -51,11 +55,11 @@ class Conversations::EventDataPresenter < SimpleDelegator
   # PK instead of the title, and casing that predates the downcase hook on Label.
   def label_indexes_for(tags)
     scope = Label.where('LOWER(labels.title) IN (?)', tags.map(&:downcase))
-    ids = tags.grep(UUID_FORMAT).map(&:downcase)
+    ids = tags.grep(UUID_FORMAT)
     scope = scope.or(Label.where(id: ids)) if ids.any?
     records = scope.to_a
 
-    [records.index_by { |label| label.title.to_s.downcase }, records.index_by { |label| label.id.to_s.downcase }]
+    [records.index_by { |label| label.title.to_s.downcase }, records.index_by { |label| label.id.to_s }]
   end
 
   # EVO-1551 round 3 / CB-4: `contact_inbox: contact_inbox` previously dumped

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -46,7 +46,10 @@ class Conversations::EventDataPresenter < SimpleDelegator
       label = by_title[tag.downcase] || by_id[tag]
       next if label.nil?
 
-      { id: label.id, title: label.title, color: label.color }
+      # Never emit a colourless label: the front only accepts an incoming label that
+      # has one, so a blank colour would send the chip back to appearing only after
+      # F5. `#1f93ff` is the column default, not an invented colour.
+      { id: label.id, title: label.title, color: label.color.presence || '#1f93ff' }
     end.uniq { |label| label[:id] }
   end
 

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -1,9 +1,9 @@
 class Conversations::EventDataPresenter < SimpleDelegator
-  # Case-sensitive on purpose. Postgres renders uuid lower-case, so ConversationSerializer
-  # — which indexes by `label.id.to_s` and looks the raw tag up — only ever resolves a
-  # lower-case id tag. Matching it here keeps a chip from lighting up over the WebSocket
-  # and vanishing on the next REST load, which is this card's bug with the sign flipped.
+  # Case-sensitive: Postgres renders uuid lower-case and ConversationSerializer indexes
+  # by `label.id.to_s`, so an upper-case id tag resolves to no chip over REST. Matching
+  # that keeps both paths agreeing on which chips exist.
   UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
+  DEFAULT_LABEL_COLOR = '#1f93ff'.freeze
 
   # `include_labels_data: false` is the webhook egress — see PushDataHelper.
   def push_data(include_labels_data: true)
@@ -46,11 +46,14 @@ class Conversations::EventDataPresenter < SimpleDelegator
       label = by_title[tag.downcase] || by_id[tag]
       next if label.nil?
 
-      # Never emit a colourless label: the front only accepts an incoming label that
-      # has one, so a blank colour would send the chip back to appearing only after
-      # F5. `#1f93ff` is the column default, not an invented colour.
-      { id: label.id, title: label.title, color: label.color.presence || '#1f93ff' }
+      { id: label.id, title: label.title, color: label_color(label) }
     end.uniq { |label| label[:id] }
+  end
+
+  # The front drops an incoming label with no colour, so a blank one would leave the
+  # chip invisible until a reload. The fallback is the column default.
+  def label_color(label)
+    label.color.presence || DEFAULT_LABEL_COLOR
   end
 
   # One query per broadcast, never one per label. Resolves in the same round trip

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -1,4 +1,6 @@
 class Conversations::EventDataPresenter < SimpleDelegator
+  UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
   def push_data
     {
       additional_attributes: additional_attributes,
@@ -10,6 +12,7 @@ class Conversations::EventDataPresenter < SimpleDelegator
       inbox_id: inbox_id,
       messages: push_messages,
       labels: label_list,
+      labels_data: push_labels_data,
       meta: push_meta,
       status: status,
       custom_attributes: custom_attributes,
@@ -24,6 +27,36 @@ class Conversations::EventDataPresenter < SimpleDelegator
   end
 
   private
+
+  # CRM-155: `labels` stays a list of titles because `push_data` is also the
+  # webhook body delivered to customer integrations — changing its type is a
+  # silent breaking change. `labels_data` is additive and carries what the
+  # realtime consumers need (id + title + color), so a label arriving over the
+  # WebSocket no longer lands on the screen colourless.
+  def push_labels_data
+    tags = label_list.map { |tag| tag.to_s.strip }.reject(&:blank?)
+    return [] if tags.empty?
+
+    by_title, by_id = label_indexes_for(tags)
+
+    tags.filter_map do |tag|
+      label = by_title[tag.downcase] || by_id[tag]
+      next if label.nil?
+
+      { id: label.id, title: label.title, color: label.color }
+    end
+  end
+
+  # One query per broadcast, never one per label. Legacy rows may still hold the
+  # Label PK instead of the title, so both are resolved in the same round trip.
+  def label_indexes_for(tags)
+    ids = tags.grep(UUID_FORMAT)
+    scope = Label.where(title: tags.map(&:downcase))
+    scope = scope.or(Label.where(id: ids)) if ids.any?
+    records = scope.to_a
+
+    [records.index_by { |label| label.title.to_s.downcase }, records.index_by { |label| label.id.to_s }]
+  end
 
   # EVO-1551 round 3 / CB-4: `contact_inbox: contact_inbox` previously dumped
   # the raw ActiveRecord model via `as_json`, which exposed `source_id` (the

--- a/app/presenters/conversations/event_data_presenter.rb
+++ b/app/presenters/conversations/event_data_presenter.rb
@@ -1,8 +1,7 @@
 class Conversations::EventDataPresenter < SimpleDelegator
   UUID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
-  # `include_labels_data: false` is the webhook egress: the body delivered to
-  # customer integrations stays byte-for-byte what it was before CRM-155.
+  # `include_labels_data: false` is the webhook egress — see PushDataHelper.
   def push_data(include_labels_data: true)
     {
       additional_attributes: additional_attributes,
@@ -30,15 +29,9 @@ class Conversations::EventDataPresenter < SimpleDelegator
 
   private
 
-  # CRM-155: `labels` stays a list of titles because the same hash is also the
-  # webhook body delivered to customer integrations — changing its type is a
-  # silent breaking change. `labels_data` is additive and carries what the
-  # realtime consumers need (id + title + color), so a label arriving over the
-  # WebSocket no longer lands on the screen colourless.
-  #
-  # A tag that resolves to no Label row is dropped, matching what the REST
-  # source of truth already does (ConversationSerializer#serialize), so both
-  # paths agree on which chips exist.
+  # `labels` stays a list of titles: the same hash is the webhook body, so changing
+  # its type is a silent breaking change. A tag resolving to no Label row is dropped,
+  # matching ConversationSerializer, so REST and realtime agree on which chips exist.
   def push_labels_data
     tags = label_list.map { |tag| tag.to_s.strip }.reject(&:blank?)
     return [] if tags.empty?
@@ -53,10 +46,9 @@ class Conversations::EventDataPresenter < SimpleDelegator
     end.uniq { |label| label[:id] }
   end
 
-  # One query per broadcast, never one per label. Two things are resolved in the
-  # same round trip: legacy rows still holding the Label PK instead of the
-  # title, and titles whose casing predates the downcase hook on Label — the
-  # REST path tolerates both, so this one has to as well.
+  # One query per broadcast, never one per label. Resolves in the same round trip
+  # the two legacy shapes the REST path already tolerates: a tag holding the Label
+  # PK instead of the title, and casing that predates the downcase hook on Label.
   def label_indexes_for(tags)
     scope = Label.where('LOWER(labels.title) IN (?)', tags.map(&:downcase))
     ids = tags.grep(UUID_FORMAT).map(&:downcase)

--- a/spec/models/concerns/push_data_helper_spec.rb
+++ b/spec/models/concerns/push_data_helper_spec.rb
@@ -2,10 +2,9 @@
 
 require 'rails_helper'
 
-# CRM-155: the presenter spec proves `push_data(include_labels_data:)` behaves.
-# This one proves each egress is wired to the right side of that flag — the
-# webhook body is a customer-facing contract, so the assertion has to sit on
-# `webhook_data` itself and not on the presenter it delegates to.
+# The presenter spec proves `push_data(include_labels_data:)` behaves; this one
+# proves each egress is wired to the right side of that flag. The webhook body is
+# a customer contract, so the assertion sits on `webhook_data`, not the presenter.
 RSpec.describe PushDataHelper do
   let!(:label) { Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true) }
 
@@ -30,8 +29,8 @@ RSpec.describe PushDataHelper do
       expect(conversation.webhook_data[:labels].to_a).to eq(['urgente'])
     end
 
-    # Message#webhook_data embeds this hash and is built before the "is any
-    # webhook configured?" check, so a leak here is paid by every message.
+    # Built before the "is any webhook configured?" check, so a leak here is
+    # paid by every message, not only by accounts with a webhook.
     it 'stays out of the conversation embedded in Message#webhook_data' do
       message = Message.create!(
         inbox: inbox,

--- a/spec/models/concerns/push_data_helper_spec.rb
+++ b/spec/models/concerns/push_data_helper_spec.rb
@@ -2,9 +2,8 @@
 
 require 'rails_helper'
 
-# The presenter spec proves `push_data(include_labels_data:)` behaves; this one
-# proves each egress is wired to the right side of that flag. The webhook body is
-# a customer contract, so the assertion sits on `webhook_data`, not the presenter.
+# Covers the wiring of each egress to its side of `include_labels_data:`. The webhook
+# body is a customer contract, so the assertion sits on `webhook_data`, not the presenter.
 RSpec.describe PushDataHelper do
   let!(:label) { Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true) }
 

--- a/spec/models/concerns/push_data_helper_spec.rb
+++ b/spec/models/concerns/push_data_helper_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-155: the presenter spec proves `push_data(include_labels_data:)` behaves.
+# This one proves each egress is wired to the right side of that flag — the
+# webhook body is a customer-facing contract, so the assertion has to sit on
+# `webhook_data` itself and not on the presenter it delegates to.
+RSpec.describe PushDataHelper do
+  let!(:label) { Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true) }
+
+  let(:contact) { Contact.create!(name: 'PD', email: "pd-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://pd.example.com') }
+  let(:inbox) { Inbox.create!(name: 'PD Inbox', channel: channel) }
+  let(:contact_inbox) do
+    ContactInbox.create!(inbox: inbox, contact: contact, source_id: "pd-#{SecureRandom.hex(4)}")
+  end
+  let(:conversation) do
+    Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+  end
+
+  before { conversation.update!(label_list: ['urgente']) }
+
+  describe '#webhook_data' do
+    it 'does not carry labels_data' do
+      expect(conversation.webhook_data).not_to have_key(:labels_data)
+    end
+
+    it 'keeps labels as the list of titles it has always been' do
+      expect(conversation.webhook_data[:labels].to_a).to eq(['urgente'])
+    end
+
+    # Message#webhook_data embeds this hash and is built before the "is any
+    # webhook configured?" check, so a leak here is paid by every message.
+    it 'stays out of the conversation embedded in Message#webhook_data' do
+      message = Message.create!(
+        inbox: inbox,
+        conversation: conversation,
+        message_type: :incoming,
+        content: 'oi'
+      )
+
+      expect(message.webhook_data[:conversation]).not_to have_key(:labels_data)
+    end
+  end
+
+  describe '#push_event_data' do
+    it 'carries the full label for the realtime consumers' do
+      expect(conversation.push_event_data[:labels_data]).to eq(
+        [{ id: label.id, title: 'urgente', color: '#ff0000' }]
+      )
+    end
+
+    it 'keeps labels as titles alongside it' do
+      expect(conversation.push_event_data[:labels].to_a).to eq(['urgente'])
+    end
+  end
+end

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe Conversations::EventDataPresenter do
       expect(result).to eq([])
     end
 
+    # The ChatContext merge drops any incoming label without a colour, so a blank one
+    # would put the chip back to appearing only after F5.
+    it 'falls back to the column default when the row has a blank colour' do
+      urgent.update_column(:color, '')
+
+      result = presenter_for(['urgente']).send(:push_labels_data)
+
+      expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#1f93ff' }])
+    end
+
     it 'resolves a title whose casing predates the downcase hook on Label' do
       urgent.update_column(:title, 'Urgente')
 

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -3,13 +3,27 @@
 require 'rails_helper'
 
 RSpec.describe Conversations::EventDataPresenter do
+  # The label list is faked so the resolution itself is under test; the tagging
+  # cache that feeds it is covered by acts-as-taggable-on and is memoized per
+  # instance (`cached_label_list`), so it is not the N+1 risk here.
+  def presenter_for(label_list)
+    described_class.new(Struct.new(:label_list).new(label_list))
+  end
+
+  def count_queries
+    count = 0
+    subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+      count += 1 unless payload[:name].to_s.in?(%w[SCHEMA TRANSACTION])
+    end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscription)
+  end
+
   describe '#push_labels_data' do
     let!(:urgent) { Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true) }
     let!(:vip) { Label.create!(title: 'vip', color: '#00ff00', show_on_sidebar: false) }
-
-    def presenter_for(label_list)
-      described_class.new(Struct.new(:label_list).new(label_list))
-    end
 
     it 'resolves each title into id, title and color' do
       result = presenter_for(%w[urgente vip]).send(:push_labels_data)
@@ -28,44 +42,50 @@ RSpec.describe Conversations::EventDataPresenter do
       expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
     end
 
-    it 'ignores tags with no matching label' do
+    it 'resolves a legacy id written in upper case' do
+      result = presenter_for([urgent.id.to_s.upcase]).send(:push_labels_data)
+
+      expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
+    end
+
+    it 'resolves a title whose casing predates the downcase hook on Label' do
+      urgent.update_column(:title, 'Urgente')
+
+      result = presenter_for(['urgente']).send(:push_labels_data)
+
+      expect(result).to eq([{ id: urgent.id, title: 'Urgente', color: '#ff0000' }])
+    end
+
+    it 'emits the label once when both its title and its id are tagged' do
+      result = presenter_for([urgent.id.to_s, 'urgente']).send(:push_labels_data)
+
+      expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
+    end
+
+    # Same rule as ConversationSerializer, which the REST list already applies:
+    # a tag pointing at no Label row renders no chip.
+    it 'drops tags that resolve to no label, like the REST serializer does' do
       result = presenter_for(%w[urgente sumiu]).send(:push_labels_data)
 
       expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
     end
 
     it 'returns an empty list without touching the database when there are no tags' do
-      queries = count_queries { presenter_for([]).send(:push_labels_data) }
-
-      expect(queries).to eq(0)
+      expect(count_queries { presenter_for([]).send(:push_labels_data) }).to eq(0)
     end
 
     it 'resolves the whole list in a single query' do
-      queries = count_queries { presenter_for([urgent.id.to_s, 'vip']).send(:push_labels_data) }
-
-      expect(queries).to eq(1)
-    end
-
-    def count_queries(&block)
-      count = 0
-      subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
-        count += 1 unless payload[:name].to_s.in?(%w[SCHEMA TRANSACTION])
-      end
-      block.call
-      count
-    ensure
-      ActiveSupport::Notifications.unsubscribe(subscription)
+      expect(count_queries { presenter_for([urgent.id.to_s, 'vip']).send(:push_labels_data) }).to eq(1)
     end
   end
 
   describe '#push_data' do
-    # This hash is also the webhook body delivered to customer integrations
-    # (PushDataHelper#webhook_data), so `labels` has to stay a list of titles.
-    it 'keeps labels as titles and adds labels_data alongside it' do
-      label = Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true)
+    let!(:label) { Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true) }
+
+    def conversation_double
       now = Time.zone.parse('2026-08-14 10:00:00')
 
-      conversation = double('Conversation',
+      double('Conversation',
         additional_attributes: {},
         can_reply?: true,
         inbox: nil,
@@ -90,11 +110,28 @@ RSpec.describe Conversations::EventDataPresenter do
         last_activity_at: now,
         created_at: now,
         updated_at: now)
+    end
 
-      result = described_class.new(conversation).push_data
+    it 'keeps labels as titles and adds labels_data alongside it' do
+      result = described_class.new(conversation_double).push_data
 
       expect(result[:labels]).to eq(['urgente'])
       expect(result[:labels_data]).to eq([{ id: label.id, title: 'urgente', color: '#ff0000' }])
+    end
+
+    # This hash is also the webhook body delivered to customer integrations
+    # (PushDataHelper#webhook_data), so the egress must stay exactly as it was.
+    it 'omits labels_data entirely when built for the webhook egress' do
+      result = described_class.new(conversation_double).push_data(include_labels_data: false)
+
+      expect(result).not_to have_key(:labels_data)
+      expect(result[:labels]).to all(be_a(String))
+    end
+
+    it 'costs no label query when built for the webhook egress' do
+      presenter = described_class.new(conversation_double)
+
+      expect(count_queries { presenter.push_data(include_labels_data: false) }).to eq(0)
     end
   end
 end

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -40,10 +40,13 @@ RSpec.describe Conversations::EventDataPresenter do
       expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
     end
 
-    it 'resolves a legacy id written in upper case' do
+    # ConversationSerializer looks the raw tag up in an index keyed by `label.id.to_s`,
+    # so an upper-case id tag renders no chip over REST. Resolving it here would paint
+    # a chip that the next page load takes away — this card's bug with the sign flipped.
+    it 'drops a legacy id written in upper case, as the REST serializer does' do
       result = presenter_for([urgent.id.to_s.upcase]).send(:push_labels_data)
 
-      expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
+      expect(result).to eq([])
     end
 
     it 'resolves a title whose casing predates the downcase hook on Label' do

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Conversations::EventDataPresenter do
+  describe '#push_labels_data' do
+    let!(:urgent) { Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true) }
+    let!(:vip) { Label.create!(title: 'vip', color: '#00ff00', show_on_sidebar: false) }
+
+    def presenter_for(label_list)
+      described_class.new(Struct.new(:label_list).new(label_list))
+    end
+
+    it 'resolves each title into id, title and color' do
+      result = presenter_for(%w[urgente vip]).send(:push_labels_data)
+
+      expect(result).to eq(
+        [
+          { id: urgent.id, title: 'urgente', color: '#ff0000' },
+          { id: vip.id, title: 'vip', color: '#00ff00' }
+        ]
+      )
+    end
+
+    it 'resolves legacy entries that still hold the Label id' do
+      result = presenter_for([urgent.id.to_s]).send(:push_labels_data)
+
+      expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
+    end
+
+    it 'ignores tags with no matching label' do
+      result = presenter_for(%w[urgente sumiu]).send(:push_labels_data)
+
+      expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
+    end
+
+    it 'returns an empty list without touching the database when there are no tags' do
+      queries = count_queries { presenter_for([]).send(:push_labels_data) }
+
+      expect(queries).to eq(0)
+    end
+
+    it 'resolves the whole list in a single query' do
+      queries = count_queries { presenter_for([urgent.id.to_s, 'vip']).send(:push_labels_data) }
+
+      expect(queries).to eq(1)
+    end
+
+    def count_queries(&block)
+      count = 0
+      subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+        count += 1 unless payload[:name].to_s.in?(%w[SCHEMA TRANSACTION])
+      end
+      block.call
+      count
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription)
+    end
+  end
+
+  describe '#push_data' do
+    # This hash is also the webhook body delivered to customer integrations
+    # (PushDataHelper#webhook_data), so `labels` has to stay a list of titles.
+    it 'keeps labels as titles and adds labels_data alongside it' do
+      label = Label.create!(title: 'urgente', color: '#ff0000', show_on_sidebar: true)
+      now = Time.zone.parse('2026-08-14 10:00:00')
+
+      conversation = double('Conversation',
+        additional_attributes: {},
+        can_reply?: true,
+        inbox: nil,
+        contact_inbox: nil,
+        id: SecureRandom.uuid,
+        display_id: 1,
+        inbox_id: SecureRandom.uuid,
+        messages: double('Relation', chat: double('Chat', last: nil)),
+        label_list: ['urgente'],
+        contact: double('Contact', push_event_data: {}, group?: false),
+        assignee: nil,
+        team: nil,
+        status: 'open',
+        custom_attributes: {},
+        snoozed_until: nil,
+        unread_incoming_messages_count: 0,
+        first_reply_created_at: nil,
+        priority: nil,
+        waiting_since: now,
+        agent_last_seen_at: now,
+        contact_last_seen_at: now,
+        last_activity_at: now,
+        created_at: now,
+        updated_at: now)
+
+      result = described_class.new(conversation).push_data
+
+      expect(result[:labels]).to eq(['urgente'])
+      expect(result[:labels_data]).to eq([{ id: label.id, title: 'urgente', color: '#ff0000' }])
+    end
+  end
+end

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Conversations::EventDataPresenter do
-  # The label list is faked so the resolution itself is under test; the tagging
-  # cache that feeds it is covered by acts-as-taggable-on and is memoized per
-  # instance (`cached_label_list`), so it is not the N+1 risk here.
+  # The label list is faked so the resolution itself is what is under test.
   def presenter_for(label_list)
     described_class.new(Struct.new(:label_list).new(label_list))
   end
@@ -62,8 +60,6 @@ RSpec.describe Conversations::EventDataPresenter do
       expect(result).to eq([{ id: urgent.id, title: 'urgente', color: '#ff0000' }])
     end
 
-    # Same rule as ConversationSerializer, which the REST list already applies:
-    # a tag pointing at no Label row renders no chip.
     it 'drops tags that resolve to no label, like the REST serializer does' do
       result = presenter_for(%w[urgente sumiu]).send(:push_labels_data)
 
@@ -119,8 +115,6 @@ RSpec.describe Conversations::EventDataPresenter do
       expect(result[:labels_data]).to eq([{ id: label.id, title: 'urgente', color: '#ff0000' }])
     end
 
-    # This hash is also the webhook body delivered to customer integrations
-    # (PushDataHelper#webhook_data), so the egress must stay exactly as it was.
     it 'omits labels_data entirely when built for the webhook egress' do
       result = described_class.new(conversation_double).push_data(include_labels_data: false)
 

--- a/spec/presenters/conversations/event_data_presenter_spec.rb
+++ b/spec/presenters/conversations/event_data_presenter_spec.rb
@@ -41,16 +41,14 @@ RSpec.describe Conversations::EventDataPresenter do
     end
 
     # ConversationSerializer looks the raw tag up in an index keyed by `label.id.to_s`,
-    # so an upper-case id tag renders no chip over REST. Resolving it here would paint
-    # a chip that the next page load takes away — this card's bug with the sign flipped.
+    # so an upper-case id tag renders no chip over REST.
     it 'drops a legacy id written in upper case, as the REST serializer does' do
       result = presenter_for([urgent.id.to_s.upcase]).send(:push_labels_data)
 
       expect(result).to eq([])
     end
 
-    # The ChatContext merge drops any incoming label without a colour, so a blank one
-    # would put the chip back to appearing only after F5.
+    # The ChatContext merge drops any incoming label without a colour.
     it 'falls back to the column default when the row has a blank colour' do
       urgent.update_column(:color, '')
 


### PR DESCRIPTION
## Contexto

[CRM-155](https://plane.evosetup.com/evolution/browse/CRM-155/) — etiqueta aplicada por macro (ou automação, jornada, API, outro atendente) **só aparece depois de F5**.

O servidor e o transporte estão corretos: o frame `conversation.updated` chega ao navegador com a etiqueta. O que falha é o encontro entre payload e consumo:

1. `Conversations::EventDataPresenter#push_data` manda `labels: label_list` — lista de **títulos**, sem id e sem cor.
2. O front converte string → objeto com `color: ''`.
3. A guarda de merge do front (`incomingLabels.every(l => l.title && l.color)`) é **sempre falsa**, porque o WS nunca manda cor — e descarta 100% dos labels vindos do WebSocket.

Caminho de correção decidido pelo TL: **servidor manda a etiqueta completa**. Esta é a **PR 1 de 2** (backend primeiro); a PR do front é [evo-ai-frontend-community#295](https://github.com/evolution-foundation/evo-ai-frontend-community/pull/295).

## O que muda

`push_data` ganha o parâmetro `include_labels_data:` e passa a ter **dois egressos distintos**:

| chamador | campo `labels` | campo `labels_data` |
|---|---|---|
| `push_event_data` (ActionCable / realtime) | lista de títulos, inalterado | `[{ id, title, color }]` |
| `webhook_data` (integrações de cliente) | lista de títulos, inalterado | **ausente** |

### Por que o webhook não recebe o campo novo

`push_data` **é** o corpo dos webhooks externos:

```ruby
# app/models/concerns/push_data_helper.rb:12-14
def webhook_data
  Conversations::EventDataPresenter.new(self).push_data
end
```

O bug é do caminho realtime; o webhook não tem nada a ganhar com o campo. Mantê-lo fora dá duas coisas:

1. **Corpo do webhook literalmente idêntico ao de antes do CRM-155** — nem um campo a mais. Consumidor com validação estrita (`additionalProperties: false`) não quebra, e o AC "webhook externo intacto" vale ao pé da letra, não só para o campo `labels`.
2. **A query de labels sai do caminho quente de mensagem.** `Message#webhook_data` (`app/models/message.rb:220`) embute `conversation.webhook_data`, e o `WebhookListener` monta esse payload **antes** de checar se existe algum webhook configurado (`app/listeners/webhook_listener.rb:24-33`). Sem essa separação, toda mensagem da conta pagaria a query de labels mesmo sem nenhum webhook cadastrado — volume de mensagem domina volume de conversa.

`labels` continua lista de títulos nos dois egressos: trocar o tipo quebraria, sem aviso e sem versionamento, toda integração que hoje lê `["urgente"]`.

### Custo do payload

`label_indexes_for` resolve a lista inteira em **1 query por broadcast** — nunca uma por label. Conversa **sem etiqueta custa 0 query** (o caso comum), então o overhead no realtime de alta frequência (inclusive `conversation_typing_on/off`, que também usam `push_event_data`) só existe em conversa etiquetada.

### Resolução de tag → Label

Um round trip resolve os três casos que a REST já tolera, para os dois caminhos concordarem sobre quais chips existem:

- título normal;
- linha legada que ainda guarda o **PK do Label** em vez do título (ver `LabelConcern#resolve_label_titles`, que preserva o UUID de propósito) — inclusive em caixa alta;
- título cuja **caixa** é anterior ao hook de downcase do `Label` (`Urgente` vs `urgente`). Comparação case-sensitive aqui faria a etiqueta sumir no evento e voltar no F5 — o bug do card com o sinal trocado.

Tag que não resolve para nenhuma linha é **descartada**, que é exatamente o que `ConversationSerializer#serialize` já faz no caminho REST. E título + id da mesma etiqueta na mesma lista rendem **uma** entrada, não duas.

## Validação

Rodado no container `evolution-ecosystem-enterprise-1` com o presenter modificado, contando queries por `ActiveSupport::Notifications`:

| caso | queries | resultado |
|---|---|---|
| 2 títulos | 1 | ambos com id + cor certos |
| uuid legado (minúsculo) | 1 | resolvido |
| uuid legado (MAIÚSCULO) | 1 | resolvido |
| título + id da mesma etiqueta | 1 | 1 entrada, sem duplicata |
| título com caixa legada (`PROBE-155-A`) | 1 | resolvido |
| título inexistente | 1 | descartado, não quebra |
| lista vazia | **0** | `[]` |
| misto (uuid + título) | 1 | ambos |

Split de egresso, no mesmo container:

```
realtime  labels=["probe-155-c"]  labels_data=[{id: "3877b5c2-…", title: "probe-155-c", color: "#123456"}]
webhook   has_labels_data=false   labels=["probe-155-c"]
webhook_keys_equal_old=true
```

Dados de teste removidos no fim (`labels=0`), e os arquivos do container restaurados ao original.

`spec/presenters/conversations/event_data_presenter_spec.rb` cobre os mesmos casos + o contrato de egresso (webhook sem a chave, `labels` só com String, e 0 query no caminho de webhook).

`spec/models/concerns/push_data_helper_spec.rb` cobre a **fiação**, que o spec acima não alcança: ele prova `push_data(include_labels_data:)`, mas trocar a chamada em `webhook_data` de volta para `push_data` devolveria `labels_data` ao corpo das integrações **sem nenhum teste reclamar** — e esse corpo é contrato externo. Usa conversa real (este repo não tem factories de conversation/label; o setup segue o idioma de `spec/jobs/action_cable_broadcast_job_spec.rb`) e assere os dois egressos, incluindo o `conversation` embutido em `Message#webhook_data`.

Confirmado em runtime no container, com conversa e label reais sob `TenantContext` e rollback:

```
webhook_data sem :labels_data                        => PASS
webhook_data[:labels] == ['urgente']                 => PASS
push_event_data[:labels_data] completo               => PASS
push_event_data[:labels] == ['urgente']              => PASS
Message#webhook_data[:conversation] sem :labels_data => PASS
```

⚠️ **Não executei o rspec** — nem localmente (Windows não boota a suíte) nem no container (a imagem enterprise é bundle de produção, sem o grupo de teste: `bundle exec rspec` → `command not found`). Consequência a pesar no merge: **nenhum dos dois specs roda em CI hoje.** `spec-staleness-guard.yml` é allowlist explícita e não inclui nem os `paths:` do presenter/helper nem os arquivos de spec, e nenhuma outra lane roda a suíte inteira — dá para apagar `labels_data` do presenter e a PR continua verde. Entram na guarda assim que rodarem verdes uma vez num ambiente com a suíte.

## Critérios de aceite

- [x] **Webhook externo intacto** — conjunto de chaves idêntico ao de antes do CRM-155, verificado (`webhook_keys_equal_old=true`).
- [x] **Zero requisição HTTP nova por evento de WS** — o conserto é o payload, não refetch.
- [x] **Sem N+1 no broadcast** — 1 query por conversa etiquetada, 0 sem etiqueta.
- [x] **Etiqueta aparecendo/sumindo sem F5, conversa nova com nome e cor, reflexo sem o navegador agir** — validados manualmente no ecossistema local, com a PR 2 (front) e este backend injetado nos **dois** containers (`enterprise` monta o payload de `conversation.created`; `sidekiq` refaz o de `conversation.updated` em `ActionCableBroadcastJob#prepare_broadcast_data`). Detalhe no card.

## Não-regressão

`assign_team` / `assign_agent` chegam por `meta.assignee` / `meta.team` e não passam por nada que esta PR toca.

## Fora de escopo, registrado

`Label` não tem coluna de tenant nesta base — o isolamento vem da RLS do enterprise, cuja policy é permissiva quando o GUC `app.current_tenant_id` está **desligado**. Num broadcast não vinculado a tenant, `Label.where(...)` enxergaria linhas de outros tenants. Isso **não é novo nem específico desta PR**: `ConversationsController#label_indexes` já faz `Label.all` na mesma base, e a mitigação certa é no binding de tenant do enterprise, não em código community. Fica aqui para decisão do TL.
