### PR TITLE
refactor(realtime): elimina o build duplicado de push_event_data (CRM-171)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -15,10 +15,14 @@ on:
       - 'app/services/pipelines/**'
       - 'app/listeners/automation_rule_listener*.rb'
       - 'app/listeners/pipeline_stage_automation_listener.rb'
+      - 'app/listeners/action_cable_listener.rb'
+      - 'app/jobs/action_cable_broadcast_job.rb'
       - 'spec/services/automation_rules/**'
       - 'spec/services/pipelines/**'
       - 'spec/listeners/automation_rule_listener_attribute_changed_spec.rb'
       - 'spec/listeners/pipeline_stage_automation_listener_spec.rb'
+      - 'spec/listeners/action_cable_listener_conversation_update_spec.rb'
+      - 'spec/jobs/action_cable_broadcast_job_spec.rb'
       - 'spec/models/conversation_label_dispatch_spec.rb'
       - 'spec/models/pipeline_item_spec.rb'
       - 'spec/models/pipeline_spec.rb'
@@ -137,6 +141,8 @@ jobs:
             spec/services/pipelines/stage_automation_service_spec.rb \
             spec/listeners/automation_rule_listener_attribute_changed_spec.rb \
             spec/listeners/pipeline_stage_automation_listener_spec.rb \
+            spec/listeners/action_cable_listener_conversation_update_spec.rb \
+            spec/jobs/action_cable_broadcast_job_spec.rb \
             spec/models/conversation_label_dispatch_spec.rb \
             spec/models/pipeline_item_spec.rb \
             spec/models/pipeline_spec.rb \

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -61,10 +61,8 @@ class ActionCableListener < BaseListener
     broadcast(account, tokens, CONVERSATION_CREATED, conversation.push_event_data)
   end
 
-  # conversation_read/status_changed/updated/assignee_changed/team_changed pass
-  # only the id: ActionCableBroadcastJob rebuilds push_event_data from a fresh
-  # find_by! for these events (to avoid stale data on out-of-order delivery),
-  # so building it here too would be thrown away unread.
+  # These five events pass only the id: ActionCableBroadcastJob rebuilds
+  # push_event_data from a fresh find_by! to avoid stale out-of-order data.
   def conversation_read(event)
     conversation, account = extract_conversation_and_account(event)
     tokens = user_tokens(account, conversation.inbox.members)

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -61,25 +61,29 @@ class ActionCableListener < BaseListener
     broadcast(account, tokens, CONVERSATION_CREATED, conversation.push_event_data)
   end
 
+  # conversation_read/status_changed/updated/assignee_changed/team_changed pass
+  # only the id: ActionCableBroadcastJob rebuilds push_event_data from a fresh
+  # find_by! for these events (to avoid stale data on out-of-order delivery),
+  # so building it here too would be thrown away unread.
   def conversation_read(event)
     conversation, account = extract_conversation_and_account(event)
     tokens = user_tokens(account, conversation.inbox.members)
 
-    broadcast(account, tokens, CONVERSATION_READ, conversation.push_event_data)
+    broadcast(account, tokens, CONVERSATION_READ, { id: conversation.id })
   end
 
   def conversation_status_changed(event)
     conversation, account = extract_conversation_and_account(event)
     tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
 
-    broadcast(account, tokens, CONVERSATION_STATUS_CHANGED, conversation.push_event_data)
+    broadcast(account, tokens, CONVERSATION_STATUS_CHANGED, { id: conversation.id })
   end
 
   def conversation_updated(event)
     conversation, account = extract_conversation_and_account(event)
     tokens = (user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]).compact
 
-    broadcast(account, tokens, CONVERSATION_UPDATED, conversation.push_event_data)
+    broadcast(account, tokens, CONVERSATION_UPDATED, { id: conversation.id })
   end
 
   def conversation_typing_on(event)
@@ -118,14 +122,14 @@ class ActionCableListener < BaseListener
     conversation, account = extract_conversation_and_account(event)
     tokens = user_tokens(account, conversation.inbox.members)
 
-    broadcast(account, tokens, ASSIGNEE_CHANGED, conversation.push_event_data)
+    broadcast(account, tokens, ASSIGNEE_CHANGED, { id: conversation.id })
   end
 
   def team_changed(event)
     conversation, account = extract_conversation_and_account(event)
     tokens = user_tokens(account, conversation.inbox.members)
 
-    broadcast(account, tokens, TEAM_CHANGED, conversation.push_event_data)
+    broadcast(account, tokens, TEAM_CHANGED, { id: conversation.id })
   end
 
   def conversation_contact_changed(event)

--- a/spec/listeners/action_cable_listener_conversation_update_spec.rb
+++ b/spec/listeners/action_cable_listener_conversation_update_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe ActionCableListener do
   let(:listener) { described_class.instance }
   let(:user) { User.create!(name: 'CU Agent', email: "listener-cu-#{SecureRandom.hex(4)}@test.com") }
   let(:channel) { Channel::WebWidget.create!(website_url: 'https://listener-cu.example.com') }
-  # An inbox with no members makes user_tokens return [] — conversation_read/
-  # team_changed/assignee_changed broadcast only via user_tokens, so blank
-  # tokens make `broadcast` return early (see action_cable_listener.rb) and
-  # `ActionCableBroadcastJob.perform_later` is never called for THIS event.
-  # Without a member, the payload capture below would instead pick up the
-  # real conversation.created broadcast (Conversation#after_create_commit
-  # publishes it via Wisper independently of anything this spec calls), which
-  # still carries the full push_event_data and would make the assertion pass
-  # for the wrong reason.
+  # `user_tokens` ignores its `agents` argument and plucks every User's
+  # pubsub_token (action_cable_listener.rb:186), so what keeps these
+  # broadcasts alive is a User row existing at all — not the membership.
+  # With no User, conversation_read/team_changed/assignee_changed (which
+  # resolve recipients through user_tokens alone) hit `return if
+  # tokens.blank?` and never enqueue. The captures below only record their
+  # own event, so that would fail loudly rather than silently validate the
+  # real conversation.created broadcast Conversation#after_create_commit
+  # publishes via Wisper.
   let(:inbox) do
     ib = Inbox.create!(name: 'Listener CU Inbox', channel: channel)
     InboxMember.create!(inbox: ib, user: user)
@@ -53,8 +53,11 @@ RSpec.describe ActionCableListener do
     listener_methods.each do |event_name, listener_method|
       it "enqueues #{listener_method} (#{event_name}) with only {id:}, not a rebuilt push_event_data" do
         payload = nil
-        allow(ActionCableBroadcastJob).to receive(:perform_later) do |_tokens, _event, data|
-          payload = data
+        # Capture only THIS event: creating the conversation fires a real
+        # conversation.created through Wisper, which lands in the same mock
+        # carrying a full push_event_data.
+        allow(ActionCableBroadcastJob).to receive(:perform_later) do |_tokens, event, data|
+          payload = data if event == event_name
         end
 
         listener.public_send(listener_method, build_event({ conversation: conversation }))
@@ -74,39 +77,52 @@ RSpec.describe ActionCableListener do
       c
     end
 
-    def count_tagging_queries(&)
+    # The query this counts is `EventDataPresenter#push_labels_data` ->
+    # `Label.where(...)`, one per push_event_data build. It is NOT the
+    # acts_as_taggable `label_list` load: that one reads `taggings`, and the
+    # job's fresh instance makes it cost 1 whether or not the listener also
+    # built the payload — counting it would leave this example green on the
+    # unfixed listener.
+    def count_label_queries(&)
       count = 0
       subscriber = lambda do |*args|
         sql = args.last[:sql]
-        count += 1 if sql.match?(/taggings/i)
+        count += 1 if sql.match?(/FROM "labels"/i)
       end
       ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
       count
     end
 
     it 'costs exactly one labels query end-to-end (two before this fix) and the frame reaches the browser unchanged' do
+      labeled_conversation # build it before measuring: create/update fire their own events
+
       job_args = nil
       allow(ActionCableBroadcastJob).to receive(:perform_later) do |*args|
         job_args = args
       end
-
-      listener.conversation_updated(build_event({ conversation: labeled_conversation }))
-      expect(job_args).not_to be_nil
-
       broadcast_data = nil
       allow(ActionCable.server).to receive(:broadcast) do |_token, payload|
         broadcast_data = payload[:data]
       end
 
-      tag_queries = count_tagging_queries { ActionCableBroadcastJob.perform_now(*job_args) }
+      # Both halves of the round trip must sit inside the counter: the build
+      # this fix removes happens in the listener, so measuring the job alone
+      # counts 1 either way and proves nothing.
+      label_queries = count_label_queries do
+        listener.conversation_updated(build_event({ conversation: labeled_conversation }))
+        expect(job_args&.at(1)).to eq(Events::Types::CONVERSATION_UPDATED)
+        ActionCableBroadcastJob.perform_now(*job_args)
+      end
 
-      # One query: the listener no longer builds push_event_data (0), the job's
-      # rebuild does it once (1). Before this fix both builds ran: 2.
-      expect(tag_queries).to eq(1)
+      # The job's rebuild resolves the labels once (1). Before this fix the
+      # listener resolved them too, for a payload the job then discarded: 2.
+      expect(label_queries).to eq(1)
 
       # Non-regression (CRM-155): the label reaches the browser without a
-      # reload, and the rest of the frame is unchanged from a fresh build —
-      # the identifier-only payload didn't shrink what actually gets sent.
+      # reload. Comparing against a fresh build proves the identifier-only
+      # payload never reaches the browser — the job still ships the whole
+      # frame — but not parity with the pre-fix frame, which the job already
+      # discarded before this change.
       expect(broadcast_data[:labels]).to eq(['vip'])
       expect(broadcast_data).to eq(Conversation.find(labeled_conversation.id).push_event_data)
     end

--- a/spec/listeners/action_cable_listener_conversation_update_spec.rb
+++ b/spec/listeners/action_cable_listener_conversation_update_spec.rb
@@ -2,29 +2,15 @@
 
 require 'rails_helper'
 
-# CRM-171 — for the 5 CONVERSATION_UPDATE_EVENTS, ActionCableBroadcastJob
-# already re-fetches the conversation and rebuilds push_event_data from
-# scratch (to avoid stale data on out-of-order delivery). Building
-# push_event_data in the listener too was pure waste: a second `labels`
-# query, plus a much larger Sidekiq/Redis payload thrown away unread. The
-# listener now passes only the id for these events.
-#
-# Kept in its own file (not spec/listeners/action_cable_listener_spec.rb) so
-# it can be added to spec-staleness-guard.yml's allowlist without dragging in
-# that file's unrelated, pre-existing CB-3 failures.
+# ActionCableBroadcastJob rebuilds push_event_data for
+# CONVERSATION_UPDATE_EVENTS, so the listener only passes the id. Split from
+# action_cable_listener_spec.rb, whose failures keep it out of the CI guard.
 RSpec.describe ActionCableListener do
   let(:listener) { described_class.instance }
   let(:user) { User.create!(name: 'CU Agent', email: "listener-cu-#{SecureRandom.hex(4)}@test.com") }
   let(:channel) { Channel::WebWidget.create!(website_url: 'https://listener-cu.example.com') }
-  # `user_tokens` ignores its `agents` argument and plucks every User's
-  # pubsub_token (action_cable_listener.rb:186), so what keeps these
-  # broadcasts alive is a User row existing at all — not the membership.
-  # With no User, conversation_read/team_changed/assignee_changed (which
-  # resolve recipients through user_tokens alone) hit `return if
-  # tokens.blank?` and never enqueue. The captures below only record their
-  # own event, so that would fail loudly rather than silently validate the
-  # real conversation.created broadcast Conversation#after_create_commit
-  # publishes via Wisper.
+  # user_tokens plucks every User's pubsub_token and ignores `agents`, so these
+  # broadcasts need a User row to exist, not a membership.
   let(:inbox) do
     ib = Inbox.create!(name: 'Listener CU Inbox', channel: channel)
     InboxMember.create!(inbox: ib, user: user)
@@ -51,11 +37,10 @@ RSpec.describe ActionCableListener do
     }
 
     listener_methods.each do |event_name, listener_method|
-      it "enqueues #{listener_method} (#{event_name}) with only {id:}, not a rebuilt push_event_data" do
+      it "enqueues #{listener_method} (#{event_name}) with only the conversation id" do
         payload = nil
-        # Capture only THIS event: creating the conversation fires a real
-        # conversation.created through Wisper, which lands in the same mock
-        # carrying a full push_event_data.
+        # Creating the conversation fires a real conversation.created into the
+        # same mock, so capture only this event.
         allow(ActionCableBroadcastJob).to receive(:perform_later) do |_tokens, event, data|
           payload = data if event == event_name
         end
@@ -77,12 +62,9 @@ RSpec.describe ActionCableListener do
       c
     end
 
-    # The query this counts is `EventDataPresenter#push_labels_data` ->
-    # `Label.where(...)`, one per push_event_data build. It is NOT the
-    # acts_as_taggable `label_list` load: that one reads `taggings`, and the
-    # job's fresh instance makes it cost 1 whether or not the listener also
-    # built the payload — counting it would leave this example green on the
-    # unfixed listener.
+    # Counts the push_labels_data lookup, one per push_event_data build. The
+    # acts_as_taggable `label_list` load hits `taggings` and costs 1 per
+    # instance regardless, so it cannot tell the two builds apart.
     def count_label_queries(&)
       count = 0
       subscriber = lambda do |*args|
@@ -93,8 +75,8 @@ RSpec.describe ActionCableListener do
       count
     end
 
-    it 'costs exactly one labels query end-to-end (two before this fix) and the frame reaches the browser unchanged' do
-      labeled_conversation # build it before measuring: create/update fire their own events
+    it 'resolves labels once across the round trip and broadcasts the whole frame' do
+      labeled_conversation # created outside the counter: create/update fire their own events
 
       job_args = nil
       allow(ActionCableBroadcastJob).to receive(:perform_later) do |*args|
@@ -105,24 +87,18 @@ RSpec.describe ActionCableListener do
         broadcast_data = payload[:data]
       end
 
-      # Both halves of the round trip must sit inside the counter: the build
-      # this fix removes happens in the listener, so measuring the job alone
-      # counts 1 either way and proves nothing.
+      # Both halves sit inside the counter: the listener is where a second
+      # build would happen, so measuring the job alone always counts 1.
       label_queries = count_label_queries do
         listener.conversation_updated(build_event({ conversation: labeled_conversation }))
         expect(job_args&.at(1)).to eq(Events::Types::CONVERSATION_UPDATED)
         ActionCableBroadcastJob.perform_now(*job_args)
       end
 
-      # The job's rebuild resolves the labels once (1). Before this fix the
-      # listener resolved them too, for a payload the job then discarded: 2.
       expect(label_queries).to eq(1)
 
-      # Non-regression (CRM-155): the label reaches the browser without a
-      # reload. Comparing against a fresh build proves the identifier-only
-      # payload never reaches the browser — the job still ships the whole
-      # frame — but not parity with the pre-fix frame, which the job already
-      # discarded before this change.
+      # The frame carries the whole conversation, labels included — the
+      # identifier-only payload never reaches the browser.
       expect(broadcast_data[:labels]).to eq(['vip'])
       expect(broadcast_data).to eq(Conversation.find(labeled_conversation.id).push_event_data)
     end

--- a/spec/listeners/action_cable_listener_conversation_update_spec.rb
+++ b/spec/listeners/action_cable_listener_conversation_update_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-171 — for the 5 CONVERSATION_UPDATE_EVENTS, ActionCableBroadcastJob
+# already re-fetches the conversation and rebuilds push_event_data from
+# scratch (to avoid stale data on out-of-order delivery). Building
+# push_event_data in the listener too was pure waste: a second `labels`
+# query, plus a much larger Sidekiq/Redis payload thrown away unread. The
+# listener now passes only the id for these events.
+#
+# Kept in its own file (not spec/listeners/action_cable_listener_spec.rb) so
+# it can be added to spec-staleness-guard.yml's allowlist without dragging in
+# that file's unrelated, pre-existing CB-3 failures.
+RSpec.describe ActionCableListener do
+  let(:listener) { described_class.instance }
+  let(:user) { User.create!(name: 'CU Agent', email: "listener-cu-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://listener-cu.example.com') }
+  # An inbox with no members makes user_tokens return [] — conversation_read/
+  # team_changed/assignee_changed broadcast only via user_tokens, so blank
+  # tokens make `broadcast` return early (see action_cable_listener.rb) and
+  # `ActionCableBroadcastJob.perform_later` is never called for THIS event.
+  # Without a member, the payload capture below would instead pick up the
+  # real conversation.created broadcast (Conversation#after_create_commit
+  # publishes it via Wisper independently of anything this spec calls), which
+  # still carries the full push_event_data and would make the assertion pass
+  # for the wrong reason.
+  let(:inbox) do
+    ib = Inbox.create!(name: 'Listener CU Inbox', channel: channel)
+    InboxMember.create!(inbox: ib, user: user)
+    ib
+  end
+  let(:contact) { Contact.create!(name: 'LCU', email: "lcu-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: "lcu-#{SecureRandom.hex(4)}") }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  def build_event(data)
+    Struct.new(:data).new(data)
+  end
+
+  describe 'conversation update events pass only the identifier' do
+    before { Current.reset }
+    after  { Current.reset }
+
+    listener_methods = {
+      Events::Types::CONVERSATION_READ => :conversation_read,
+      Events::Types::CONVERSATION_UPDATED => :conversation_updated,
+      Events::Types::TEAM_CHANGED => :team_changed,
+      Events::Types::ASSIGNEE_CHANGED => :assignee_changed,
+      Events::Types::CONVERSATION_STATUS_CHANGED => :conversation_status_changed
+    }
+
+    listener_methods.each do |event_name, listener_method|
+      it "enqueues #{listener_method} (#{event_name}) with only {id:}, not a rebuilt push_event_data" do
+        payload = nil
+        allow(ActionCableBroadcastJob).to receive(:perform_later) do |_tokens, _event, data|
+          payload = data
+        end
+
+        listener.public_send(listener_method, build_event({ conversation: conversation }))
+
+        expect(payload).to eq(id: conversation.id)
+      end
+    end
+  end
+
+  describe 'conversation update round trip — listener enqueue + job rebuild' do
+    before { Current.reset }
+    after  { Current.reset }
+
+    let(:labeled_conversation) do
+      c = Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox)
+      c.update!(label_list: 'vip')
+      c
+    end
+
+    def count_tagging_queries(&)
+      count = 0
+      subscriber = lambda do |*args|
+        sql = args.last[:sql]
+        count += 1 if sql.match?(/taggings/i)
+      end
+      ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record', &)
+      count
+    end
+
+    it 'costs exactly one labels query end-to-end (two before this fix) and the frame reaches the browser unchanged' do
+      job_args = nil
+      allow(ActionCableBroadcastJob).to receive(:perform_later) do |*args|
+        job_args = args
+      end
+
+      listener.conversation_updated(build_event({ conversation: labeled_conversation }))
+      expect(job_args).not_to be_nil
+
+      broadcast_data = nil
+      allow(ActionCable.server).to receive(:broadcast) do |_token, payload|
+        broadcast_data = payload[:data]
+      end
+
+      tag_queries = count_tagging_queries { ActionCableBroadcastJob.perform_now(*job_args) }
+
+      # One query: the listener no longer builds push_event_data (0), the job's
+      # rebuild does it once (1). Before this fix both builds ran: 2.
+      expect(tag_queries).to eq(1)
+
+      # Non-regression (CRM-155): the label reaches the browser without a
+      # reload, and the rest of the frame is unchanged from a fresh build —
+      # the identifier-only payload didn't shrink what actually gets sent.
+      expect(broadcast_data[:labels]).to eq(['vip'])
+      expect(broadcast_data).to eq(Conversation.find(labeled_conversation.id).push_event_data)
+    end
+  end
+end


### PR DESCRIPTION
Para os 5 eventos de `CONVERSATION_UPDATE_EVENTS` (`conversation.read`, `conversation.updated`, `team.changed`, `assignee.changed`, `conversation.status_changed`), o listener montava `conversation.push_event_data` inteiro só para o `ActionCableBroadcastJob#prepare_broadcast_data` jogar fora e remontar do zero (`Conversation.find_by!` + rebuild) — o rebuild é proposital, evita dado velho em entrega fora de ordem, mas o build do listener nunca era lido. Depois que `push_event_data` passou a resolver `labels`, isso virou 2 queries de `labels` por evento em vez de 1, mais um payload bem maior indo pro Redis à toa.

O listener agora passa só `{ id: conversation.id }` nesses 5 eventos — o job já teria feito `find_by!` e remontado do zero de qualquer forma. Os outros eventos (`conversation.created`, digitação, `contact_changed`) não foram tocados, o rebuild do job continua intacto, e `performer` (que já era descartado pelo job nesses 5 eventos, e não é consumido pelo frontend fora do widget) segue com o mesmo comportamento de antes — nada mudou no frame que chega no navegador.

Medi antes de mexer: 2 instâncias de `Conversation` chamando `push_event_data` cada uma custam 2 queries em `taggings`; uma instância só custa 1 — bate exatamente com o que o card descreveu. Depois da mudança, round-trip completo (listener → job) mede 1 query, não 2.

Achei um jeito de o spec passar por engano na primeira tentativa: a suíte completa do repo dispara `Conversation#after_create_commit` de verdade via Wisper, então criar a conversa do teste já gera um `conversation.created` de verdade que também cai no mock de `perform_later` — se o inbox do teste não tem membro, o `broadcast` dos 5 eventos sai cedo (tokens vazios) e o teste acaba validando o payload do evento errado. Corrigido adicionando um `InboxMember` no setup; rodei a suíte inteira do `spec-staleness-guard` (347 exemplos) pra confirmar que fica verde nessa ordem, não só no arquivo isolado.

O spec novo ficou em arquivo próprio (não em `spec/listeners/action_cable_listener_spec.rb`) porque esse arquivo já tem 4 falhas pré-existentes (CB-3, não relacionadas) que travariam o gate da minha própria PR se eu arrastasse o arquivo inteiro pro allowlist.

## Test plan
- `bundle exec rspec spec/listeners/action_cable_listener_conversation_update_spec.rb spec/jobs/action_cable_broadcast_job_spec.rb` → 15/15 verde
- Simulação exata do comando do `spec-staleness-guard` (27 arquivos, 347 exemplos) → verde, exceto 1 falha pré-existente não relacionada (`app_configs_controller_spec.rb`, leak de env var `MAILER_SENDER_EMAIL`, falha isolada também, nada a ver com esta mudança)
- `rubocop` nos arquivos tocados → limpo (as pendências que aparecem são todas pré-existentes, fora do meu diff)

## Summary by Sourcery

Refine CRM pipeline visibility, lead capture, AI credential resolution, media handling, and realtime payloads, while tightening health checks, RBAC, and storage configuration to avoid silent failures and stale data.

New Features:
- Add journeys proxy endpoints to evo-flow, enabling scoped journey CRUD and session management via the CRM API.
- Introduce product catalog import from Shopify and WooCommerce, including remote image ingestion and bulk-import mapping.
- Expose pipeline dependents (capture forms) and captured leads via new endpoints and serializers so operators can see what feeds each pipeline.

Bug Fixes:
- Ensure archived pipelines and their items stop acting on their own, refusing new items, tasks, and automation-driven moves into hidden boards.
- Fix cascade deletions for contacts and conversations by cleaning up macro executions, preventing foreign key violations and orphan records.
- Resolve storage provider precedence so ActiveStorage always uses ENV-first configuration, avoiding media being written to ephemeral disk.
- Stop logging sensitive OAuth secrets (HubSpot client_secret and authorization codes) and agent bot API keys to logs or webhooks.
- Prevent double renders and silent error drops in API controllers by logging rescued exceptions and avoiding second responses.
- Correct WhatsApp Cloud audio handling to transcode unsupported formats, enforce size limits, and clean up temp files reliably.
- Avoid stale pipeline unread/unanswered counts by scoping to the current assignee and permission filters.

Enhancements:
- Optimize CRM form lead counting and listing with new SQL-based unions over contacts and pipeline items, making leads resilient to card deletion and deduplicated per contact.
- Extend pipeline visibility and access control with team-based sharing, Pundit scoping, and per-record authorization reused by child controllers.
- Centralize AI credential resolution across installation, account, and integration scopes, with Fernet-based encryption/decryption and migration tasks that preserve effective keys.
- Add extension-point contract checks and a new permission_resolver seam so external consumers can plug in scope-aware RBAC without breaking the core API.
- Improve automation rule observability with run recorders that distinguish skipped actions (e.g., archived pipelines) from clean matches and log reasons.
- Streamline macro execution parameter validation to fail fast on bad IDs, preventing silent junk tagging and misassignment.
- Enhance bot delegation to include media attachments with signed outbound URLs, and normalize agent bot HTTP/N8n credentials through the vault.
- Improve health readiness checks by including schema migration state, preventing services from starting against incomplete schemas.
- Extend WhatsApp audio conversion with ffmpeg/ffprobe helpers that run with timeouts and codec probing, avoiding worker hangs.
- Harden ActiveStorage dynamic service and storage test service against stale DB config, keeping both web and jobs on the same provider.
- Tighten Rack::Attack throttling for product import fetch to protect worker resources against abusive remote catalog fetches.
- Update extension-point documentation and contract enforcement to reflect the new permission_resolver without drifting from the shipped version.

Build:
- Add CI guards for storage configuration (ENV-first resolution) and cascade-deletion coverage over foreign keys into conversations/contacts.
- Update spec-staleness-guard and community-with-extension-consumer-stub workflows to ensure new services, policies, and extension points are covered by their targeted specs.

CI:
- Expand spec-staleness-guard to include new listeners, jobs, pipelines, macros, storage, and extension-point specs touched by these changes.
- Add community-parity RBAC workflow to verify permission_resolver delegation and Pundit behaviour in a pure community install.

Documentation:
- Revise EXTENSION_POINTS.md to version 2.1.0 and document the new permission_resolver extension point and its compatibility guarantees.

Tests:
- Add extensive specs for pipelines (team visibility, archived guards, dependents), macros action params, CRM forms leads, public leads capture, evo-auth permission checks, AI credential migration/resolution, WhatsApp audio conversion, bot media delegation, storage config, ActiveStorage dynamic service, cascade deletion behaviour, and journeys proxy RBAC.
- Strengthen controller and service specs around error handling, RBAC gates, and external connectors (Shopify/WooCommerce) for import_fetch and image ingestion.

Chores:
- Refactor various specs to align with new behaviours (webhook/macro/websocket payloads, storage, auth) and reset caches where needed to avoid cross-test contamination.