### PR TITLE
refactor(rbac): remove dead conversations.read visibility bypass + fix stale comments

### DIFF
--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -19,9 +19,6 @@ class ConversationFinder
 
   def initialize(current_user, params)
     @current_user = current_user
-    # Nil-safe snapshot of the request role. `User#administrator?` reads
-    # `Current.evo_role_key`, resolved once per request by EvoAuthConcern, so this
-    # is an in-memory read — no remote evo-auth lookup happens here or below.
     @is_admin = current_user&.administrator? || false
     @params = params || {}
   end
@@ -140,26 +137,17 @@ class ConversationFinder
   def apply_inbox_filter(query)
     return query unless @params[:inbox_id]
 
-    # The guard above already returned, so the requested inbox is always present:
-    # narrow `assigned_inboxes` to it, which drops an inbox the user may not access.
+    # Narrowing `assigned_inboxes` drops an inbox the user may not access.
     inbox_ids = @current_user.assigned_inboxes.where(id: @params[:inbox_id]).pluck(:id)
 
     query.where(inbox_id: inbox_ids)
   end
 
   def apply_permission_filter(query)
-    # Admins short-circuit to every conversation. `@is_admin` is the constructor
-    # snapshot of User#administrator?, the same check that gates `assigned_inboxes`
-    # below.
     return query if @is_admin
 
-    # Otherwise scope to the inboxes the user may access. `assigned_inboxes`
-    # (User#assigned_inboxes) is the role-aware source: admins and users granted
-    # `conversations.read_all` see every inbox; a user with `inbox_member` rows sees
-    # only those; and a user with NO membership and no read_all sees NONE — there is
-    # deliberately no zero-membership "see all" fallback (User#assigned_inboxes). Using
-    # the raw `inboxes` relation here would return [] and honor neither read_all nor
-    # admin (the 0/74 bug this method was written to fix).
+    # `assigned_inboxes` is the role-aware source: admin or `conversations.read_all`
+    # sees every inbox, an assigned member only theirs, no membership none.
     query.where(inbox: @current_user.assigned_inboxes)
   end
 

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -21,7 +21,6 @@ class ConversationFinder
     @current_user = current_user
     # Avoid remote role lookup (evo-auth get_role) on conversations index hot path.
     @is_admin = current_user&.administrator? || false
-    @has_conversations_read = false
     @params = params || {}
   end
 
@@ -149,16 +148,18 @@ class ConversationFinder
   end
 
   def apply_permission_filter(query)
-    # Allow access if user is admin or has conversations.read permission
-    return query if @is_admin || @has_conversations_read
+    # Admins short-circuit to every conversation. `@is_admin` is resolved once in the
+    # constructor to avoid a remote role lookup on this hot path; it mirrors
+    # User#administrator?, which also gates `assigned_inboxes` below.
+    return query if @is_admin
 
-    # Otherwise, filter by the inboxes the user may access. `assigned_inboxes`
-    # (User#assigned_inboxes) is the role-aware source: admins / users granted
-    # `conversations.read_all` see every inbox, a user with no `inbox_member`
-    # assignment sees all (zero rupture on upgrade), and a user with assignments
-    # sees only those. Using the raw `inboxes` relation here returned [] for any
-    # user without an inbox_member — collapsing the list to "no conversations"
-    # even for the account admin (the 0/74 bug).
+    # Otherwise scope to the inboxes the user may access. `assigned_inboxes`
+    # (User#assigned_inboxes) is the role-aware source: admins and users granted
+    # `conversations.read_all` see every inbox; a user with `inbox_member` rows sees
+    # only those; and a user with NO membership and no read_all sees NONE — there is
+    # deliberately no zero-membership "see all" fallback (User#assigned_inboxes). Using
+    # the raw `inboxes` relation here would return [] and honor neither read_all nor
+    # admin (the 0/74 bug this method was written to fix).
     query.where(inbox: @current_user.assigned_inboxes)
   end
 

--- a/app/finders/conversation_finder.rb
+++ b/app/finders/conversation_finder.rb
@@ -19,7 +19,9 @@ class ConversationFinder
 
   def initialize(current_user, params)
     @current_user = current_user
-    # Avoid remote role lookup (evo-auth get_role) on conversations index hot path.
+    # Nil-safe snapshot of the request role. `User#administrator?` reads
+    # `Current.evo_role_key`, resolved once per request by EvoAuthConcern, so this
+    # is an in-memory read — no remote evo-auth lookup happens here or below.
     @is_admin = current_user&.administrator? || false
     @params = params || {}
   end
@@ -138,19 +140,17 @@ class ConversationFinder
   def apply_inbox_filter(query)
     return query unless @params[:inbox_id]
 
-    inbox_ids = if @params[:inbox_id]
-                  @current_user.assigned_inboxes.where(id: @params[:inbox_id]).pluck(:id)
-                else
-                  @current_user.assigned_inboxes.pluck(:id)
-                end
+    # The guard above already returned, so the requested inbox is always present:
+    # narrow `assigned_inboxes` to it, which drops an inbox the user may not access.
+    inbox_ids = @current_user.assigned_inboxes.where(id: @params[:inbox_id]).pluck(:id)
 
     query.where(inbox_id: inbox_ids)
   end
 
   def apply_permission_filter(query)
-    # Admins short-circuit to every conversation. `@is_admin` is resolved once in the
-    # constructor to avoid a remote role lookup on this hot path; it mirrors
-    # User#administrator?, which also gates `assigned_inboxes` below.
+    # Admins short-circuit to every conversation. `@is_admin` is the constructor
+    # snapshot of User#administrator?, the same check that gates `assigned_inboxes`
+    # below.
     return query if @is_admin
 
     # Otherwise scope to the inboxes the user may access. `assigned_inboxes`

--- a/app/services/conversations/cached_count_service.rb
+++ b/app/services/conversations/cached_count_service.rb
@@ -76,8 +76,11 @@ class Conversations::CachedCountService
 
     # Scope by the role-aware `assigned_inboxes` (same source as
     # ConversationFinder#apply_permission_filter and apply_inbox_filter above):
-    # a user with no `inbox_member` assignment still sees all inboxes, so the
-    # cached count stays consistent with the conversation list (no 0/74 split).
+    # admins and users granted `conversations.read_all` see every inbox; a user with
+    # `inbox_member` rows sees only those; and a user with NO membership and no
+    # read_all sees NONE — there is deliberately no zero-membership "see all"
+    # fallback (User#assigned_inboxes). Sharing that source is what keeps the cached
+    # count consistent with the conversation list (no 0/74 split).
     query.where(inbox: @user.assigned_inboxes)
   end
 

--- a/app/services/conversations/cached_count_service.rb
+++ b/app/services/conversations/cached_count_service.rb
@@ -74,13 +74,8 @@ class Conversations::CachedCountService
     is_admin = @user.administrator?
     return query if is_admin
 
-    # Scope by the role-aware `assigned_inboxes` (same source as
-    # ConversationFinder#apply_permission_filter and apply_inbox_filter above):
-    # admins and users granted `conversations.read_all` see every inbox; a user with
-    # `inbox_member` rows sees only those; and a user with NO membership and no
-    # read_all sees NONE — there is deliberately no zero-membership "see all"
-    # fallback (User#assigned_inboxes). Sharing that source is what keeps the cached
-    # count consistent with the conversation list (no 0/74 split).
+    # Same role-aware source as ConversationFinder#apply_permission_filter, so the count
+    # matches the list: admin/read_all every inbox, assigned member only theirs, none otherwise.
     query.where(inbox: @user.assigned_inboxes)
   end
 

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -100,8 +100,9 @@ RSpec.describe ConversationFinder do
   describe '#apply_permission_filter' do
     let(:relation) { double('Relation') }
 
-    # AC3: the admin / conversations.read short-circuit must keep returning the
-    # untouched relation (no inbox scoping at all).
+    # AC3: the admin short-circuit must keep returning the untouched relation (no
+    # inbox scoping at all). The dead `conversations.read` branch was removed
+    # (#179/#183) — only admins short-circuit now.
     it 'returns the query untouched for an admin (short-circuit)' do
       user = instance_double(User, id: 1, administrator?: true)
       finder = described_class.new(user, {})
@@ -113,7 +114,8 @@ RSpec.describe ConversationFinder do
     # AC1 + AC2: a non-admin user is scoped by `assigned_inboxes`, the role-aware
     # source — NOT the raw `inboxes` relation that returned [] for any user with
     # no inbox_member (the 0/74 bug). `assigned_inboxes` returns Inbox.all for an
-    # admin / unassigned member, and only the assigned inboxes for an assigned one.
+    # admin or a user with conversations.read_all, only the assigned inboxes for an
+    # assigned member, and NONE for a member with no assignment (no fallback).
     it 'scopes a non-admin user by assigned_inboxes (not raw inboxes)' do
       assigned = double('AssignedInboxes')
       user = instance_double(User, id: 2, administrator?: false, assigned_inboxes: assigned)
@@ -123,6 +125,20 @@ RSpec.describe ConversationFinder do
       expect(user).not_to receive(:inboxes)
       expect(relation).to receive(:where).with(inbox: assigned).and_return(scoped)
 
+      expect(finder.send(:apply_permission_filter, relation)).to eq(scoped)
+    end
+
+    # #179/#183 regression: there is no `conversations.read` bypass and no
+    # zero-membership fallback. A non-admin is ALWAYS scoped by assigned_inboxes,
+    # even when that set is empty (they then see no conversations) — the finder must
+    # never short-circuit to the full relation for a non-admin.
+    it 'never bypasses inbox scoping for a non-admin, even with no assigned inboxes' do
+      empty = double('EmptyAssignedInboxes')
+      user = instance_double(User, id: 3, administrator?: false, assigned_inboxes: empty)
+      finder = described_class.new(user, {})
+      scoped = double('ScopedToNone')
+
+      expect(relation).to receive(:where).with(inbox: empty).and_return(scoped)
       expect(finder.send(:apply_permission_filter, relation)).to eq(scoped)
     end
   end

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe ConversationFinder do
 
     # AC3: the admin short-circuit must keep returning the untouched relation (no
     # inbox scoping at all). The dead `conversations.read` branch was removed
-    # (#179/#183) — only admins short-circuit now.
+    # (CRM-179/CRM-183) — only admins short-circuit now.
     it 'returns the query untouched for an admin (short-circuit)' do
       user = instance_double(User, id: 1, administrator?: true)
       finder = described_class.new(user, {})
@@ -128,18 +128,23 @@ RSpec.describe ConversationFinder do
       expect(finder.send(:apply_permission_filter, relation)).to eq(scoped)
     end
 
-    # #179/#183 regression: there is no `conversations.read` bypass and no
+    # CRM-179/CRM-183 regression: there is no `conversations.read` bypass and no
     # zero-membership fallback. A non-admin is ALWAYS scoped by assigned_inboxes,
-    # even when that set is empty (they then see no conversations) — the finder must
-    # never short-circuit to the full relation for a non-admin.
+    # even when that set is genuinely empty (`Inbox.none`, what a member with no
+    # inbox_member and no read_all gets) — the relation must come back scoped, never
+    # the untouched one the admin branch returns.
     it 'never bypasses inbox scoping for a non-admin, even with no assigned inboxes' do
-      empty = double('EmptyAssignedInboxes')
+      empty = Inbox.none
       user = instance_double(User, id: 3, administrator?: false, assigned_inboxes: empty)
       finder = described_class.new(user, {})
       scoped = double('ScopedToNone')
 
       expect(relation).to receive(:where).with(inbox: empty).and_return(scoped)
-      expect(finder.send(:apply_permission_filter, relation)).to eq(scoped)
+
+      result = finder.send(:apply_permission_filter, relation)
+
+      expect(result).to eq(scoped)
+      expect(result).not_to eq(relation)
     end
   end
 end

--- a/spec/finders/conversation_finder_spec.rb
+++ b/spec/finders/conversation_finder_spec.rb
@@ -100,9 +100,6 @@ RSpec.describe ConversationFinder do
   describe '#apply_permission_filter' do
     let(:relation) { double('Relation') }
 
-    # AC3: the admin short-circuit must keep returning the untouched relation (no
-    # inbox scoping at all). The dead `conversations.read` branch was removed
-    # (CRM-179/CRM-183) — only admins short-circuit now.
     it 'returns the query untouched for an admin (short-circuit)' do
       user = instance_double(User, id: 1, administrator?: true)
       finder = described_class.new(user, {})
@@ -111,11 +108,6 @@ RSpec.describe ConversationFinder do
       expect(finder.send(:apply_permission_filter, relation)).to eq(relation)
     end
 
-    # AC1 + AC2: a non-admin user is scoped by `assigned_inboxes`, the role-aware
-    # source — NOT the raw `inboxes` relation that returned [] for any user with
-    # no inbox_member (the 0/74 bug). `assigned_inboxes` returns Inbox.all for an
-    # admin or a user with conversations.read_all, only the assigned inboxes for an
-    # assigned member, and NONE for a member with no assignment (no fallback).
     it 'scopes a non-admin user by assigned_inboxes (not raw inboxes)' do
       assigned = double('AssignedInboxes')
       user = instance_double(User, id: 2, administrator?: false, assigned_inboxes: assigned)
@@ -128,11 +120,6 @@ RSpec.describe ConversationFinder do
       expect(finder.send(:apply_permission_filter, relation)).to eq(scoped)
     end
 
-    # CRM-179/CRM-183 regression: there is no `conversations.read` bypass and no
-    # zero-membership fallback. A non-admin is ALWAYS scoped by assigned_inboxes,
-    # even when that set is genuinely empty (`Inbox.none`, what a member with no
-    # inbox_member and no read_all gets) — the relation must come back scoped, never
-    # the untouched one the admin branch returns.
     it 'never bypasses inbox scoping for a non-admin, even with no assigned inboxes' do
       empty = Inbox.none
       user = instance_double(User, id: 3, administrator?: false, assigned_inboxes: empty)


### PR DESCRIPTION
## Problema
`ConversationFinder` carregava `@has_conversations_read`, atribuído `false` no construtor e **nunca reatribuído**, guardando `return query if @is_admin || @has_conversations_read`.

- **CRM-183** — a variável é sempre `false`, então o ramo é na prática `return query if @is_admin`; mas o comentário dizia que o acesso é liberado para quem tem `conversations.read` (chave que o papel `agent` possui). Comentário **enganoso**: nunca se aplica, e popular a variável reabriria silenciosamente um bypass de visibilidade total (HTTP + o WS).
- **CRM-179** — um segundo comentário descrevia um fallback de zero-membership *"sees all (zero rupture)"* que `User#assigned_inboxes` **deliberadamente NÃO tem** — contradizendo o código e o comentário-irmão em `user.rb`.

## Fix
Remove a variável e o ramo mortos (**preserva comportamento** — sempre foi `false`) e reescreve os dois comentários: admin faz short-circuit; o resto é escopado por `assigned_inboxes` (read_all/admin → todas; atribuído → as suas; sem membership → NENHUMA).

## Teste
`spec/finders/conversation_finder_spec.rb` — comentários corrigidos + novo caso: um não-admin é **sempre** escopado por `assigned_inboxes`, mesmo vazio (vê nada) — nunca short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve administrator access while enforcing assigned-inbox visibility for all non-admin conversation queries and cached counts.

Bug Fixes:
- Ensure non-admin conversation visibility is always constrained by assigned inboxes, including when the user has no memberships.

Enhancements:
- Remove the unused conversations.read visibility bypass and align permission-filter comments with the actual assigned-inbox behavior.

Tests:
- Add coverage confirming non-admin users with no assigned inboxes cannot bypass inbox scoping.
