### PR TITLE
docs(readme): correct "no super-admin" — the role exists (installation owner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **EVO-1239** — Telegram `send_on_telegram` passa a registrar status `delivered` após envio bem-sucedido. Read receipts não são suportados pela Bot API (Telegram limitation) e portanto `read` permanece n/a neste canal.
+- **CRM-180 — README: modelo de papéis corrigido** — a introdução afirmava que a Community não tem `super_admin`. O seed de RBAC do `evo-auth-service-community` cria o papel (único com `installation_configs.manage`), o setup wizard o concede ao usuário do bootstrap e a migration `PromoteFirstUserToSuperAdmin` ao usuário mais antigo de instalações já bootstrapadas — sem nenhuma garantia de titular único. O texto passa a descrever os três papéis semeados e os papéis customizados criáveis em runtime (`POST /api/v1/roles`), e aponta `db/seeds/rbac.rb` como fonte autoritativa; `Role::ADMIN_ROLE_KEYS` deste repo é allowlist de bypass administrativo, não o modelo de papéis.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Evo CRM Backend is part of the [Evo CRM Community](https://github.com/evolution-
 git clone --recurse-submodules git@github.com:evolution-foundation/evo-crm-community.git
 ```
 
-The Community Edition is **single-tenant** by design — one account, no multi-tenancy overhead, no billing or plans. All limits are removed and features are unlocked by default. The role hierarchy is `account_owner` + `agent`, plus a single installation-owner (`super_admin`) created by the setup wizard that holds the installation-level configuration (SMTP, Storage, OpenAI, etc.). See the `evo-auth-service-community` RBAC seed and `Role::ADMIN_ROLE_KEYS` for the authoritative role model.
+The Community Edition is **single-tenant** by design — one account, no multi-tenancy overhead, no billing or plans. All limits are removed and features are unlocked by default.
+
+RBAC seeds three roles: `agent` (attendance only), `account_owner` (the whole catalog except `accounts.stats` and `installation_configs.manage`) and `super_admin` — the installation owner, the only role holding `installation_configs.manage` (SMTP, Storage, Social Login, OpenAI, Channels, Inbound Email, Frontend Runtime). Two facts a security review needs, because neither is enforced by the code: `super_admin` has **no single-holder guarantee** — the setup wizard grants it to the user it creates and the `PromoteFirstUserToSuperAdmin` migration grants it to the oldest user of an already-bootstrapped installation, but nothing prevents more, so audit `user_roles` for the role key instead of assuming one; and the seeded three are **not the whole set** — `account_owner` holds `roles.create`, so custom roles can be created at runtime via `POST /api/v1/roles`. The authoritative role model is `db/seeds/rbac.rb` in `evo-auth-service-community`; `Role::ADMIN_ROLE_KEYS` in this repo is an admin-bypass allowlist that also names legacy `administrator`/`admin` keys, not the role model.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Evo CRM Backend is part of the [Evo CRM Community](https://github.com/evolution-
 git clone --recurse-submodules git@github.com:evolution-foundation/evo-crm-community.git
 ```
 
-The Community Edition is **single-tenant** by design — one account, no multi-tenancy overhead, no super-admin, no billing or plans. All limits are removed and features are unlocked by default.
+The Community Edition is **single-tenant** by design — one account, no multi-tenancy overhead, no billing or plans. All limits are removed and features are unlocked by default. The role hierarchy is `account_owner` + `agent`, plus a single installation-owner (`super_admin`) created by the setup wizard that holds the installation-level configuration (SMTP, Storage, OpenAI, etc.). See the `evo-auth-service-community` RBAC seed and `Role::ADMIN_ROLE_KEYS` for the authoritative role model.
 
 ---
 


### PR DESCRIPTION
## Problema

O README da Community afirmava que a edição tem **"no super-admin"**. Mas `evo-auth-service-community db/seeds/rbac.rb` **cria** o papel, e ele é o único com `installation_configs.manage` (SMTP, Storage, Social Login, OpenAI, Channels, Inbound Email, Frontend Runtime).

A afirmação falsa **escondia o papel de auditorias de segurança** — um cliente tinha 5 `super_admin`, e um revisor confiando no README não procuraria por eles.

## Fix

Documenta o modelo real:

- os três papéis semeados — `agent`, `account_owner` e `super_admin`;
- que **nada garante titular único**: `SetupBootstrapService#assign_global_role` concede ao usuário do bootstrap, a migration `PromoteFirstUserToSuperAdmin` concede ao usuário mais antigo de instalações já bootstrapadas, e `UserRole` valida apenas `uniqueness: { scope: :role_id }` — auditar `user_roles` em vez de assumir um titular;
- que os três **não são o conjunto todo**: `account_owner` tem `roles.create`, então papéis customizados nascem em runtime via `POST /api/v1/roles`;
- `db/seeds/rbac.rb` como fonte autoritativa.

⚠️ **Correção de uma afirmação da primeira versão deste PR:** `Role::ADMIN_ROLE_KEYS` **não** é `[account_owner, super_admin]`. É `%w[super_admin account_owner administrator admin]` (`app/models/role.rb:44`) — allowlist de bypass administrativo, não modelo de papéis; nomeia `administrator`/`admin`, que o seed nunca cria; e as cópias em `evo-auth-service-community` (`account_controller.rb:14`, 4 chaves) e `evo-ai-frontend-community` (`src/constants/roles.ts`, 3 chaves) divergem entre si. O README passa a dizer isso explicitamente.

Entrada no `CHANGELOG.md` sob `[Unreleased]`.

**Escopo:** este é o README do repo do **serviço**. O README do **monorepo**, que o CRM-180 nomeia, é corrigido em [evo-crm-community #173](https://github.com/evolution-foundation/evo-crm-community/pull/173).

Doc — sem teste.
