### PR TITLE
test(security): move o guard de user_tokens para a lane de CI (CRM-185)

### DIFF
--- a/spec/listeners/action_cable_listener_conversation_update_spec.rb
+++ b/spec/listeners/action_cable_listener_conversation_update_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe ActionCableListener do
   let(:listener) { described_class.instance }
   let(:user) { User.create!(name: 'CU Agent', email: "listener-cu-#{SecureRandom.hex(4)}@test.com") }
   let(:channel) { Channel::WebWidget.create!(website_url: 'https://listener-cu.example.com') }
-  # user_tokens plucks every User's pubsub_token and ignores `agents`, so these
-  # broadcasts need a User row to exist, not a membership.
+  # user_tokens returns the pubsub tokens of the inbox members the event passes,
+  # so these broadcasts need the membership below, not just a User row.
   let(:inbox) do
     ib = Inbox.create!(name: 'Listener CU Inbox', channel: channel)
     InboxMember.create!(inbox: ib, user: user)
@@ -101,6 +101,63 @@ RSpec.describe ActionCableListener do
       # identifier-only payload never reaches the browser.
       expect(broadcast_data[:labels]).to eq(['vip'])
       expect(broadcast_data).to eq(Conversation.find(labeled_conversation.id).push_event_data)
+    end
+  end
+
+  # WS conversation-visibility leak regression: recipients are the inbox members
+  # each event passes (conversation.inbox.members), never every user. Before the
+  # fix #user_tokens ignored its argument and returned User.pluck(:pubsub_token),
+  # so an agent NOT assigned to the inbox received every frame over the socket —
+  # the real-time bypass of the assigned_inboxes / conversations.read_all scoping.
+  #
+  # Every example materializes `non_member` on purpose: against an empty users
+  # table the global pluck returns the same set as the fix, so an example that
+  # skips it stays green on the vulnerable code and guards nothing.
+  describe '#user_tokens (inbox-scoped recipients)' do
+    before { Current.reset }
+    after  { Current.reset }
+
+    let(:non_member) do
+      User.create!(name: 'CU Outsider', email: "listener-cu-out-#{SecureRandom.hex(4)}@test.com")
+    end
+
+    it 'returns only the given inbox members pubsub tokens, de-duplicated' do
+      non_member
+
+      expect(listener.send(:user_tokens, nil, [user, user])).to eq([user.pubsub_token])
+    end
+
+    it 'does NOT leak to a user who is not a member of the inbox' do
+      non_member
+
+      tokens = listener.send(:user_tokens, nil, [user])
+
+      expect(tokens).not_to include(non_member.pubsub_token)
+      expect(tokens).to eq([user.pubsub_token])
+    end
+
+    it 'returns nothing when there are no inbox members (never a global broadcast)' do
+      user
+      non_member
+
+      expect(listener.send(:user_tokens, nil, [])).to eq([])
+    end
+
+    # The cases above pin the method; this one pins the callers — passing any
+    # collection wider than conversation.inbox.members reopens the leak.
+    it 'broadcasts a conversation event only to the inbox members' do
+      conversation # created before the mock: its own create event uses the real job
+      non_member
+
+      tokens = nil
+      allow(ActionCableBroadcastJob).to receive(:perform_later) do |broadcast_tokens, event, _data|
+        tokens = broadcast_tokens if event == Events::Types::CONVERSATION_UPDATED
+      end
+
+      listener.conversation_updated(build_event({ conversation: conversation }))
+
+      expect(tokens).to include(user.pubsub_token)
+      expect(tokens).not_to include(non_member.pubsub_token)
     end
   end
 end

--- a/spec/listeners/action_cable_listener_conversation_update_spec.rb
+++ b/spec/listeners/action_cable_listener_conversation_update_spec.rb
@@ -104,15 +104,9 @@ RSpec.describe ActionCableListener do
     end
   end
 
-  # WS conversation-visibility leak regression: recipients are the inbox members
-  # each event passes (conversation.inbox.members), never every user. Before the
-  # fix #user_tokens ignored its argument and returned User.pluck(:pubsub_token),
-  # so an agent NOT assigned to the inbox received every frame over the socket —
-  # the real-time bypass of the assigned_inboxes / conversations.read_all scoping.
-  #
-  # Every example materializes `non_member` on purpose: against an empty users
-  # table the global pluck returns the same set as the fix, so an example that
-  # skips it stays green on the vulnerable code and guards nothing.
+  # Recipients are the inbox members each event passes, never every user.
+  # Every example materializes a non-member: against an empty users table a
+  # global pluck returns the same set as the scoped one and proves nothing.
   describe '#user_tokens (inbox-scoped recipients)' do
     before { Current.reset }
     after  { Current.reset }
@@ -143,8 +137,8 @@ RSpec.describe ActionCableListener do
       expect(listener.send(:user_tokens, nil, [])).to eq([])
     end
 
-    # The cases above pin the method; this one pins the callers — passing any
-    # collection wider than conversation.inbox.members reopens the leak.
+    # Pins the callers, not just the method: any collection wider than
+    # conversation.inbox.members reopens the leak.
     it 'broadcasts a conversation event only to the inbox members' do
       conversation # created before the mock: its own create event uses the real job
       non_member

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -200,6 +200,6 @@ RSpec.describe ActionCableListener do
     end
   end
 
-  # The #user_tokens leak regression lives in action_cable_listener_conversation_update_spec.rb:
-  # this file is not in the spec-staleness-guard allowlist, so a guard placed here never runs.
+  # #user_tokens is guarded in action_cable_listener_conversation_update_spec.rb:
+  # this file is outside the spec-staleness-guard allowlist and runs in no lane.
 end

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -200,31 +200,6 @@ RSpec.describe ActionCableListener do
     end
   end
 
-  # WS conversation-visibility leak regression: recipients are the inbox members
-  # each event passes (conversation.inbox.members), never every user. Before the
-  # fix #user_tokens ignored its argument and returned User.pluck(:pubsub_token),
-  # so an agent NOT assigned to the inbox received every frame over the socket —
-  # the real-time bypass of the assigned_inboxes / conversations.read_all scoping.
-  describe '#user_tokens (inbox-scoped recipients)' do
-    let(:non_member) do
-      User.create!(name: 'Outsider', email: "outsider-#{SecureRandom.hex(4)}@test.com")
-    end
-
-    it 'returns only the given inbox members\' pubsub tokens, de-duplicated' do
-      tokens = listener.send(:user_tokens, nil, [user, user])
-
-      expect(tokens).to eq([user.pubsub_token])
-    end
-
-    it 'does NOT leak to a user who is not a member of the inbox' do
-      non_member # ensure the outsider exists in the DB
-      tokens = listener.send(:user_tokens, nil, [user])
-
-      expect(tokens).not_to include(non_member.pubsub_token)
-    end
-
-    it 'returns nothing when there are no inbox members (never a global broadcast)' do
-      expect(listener.send(:user_tokens, nil, [])).to eq([])
-    end
-  end
+  # The #user_tokens leak regression lives in action_cable_listener_conversation_update_spec.rb:
+  # this file is not in the spec-staleness-guard allowlist, so a guard placed here never runs.
 end


### PR DESCRIPTION
Correções do code review do CRM-185, apontadas para a branch da PR #273 para revisão antes do merge. **Não toca em código de produção** — só nos dois specs.

## H1 — o guard não rodava em lane nenhuma

O `spec-staleness-guard.yml` é allowlist dupla: dispara pelo `paths:` (que já inclui `app/listeners/action_cable_listener.rb`, linha 18) mas roda uma **lista fixa de arquivos** no `run:` (linhas 138-166), e `spec/listeners/action_cable_listener_spec.rb` não está nela. Não existe lane de suíte completa no repo: só `community-parity`, `community-with-extension-consumer-stub` e o próprio guard rodam rspec, todos em `pull_request`.

Os casos passam para `spec/listeners/action_cable_listener_conversation_update_spec.rb`, que **já está** na lista do guard e está verde. Registrar o arquivo original exigiria antes consertar as 4 falhas pré-existentes de `contact_* CB-3` (presentes na `develop`, confirmadas rodando a suíte no merge-base `91bdb3e`) — é o que o cabeçalho daquele arquivo já registra: *"Split from action_cable_listener_spec.rb, whose failures keep it out of the CI guard"*.

Com os casos fora dele, `action_cable_listener_spec.rb` volta **idêntico à `develop`**.

## M1 — 2 dos 3 casos passavam contra o código vulnerável

Teste de mutação (revertendo `user_tokens` para `User.pluck(:pubsub_token).compact.uniq`): só `does NOT leak to a non-member` ficava vermelho. Os outros dois usam `let` preguiçoso e nunca materializam um segundo usuário, então o pluck global devolve por acaso o mesmo conjunto — inclusive o caso batizado `never a global broadcast`, que com a tabela `users` vazia também devolve `[]`.

Agora todo exemplo materializa `non_member`, e o caso do não-membro assere o conjunto exato além do `not_to include` (sugestão do Sourcery em `spec:223`, que estava em aberto).

## M2 — nenhum caso no nível do evento

Os três casos chamam o método privado por `send`; um caller que passe uma coleção mais larga que `conversation.inbox.members` não seria pego. Acrescentado um caso que dispara `conversation_updated` de verdade e assere os tokens do frame: inclui o membro, não inclui o não-membro.

## M3 — comentário obsoleto

`action_cable_listener_conversation_update_spec.rb:12-13` afirmava *"user_tokens plucks every User's pubsub_token and ignores `agents`, so these broadcasts need a User row to exist, not a membership"* — o inverso do invariante que a #273 estabelece, no arquivo que o CI guard roda.

## Verificação

Container `ruby:3.4.4` + `postgres:14` + `redis:7` (receita do `spec-staleness-guard`):

- `action_cable_listener_conversation_update_spec.rb` (o arquivo que o CI roda): **10 exemplos, 0 falhas**
- Os dois arquivos juntos: 19 exemplos, 4 falhas — só as `contact_* CB-3` pré-existentes na `develop`
- Mutação com o `user_tokens` vulnerável: os **4** casos novos ficam vermelhos (antes: 1 de 3)
- RuboCop: nenhuma ofensa nova

## Fora do escopo desta PR

O override enterprise (`evo_enterprise_action_cable_tenant_scope.rb:131-146`) reescreve `user_tokens` sem chamar `super` dentro do escopo PII — que é onde todos os eventos de conversa entram —, descarta `agents` e devolve os tokens de toda a agência. No SaaS, o fix da #273 é no-op até esse patch interseccionar tenant ∩ membros da inbox. Já registrado como follow-up no card.
