### PR TITLE
style(listeners): enxuga os comentarios do user_tokens e do guard (CRM-185)

### DIFF
--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -182,13 +182,7 @@ class ActionCableListener < BaseListener
   end
 
   def user_tokens(_account, agents)
-    # Recipients are the inbox members each caller passes (agents ==
-    # conversation.inbox.members), NOT every user. Broadcasting to
-    # User.pluck(:pubsub_token) leaked every conversation/message frame over the
-    # WebSocket to agents NOT assigned to the inbox — the real-time bypass of the
-    # assigned_inboxes / conversations.read_all HTTP scoping (User#assigned_inboxes).
-    # An admin who needs realtime for an inbox they don't own must be added as a
-    # member; they still see everything over HTTP via administrator?.
+    # Members only: an admin wanting realtime on someone else's inbox joins it.
     agents.filter_map(&:pubsub_token).uniq
   end
 

--- a/spec/listeners/action_cable_listener_conversation_update_spec.rb
+++ b/spec/listeners/action_cable_listener_conversation_update_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe ActionCableListener do
   let(:listener) { described_class.instance }
   let(:user) { User.create!(name: 'CU Agent', email: "listener-cu-#{SecureRandom.hex(4)}@test.com") }
   let(:channel) { Channel::WebWidget.create!(website_url: 'https://listener-cu.example.com') }
-  # user_tokens returns the pubsub tokens of the inbox members the event passes,
-  # so these broadcasts need the membership below, not just a User row.
   let(:inbox) do
     ib = Inbox.create!(name: 'Listener CU Inbox', channel: channel)
     InboxMember.create!(inbox: ib, user: user)
@@ -104,9 +102,8 @@ RSpec.describe ActionCableListener do
     end
   end
 
-  # Recipients are the inbox members each event passes, never every user.
-  # Every example materializes a non-member: against an empty users table a
-  # global pluck returns the same set as the scoped one and proves nothing.
+  # Every example materializes a non-member: with an empty users table a global
+  # pluck returns the same set as the scoped one and proves nothing.
   describe '#user_tokens (inbox-scoped recipients)' do
     before { Current.reset }
     after  { Current.reset }
@@ -137,8 +134,6 @@ RSpec.describe ActionCableListener do
       expect(listener.send(:user_tokens, nil, [])).to eq([])
     end
 
-    # Pins the callers, not just the method: any collection wider than
-    # conversation.inbox.members reopens the leak.
     it 'broadcasts a conversation event only to the inbox members' do
       conversation # created before the mock: its own create event uses the real job
       non_member

--- a/spec/listeners/action_cable_listener_spec.rb
+++ b/spec/listeners/action_cable_listener_spec.rb
@@ -199,7 +199,4 @@ RSpec.describe ActionCableListener do
       expect(source_id).to end_with('@s.whatsapp.net')
     end
   end
-
-  # #user_tokens is guarded in action_cable_listener_conversation_update_spec.rb:
-  # this file is outside the spec-staleness-guard allowlist and runs in no lane.
 end


### PR DESCRIPTION
Continuação da #278 (já mergeada nesta branch) — este commit ficou de fora dela por erro meu no push. Só comentário: **nenhuma linha de código muda**.

## `app/listeners/action_cable_listener.rb`

7 linhas de comentário para documentar uma linha de código viram uma. Sobra o único fato que não se deriva do código — o admin que quer realtime numa inbox que não é dele entra como membro. O resto (o `User.pluck` antigo, o `assigned_inboxes`, o `read_all`) é história do bug: está na commit message da #273 e no card, não precisa estar no arquivo.

## `spec/listeners/action_cable_listener_spec.rb`

Volta **idêntico à `develop`**. O comentário-ponteiro que eu tinha deixado na #278 fazia deste arquivo um delta de 3 linhas de comentário e nada mais — não se paga. O cabeçalho do `action_cable_listener_conversation_update_spec.rb` já registra o porquê do split.

## `spec/listeners/action_cable_listener_conversation_update_spec.rb`

Sobram 2 linhas: por que todo exemplo materializa o não-membro (sem isso o caso fica verde contra o código vulnerável — foi o defeito que a #278 corrigiu). Cai o comentário do caso no nível do evento, que só repetia o nome do `it`, e cai o comentário obsoleto do `let(:inbox)` em vez de ser reescrito: com a membership agora exigida, o `InboxMember.create!` logo abaixo se explica sozinho.

## Verificação

- `action_cable_listener_conversation_update_spec.rb` (o arquivo que o CI guard roda): **10 exemplos, 0 falhas**
- RuboCop no listener: 5 ofensas, todas pré-existentes (a `develop` tem 6 — a #273 fecha a do `agents` não usado)

## Summary by Sourcery

Streamline listener and spec comments without changing application behavior.

Enhancements:
- Simplify comments around inbox-scoped Action Cable recipients and their membership requirements.
- Remove redundant test comments while retaining the rationale for exercising non-member recipients.