### PR TITLE
docs(rbac): correct assigned_inboxes comment for secure-by-default agent (CRM-181)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,8 +149,12 @@ class User < ApplicationRecord
     # treated as false here.
     #
     # There is deliberately NO zero-membership fallback: "see everything" comes
-    # ONLY from the conversations.read_all grant (which the upgrade migration
-    # gave every pre-existing role, so revoking it is the admin's explicit act).
+    # ONLY from the conversations.read_all grant. The default `agent` role is
+    # SECURE-BY-DEFAULT — it does NOT hold read_all (CRM-181), so an agent sees
+    # only its member inboxes and an agent with no membership sees nothing until
+    # assigned; account_owner/super_admin keep read_all. The evo-auth CRM-181
+    # data-migration revokes read_all from the system `agent` role on upgrade;
+    # for CUSTOM roles an admin created, revoking is the admin's explicit act.
     # The old `inbox_members.empty? -> Inbox.all` degrade made that revoke
     # unenforceable for users with no memberships — the common state, since
     # most installs never assigned inboxes.


### PR DESCRIPTION
## CRM-181 (lado CRM) — corrige o comentário de `User#assigned_inboxes`

Par do PR do auth que revoga `conversations.read_all` do papel `agent`.

O comentário afirmava que a migration de upgrade **deu** `read_all` a todo papel pré-existente, logo revogar seria sempre "ato explícito do admin". Com o CRM-181 a data-migration do auth **revoga** `read_all` do papel `agent` de sistema automaticamente (secure-by-default) — o comentário viraria falso. Reescrito: o agent não tem mais `read_all` e vê só suas inboxes-membro; `account_owner`/`super_admin` mantêm; para roles custom, revogar segue sendo ato explícito do admin.

Só comentário — comportamento inalterado (o enforcement aqui, `read_all`/`administrator?`, já casa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update the `User#assigned_inboxes` documentation to accurately describe secure-by-default inbox visibility and role-specific `read_all` permissions.