### PR TITLE
docs(license): credita o Chatwoot Inc. sob MIT no NOTICE e no README

### DIFF
--- a/LICENSE-chatwoot
+++ b/LICENSE-chatwoot
@@ -1,0 +1,25 @@
+Copyright (c) 2017-2026 Chatwoot Inc.
+
+Portions of this software are licensed as follows:
+
+* All content that resides under the "enterprise/" directory of this repository, if that directory exists, is licensed under the license defined in "enterprise/LICENSE".
+* All third party components incorporated into the Chatwoot Software are licensed under the original license provided by the owner of the applicable component.
+* Content outside of the above mentioned directories or restrictions above is available under the "MIT Expat" license as defined below.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -4,10 +4,13 @@ Copyright 2026 Evolution Foundation
 This product includes software developed by Evolution Foundation
 (https://evolutionfoundation.com.br).
 
+Third-party software
+This product includes software from Chatwoot (https://github.com/chatwoot/chatwoot),
+Copyright (c) 2017-2026 Chatwoot Inc., licensed under the MIT Expat license.
+The full text of that license is included in this repository as LICENSE-chatwoot.
+
 Trademark notice
 "Evolution Foundation", "Evolution" and "Evo CRM Backend" are trademarks of
 Evolution Foundation. The Evo CRM Backend logo, wordmark, and visual identity
 are governed by the Trademark and Brand Assets Policy included in this
 repository (TRADEMARKS.md).
-
-

--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ For security issues, **do not open a public issue**. Email **suporte@evofoundati
 
 Evo CRM Backend is licensed under the Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
+This product includes software from [Chatwoot](https://github.com/chatwoot/chatwoot),
+Copyright (c) 2017-2026 Chatwoot Inc., licensed under the MIT Expat license. See
+[LICENSE-chatwoot](./LICENSE-chatwoot) and [NOTICE](./NOTICE).
+
 ## Trademarks
 
 "Evolution Foundation", "Evolution" and "Evo CRM Backend" are trademarks of Evolution Foundation. See [TRADEMARKS.md](./TRADEMARKS.md) for the brand assets policy.


### PR DESCRIPTION
## Por quê

Este projeto deriva do **Chatwoot**, cujo código fora de `enterprise/` é licenciado sob **MIT Expat**.

A MIT permite usar, modificar e redistribuir sob Apache — a licença do projeto continua exatamente como está. Mas ela tem uma condição:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

Esse aviso **não estava no repositório**, e o `NOTICE` atribuía o software inteiro à Evolution Foundation.

## Evidência da origem

O repo nasceu num commit squash (`57eee4d`, "initial community open source release"), que descartou a história anterior — ninguém tinha como ver a procedência olhando o git. A origem se confirma pelo código:

| Marcador | Arquivos |
|---|---|
| `Redis::Alfred` | 39 |
| `InstallationConfig` | 24 |
| `SuperAdmin` | 14 |

São identificadores idiossincráticos do Chatwoot, não nomes genéricos. O próprio time já havia documentado isso em `app/services/filter_service.rb:276` (`# ... upstream Chatwoot`) e no spec correspondente.

## O que muda

- **`LICENSE-chatwoot`** (novo) — texto oficial, copiado **literal** de `github.com/chatwoot/chatwoot` (1581 bytes, conferido byte a byte). Arquivo separado para não conflitar com o `LICENSE` Apache do projeto.
- **`NOTICE`** — nova seção `Third-party software` creditando Chatwoot Inc. e apontando o arquivo.
- **`README.md`** — mesma referência na seção `License` já existente.

## O que NÃO muda

- O `LICENSE` Apache 2.0 do projeto fica intacto.
- Nenhum código é removido ou alterado.
- Não há `enterprise/` neste repo — a cláusula do `LICENSE-chatwoot` sobre aquele diretório não se aplica (é justamente a parte **não-MIT** do Chatwoot, que já havia sido removida na origem do fork).

## Relação com a PR #284

Escopo diferente e independente. A #284 remove o provider `baileys` (código morto). Esta apenas acrescenta atribuição. Podem ser revisadas e mergeadas em qualquer ordem.

## Summary by Sourcery

Credit Chatwoot Inc. and include its MIT license notices alongside the project's existing Apache 2.0 license.

Enhancements:
- Add explicit attribution for Chatwoot software reused under the MIT Expat license while preserving the project's Apache 2.0 licensing.

Documentation:
- Document the Chatwoot attribution and license references in the README and NOTICE files.

Chores:
- Add the official Chatwoot MIT license text in a separate LICENSE-chatwoot file.