### PR TITLE
ci(rbac): põe a visibilidade de inbox no staleness guard + tira o else morto irmão (CRM-179 review)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -106,6 +106,15 @@ on:
       - 'app/services/ai/migration_state.rb'
       - 'spec/requests/api/v1/ai_credentials_migration_state_spec.rb'
       - 'spec/services/ai/migration_state_spec.rb'
+      # CRM-179/CRM-183: `assigned_inboxes` is the whole of inbox visibility, and it
+      # deliberately has no zero-membership fallback — an agent sees nothing until
+      # assigned. Restoring that fallback, or short-circuiting the finder on a
+      # permission again, hands every inbox to every agent and answers 200. No other
+      # lane touches the finder or the model method that decide it.
+      - 'app/finders/conversation_finder.rb'
+      - 'app/models/user.rb'
+      - 'spec/finders/conversation_finder_spec.rb'
+      - 'spec/models/user_assigned_inboxes_spec.rb'
 
 permissions:
   contents: read
@@ -198,4 +207,6 @@ jobs:
             spec/requests/api/v1/contacts/notes_spec.rb \
             spec/requests/api/v1/ai_credentials_migration_state_spec.rb \
             spec/services/ai/migration_state_spec.rb \
+            spec/finders/conversation_finder_spec.rb \
+            spec/models/user_assigned_inboxes_spec.rb \
             --format progress

--- a/app/services/conversations/cached_count_service.rb
+++ b/app/services/conversations/cached_count_service.rb
@@ -60,12 +60,10 @@ class Conversations::CachedCountService
     query
   end
 
+  # Only reached when `@filters[:inbox_id]` is set (see #apply_filters).
+  # Narrowing `assigned_inboxes` drops an inbox the user may not access.
   def apply_inbox_filter(query)
-    inbox_ids = if @filters[:inbox_id]
-                  @user.assigned_inboxes.where(id: @filters[:inbox_id]).pluck(:id)
-                else
-                  @user.assigned_inboxes.pluck(:id)
-                end
+    inbox_ids = @user.assigned_inboxes.where(id: @filters[:inbox_id]).pluck(:id)
 
     query.where(inbox_id: inbox_ids)
   end


### PR DESCRIPTION
## Contexto

Follow-ups do code review do **CRM-179** (a entrega em si — PR #276 — está correta e verificada; estes são os dois MEDIUM levantados na revisão).

## M1 — o spec de regressão não rodava em lane nenhuma

O PR #276 adicionou a `conversation_finder_spec.rb` o caso que prova que um não-admin **nunca** escapa do escopo de `assigned_inboxes`. Só que nenhum workflow do repo executa esse arquivo:

- `community-parity.yml` roda `spec/rbac` + `spec/requests/api/v1/*_rbac_spec.rb`;
- `spec-staleness-guard.yml` é allowlist dupla (`paths:` + lista fixa no `run:`) e `spec/finders/**` não está em nenhuma das duas;
- `docker-publish.yml` builda com `BUNDLE_WITHOUT=development:test`.

Não existe lane de suíte completa — nem na `develop`, nem na `main`. Mesma situação do `spec/models/user_assigned_inboxes_spec.rb` (pré-existente), que é quem cobre o no-fallback de verdade, contra o banco.

Os dois entram no `spec-staleness-guard.yml`, junto com os arquivos que os disparam (`app/finders/conversation_finder.rb`, `app/models/user.rb`).

## M2 — `else` morto irmão

`ConversationFinder#apply_inbox_filter` teve o `if/else` inalcançável removido no #276. `CachedCountService#apply_inbox_filter` tem o mesmo padrão — `apply_filters` só o chama `if @filters[:inbox_id]` —, e o arquivo foi tocado no mesmo PR. Fecha a limpeza.

## Verificação

Lane inteira do `spec-staleness-guard` rodada localmente (ruby 3.4.4 + pg14 + redis7), já com as duas adições: **418 exemplos, 0 falhas**.

Teste de mutação no caso novo (reintroduzindo `return query if assigned_inboxes.empty?` — o fallback de zero-membership que o card descreve): fica **vermelho pelo motivo certo** (`expected ScopedToNone, got Relation`). O guard passa a valer alguma coisa.

## Summary by Sourcery

Strengthen CI coverage for assigned-inbox visibility and simplify cached conversation inbox filtering.

Enhancements:
- Ensure inbox visibility regression specs run in the staleness-guard workflow alongside the code that determines access.
- Remove unreachable inbox-filter branching from cached conversation counts.

CI:
- Expand the staleness-guard workflow allowlist and test command to cover conversation finder and assigned-inbox visibility specs.

Tests:
- Add conversation finder and user assigned-inbox regression specs to the staleness-guard lane.