### PR TITLE
fix(macros): correções da 2ª rodada de review do CRM-195

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -70,6 +70,10 @@ on:
       - 'app/services/macros/**'
       - 'spec/services/macros/**'
       - 'spec/requests/api/v1/macros_spec.rb'
+      # CRM-195: the controller decides which macro a member action even reaches, and
+      # macros_spec is the only lane-covered spec of that round trip. It was missing
+      # from this trigger, so a controller-only change ran without it.
+      - 'app/controllers/api/v1/macros_controller.rb'
       # The webhook body and the realtime payload are the same hash, told apart only
       # by `include_labels_data:`. Wiring `webhook_data` back to the default ships
       # `labels_data` to every customer integration; dropping the field leaves the

--- a/app/controllers/api/v1/macros_controller.rb
+++ b/app/controllers/api/v1/macros_controller.rb
@@ -135,36 +135,24 @@ class Api::V1::MacrosController < Api::V1::BaseController
   end
 
   def fetch_macro
-    # CRM-195: scope the direct-by-id lookup by the SAME visibility rule as the list
-    # (Macro.with_visibility = global + the caller's own personal), instead of a raw
-    # find_by. Otherwise a third party reaches another user's PERSONAL macro by UUID
-    # (show/update/destroy/execute) even though the list hides it — an out-of-scope
-    # read/write. Rendering 404 here halts the before_action chain, so a caller that
-    # DOES hold the action's base permission but targets an out-of-scope id (another
-    # user's personal macro, or an unknown id) gets a uniform 404 — never a 200 leak.
-    # Note the two distinct gates by action: show/update/execute carry a
-    # require_permissions entry that 403s a caller missing macros.read/update/execute
-    # BEFORE this runs; destroy has no such entry, so its key check runs AFTER, in
-    # check_destroy_permission! — which is exactly why the 404 lands before that gate.
+    # CRM-195: scope the direct-by-id lookup by the same rule as the list, so another
+    # user's PERSONAL macro answers 404 instead of leaking through 200/403. The 404
+    # halts the before_action chain — see check_destroy_permission! for what that
+    # ordering costs and why it is worth it.
     @macro = Macro.with_visibility(current_user, params).find_by(id: params[:id])
     macro_not_found if @macro.nil?
   end
 
-  # Macro#set_visibility forces `personal` for every non-admin, so a macro an agent
-  # creates belongs to that agent alone — deleting it is not deleting a shared asset.
-  # Without this carve-out the least-privilege agent (CRM-190 revoked macros.delete)
-  # could create personal macros it can never remove, and no admin could either: they
-  # are absent from Macro.with_visibility for everyone but their owner.
+  # CRM-190 carve-out: Macro#set_visibility forces `personal` for every non-admin, so a
+  # macro an agent creates is its own, not a shared asset — without this it could create
+  # personal macros nobody, not even an admin, is able to remove.
   #
-  # CRM-195 changed the order this gate sees: fetch_macro now scopes by
-  # Macro.with_visibility and renders 404 in the before_action BEFORE this hook runs,
-  # so by the time we get here @macro is always in the caller's scope (their own
-  # personal or a global). An id outside the scope — an unknown id OR another user's
-  # personal macro — already 404'd and never reaches the key check. So this only ever
-  # decides between "own personal → skip the key" and "global → require macros.delete".
-  # This is a deliberate divergence from labels/canned_responses/message_templates,
-  # whose destroy still gates before the fetch (403 for a non-holder on any id): here
-  # hiding "user X has a personal macro at this UUID" outranks a uniform 403.
+  # CRM-195 moved fetch_macro's scoped 404 AHEAD of this gate, so @macro is always in the
+  # caller's scope by now: this only decides "own personal -> skip the key" vs "global ->
+  # require macros.delete". Deliberate divergence from labels/canned_responses/
+  # message_templates, which still gate before the fetch: hiding "user X has a personal
+  # macro at this UUID" outranks a uniform 403. What that leaves open on GLOBAL ids is
+  # pinned by macros_visibility_scope_rbac_spec.
   def check_destroy_permission!
     return if own_personal_macro?
 

--- a/app/models/macro.rb
+++ b/app/models/macro.rb
@@ -40,6 +40,12 @@ class Macro < ApplicationRecord
   end
 
   def self.with_visibility(user, _params)
+    # A service token authenticates with NO user (ServiceTokenAuthConcern) and already
+    # holds elevated access through check_permission!, so scope it to everything like
+    # PipelinePolicy::Scope does. Any other userless caller falls back to globals —
+    # never `nil.id`, which is a 500 on every action that scopes through here.
+    return (Current.service_authenticated ? all : global).order(:id) if user.nil?
+
     records = Macro.global
     records = records.or(personal.where(created_by_id: user.id))
     records.order(:id)

--- a/spec/requests/api/v1/agent_shared_asset_deletes_rbac_spec.rb
+++ b/spec/requests/api/v1/agent_shared_asset_deletes_rbac_spec.rb
@@ -74,16 +74,18 @@ RSpec.describe 'Agent shared-asset deletes RBAC (CRM-190)', type: :request do
   # Macro.with_visibility and renders 404 in the before_action, ahead of
   # check_destroy_permission!. An id outside the caller's scope — unknown OR another
   # user's personal macro — 404s before the gate. That is deliberate: hiding "user X
-  # has a personal macro at this UUID" outranks a uniform 403, and the only records
-  # the :forbidden path protected here were GLOBAL macros, which any macros.read
-  # holder already lists. Global macros still 403 for a non-holder (they're in scope,
-  # so the fetch finds them and the gate fires) — proven by the "denies the hardened
-  # agent" example above, which uses a global macro.
+  # has a personal macro at this UUID" outranks a uniform 403. The cost is that a GLOBAL
+  # id stays distinguishable from an unknown one (403 vs 404) by a caller holding NO
+  # macro key at all — destroy has no require_permissions entry to stop it before the
+  # fetch. Accepted: a global macro is an account-wide shared asset, and every list
+  # already hands it to any macros.read holder. macros_visibility_scope_rbac_spec pins
+  # that split so it stays a decision instead of drifting back by accident.
   {
     'labels' => { key: 'labels.delete', model: Label, factory: :create_label, unknown_id_status: :forbidden },
     'macros' => { key: 'macros.delete', model: Macro, factory: :create_macro, unknown_id_status: :not_found },
     'canned_responses' => { key: 'canned_responses.delete', model: CannedResponse, factory: :create_canned_response, unknown_id_status: :forbidden },
-    'message_templates' => { key: 'message_templates.delete', model: MessageTemplate, factory: :create_message_template, unknown_id_status: :forbidden }
+    'message_templates' => { key: 'message_templates.delete', model: MessageTemplate,
+                             factory: :create_message_template, unknown_id_status: :forbidden }
   }.each do |resource, spec|
     describe "DELETE /api/v1/#{resource}/:id (#{spec[:key]})" do
       it 'denies the hardened agent and leaves the record in place' do

--- a/spec/requests/api/v1/macros_visibility_scope_rbac_spec.rb
+++ b/spec/requests/api/v1/macros_visibility_scope_rbac_spec.rb
@@ -61,6 +61,15 @@ RSpec.describe 'Macro visibility scope on member actions (CRM-195)', type: :requ
   end
 
   describe 'PATCH /api/v1/macros/:id (update)' do
+    it 'lets the owner update their own personal macro (200)' do
+      login_as(owner, 'macros.update')
+
+      patch "/api/v1/macros/#{personal_macro.id}", params: { name: 'renamed' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(personal_macro.reload.name).to eq('renamed')
+    end
+
     it "404s a third party on another user's personal macro and leaves it unchanged" do
       login_as(third_party, 'macros.update')
 
@@ -121,12 +130,76 @@ RSpec.describe 'Macro visibility scope on member actions (CRM-195)', type: :requ
   end
 
   describe 'POST /api/v1/macros/:id/execute (execute)' do
+    it 'lets the owner execute their own personal macro (200)' do
+      login_as(owner, 'macros.execute')
+
+      post "/api/v1/macros/#{personal_macro.id}/execute", params: { conversation_ids: [] }, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
     it "404s a third party on another user's personal macro" do
       login_as(third_party, 'macros.execute')
 
       post "/api/v1/macros/#{personal_macro.id}/execute", params: { conversation_ids: [] }, as: :json
 
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # The scoped fetch reads `current_user`, and a service token authenticates with none
+  # (ServiceTokenAuthConcern). Before the Macro.with_visibility nil guard this raised
+  # NoMethodError on `nil.id` and every member action answered 500 — invisible to every
+  # lane, because nothing else exercises the service-token path on macros.
+  describe 'service-token caller (no user in Current)' do
+    around do |example|
+      previous = ENV.fetch('EVOAI_CRM_API_TOKEN', nil)
+      ENV['EVOAI_CRM_API_TOKEN'] = 'service-token-probe'
+      example.run
+      ENV['EVOAI_CRM_API_TOKEN'] = previous
+    end
+
+    let(:service_headers) { { 'X-Service-Token' => 'service-token-probe' } }
+
+    it 'reads a macro instead of crashing on the nil user' do
+      get "/api/v1/macros/#{global_macro.id}", headers: service_headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'is elevated, like the policies: it also reads another user\'s personal macro' do
+      get "/api/v1/macros/#{personal_macro.id}", headers: service_headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # Pins the 403-vs-404 split the 404-first order leaves behind, so it stays a decision.
+  # A caller with NO macro key at all still separates an existing GLOBAL id (403, from
+  # check_destroy_permission!) from an unknown one (404, from the scoped fetch), because
+  # destroy carries no require_permissions entry to stop it before the fetch. Accepted:
+  # a global macro is an account-wide shared asset. A personal macro must NOT be
+  # separable that way — that is the leak CRM-195 closed.
+  describe 'DELETE with no macro permission at all — what the 404-first order still tells' do
+    before { login_as(third_party) }
+
+    it 'answers 404 for an unknown id' do
+      delete "/api/v1/macros/#{SecureRandom.uuid}", as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'answers 403 for an existing GLOBAL macro (accepted: shared asset)' do
+      delete "/api/v1/macros/#{global_macro.id}", as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "answers 404 for another user's PERSONAL macro — indistinguishable from unknown" do
+      delete "/api/v1/macros/#{personal_macro.id}", as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(Macro.exists?(personal_macro.id)).to be(true)
     end
   end
 end


### PR DESCRIPTION
Correções da segunda rodada de review do **CRM-195** (#287). Alvo é a branch do card, não a `develop` — o merge aqui entra dentro do #287.

## 🔴 Regressão: chamada por service token virou 500

`fetch_macro` passou a scopar por `Macro.with_visibility(current_user, params)`, e um request com `X-Service-Token` **não tem `Current.user`** — o próprio `ServiceTokenAuthConcern#set_service_authenticated_context` diz isso em comentário. `macro.rb:44` faz `user.id` sem guarda.

Contraprova rodada nos dois commits, mesmo probe:

| `GET /api/v1/macros/:id` com service token | resultado |
|---|---|
| base `2b3c252` (pré-PR) | **200** |
| head `44d0881` | **500** `undefined method 'id' for nil` |

Vale para `show`/`update`/`destroy`/`execute`. O `index` **já** estava 500 assim antes do PR — por isso a guarda vai no model e conserta os cinco pontos de uma vez:

```ruby
return (Current.service_authenticated ? all : global).order(:id) if user.nil?
```

Service token vê tudo, como `PipelinePolicy::Scope` já faz; qualquer outro caller sem usuário cai em globais (fail-closed) em vez de estourar. Sem consumidor vivo hoje — o Darwin faz bearer-relay do operador nos tools de CRM (`catalog.go:9`), e `X-Service-Token` lá só serve o KB. Era 500 latente que nenhuma lane via.

## 🟡 O `403` vs `404` que a ordem 404-first deixa aberto

Com **zero chaves de macro**, um caller separa id global existente (403) de id inexistente (404), porque `destroy` não tem entrada em `require_permissions` e o fetch roda antes do gate:

| alvo | base `2b3c252` | head `44d0881` |
|---|---|---|
| uuid inexistente | 403 | **404** |
| macro GLOBAL existente | 403 | **403** |
| pessoal de terceiro | 403 | **404** |

A parte que importa está certa: pessoal alheia é indistinguível de inexistente — é o furo que o card fechou. O split em id global fica aceito (macro global é ativo compartilhado da conta), mas agora é **contrato testado**, não acidente. O comentário do spec dizia que só portador de `macros.read` alcançava isso; não precisa de chave nenhuma.

## 🟡 O `macros_spec.rb` não rodou neste PR

Ele já está na lista de execução do `spec-staleness-guard`, mas o trigger só nomeava `app/services/macros/**`. Mudança só de controller — esta — pulava a lane. Uma linha resolve.

## 🟢 Comentário e cobertura

- O mesmo racional estava escrito 3× (`fetch_macro`, `check_destroy_permission!`, spec do CRM-190). `check_destroy_permission!` ficou dono único (15 → 9 linhas); `fetch_macro` foi de 11 → 4 apontando pra lá.
- Dono não tinha exemplo verde em `update`/`execute` depois da mudança de escopo. Tem agora.
- Lint: corrigidas as duas ofensas que **este PR** introduziu (`Style/FetchEnvVar`, `Layout/LineLength` 152 na tabela `unknown_id_status`). O resto do RuboCop nesses arquivos é pré-existente.

## QA

| verificação | resultado |
|---|---|
| `community-parity` (roda em todo PR) | **268 examples, 0 failures, 1 pending** (era 261; o pending é ambiental) |
| alvos de macro do `spec-staleness-guard` | **56 examples, 0 failures** |
| red-check da guarda de service token | 2/2 vermelhos sem ela (500) |
| red-check do lock de admin (do #287) | 2/2 vermelhos com ramo admin injetado — o lock tem dente |

## Summary by Sourcery

Harden macro visibility and authorization behavior across userless service-token requests and member actions.

Bug Fixes:
- Prevent service-token macro requests from failing with a 500 when no current user is present.
- Preserve 404 behavior for inaccessible personal macros while explicitly covering the accepted 403 response for existing global macros.

Enhancements:
- Consolidate macro visibility and deletion-permission rationale in controller comments.

CI:
- Ensure controller changes trigger the macro request specs in the staleness-guard workflow.

Tests:
- Add coverage for owners updating and executing personal macros.
- Add service-token coverage for global and personal macro access.
- Pin DELETE authorization behavior for unknown, global, and third-party personal macro IDs.