### PR TITLE
fix(rbac): dono da macro pessoal continua editando a dele (CRM-70 — review)

### DIFF
--- a/app/controllers/api/v1/macros_controller.rb
+++ b/app/controllers/api/v1/macros_controller.rb
@@ -1,22 +1,23 @@
 class Api::V1::MacrosController < Api::V1::BaseController
   # Use-vs-manage split (CRM-70): reading and executing are attendance and stay
   # on read/execute; creating and editing are Settings-screen management and
-  # demand macros.manage (admin roles only).
+  # demand macros.manage (admin roles only) — except on a personal macro, which
+  # its owner keeps editing and deleting (see check_update_permission! below).
   require_permissions({
     index: 'macros.read',
     show: 'macros.read',
     create: 'macros.manage',
-    update: 'macros.manage',
     execute: 'macros.execute'
   })
 
-  # `destroy` is not in require_permissions because its check depends on the record,
-  # so it has to run after fetch_macro. It still answers to the conventional
-  # check_<action>_permission! hook (see below), which is what the mutating-actions
-  # gate guard and the permission-key conformance registry look for.
+  # `update` and `destroy` are not in require_permissions because their check
+  # depends on the record, so it has to run after fetch_macro. They still answer to
+  # the conventional check_<action>_permission! hook (see below), which is what the
+  # mutating-actions gate guard and the permission-key conformance registry look for.
   EvoPermissionConcern.register_permission_key('macros.delete')
 
   before_action :fetch_macro, only: [:show, :update, :destroy, :execute]
+  before_action :check_update_permission!, only: [:update]
   before_action :check_destroy_permission!, only: [:destroy]
 
   def index
@@ -147,6 +148,16 @@ class Api::V1::MacrosController < Api::V1::BaseController
 
   def fetch_macro
     @macro = Macro.find_by(id: params[:id])
+  end
+
+  # Same carve-out as destroy, for the same reason: a personal macro is not a shared
+  # asset, so its owner keeps editing it without macros.manage (CRM-70 moved
+  # create/update to that admin-only key). Without this the owner of a personal macro
+  # could run it and delete it but never fix a typo in it.
+  def check_update_permission!
+    return if own_personal_macro?
+
+    check_permission!('macros.manage', :user)
   end
 
   # Macro#set_visibility forces `personal` for every non-admin, so a macro an agent

--- a/spec/requests/api/v1/use_vs_manage_rbac_spec.rb
+++ b/spec/requests/api/v1/use_vs_manage_rbac_spec.rb
@@ -74,6 +74,38 @@ RSpec.describe 'Use-vs-manage RBAC (macros, message templates)', type: :request 
 
       expect(response).to have_http_status(:forbidden)
     end
+
+    # A personal macro is not a shared asset (Macro#set_visibility forces
+    # `personal` for every non-admin), so its owner keeps editing it without
+    # macros.manage — the same carve-out destroy has since CRM-190. Otherwise the
+    # owner could run and delete its macro but never fix a typo in it.
+    context 'personal macro carve-out' do
+      let(:personal_macro) do
+        Macro.create!(name: "p-#{SecureRandom.hex(4)}", visibility: 'personal',
+                      created_by: user, updated_by: user,
+                      actions: [{ 'action_name' => 'add_label', 'action_params' => ['spec'] }])
+      end
+
+      it 'lets the owner edit its own personal macro with the agent key set' do
+        grant_permissions(*agent_keys)
+
+        patch "/api/v1/macros/#{personal_macro.id}", params: { name: 'Corrigida' }, as: :json
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'does not extend the carve-out to someone else personal macro' do
+        other = User.create!(name: 'Other', email: "other-#{SecureRandom.hex(4)}@example.com")
+        foreign = Macro.create!(name: "f-#{SecureRandom.hex(4)}", visibility: 'personal',
+                                created_by: other, updated_by: other,
+                                actions: [{ 'action_name' => 'add_label', 'action_params' => ['spec'] }])
+        grant_permissions(*agent_keys)
+
+        patch "/api/v1/macros/#{foreign.id}", params: { name: 'Invadida' }, as: :json
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe 'message templates' do


### PR DESCRIPTION
Correção do code review da #290. **Base é a branch da #290**, então o diff aqui é só o delta.

## M1 — o atendente perdia a edição da própria macro pessoal

O `update` foi para `macros.manage` sem o carve-out que o `destroy` tem desde o CRM-190. Saldo para o atendente na macro pessoal **dele**: executa, apaga — e toma 403 para corrigir um typo.

A decisão de produto registrada no card diz "as macros pessoais já existentes seguem funcionando e deletáveis pelo dono; o que acaba é a criação de novas". Edição não estava na lista, e como a criação acabou, o estoque só encolhe: cada correção necessária vira "apaga e não recria".

`Macro#set_visibility` força `personal` para todo não-admin, então a macro que o atendente tem é dele sozinho — some do `with_visibility` de qualquer outro. Editá-la não é mexer em ativo compartilhado, que é exatamente o raciocínio que sustentou o carve-out do delete.

- `update` sai do `require_permissions` (a checagem depende do registro, tem que rodar depois do `fetch_macro`) e ganha `check_update_permission!`, no mesmo molde do `destroy`
- id desconhecido cai na checagem de chave, então quem não tem `manage` segue tomando 403 antes de 404
- o guard `mutating_actions_gate_guard` aceita o hook como método privado, igual ao do destroy

Sem escalonamento de privilégio: `agent?` é `!administrator?`, então `set_visibility` força `personal` para qualquer um fora dos quatro papéis admin — que já têm `macros.manage`. Ninguém promove a própria macro a global por essa porta.

## Specs

- dono edita a pessoal dele com o conjunto de chaves do agente (`macros.read`, `macros.execute`, `message_templates.read`)
- macro pessoal de OUTRO usuário continua 403
- macro global segue exigindo `manage` (exemplo que já existia)

## Validação

`use_vs_manage_rbac` + `mutating_actions_gate_guard` + `permission_key_catalog_conformance` + `message_templates`: **37 exemplos, 0 falhas**.

O `permission_key_catalog_conformance` rodou também com o `evo-auth-service-community` montado como repo irmão — o exemplo que normalmente fica `pending` executou e passou, confirmando que o espelho regenerado bate com o SSOT (332 chaves).

## Summary by Sourcery

Preserve owner editing access for personal macros while maintaining management restrictions for shared and foreign macros.

Bug Fixes:
- Allow owners to update their own personal macros without requiring `macros.manage`, while continuing to restrict edits to other users’ personal macros and global macros.

Enhancements:
- Align update authorization with the existing record-specific delete permission handling for personal macros.

Tests:
- Add request coverage for owner updates to personal macros and rejection of updates to another user’s personal macro.