### PR TITLE
fix(agent-bot): name the rule that silences the bot (CRM-212)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -126,6 +126,13 @@ on:
       - 'app/models/user.rb'
       - 'spec/finders/conversation_finder_spec.rb'
       - 'spec/models/user_assigned_inboxes_spec.rb'
+      # CRM-212: this gate is the whole of "does the bot get the message", and the
+      # reason it reports is the only way an operator can tell which of the three
+      # rules rejected. Every call site logs it; nothing else covers it.
+      - 'app/models/agent_bot_inbox.rb'
+      - 'app/listeners/agent_bot_listener.rb'
+      - 'app/services/agent_bots/**'
+      - 'spec/models/agent_bot_inbox_spec.rb'
 
 permissions:
   contents: read
@@ -220,6 +227,7 @@ jobs:
             spec/services/ai/migration_state_spec.rb \
             spec/finders/conversation_finder_spec.rb \
             spec/models/user_assigned_inboxes_spec.rb \
+            spec/models/agent_bot_inbox_spec.rb \
             spec/services/labels/token_resolver_spec.rb \
             spec/controllers/concerns/label_concern_spec.rb \
             spec/services/automation_rules/contact_action_service_spec.rb \

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -150,8 +150,8 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(conversation)
-          Rails.logger.info "[AgentBot Listener] Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)"
+        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
+          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
           return
         end
       else
@@ -165,15 +165,15 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(conversation)
-          Rails.logger.info "[AgentBot Listener] Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)"
+        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
+          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
           return
         end
       end
     else
       # For non-Facebook conversations, check status and labels (includes ignored labels check)
-      if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(conversation)
-        Rails.logger.info "[AgentBot Listener] Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)"
+      if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
+        Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
         return
       end
     end
@@ -305,8 +305,8 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(conversation)
-          Rails.logger.info "[AgentBot Listener] Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)"
+        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
+          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
           return
         end
       else
@@ -320,15 +320,15 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(conversation)
-          Rails.logger.info "[AgentBot Listener] Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)"
+        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
+          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
           return
         end
       end
     else
       # For non-Facebook conversations, check status and labels (includes ignored labels check)
-      if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(conversation)
-        Rails.logger.info "[AgentBot Listener] Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)"
+      if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
+        Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
         return
       end
     end

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -150,10 +150,7 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       else
         # Regular Facebook Messenger direct message
         Rails.logger.info "[AgentBot Listener] Facebook Messenger direct message detected"
@@ -165,17 +162,11 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       end
     else
       # For non-Facebook conversations, check status and labels (includes ignored labels check)
-      if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-        Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-        return
-      end
+      return if skip_for_gate?(agent_bot_inbox, conversation)
     end
 
     method_name = __method__.to_s
@@ -305,10 +296,7 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       else
         # Regular Facebook Messenger direct message
         Rails.logger.info "[AgentBot Listener] Facebook Messenger direct message detected"
@@ -320,17 +308,11 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       end
     else
       # For non-Facebook conversations, check status and labels (includes ignored labels check)
-      if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-        Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-        return
-      end
+      return if skip_for_gate?(agent_bot_inbox, conversation)
     end
 
     method_name = __method__.to_s
@@ -388,7 +370,20 @@ class AgentBotListener < BaseListener
     agent_bot_inbox = inbox.agent_bot_inbox
     return true if agent_bot_inbox.blank? # Mantém comportamento antigo se não houver configuração
 
-    agent_bot_inbox.should_process_conversation?(conversation)
+    !skip_for_gate?(agent_bot_inbox, conversation, label: 'conversation event')
+  end
+
+  # CRM-212: the status/label gate silently decided whether the bot was reached.
+  # Logging the reason here is what turns "the AI stopped answering" into a
+  # question an operator can answer from the log alone.
+  def skip_for_gate?(agent_bot_inbox, conversation, label: 'message')
+    return false if agent_bot_inbox.blank?
+
+    skip_reason = agent_bot_inbox.processing_block_reason(conversation)
+    return false if skip_reason.nil?
+
+    Rails.logger.info "[AgentBot Listener] Skipping #{label} - conv #{conversation.id}: #{skip_reason}"
+    true
   end
 
   # Get the appropriate agent bot for a message

--- a/app/models/agent_bot_inbox.rb
+++ b/app/models/agent_bot_inbox.rb
@@ -61,20 +61,19 @@ class AgentBotInbox < ApplicationRecord
 
   # Check if conversation status is allowed
   # Default to 'pending' if no statuses are configured
+  #
+  # CRM-212: this is the gate operators hit most often, and it is invisible from
+  # the UI — the default (pending only) silences the bot as soon as the status
+  # leaves `pending` (e.g. an agent takes the conversation and it becomes `open`).
+  # `processing_block_reason` names it so the log says WHICH rule rejected and
+  # with which values, instead of the previous generic "status/labels" message.
   def allows_conversation_status?(status)
     status_str = status.to_s
-    Rails.logger.info "[AgentBotInbox] allows_conversation_status? - status: #{status.inspect} (#{status.class}), status_str: #{status_str}, allowed_statuses: #{allowed_conversation_statuses.inspect}"
 
     # If no statuses configured, default to pending only
-    if allowed_conversation_statuses.blank?
-      result = status_str == 'pending'
-      Rails.logger.info "[AgentBotInbox] No statuses configured, defaulting to pending check: #{result}"
-      return result
-    end
+    return status_str == 'pending' if allowed_conversation_statuses.blank?
 
-    result = allowed_conversation_statuses.include?(status_str)
-    Rails.logger.info "[AgentBotInbox] Status check result: #{result} (looking for #{status_str} in #{allowed_conversation_statuses.inspect})"
-    result
+    allowed_conversation_statuses.include?(status_str)
   end
 
   # Check if conversation has any allowed label
@@ -106,18 +105,36 @@ class AgentBotInbox < ApplicationRecord
 
   # Check if conversation matches all conditions
   def should_process_conversation?(conversation)
-    # First check if conversation has ignored labels - if so, don't process
+    processing_block_reason(conversation).nil?
+  end
+
+  # Why this conversation is NOT eligible for the bot, or nil when it is.
+  #
+  # CRM-212: "the AI stopped answering after I moved the card" is almost always
+  # this gate, but the operator had no way to see it — the listener logged a
+  # generic "does not match configuration criteria (status/labels/ignored_labels)"
+  # without saying which rule rejected, nor the values involved. Moving the card
+  # is not what silences the bot: a conversation status change is what triggers
+  # the stage automation (PipelineStageAutomationListener::TRIGGER_KEYS) AND what
+  # trips this gate — the card moving and the bot going quiet are two effects of
+  # the same cause.
+  #
+  # Returns a short, log-safe string (no message content, no PII).
+  def processing_block_reason(conversation)
     if has_ignored_labels?(conversation)
-      return false
+      return "ignored_label present (ignored_label_ids=#{ignored_label_ids.inspect})"
     end
 
-    status_allowed = allows_conversation_status?(conversation.status)
-    labels_allowed = allows_conversation_labels?(conversation)
+    unless allows_conversation_status?(conversation.status)
+      configured = allowed_conversation_statuses.presence || ['pending (default: none configured)']
+      return "status #{conversation.status.inspect} not in allowed_conversation_statuses=#{configured.inspect}"
+    end
 
-    return false unless status_allowed
-    return false unless labels_allowed
+    unless allows_conversation_labels?(conversation)
+      return "no allowed label on conversation/contact (allowed_label_ids=#{allowed_label_ids.inspect})"
+    end
 
-    true
+    nil
   end
 
   # Get the appropriate agent bot for a conversation

--- a/app/models/agent_bot_inbox.rb
+++ b/app/models/agent_bot_inbox.rb
@@ -61,12 +61,6 @@ class AgentBotInbox < ApplicationRecord
 
   # Check if conversation status is allowed
   # Default to 'pending' if no statuses are configured
-  #
-  # CRM-212: this is the gate operators hit most often, and it is invisible from
-  # the UI — the default (pending only) silences the bot as soon as the status
-  # leaves `pending` (e.g. an agent takes the conversation and it becomes `open`).
-  # `processing_block_reason` names it so the log says WHICH rule rejected and
-  # with which values, instead of the previous generic "status/labels" message.
   def allows_conversation_status?(status)
     status_str = status.to_s
 
@@ -110,15 +104,9 @@ class AgentBotInbox < ApplicationRecord
 
   # Why this conversation is NOT eligible for the bot, or nil when it is.
   #
-  # CRM-212: "the AI stopped answering after I moved the card" is almost always
-  # this gate, but the operator had no way to see it — the listener logged a
-  # generic "does not match configuration criteria (status/labels/ignored_labels)"
-  # without saying which rule rejected, nor the values involved. Moving the card
-  # is not what silences the bot: a conversation status change is what triggers
-  # the stage automation (PipelineStageAutomationListener::TRIGGER_KEYS) AND what
-  # trips this gate — the card moving and the bot going quiet are two effects of
-  # the same cause.
-  #
+  # CRM-212: the rule that rejected was never logged, so "the AI stopped
+  # answering" could not be told apart from a status, an allowed label or an
+  # ignored label. Callers log this instead of a generic phrase.
   # Returns a short, log-safe string (no message content, no PII).
   def processing_block_reason(conversation)
     if has_ignored_labels?(conversation)
@@ -126,8 +114,8 @@ class AgentBotInbox < ApplicationRecord
     end
 
     unless allows_conversation_status?(conversation.status)
-      configured = allowed_conversation_statuses.presence || ['pending (default: none configured)']
-      return "status #{conversation.status.inspect} not in allowed_conversation_statuses=#{configured.inspect}"
+      configured = allowed_conversation_statuses.presence&.inspect || '[] (default: pending only)'
+      return "status #{conversation.status.inspect} not in allowed_conversation_statuses=#{configured}"
     end
 
     unless allows_conversation_labels?(conversation)

--- a/app/services/agent_bots/inactivity_actions_service.rb
+++ b/app/services/agent_bots/inactivity_actions_service.rb
@@ -170,9 +170,8 @@ class AgentBots::InactivityActionsService
     # A validação completa será feita novamente quando a resposta voltar (no MessageCreator)
     # mas fazemos uma pré-validação aqui para evitar requests desnecessários
     agent_bot_inbox = @inbox.agent_bot_inbox
-    if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(@conversation)
-      Rails.logger.warn "[InactivityActions] ⚠️  Conversation #{@conversation.id} does not match bot criteria (status/labels)"
-      Rails.logger.warn "[InactivityActions] Status: #{@conversation.status}, Allowed: #{agent_bot_inbox.allowed_conversation_statuses.inspect}"
+    if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(@conversation))
+      Rails.logger.warn "[InactivityActions] ⚠️  Conversation #{@conversation.id} not eligible: #{skip_reason}"
       Rails.logger.warn "[InactivityActions] Skipping inactivity action to avoid sending request to bot that won't be able to reply"
       return
     end

--- a/app/services/agent_bots/message_creator.rb
+++ b/app/services/agent_bots/message_creator.rb
@@ -18,14 +18,11 @@ class AgentBots::MessageCreator
     return if content.blank? && media.blank?
 
     # If force is true, skip eligibility check (e.g., for final response after transfer)
-    unless force
-      unless conversation_eligible_for_bot_reply?(conversation)
-        Rails.logger.warn "[AgentBot HTTP] ⚠️  Bot response blocked - conversation #{conversation.id} not eligible for bot reply"
-        Rails.logger.warn "[AgentBot HTTP] This can happen if status/labels/ignored_labels don't match bot configuration"
-        return
-      end
-    else
+    if force
       Rails.logger.info "[AgentBot HTTP] Force creating bot reply (skipping eligibility check) in conversation #{conversation.id}"
+    else
+      # conversation_eligible_for_bot_reply? already logs which rule rejected.
+      return unless conversation_eligible_for_bot_reply?(conversation)
     end
 
     Rails.logger.info "[AgentBot HTTP] Creating bot reply in conversation #{conversation.id} (#{media.size} media)"
@@ -61,22 +58,13 @@ class AgentBots::MessageCreator
       return is_pending
     end
 
-    # Use the same logic as AgentBotListener: check if conversation matches configuration
-    Rails.logger.info "[AgentBot HTTP] Checking conversation eligibility for bot reply:"
-    Rails.logger.info "[AgentBot HTTP]   Conversation: #{conversation.id} (status: #{conversation.status})"
-    Rails.logger.info "[AgentBot HTTP]   Allowed statuses: #{agent_bot_inbox.allowed_conversation_statuses.inspect}"
-    Rails.logger.info "[AgentBot HTTP]   Allowed labels: #{agent_bot_inbox.allowed_label_ids.inspect}"
-    Rails.logger.info "[AgentBot HTTP]   Ignored labels: #{agent_bot_inbox.ignored_label_ids.inspect}"
+    # CRM-212: same gate as AgentBotListener, and the reply is discarded here
+    # AFTER the LLM already ran — so the log has to name the rule that rejected.
+    skip_reason = agent_bot_inbox.processing_block_reason(conversation)
+    return true if skip_reason.nil?
 
-    eligible = agent_bot_inbox.should_process_conversation?(conversation)
-
-    if eligible
-      Rails.logger.info "[AgentBot HTTP] ✅ Conversation is eligible for bot reply"
-    else
-      Rails.logger.warn "[AgentBot HTTP] ❌ Conversation NOT eligible - failed status/labels/ignored_labels check"
-    end
-
-    eligible
+    Rails.logger.warn "[AgentBot HTTP] ❌ reply discarded - conv #{conversation.id}: #{skip_reason}"
+    false
   end
 
   def create_message_with_fallback(content, conversation, content_type:, content_attributes:, media: [])

--- a/app/services/agent_bots/segmented_message_creator.rb
+++ b/app/services/agent_bots/segmented_message_creator.rb
@@ -93,10 +93,12 @@ class AgentBots::SegmentedMessageCreator
       return is_pending
     end
 
-    # Use the same logic as AgentBotListener: check if conversation matches configuration
-    eligible = agent_bot_inbox.should_process_conversation?(conversation)
-    Rails.logger.info "[AgentBot Segmented] Conversation status check: #{conversation.status}, Allowed statuses: #{agent_bot_inbox.allowed_conversation_statuses.inspect}, Eligible: #{eligible}"
-    eligible
+    # Same gate as AgentBotListener; the reason names the rule that rejected.
+    skip_reason = agent_bot_inbox.processing_block_reason(conversation)
+    return true if skip_reason.nil?
+
+    Rails.logger.warn "[AgentBot Segmented] reply discarded - conv #{conversation.id}: #{skip_reason}"
+    false
   end
 
   def media_segment?(segment)

--- a/app/services/pipelines/stage_message_actions.rb
+++ b/app/services/pipelines/stage_message_actions.rb
@@ -22,8 +22,8 @@ module Pipelines::StageMessageActions
     end
 
     agent_bot_inbox = conversation.inbox.agent_bot_inbox
-    if agent_bot_inbox.present? && !agent_bot_inbox.should_process_conversation?(conversation)
-      Rails.logger.warn "[StageMessageActions] send_ai_message skipped: conv #{conversation.id} does not match bot criteria"
+    if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
+      Rails.logger.warn "[StageMessageActions] send_ai_message skipped: conv #{conversation.id}: #{skip_reason}"
       return false
     end
 

--- a/spec/models/agent_bot_inbox_spec.rb
+++ b/spec/models/agent_bot_inbox_spec.rb
@@ -20,4 +20,60 @@ RSpec.describe AgentBotInbox do
       expect(agent_bot_inbox.status).to eq('inactive')
     end
   end
+
+  # CRM-212: the operator sees "the AI stopped answering after I moved the card"
+  # and the log only said "does not match configuration criteria
+  # (status/labels/ignored_labels)" — which of the three rejected, and with which
+  # values, was invisible. These lock the reason down so the log can name it.
+  describe '#processing_block_reason' do
+    let(:conversation) { instance_double(Conversation, id: 'conv-1', status: 'open') }
+
+    it 'names the status rule and the configured list when the status is not allowed' do
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['pending'])
+
+      reason = agent_bot_inbox.processing_block_reason(conversation)
+
+      expect(reason).to include('status "open"')
+      expect(reason).to include('allowed_conversation_statuses=["pending"]')
+    end
+
+    # The default is the case that bites in production: nothing is configured, so
+    # only `pending` passes and the bot goes quiet as soon as an agent takes the
+    # conversation (status becomes `open`).
+    it 'spells out that the default is pending-only when nothing is configured' do
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: [])
+
+      reason = agent_bot_inbox.processing_block_reason(conversation)
+
+      expect(reason).to include('pending (default: none configured)')
+    end
+
+    it 'reports the ignored label before any other rule' do
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], ignored_label_ids: ['7'])
+      allow(agent_bot_inbox).to receive(:resolve_label_ids_for_conversation).and_return(['7'])
+
+      expect(agent_bot_inbox.processing_block_reason(conversation)).to include('ignored_label present')
+    end
+
+    it 'reports the allowed-label rule when the conversation carries none of them' do
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], allowed_label_ids: ['9'])
+      allow(agent_bot_inbox).to receive(:resolve_label_ids_for_conversation).and_return(['3'])
+
+      expect(agent_bot_inbox.processing_block_reason(conversation)).to include('no allowed label')
+    end
+
+    it 'returns nil when the conversation is eligible' do
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: %w[pending open])
+
+      expect(agent_bot_inbox.processing_block_reason(conversation)).to be_nil
+    end
+
+    it 'keeps should_process_conversation? in sync with the reason' do
+      blocked = described_class.new(allowed_conversation_statuses: ['pending'])
+      eligible = described_class.new(allowed_conversation_statuses: ['open'])
+
+      expect(blocked.should_process_conversation?(conversation)).to be(false)
+      expect(eligible.should_process_conversation?(conversation)).to be(true)
+    end
+  end
 end

--- a/spec/models/agent_bot_inbox_spec.rb
+++ b/spec/models/agent_bot_inbox_spec.rb
@@ -21,12 +21,18 @@ RSpec.describe AgentBotInbox do
     end
   end
 
-  # CRM-212: the operator sees "the AI stopped answering after I moved the card"
-  # and the log only said "does not match configuration criteria
-  # (status/labels/ignored_labels)" — which of the three rejected, and with which
-  # values, was invisible. These lock the reason down so the log can name it.
+  # CRM-212: the log only said "does not match configuration criteria
+  # (status/labels/ignored_labels)" — which of the three rejected, and with
+  # which values, was invisible. These lock the reason down.
   describe '#processing_block_reason' do
-    let(:conversation) { instance_double(Conversation, id: 'conv-1', status: 'open') }
+    # Tag names that look like UUIDs are already CRM Label ids, so the real
+    # resolution runs here without touching the labels table.
+    let(:ignored_label) { '11111111-1111-4111-8111-111111111111' }
+    let(:allowed_label) { '22222222-2222-4222-8222-222222222222' }
+
+    def conversation(status: 'open', labels: [])
+      instance_double(Conversation, status: status, label_list: labels, contact: nil)
+    end
 
     it 'names the status rule and the configured list when the status is not allowed' do
       agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['pending'])
@@ -45,27 +51,29 @@ RSpec.describe AgentBotInbox do
 
       reason = agent_bot_inbox.processing_block_reason(conversation)
 
-      expect(reason).to include('pending (default: none configured)')
+      expect(reason).to include('allowed_conversation_statuses=[] (default: pending only)')
     end
 
     it 'reports the ignored label before any other rule' do
-      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], ignored_label_ids: ['7'])
-      allow(agent_bot_inbox).to receive(:resolve_label_ids_for_conversation).and_return(['7'])
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], ignored_label_ids: [ignored_label])
 
-      expect(agent_bot_inbox.processing_block_reason(conversation)).to include('ignored_label present')
+      reason = agent_bot_inbox.processing_block_reason(conversation(labels: [ignored_label]))
+
+      expect(reason).to include('ignored_label present')
     end
 
     it 'reports the allowed-label rule when the conversation carries none of them' do
-      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], allowed_label_ids: ['9'])
-      allow(agent_bot_inbox).to receive(:resolve_label_ids_for_conversation).and_return(['3'])
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], allowed_label_ids: [allowed_label])
 
-      expect(agent_bot_inbox.processing_block_reason(conversation)).to include('no allowed label')
+      reason = agent_bot_inbox.processing_block_reason(conversation(labels: [ignored_label]))
+
+      expect(reason).to include('no allowed label')
     end
 
-    it 'returns nil when the conversation is eligible' do
-      agent_bot_inbox = described_class.new(allowed_conversation_statuses: %w[pending open])
+    it 'returns nil when the conversation carries an allowed label and an allowed status' do
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: %w[pending open], allowed_label_ids: [allowed_label])
 
-      expect(agent_bot_inbox.processing_block_reason(conversation)).to be_nil
+      expect(agent_bot_inbox.processing_block_reason(conversation(labels: [allowed_label]))).to be_nil
     end
 
     it 'keeps should_process_conversation? in sync with the reason' do


### PR DESCRIPTION
## Problema

"A IA parou de responder depois que movi o card." O gate existe e funciona, mas era **invisível**: os 8 pontos que barram a delegação logavam a mesma frase genérica —

```
Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)
```

— sem dizer **qual** das três regras reprovou nem **com que valores**. Sem isso não há como diagnosticar em produção, que é exatamente o bloqueio registrado no card ("precisa de dado de runtime do cliente").

## Causa-raiz (a cadeia está invertida no card)

O card supõe que *"a automação do estágio muda status/label da conversa e o gate bloqueia"*. É o contrário:

```ruby
class PipelineStageAutomationListener < BaseListener
  TRIGGER_KEYS = %w[label_list status custom_attributes]   # a CONVERSA mudar é o GATILHO
```
```ruby
SUPPORTED_ACTIONS = %w[move_to_stage move_to_pipeline assign_agent apply_label]  # mover o card é a CONSEQUÊNCIA
```

A sequência real é: **o status da conversa muda** (um agente assume → `pending` → `open`) → isso dispara a automação, que **move o card**, e a mesma mudança faz o gate reprovar → **a IA silencia**. Mover o card e o bot calar são dois efeitos da mesma causa; por isso mexer na automação não resolveria nada.

Comprovado na stack em execução:

```
allowed_conversation_statuses = []   (default)
  status=pending   -> true
  status=open      -> false     ← bot silencia
  status=resolved  -> false
  status=snoozed   -> false
```

## Mudanças

- **`app/models/agent_bot_inbox.rb`** — `processing_block_reason(conversation)` devolve a regra que reprovou e os valores, ou `nil` se elegível. `should_process_conversation?` passou a delegar, então os dois nunca divergem. Removidos 3 `Rails.logger.info` de dentro de `allows_conversation_status?` (duas linhas por chamada, em caminho quente).
- **`app/listeners/agent_bot_listener.rb`** — as 6 mensagens idênticas passam a reportar o motivo e o id da conversa.
- **`app/services/pipelines/stage_message_actions.rb`** e **`app/services/agent_bots/inactivity_actions_service.rb`** — mesmo tratamento nos outros dois pontos.

Cada call site avalia o motivo **uma vez** (atribuição na condição), em vez de perguntar ao gate duas vezes — a primeira versão deste PR chamava `should_process_conversation?` e depois `processing_block_reason` no log, dobrando a resolução de labels no caminho de bloqueio.

Saída antes → depois:
```
- Skipping message - conversation does not match configuration criteria (status/labels/ignored_labels)
+ Skipping message - conv abc-123: status "open" not in allowed_conversation_statuses=["pending (default: none configured)"]
```

Os motivos são curtos e **sem PII**: nada de conteúdo de mensagem ou dado de contato, apenas ids de configuração e o status.

## Comportamento inalterado

O default continua **pending-only**. Este PR torna o bloqueio diagnosticável; **não** amplia quando o bot responde. Ampliar o default mudaria o comportamento de toda instalação no upgrade (inclusive fazendo o bot falar em conversa que um humano já assumiu) — decisão de produto, deliberadamente fora daqui.

## Testes

- `spec/models/agent_bot_inbox_spec.rb` — **8 examples, 0 failures**: um por motivo de reprovação (status configurado, default pending-only, ignored label, allowed label) + o caso elegível + a sincronia com `should_process_conversation?`.
- **Prova negativa:** revertendo apenas o modelo, **5 dos 8 falham**. Restaurado em seguida.
- **Baseline:** `spec/listeners spec/services/pipelines` → **165 examples, 4 failures**, número **idêntico** ao da mesma execução no `develop` limpo (`git stash`). As 4 são pré-existentes, em `spec/listeners/evo_flow/*`, arquivos não tocados aqui.
- **Rubocop** nos arquivos alterados: **109** ofensas contra **115** no baseline — nenhuma introduzida, seis a menos.

## Trade-offs assumidos

1. **`processing_block_reason` é público.** Precisa ser, porque os call sites (listener/serviços) montam o log. A alternativa — devolver o motivo por um segundo valor de retorno — mudaria a assinatura de `should_process_conversation?`, usada em 13 pontos.
2. **A ordem de avaliação mudou.** Antes, `allows_conversation_status?` e `allows_conversation_labels?` eram sempre ambos avaliados; agora há short-circuit no primeiro motivo. É menos trabalho, e nenhum dos dois tem efeito colateral (são leitura pura).
3. **O card pede mais que isto.** A ação de produto sugerida lá — rever o default "só pending" — **não** está neste PR, por ser mudança de comportamento em base instalada.

## Summary by Sourcery

Name the agent-bot eligibility rule that prevents a conversation from being processed so production skips can be diagnosed from logs.

Bug Fixes:
- Make agent-bot eligibility failures actionable by logging whether status, ignored labels, or allowed labels blocked processing, including relevant configuration values.
- Preserve the existing pending-only default and bot eligibility behavior while improving diagnostics across listeners and bot message services.

Enhancements:
- Centralize eligibility-rejection reasoning so should_process_conversation? and all call sites use the same gate result without duplicate evaluation.
- Remove verbose hot-path eligibility logging in favor of concise, conversation-scoped diagnostic messages.

CI:
- Extend the spec staleness guard to cover the agent-bot eligibility model, listeners, services, and associated specs.

Tests:
- Add coverage for status, default status, ignored-label, allowed-label, eligible, and gate-synchronization outcomes.

---

## Ordem de merge

PR único e **independente** — base em `develop`, sem dependência de nenhum outro PR do lote
CRM-210/235/236/237/238. Pode ser mergeado isoladamente.
