### PR TITLE
fix(agent-bot): follow-ups do code review do #295 (CRM-212)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -126,6 +126,13 @@ on:
       - 'app/models/user.rb'
       - 'spec/finders/conversation_finder_spec.rb'
       - 'spec/models/user_assigned_inboxes_spec.rb'
+      # CRM-212: this gate is the whole of "does the bot get the message", and the
+      # reason it reports is the only way an operator can tell which of the three
+      # rules rejected. Every call site logs it; nothing else covers it.
+      - 'app/models/agent_bot_inbox.rb'
+      - 'app/listeners/agent_bot_listener.rb'
+      - 'app/services/agent_bots/**'
+      - 'spec/models/agent_bot_inbox_spec.rb'
 
 permissions:
   contents: read
@@ -220,6 +227,7 @@ jobs:
             spec/services/ai/migration_state_spec.rb \
             spec/finders/conversation_finder_spec.rb \
             spec/models/user_assigned_inboxes_spec.rb \
+            spec/models/agent_bot_inbox_spec.rb \
             spec/services/labels/token_resolver_spec.rb \
             spec/controllers/concerns/label_concern_spec.rb \
             spec/services/automation_rules/contact_action_service_spec.rb \

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -150,10 +150,7 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       else
         # Regular Facebook Messenger direct message
         Rails.logger.info "[AgentBot Listener] Facebook Messenger direct message detected"
@@ -165,17 +162,11 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       end
     else
       # For non-Facebook conversations, check status and labels (includes ignored labels check)
-      if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-        Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-        return
-      end
+      return if skip_for_gate?(agent_bot_inbox, conversation)
     end
 
     method_name = __method__.to_s
@@ -305,10 +296,7 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       else
         # Regular Facebook Messenger direct message
         Rails.logger.info "[AgentBot Listener] Facebook Messenger direct message detected"
@@ -320,17 +308,11 @@ class AgentBotListener < BaseListener
         end
 
         # Check status and labels (includes ignored labels check)
-        if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-          Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-          return
-        end
+        return if skip_for_gate?(agent_bot_inbox, conversation)
       end
     else
       # For non-Facebook conversations, check status and labels (includes ignored labels check)
-      if agent_bot_inbox.present? && (skip_reason = agent_bot_inbox.processing_block_reason(conversation))
-        Rails.logger.info "[AgentBot Listener] Skipping message - conv #{conversation.id}: #{skip_reason}"
-        return
-      end
+      return if skip_for_gate?(agent_bot_inbox, conversation)
     end
 
     method_name = __method__.to_s
@@ -388,7 +370,20 @@ class AgentBotListener < BaseListener
     agent_bot_inbox = inbox.agent_bot_inbox
     return true if agent_bot_inbox.blank? # Mantém comportamento antigo se não houver configuração
 
-    agent_bot_inbox.should_process_conversation?(conversation)
+    !skip_for_gate?(agent_bot_inbox, conversation, label: 'conversation event')
+  end
+
+  # CRM-212: the status/label gate silently decided whether the bot was reached.
+  # Logging the reason here is what turns "the AI stopped answering" into a
+  # question an operator can answer from the log alone.
+  def skip_for_gate?(agent_bot_inbox, conversation, label: 'message')
+    return false if agent_bot_inbox.blank?
+
+    skip_reason = agent_bot_inbox.processing_block_reason(conversation)
+    return false if skip_reason.nil?
+
+    Rails.logger.info "[AgentBot Listener] Skipping #{label} - conv #{conversation.id}: #{skip_reason}"
+    true
   end
 
   # Get the appropriate agent bot for a message

--- a/app/models/agent_bot_inbox.rb
+++ b/app/models/agent_bot_inbox.rb
@@ -61,12 +61,6 @@ class AgentBotInbox < ApplicationRecord
 
   # Check if conversation status is allowed
   # Default to 'pending' if no statuses are configured
-  #
-  # CRM-212: this is the gate operators hit most often, and it is invisible from
-  # the UI — the default (pending only) silences the bot as soon as the status
-  # leaves `pending` (e.g. an agent takes the conversation and it becomes `open`).
-  # `processing_block_reason` names it so the log says WHICH rule rejected and
-  # with which values, instead of the previous generic "status/labels" message.
   def allows_conversation_status?(status)
     status_str = status.to_s
 
@@ -110,15 +104,9 @@ class AgentBotInbox < ApplicationRecord
 
   # Why this conversation is NOT eligible for the bot, or nil when it is.
   #
-  # CRM-212: "the AI stopped answering after I moved the card" is almost always
-  # this gate, but the operator had no way to see it — the listener logged a
-  # generic "does not match configuration criteria (status/labels/ignored_labels)"
-  # without saying which rule rejected, nor the values involved. Moving the card
-  # is not what silences the bot: a conversation status change is what triggers
-  # the stage automation (PipelineStageAutomationListener::TRIGGER_KEYS) AND what
-  # trips this gate — the card moving and the bot going quiet are two effects of
-  # the same cause.
-  #
+  # CRM-212: the rule that rejected was never logged, so "the AI stopped
+  # answering" could not be told apart from a status, an allowed label or an
+  # ignored label. Callers log this instead of a generic phrase.
   # Returns a short, log-safe string (no message content, no PII).
   def processing_block_reason(conversation)
     if has_ignored_labels?(conversation)
@@ -126,8 +114,8 @@ class AgentBotInbox < ApplicationRecord
     end
 
     unless allows_conversation_status?(conversation.status)
-      configured = allowed_conversation_statuses.presence || ['pending (default: none configured)']
-      return "status #{conversation.status.inspect} not in allowed_conversation_statuses=#{configured.inspect}"
+      configured = allowed_conversation_statuses.presence&.inspect || '[] (default: pending only)'
+      return "status #{conversation.status.inspect} not in allowed_conversation_statuses=#{configured}"
     end
 
     unless allows_conversation_labels?(conversation)

--- a/app/services/agent_bots/message_creator.rb
+++ b/app/services/agent_bots/message_creator.rb
@@ -18,14 +18,11 @@ class AgentBots::MessageCreator
     return if content.blank? && media.blank?
 
     # If force is true, skip eligibility check (e.g., for final response after transfer)
-    unless force
-      unless conversation_eligible_for_bot_reply?(conversation)
-        Rails.logger.warn "[AgentBot HTTP] ⚠️  Bot response blocked - conversation #{conversation.id} not eligible for bot reply"
-        Rails.logger.warn "[AgentBot HTTP] This can happen if status/labels/ignored_labels don't match bot configuration"
-        return
-      end
-    else
+    if force
       Rails.logger.info "[AgentBot HTTP] Force creating bot reply (skipping eligibility check) in conversation #{conversation.id}"
+    else
+      # conversation_eligible_for_bot_reply? already logs which rule rejected.
+      return unless conversation_eligible_for_bot_reply?(conversation)
     end
 
     Rails.logger.info "[AgentBot HTTP] Creating bot reply in conversation #{conversation.id} (#{media.size} media)"
@@ -61,22 +58,13 @@ class AgentBots::MessageCreator
       return is_pending
     end
 
-    # Use the same logic as AgentBotListener: check if conversation matches configuration
-    Rails.logger.info "[AgentBot HTTP] Checking conversation eligibility for bot reply:"
-    Rails.logger.info "[AgentBot HTTP]   Conversation: #{conversation.id} (status: #{conversation.status})"
-    Rails.logger.info "[AgentBot HTTP]   Allowed statuses: #{agent_bot_inbox.allowed_conversation_statuses.inspect}"
-    Rails.logger.info "[AgentBot HTTP]   Allowed labels: #{agent_bot_inbox.allowed_label_ids.inspect}"
-    Rails.logger.info "[AgentBot HTTP]   Ignored labels: #{agent_bot_inbox.ignored_label_ids.inspect}"
+    # CRM-212: same gate as AgentBotListener, and the reply is discarded here
+    # AFTER the LLM already ran — so the log has to name the rule that rejected.
+    skip_reason = agent_bot_inbox.processing_block_reason(conversation)
+    return true if skip_reason.nil?
 
-    eligible = agent_bot_inbox.should_process_conversation?(conversation)
-
-    if eligible
-      Rails.logger.info "[AgentBot HTTP] ✅ Conversation is eligible for bot reply"
-    else
-      Rails.logger.warn "[AgentBot HTTP] ❌ Conversation NOT eligible - failed status/labels/ignored_labels check"
-    end
-
-    eligible
+    Rails.logger.warn "[AgentBot HTTP] ❌ reply discarded - conv #{conversation.id}: #{skip_reason}"
+    false
   end
 
   def create_message_with_fallback(content, conversation, content_type:, content_attributes:, media: [])

--- a/app/services/agent_bots/segmented_message_creator.rb
+++ b/app/services/agent_bots/segmented_message_creator.rb
@@ -93,10 +93,12 @@ class AgentBots::SegmentedMessageCreator
       return is_pending
     end
 
-    # Use the same logic as AgentBotListener: check if conversation matches configuration
-    eligible = agent_bot_inbox.should_process_conversation?(conversation)
-    Rails.logger.info "[AgentBot Segmented] Conversation status check: #{conversation.status}, Allowed statuses: #{agent_bot_inbox.allowed_conversation_statuses.inspect}, Eligible: #{eligible}"
-    eligible
+    # Same gate as AgentBotListener; the reason names the rule that rejected.
+    skip_reason = agent_bot_inbox.processing_block_reason(conversation)
+    return true if skip_reason.nil?
+
+    Rails.logger.warn "[AgentBot Segmented] reply discarded - conv #{conversation.id}: #{skip_reason}"
+    false
   end
 
   def media_segment?(segment)

--- a/spec/models/agent_bot_inbox_spec.rb
+++ b/spec/models/agent_bot_inbox_spec.rb
@@ -21,12 +21,18 @@ RSpec.describe AgentBotInbox do
     end
   end
 
-  # CRM-212: the operator sees "the AI stopped answering after I moved the card"
-  # and the log only said "does not match configuration criteria
-  # (status/labels/ignored_labels)" — which of the three rejected, and with which
-  # values, was invisible. These lock the reason down so the log can name it.
+  # CRM-212: the log only said "does not match configuration criteria
+  # (status/labels/ignored_labels)" — which of the three rejected, and with
+  # which values, was invisible. These lock the reason down.
   describe '#processing_block_reason' do
-    let(:conversation) { instance_double(Conversation, id: 'conv-1', status: 'open') }
+    # Tag names that look like UUIDs are already CRM Label ids, so the real
+    # resolution runs here without touching the labels table.
+    let(:ignored_label) { '11111111-1111-4111-8111-111111111111' }
+    let(:allowed_label) { '22222222-2222-4222-8222-222222222222' }
+
+    def conversation(status: 'open', labels: [])
+      instance_double(Conversation, status: status, label_list: labels, contact: nil)
+    end
 
     it 'names the status rule and the configured list when the status is not allowed' do
       agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['pending'])
@@ -45,27 +51,29 @@ RSpec.describe AgentBotInbox do
 
       reason = agent_bot_inbox.processing_block_reason(conversation)
 
-      expect(reason).to include('pending (default: none configured)')
+      expect(reason).to include('allowed_conversation_statuses=[] (default: pending only)')
     end
 
     it 'reports the ignored label before any other rule' do
-      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], ignored_label_ids: ['7'])
-      allow(agent_bot_inbox).to receive(:resolve_label_ids_for_conversation).and_return(['7'])
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], ignored_label_ids: [ignored_label])
 
-      expect(agent_bot_inbox.processing_block_reason(conversation)).to include('ignored_label present')
+      reason = agent_bot_inbox.processing_block_reason(conversation(labels: [ignored_label]))
+
+      expect(reason).to include('ignored_label present')
     end
 
     it 'reports the allowed-label rule when the conversation carries none of them' do
-      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], allowed_label_ids: ['9'])
-      allow(agent_bot_inbox).to receive(:resolve_label_ids_for_conversation).and_return(['3'])
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: ['open'], allowed_label_ids: [allowed_label])
 
-      expect(agent_bot_inbox.processing_block_reason(conversation)).to include('no allowed label')
+      reason = agent_bot_inbox.processing_block_reason(conversation(labels: [ignored_label]))
+
+      expect(reason).to include('no allowed label')
     end
 
-    it 'returns nil when the conversation is eligible' do
-      agent_bot_inbox = described_class.new(allowed_conversation_statuses: %w[pending open])
+    it 'returns nil when the conversation carries an allowed label and an allowed status' do
+      agent_bot_inbox = described_class.new(allowed_conversation_statuses: %w[pending open], allowed_label_ids: [allowed_label])
 
-      expect(agent_bot_inbox.processing_block_reason(conversation)).to be_nil
+      expect(agent_bot_inbox.processing_block_reason(conversation(labels: [allowed_label]))).to be_nil
     end
 
     it 'keeps should_process_conversation? in sync with the reason' do


### PR DESCRIPTION
Follow-ups do code review do #295. Base é a própria branch do card, para o #295 seguir como um PR só depois do merge.

## O que muda

**Dois portões de resposta ficaram sem motivo no #295.** `AgentBots::MessageCreator#conversation_eligible_for_bot_reply?` ainda logava a frase que o PR se propôs a eliminar — e é o portão que descarta a resposta **depois** do LLM já ter rodado. Junto foram os 5 `Rails.logger.info` por resposta que ele emitia em caminho quente (o mesmo custo que o #295 removeu do modelo) e os 2 warns redundantes do chamador. `SegmentedMessageCreator` idem, que só mostrava status.

**`should_process_conversation_event?` descartava em silêncio total.** É o gate de `conversation_resolved` e `conversation_opened` — e `conversation_resolved` é o evento que a automação de estágio dispara no cenário do card. Agora reporta o motivo. O bloco de 4 linhas repetido 6× no listener virou o helper `skip_for_gate?`, compartilhado pelos dois caminhos.

**O comentário do modelo afirmava que o gate é invisível na UI.** Não é: `AgentBotConfigurationForm.tsx` expõe os status permitidos em checkbox, com descrição e dica de vazio; `inboxes_controller.rb:168-173` lê e escreve; `agent_bot_serializer.rb:54` devolve. O que faltava era o motivo no log — é isso que o comentário diz agora. Junto, o bloco de 6 linhas que estava ancorado em `allows_conversation_status?` (mas descrevia `processing_block_reason`) saiu: de 16 linhas de comentário para 5.

**O motivo do default mentia sobre o dado.** `allowed_conversation_statuses=["pending (default: none configured)"]` lê como se a coluna contivesse essa string. Agora: `allowed_conversation_statuses=[] (default: pending only)`.

**O spec novo não rodava em CI nenhuma.** Não estava no `run:` do `spec-staleness-guard.yml`, e `app/models/agent_bot_inbox.rb` / `app/listeners/agent_bot_listener.rb` / `app/services/agent_bots/**` não estavam no `paths:`. O guard passou verde no #295 só porque `app/services/pipelines/**` casou — mas rodou outros specs, não este. Não existe lane de suíte completa no repo.

**Os specs stubavam o método privado `resolve_label_ids_for_conversation`**, então os dois casos de label nunca exercitavam a resolução (tag name vs UUID, conversa + contato). Com `label_list` em formato UUID a resolução real roda sem tocar a tabela `labels` — e os dois casos passam a falhar na prova negativa, o que antes não acontecia.

## Fora deste PR, de propósito

**Acumular os motivos** em vez de reportar só o primeiro: obriga a rodar `allows_conversation_labels?` mesmo quando o status já reprovou, e ele chama `resolve_label_ids_for_conversation` — um round-trip a mais no Postgres por mensagem barrada, em caminho quente, para melhorar marginalmente uma linha de log.

**A causa-raiz descrita no corpo do #295** (*"a cadeia está invertida no card / É o contrário"*) precisa virar o que o próprio comentário do card no Plane diz: são **dois** caminhos independentes convergindo no mesmo gate — `pipeline_item.rb:362,371` → `automation_rule_listener.rb:43` → `conversation_action_handlers` (mover o card muda a conversa) **e** `pipeline_stage_automation_listener` → `stage_automation_service` (mudar a conversa move o card). É edição de texto do #295, não de código.

## Testes

| | resultado |
|---|---|
| `spec/models/agent_bot_inbox_spec.rb` | **8 examples, 0 failures** |
| Prova negativa (modelo revertido ao `develop`) | **5 dos 8 falham** — agora incluindo os 2 de label |
| `spec/listeners` + `spec/services/pipelines` + `spec/services/agent_bots` | **217 ex / 8 falhas** — as mesmas 8 pré-existentes do `develop` (211 ex / 8 falhas), em `action_cable_listener` e `evo_flow/*` |
| Rubocop nos 7 arquivos tocados | **148** contra **161** no baseline — nenhum arquivo subiu |

Diff sobre o head do #295: 6 arquivos, **+72/−83** — o fix ficou menor que o código que substituiu.

## Summary by Sourcery

Make agent-bot processing decisions observable by logging the precise gate that rejects each conversation and ensure the associated coverage runs in CI.

Bug Fixes:
- Report the specific status or label rule that prevents agent-bot processing and replies, including conversation lifecycle events and post-LLM reply discards.
- Correct the logged default allowed-status representation so it accurately reflects pending-only behavior.

Enhancements:
- Consolidate repeated listener gate handling while reducing redundant hot-path response logging.

CI:
- Ensure agent-bot inbox, listener, service, and model specs are selected and executed by the staleness-guard workflow.

Tests:
- Exercise real conversation label resolution in agent-bot inbox specs instead of stubbing the resolver.