### PR TITLE
fix(templates): scope the export's pipelines by visibility (CRM-206)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -133,6 +133,13 @@ on:
       - 'app/listeners/agent_bot_listener.rb'
       - 'app/services/agent_bots/**'
       - 'spec/models/agent_bot_inbox_spec.rb'
+      # CRM-205/CRM-206: the export enumerates macros and pipelines, and these two
+      # specs are the whole proof it does so through each category's visibility
+      # rule — on all three paths (inventory, `all`, explicit id). Nothing else
+      # covers the export, so the code that enumerates triggers what proves it.
+      - 'app/services/templates/**'
+      - 'spec/requests/api/v1/templates_export_visibility_rbac_spec.rb'
+      - 'spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb'
 
 permissions:
   contents: read
@@ -231,4 +238,6 @@ jobs:
             spec/services/labels/token_resolver_spec.rb \
             spec/controllers/concerns/label_concern_spec.rb \
             spec/services/automation_rules/contact_action_service_spec.rb \
+            spec/requests/api/v1/templates_export_visibility_rbac_spec.rb \
+            spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb \
             --format progress

--- a/app/services/templates/bundle_builder.rb
+++ b/app/services/templates/bundle_builder.rb
@@ -96,12 +96,8 @@ module Templates
       end
     end
 
-    # CRM-205 (macros) + CRM-206 (pipelines): the categories with per-user
-    # visibility are scoped here, which covers BOTH selection paths — `all` and an
-    # explicit id crafted from a leaked UUID.
-    #
-    # The routing moved to Templates::VisibilityScope once there were two of them,
-    # so the inventory and this method can no longer answer differently.
+    # Scoping here covers BOTH selection paths — `all` and an explicit id crafted
+    # from a leaked UUID (CRM-205 macros, CRM-206 pipelines).
     def base_relation(category)
       VisibilityScope.for(category, MODEL_MAP[category], @current_user)
     end

--- a/app/services/templates/bundle_builder.rb
+++ b/app/services/templates/bundle_builder.rb
@@ -96,12 +96,14 @@ module Templates
       end
     end
 
-    # CRM-205: macros are the only category with per-user visibility, and the scope
-    # covers both selection paths — `all` and an explicit id crafted from a leaked UUID.
+    # CRM-205 (macros) + CRM-206 (pipelines): the categories with per-user
+    # visibility are scoped here, which covers BOTH selection paths — `all` and an
+    # explicit id crafted from a leaked UUID.
+    #
+    # The routing moved to Templates::VisibilityScope once there were two of them,
+    # so the inventory and this method can no longer answer differently.
     def base_relation(category)
-      return MODEL_MAP[category].all unless category == 'macros'
-
-      ::Macro.with_visibility(@current_user, {})
+      VisibilityScope.for(category, MODEL_MAP[category], @current_user)
     end
   end
 end

--- a/app/services/templates/export_service.rb
+++ b/app/services/templates/export_service.rb
@@ -27,7 +27,12 @@ module Templates
     # Used by the frontend wizard to render checkboxes.
     def self.exportable_inventory(current_user:)
       {
-        'pipelines' => ::Pipeline.order(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
+        # CRM-206: pipelines carry `visibility` (private/team/public), and this
+        # listed every one of them — so a templates.export holder read the name of
+        # another user's private funnel, and could then export it by id. Same class
+        # of hole CRM-205 closed for macros, one layer over.
+        'pipelines' => VisibilityScope.for('pipelines', ::Pipeline, current_user)
+          .reorder(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
         'agents' => ::AgentBot.order(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
         'teams' => ::Team.order(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
         'labels' => ::Label.order(:title).pluck(:id, :title).map { |id, name| { id: id, name: name } },
@@ -35,10 +40,11 @@ module Templates
           .pluck(:id, :attribute_display_name, :attribute_model)
           .map { |id, name, model| { id: id, name: "#{name} (#{model})" } },
         'canned_responses' => ::CannedResponse.order(:short_code).pluck(:id, :short_code).map { |id, name| { id: id, name: name } },
-        # CRM-205: macros are the only category with per-user visibility, so the
-        # inventory asks the same scope every other macro read path asks.
-        'macros' => ::Macro.with_visibility(current_user, {}).reorder(:name)
-          .pluck(:id, :name).map { |id, name| { id: id, name: name } },
+        # CRM-205: the inventory asks the same scope every other macro read path
+        # asks. Routed through VisibilityScope since CRM-206, so this and
+        # BundleBuilder#base_relation cannot answer differently.
+        'macros' => VisibilityScope.for('macros', ::Macro, current_user)
+          .reorder(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
         'inboxes' => ::Inbox.order(:name).pluck(:id, :name, :channel_type)
           .map { |id, name, ct| { id: id, name: "#{name} (#{ct.demodulize})" } },
         'message_templates' => ::MessageTemplate.order(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } }

--- a/app/services/templates/export_service.rb
+++ b/app/services/templates/export_service.rb
@@ -27,10 +27,8 @@ module Templates
     # Used by the frontend wizard to render checkboxes.
     def self.exportable_inventory(current_user:)
       {
-        # CRM-206: pipelines carry `visibility` (private/team/public), and this
-        # listed every one of them — so a templates.export holder read the name of
-        # another user's private funnel, and could then export it by id. Same class
-        # of hole CRM-205 closed for macros, one layer over.
+        # CRM-206: unscoped, this listed every pipeline — leaking another user's
+        # private funnel by name, and then by id through the export itself.
         'pipelines' => VisibilityScope.for('pipelines', ::Pipeline, current_user)
           .reorder(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
         'agents' => ::AgentBot.order(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
@@ -40,9 +38,7 @@ module Templates
           .pluck(:id, :attribute_display_name, :attribute_model)
           .map { |id, name, model| { id: id, name: "#{name} (#{model})" } },
         'canned_responses' => ::CannedResponse.order(:short_code).pluck(:id, :short_code).map { |id, name| { id: id, name: name } },
-        # CRM-205: the inventory asks the same scope every other macro read path
-        # asks. Routed through VisibilityScope since CRM-206, so this and
-        # BundleBuilder#base_relation cannot answer differently.
+        # CRM-205: the same scope every other macro read path asks.
         'macros' => VisibilityScope.for('macros', ::Macro, current_user)
           .reorder(:name).pluck(:id, :name).map { |id, name| { id: id, name: name } },
         'inboxes' => ::Inbox.order(:name).pluck(:id, :name, :channel_type)

--- a/app/services/templates/visibility_scope.rb
+++ b/app/services/templates/visibility_scope.rb
@@ -3,68 +3,30 @@
 module Templates
   # Which relation the export may read for a category, given the caller.
   #
-  # CRM-205 scoped macros; CRM-206 scopes pipelines. Until the second case existed
-  # the rule lived in two places on purpose — ExportService.exportable_inventory
-  # and BundleBuilder#base_relation — because designing the abstraction from a
-  # single example would have been guesswork.
-  #
-  # With two categories that reasoning flips. Each scoped category needs the same
-  # decision made in BOTH places, so leaving it spread out means four sites that
-  # can drift, and the failure mode is silent: a fix applied to the inventory but
-  # not to base_relation still leaks through an explicit id, and the export looks
-  # correct in the UI.
-  #
-  # What this class deliberately does NOT do is unify the rules themselves. They
-  # have genuinely different shapes and each belongs to its model:
-  #
-  #   macros    -> Macro.with_visibility(user, {})  — a class method that already
-  #                answers for userless and service callers
-  #   pipelines -> Pipeline.accessible_by(user)     — a plain scope, with the
-  #                userless/service decision living in PipelinePolicy::Scope
-  #
-  # This is a router, not a policy. It says WHICH rule governs a category; the
-  # models keep saying WHAT the rule is. That matters because the export must
-  # never second-guess those answers — deciding for itself is exactly what the
-  # CRM-205 review flagged as its High finding.
+  # A router, not a policy: it says WHICH rule governs a category and delegates to
+  # it, so the export never second-guesses an answer that belongs to a model or a
+  # policy. Both enumeration points (the inventory and BundleBuilder#base_relation)
+  # go through here, because a fix applied to one and not the other still leaks
+  # through an explicit id while the UI looks correct.
   module VisibilityScope
-    # Categories whose rows are not account-wide. Everything else (labels,
-    # canned_responses, message_templates, teams, inboxes, custom_attributes,
-    # agents) is shared, and scoping it would silently drop assets from bundles.
-    SCOPED_CATEGORIES = %w[macros pipelines].freeze
+    # Categories that are not account-wide, mapped to the rule that already governs
+    # every other read of them. Everything absent is shared, and scoping it would
+    # silently drop assets from bundles.
+    RULES = {
+      'macros' => ->(user) { ::Macro.with_visibility(user, {}) },
+      # Same object Pundit builds for `policy_scope(Pipeline)`, called rather than
+      # copied: the service branch and the deliberate lack of an admin bypass are
+      # the policy's answers to give.
+      'pipelines' => lambda { |user|
+        ::PipelinePolicy::Scope.new(
+          { user: user, service_authenticated: Current.service_authenticated }, ::Pipeline
+        ).resolve
+      }
+    }.freeze
 
-    class << self
-      # Returns the relation the caller is allowed to read for this category.
-      # `model` is passed in so the caller keeps owning its MODEL_MAP.
-      def for(category, model, user)
-        case category
-        when 'macros' then ::Macro.with_visibility(user, {})
-        when 'pipelines' then pipelines_for(user)
-        else model.all
-        end
-      end
-
-      def scoped?(category)
-        SCOPED_CATEGORIES.include?(category)
-      end
-
-      private
-
-      # Mirrors PipelinePolicy::Scope#resolve, which is where this rule already
-      # lives for every other pipeline read path.
-      #
-      # The service branch is not an afterthought: a service token authenticates
-      # with NO user and is already elevated by check_permission!, so scoping it
-      # by a nil user would answer with public + default only and silently shrink
-      # bundles that used to be complete.
-      #
-      # `accessible_by(nil)` is safe for a bare userless caller — it uses
-      # `user&.id` internally and yields public + default, the pipeline analogue
-      # of the macro `global` fallback. No NoMethodError, no fail-open.
-      def pipelines_for(user)
-        return ::Pipeline.all if Current.service_authenticated == true
-
-        ::Pipeline.accessible_by(user)
-      end
+    def self.for(category, model, user)
+      rule = RULES[category]
+      rule ? rule.call(user) : model.all
     end
   end
 end

--- a/app/services/templates/visibility_scope.rb
+++ b/app/services/templates/visibility_scope.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Templates
+  # Which relation the export may read for a category, given the caller.
+  #
+  # CRM-205 scoped macros; CRM-206 scopes pipelines. Until the second case existed
+  # the rule lived in two places on purpose — ExportService.exportable_inventory
+  # and BundleBuilder#base_relation — because designing the abstraction from a
+  # single example would have been guesswork.
+  #
+  # With two categories that reasoning flips. Each scoped category needs the same
+  # decision made in BOTH places, so leaving it spread out means four sites that
+  # can drift, and the failure mode is silent: a fix applied to the inventory but
+  # not to base_relation still leaks through an explicit id, and the export looks
+  # correct in the UI.
+  #
+  # What this class deliberately does NOT do is unify the rules themselves. They
+  # have genuinely different shapes and each belongs to its model:
+  #
+  #   macros    -> Macro.with_visibility(user, {})  — a class method that already
+  #                answers for userless and service callers
+  #   pipelines -> Pipeline.accessible_by(user)     — a plain scope, with the
+  #                userless/service decision living in PipelinePolicy::Scope
+  #
+  # This is a router, not a policy. It says WHICH rule governs a category; the
+  # models keep saying WHAT the rule is. That matters because the export must
+  # never second-guess those answers — deciding for itself is exactly what the
+  # CRM-205 review flagged as its High finding.
+  module VisibilityScope
+    # Categories whose rows are not account-wide. Everything else (labels,
+    # canned_responses, message_templates, teams, inboxes, custom_attributes,
+    # agents) is shared, and scoping it would silently drop assets from bundles.
+    SCOPED_CATEGORIES = %w[macros pipelines].freeze
+
+    class << self
+      # Returns the relation the caller is allowed to read for this category.
+      # `model` is passed in so the caller keeps owning its MODEL_MAP.
+      def for(category, model, user)
+        case category
+        when 'macros' then ::Macro.with_visibility(user, {})
+        when 'pipelines' then pipelines_for(user)
+        else model.all
+        end
+      end
+
+      def scoped?(category)
+        SCOPED_CATEGORIES.include?(category)
+      end
+
+      private
+
+      # Mirrors PipelinePolicy::Scope#resolve, which is where this rule already
+      # lives for every other pipeline read path.
+      #
+      # The service branch is not an afterthought: a service token authenticates
+      # with NO user and is already elevated by check_permission!, so scoping it
+      # by a nil user would answer with public + default only and silently shrink
+      # bundles that used to be complete.
+      #
+      # `accessible_by(nil)` is safe for a bare userless caller — it uses
+      # `user&.id` internally and yields public + default, the pipeline analogue
+      # of the macro `global` fallback. No NoMethodError, no fail-open.
+      def pipelines_for(user)
+        return ::Pipeline.all if Current.service_authenticated == true
+
+        ::Pipeline.accessible_by(user)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb
+++ b/spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb
@@ -99,6 +99,29 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
       expect(member_ids).to include(team_pipeline.id)
       expect(outsider_ids).not_to include(team_pipeline.id)
     end
+
+    # Pinning an inherited consequence rather than a decision of this card.
+    #
+    # Pipeline.accessible_by ORs in `where(is_default: true)`, so a pipeline that
+    # is BOTH private and default is readable by everyone — and therefore
+    # exportable by everyone. That is the rule the whole CRM already reads
+    # through, and the export deliberately inherits it instead of inventing a
+    # stricter one here.
+    #
+    # If it is ever judged wrong, it is wrong for the pipeline LIST too, and the
+    # fix belongs in accessible_by. Documented so the next reader does not mistake
+    # it for a gap in the export.
+    it 'exposes a private-but-default funnel to everyone, exactly as accessible_by does' do
+      default_private = Pipeline.create!(name: 'Default funnel', visibility: :private,
+                                         created_by: other_user, is_default: true)
+      login_as(exporter, 'templates.export')
+
+      get '/api/v1/templates/exportable_inventory', as: :json
+
+      ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+      expect(ids).to include(default_private.id)
+      expect(::Pipeline.accessible_by(exporter).pluck(:id)).to include(default_private.id)
+    end
   end
 
   describe 'POST /api/v1/templates/export' do

--- a/spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb
+++ b/spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb
@@ -4,16 +4,9 @@ require 'rails_helper'
 require 'zip'
 require 'stringio'
 
-# CRM-206 — the template export enumerated EVERY pipeline, ignoring the
-# `visibility` enum (private/team/public). A templates.export holder read the name
-# of another user's private funnel in the inventory, and could then export its
-# serialized contents by id. Same class of hole CRM-205 closed for macros, one
-# layer over.
-#
-# Every pipeline enumeration in the export path — inventory, `all`, explicit id —
-# now goes through Templates::VisibilityScope, which routes to the rule that
-# already governs pipeline reads (PipelinePolicy::Scope / Pipeline.accessible_by),
-# including its answer for a userless caller. The export must not second-guess it.
+# CRM-206 — the export enumerated EVERY pipeline, ignoring `visibility`. Each of
+# its three enumeration paths (inventory, `all`, explicit id) is covered in its own
+# example, because a fix that lands in one and misses another still leaks.
 RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :request do
   let(:exporter) { User.create!(name: 'Exporter', email: "exp-#{SecureRandom.hex(4)}@example.com") }
   let(:other_user) { User.create!(name: 'Other', email: "other-#{SecureRandom.hex(4)}@example.com") }
@@ -70,18 +63,14 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
       get '/api/v1/templates/exportable_inventory', as: :json
 
       expect(response).to have_http_status(:ok)
-      ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+      ids = response.parsed_body.dig('data', 'pipelines').map { |p| p['id'] }
       expect(ids).to include(own_private.id, public_pipeline.id)
       expect(ids).not_to include(foreign_private.id)
     end
 
-    # The branch that separates pipelines from macros: access here comes from TEAM
-    # MEMBERSHIP, not ownership. A scope that only checked `created_by` would hide
-    # this funnel from a member who is entitled to it — a fix that leans on the
-    # macro shape would pass every other example in this file and fail only here.
-    #
-    # The outsider is a THIRD user on purpose: other_user created the funnel, so
-    # they see it by ownership and would prove nothing about membership.
+    # The branch that separates pipelines from macros: access comes from TEAM
+    # MEMBERSHIP, not ownership, so a fix leaning on the macro shape fails only
+    # here. The outsider is a THIRD user because other_user owns the funnel.
     it 'includes a team-visible funnel for a member, and hides it from a non-member' do
       outsider = User.create!(name: 'Outsider', email: "out-#{SecureRandom.hex(4)}@example.com")
       TeamMember.create!(team: team, user: exporter)
@@ -89,28 +78,21 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
 
       login_as(exporter, 'templates.export')
       get '/api/v1/templates/exportable_inventory', as: :json
-      member_ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+      member_ids = response.parsed_body.dig('data', 'pipelines').map { |p| p['id'] }
 
       Current.reset
       login_as(outsider, 'templates.export')
       get '/api/v1/templates/exportable_inventory', as: :json
-      outsider_ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+      outsider_ids = response.parsed_body.dig('data', 'pipelines').map { |p| p['id'] }
 
       expect(member_ids).to include(team_pipeline.id)
       expect(outsider_ids).not_to include(team_pipeline.id)
     end
 
-    # Pinning an inherited consequence rather than a decision of this card.
-    #
-    # Pipeline.accessible_by ORs in `where(is_default: true)`, so a pipeline that
-    # is BOTH private and default is readable by everyone — and therefore
-    # exportable by everyone. That is the rule the whole CRM already reads
-    # through, and the export deliberately inherits it instead of inventing a
-    # stricter one here.
-    #
-    # If it is ever judged wrong, it is wrong for the pipeline LIST too, and the
-    # fix belongs in accessible_by. Documented so the next reader does not mistake
-    # it for a gap in the export.
+    # An inherited consequence, not a decision of this card: accessible_by ORs in
+    # `is_default`, so a private-AND-default funnel is readable — and exportable —
+    # by everyone. If that is wrong it is wrong for the pipeline LIST too, and the
+    # fix belongs in accessible_by, not in a stricter rule invented here.
     it 'exposes a private-but-default funnel to everyone, exactly as accessible_by does' do
       default_private = Pipeline.create!(name: 'Default funnel', visibility: :private,
                                          created_by: other_user, is_default: true)
@@ -118,9 +100,9 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
 
       get '/api/v1/templates/exportable_inventory', as: :json
 
-      ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+      ids = response.parsed_body.dig('data', 'pipelines').map { |p| p['id'] }
       expect(ids).to include(default_private.id)
-      expect(::Pipeline.accessible_by(exporter).pluck(:id)).to include(default_private.id)
+      expect(Pipeline.accessible_by(exporter).pluck(:id)).to include(default_private.id)
     end
   end
 
@@ -166,9 +148,7 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
 
     # --- the over-scoping guard ----------------------------------------------
 
-    # The fix must touch pipelines (and macros) ONLY. Labels and the other
-    # account-wide categories are shared, so `all` must still export every one of
-    # them — a base_relation that scoped them too would silently drop account-wide
+    # Catches the opposite error: over-scoping would silently drop account-wide
     # assets from every bundle, and no test of the leak itself would notice.
     it 'leaves account-wide categories (labels) fully exportable' do
       login_as(exporter, 'templates.export')
@@ -178,11 +158,14 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
            params: { template_name: 'T', selection: { labels: { all: true } } }, as: :json
 
       expect(response).to have_http_status(:ok)
-      expect(category_in_bundle(response.body, 'labels').length).to eq(1)
+      expect(category_in_bundle(response.body, 'labels').length).to eq(Label.count)
     end
 
     it 'still exports every agent — agents have no per-user visibility' do
       login_as(exporter, 'templates.export')
+      # The test DB has no bots of its own, so without this the count guard would
+      # compare 0 to 0 and pass against an empty relation too.
+      AgentBot.create!(name: "bot-#{SecureRandom.hex(3)}")
 
       post '/api/v1/templates/export',
            params: { template_name: 'T', selection: { agents: { all: true } } }, as: :json
@@ -194,17 +177,15 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
 
   # --- the userless caller: the export delegates, it does not decide -----------
 
-  # This is the shape of the High finding from the CRM-205 review: the export tried
-  # to answer for a userless caller on its own. The answer belongs to the rule that
-  # governs the category, and the two callers differ.
+  # The CRM-205 review's High finding was the export answering this for itself. The
+  # answer belongs to the category's rule, and the two userless callers differ.
   describe 'userless callers follow the pipeline rule' do
     it 'lists public + default only for a bare userless caller — no private, no raise' do
       Current.reset
-      expect(foreign_private).to be_present # private pipelines exist in the DB…
 
       names = Templates::ExportService.exportable_inventory(current_user: nil)['pipelines'].pluck(:name)
 
-      # …but a bare caller sees none of them.
+      # Private pipelines exist in the DB; a bare caller sees none of them.
       expect(names).to include('Shared public funnel')
       expect(names).not_to include('Foreign private funnel', 'Exporter private funnel')
     end
@@ -223,22 +204,23 @@ RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :req
   # --- the router itself -------------------------------------------------------
 
   describe 'Templates::VisibilityScope' do
-    it 'routes only the categories that have per-user visibility' do
-      expect(Templates::VisibilityScope.scoped?('pipelines')).to be(true)
-      expect(Templates::VisibilityScope.scoped?('macros')).to be(true)
+    # Asserting what the router RETURNS, never a list of category names: a constant
+    # nothing reads stays green while `for` quietly gains or loses a branch.
+    it 'hands every account-wide category its untouched relation' do
       %w[labels teams inboxes agents canned_responses message_templates custom_attributes].each do |category|
-        expect(Templates::VisibilityScope.scoped?(category)).to be(false)
+        model = Templates::BundleBuilder::MODEL_MAP[category]
+        expect(Templates::VisibilityScope.for(category, model, exporter).to_sql).to eq(model.all.to_sql)
       end
     end
 
-    it 'hands an account-wide category its untouched relation' do
-      relation = Templates::VisibilityScope.for('labels', ::Label, exporter)
-      expect(relation.to_sql).to eq(::Label.all.to_sql)
+    it 'scopes the two categories that carry per-user visibility' do
+      expect(Templates::VisibilityScope.for('pipelines', Pipeline, exporter).to_sql).not_to eq(Pipeline.all.to_sql)
+      expect(Templates::VisibilityScope.for('macros', Macro, exporter).to_sql).not_to eq(Macro.all.to_sql)
     end
 
     it 'delegates pipelines to the same rule the rest of the CRM reads through' do
-      expect(Templates::VisibilityScope.for('pipelines', ::Pipeline, exporter).pluck(:id))
-        .to match_array(::Pipeline.accessible_by(exporter).pluck(:id))
+      expect(Templates::VisibilityScope.for('pipelines', Pipeline, exporter).pluck(:id))
+        .to match_array(Pipeline.accessible_by(exporter).pluck(:id))
     end
   end
 end

--- a/spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb
+++ b/spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'zip'
+require 'stringio'
+
+# CRM-206 — the template export enumerated EVERY pipeline, ignoring the
+# `visibility` enum (private/team/public). A templates.export holder read the name
+# of another user's private funnel in the inventory, and could then export its
+# serialized contents by id. Same class of hole CRM-205 closed for macros, one
+# layer over.
+#
+# Every pipeline enumeration in the export path — inventory, `all`, explicit id —
+# now goes through Templates::VisibilityScope, which routes to the rule that
+# already governs pipeline reads (PipelinePolicy::Scope / Pipeline.accessible_by),
+# including its answer for a userless caller. The export must not second-guess it.
+RSpec.describe 'Template export pipeline visibility scope (CRM-206)', type: :request do
+  let(:exporter) { User.create!(name: 'Exporter', email: "exp-#{SecureRandom.hex(4)}@example.com") }
+  let(:other_user) { User.create!(name: 'Other', email: "other-#{SecureRandom.hex(4)}@example.com") }
+
+  let!(:own_private) do
+    Pipeline.create!(name: 'Exporter private funnel', visibility: :private, created_by: exporter)
+  end
+  let!(:public_pipeline) do
+    Pipeline.create!(name: 'Shared public funnel', visibility: :public, created_by: other_user)
+  end
+  let!(:foreign_private) do
+    Pipeline.create!(name: 'Foreign private funnel', visibility: :private, created_by: other_user)
+  end
+
+  # `team` visibility is the branch that distinguishes pipelines from macros: it
+  # grants access through TEAM MEMBERSHIP, not ownership. A scope that only checked
+  # `created_by` would wrongly hide this one from a member.
+  let!(:team) { Team.create!(name: "Squad #{SecureRandom.hex(3)}") }
+  let!(:team_pipeline) do
+    Pipeline.create!(name: 'Team funnel', visibility: :team, created_by: other_user)
+  end
+
+  def login_as(user, *granted)
+    allow_any_instance_of(Api::BaseController).to receive(:authenticate_request!) do
+      Current.user = user
+      Current.evo_permission_cache ||= {}
+    end
+    allow_any_instance_of(EvoAuthService).to receive(:check_user_permission) do |_svc, _uid, permission|
+      granted.include?(permission)
+    end
+  end
+
+  after { Current.reset }
+
+  def category_in_bundle(zip_binary, category)
+    Zip::InputStream.open(StringIO.new(zip_binary)) do |io|
+      while (entry = io.get_next_entry)
+        return JSON.parse(io.read) if entry.name == "#{category}.json"
+      end
+    end
+    []
+  end
+
+  def pipelines_in_bundle(zip_binary)
+    category_in_bundle(zip_binary, 'pipelines')
+  end
+
+  # --- path 1: the inventory the wizard renders -------------------------------
+
+  describe 'GET /api/v1/templates/exportable_inventory' do
+    it "lists the caller's own + public, never another user's private funnel" do
+      login_as(exporter, 'templates.export')
+
+      get '/api/v1/templates/exportable_inventory', as: :json
+
+      expect(response).to have_http_status(:ok)
+      ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+      expect(ids).to include(own_private.id, public_pipeline.id)
+      expect(ids).not_to include(foreign_private.id)
+    end
+
+    # The branch that separates pipelines from macros: access here comes from TEAM
+    # MEMBERSHIP, not ownership. A scope that only checked `created_by` would hide
+    # this funnel from a member who is entitled to it — a fix that leans on the
+    # macro shape would pass every other example in this file and fail only here.
+    #
+    # The outsider is a THIRD user on purpose: other_user created the funnel, so
+    # they see it by ownership and would prove nothing about membership.
+    it 'includes a team-visible funnel for a member, and hides it from a non-member' do
+      outsider = User.create!(name: 'Outsider', email: "out-#{SecureRandom.hex(4)}@example.com")
+      TeamMember.create!(team: team, user: exporter)
+      PipelineTeam.create!(pipeline: team_pipeline, team: team)
+
+      login_as(exporter, 'templates.export')
+      get '/api/v1/templates/exportable_inventory', as: :json
+      member_ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+
+      Current.reset
+      login_as(outsider, 'templates.export')
+      get '/api/v1/templates/exportable_inventory', as: :json
+      outsider_ids = JSON.parse(response.body).dig('data', 'pipelines').map { |p| p['id'] }
+
+      expect(member_ids).to include(team_pipeline.id)
+      expect(outsider_ids).not_to include(team_pipeline.id)
+    end
+  end
+
+  describe 'POST /api/v1/templates/export' do
+    # --- path 2: selection `all` ---------------------------------------------
+
+    it "with `all`, the bundle carries the caller's own + public, not another user's private" do
+      login_as(exporter, 'templates.export')
+
+      post '/api/v1/templates/export',
+           params: { template_name: 'T', selection: { pipelines: { all: true } } }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      names = pipelines_in_bundle(response.body).map { |p| p['name'] }
+      expect(names).to include('Exporter private funnel', 'Shared public funnel')
+      expect(names).not_to include('Foreign private funnel')
+    end
+
+    # --- path 3: an explicit id, crafted from a leaked UUID --------------------
+
+    it "ignores an explicit id crafted from another user's private funnel (defense in depth)" do
+      login_as(exporter, 'templates.export')
+
+      post '/api/v1/templates/export',
+           params: { template_name: 'T',
+                     selection: { pipelines: { ids: [foreign_private.id, own_private.id] } } },
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      names = pipelines_in_bundle(response.body).map { |p| p['name'] }
+      expect(names).to include('Exporter private funnel')
+      expect(names).not_to include('Foreign private funnel')
+    end
+
+    it 'denies the whole export without templates.export' do
+      login_as(exporter) # no keys
+
+      post '/api/v1/templates/export',
+           params: { template_name: 'T', selection: { pipelines: { all: true } } }, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    # --- the over-scoping guard ----------------------------------------------
+
+    # The fix must touch pipelines (and macros) ONLY. Labels and the other
+    # account-wide categories are shared, so `all` must still export every one of
+    # them — a base_relation that scoped them too would silently drop account-wide
+    # assets from every bundle, and no test of the leak itself would notice.
+    it 'leaves account-wide categories (labels) fully exportable' do
+      login_as(exporter, 'templates.export')
+      Label.create!(title: "shared-#{SecureRandom.hex(3)}")
+
+      post '/api/v1/templates/export',
+           params: { template_name: 'T', selection: { labels: { all: true } } }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(category_in_bundle(response.body, 'labels').length).to eq(1)
+    end
+
+    it 'still exports every agent — agents have no per-user visibility' do
+      login_as(exporter, 'templates.export')
+
+      post '/api/v1/templates/export',
+           params: { template_name: 'T', selection: { agents: { all: true } } }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(category_in_bundle(response.body, 'agents').length).to eq(AgentBot.count)
+    end
+  end
+
+  # --- the userless caller: the export delegates, it does not decide -----------
+
+  # This is the shape of the High finding from the CRM-205 review: the export tried
+  # to answer for a userless caller on its own. The answer belongs to the rule that
+  # governs the category, and the two callers differ.
+  describe 'userless callers follow the pipeline rule' do
+    it 'lists public + default only for a bare userless caller — no private, no raise' do
+      Current.reset
+      expect(foreign_private).to be_present # private pipelines exist in the DB…
+
+      names = Templates::ExportService.exportable_inventory(current_user: nil)['pipelines'].pluck(:name)
+
+      # …but a bare caller sees none of them.
+      expect(names).to include('Shared public funnel')
+      expect(names).not_to include('Foreign private funnel', 'Exporter private funnel')
+    end
+
+    it 'lists every pipeline for a service token, matching PipelinePolicy::Scope' do
+      Current.reset
+      Current.service_authenticated = true
+
+      names = Templates::ExportService.exportable_inventory(current_user: nil)['pipelines'].pluck(:name)
+
+      expect(names).to match_array(Pipeline.pluck(:name))
+      expect(names).to include('Foreign private funnel')
+    end
+  end
+
+  # --- the router itself -------------------------------------------------------
+
+  describe 'Templates::VisibilityScope' do
+    it 'routes only the categories that have per-user visibility' do
+      expect(Templates::VisibilityScope.scoped?('pipelines')).to be(true)
+      expect(Templates::VisibilityScope.scoped?('macros')).to be(true)
+      %w[labels teams inboxes agents canned_responses message_templates custom_attributes].each do |category|
+        expect(Templates::VisibilityScope.scoped?(category)).to be(false)
+      end
+    end
+
+    it 'hands an account-wide category its untouched relation' do
+      relation = Templates::VisibilityScope.for('labels', ::Label, exporter)
+      expect(relation.to_sql).to eq(::Label.all.to_sql)
+    end
+
+    it 'delegates pipelines to the same rule the rest of the CRM reads through' do
+      expect(Templates::VisibilityScope.for('pipelines', ::Pipeline, exporter).pluck(:id))
+        .to match_array(::Pipeline.accessible_by(exporter).pluck(:id))
+    end
+  end
+end


### PR DESCRIPTION
O export de templates enumerava **todas** as pipelines, ignorando o enum `visibility` (private/team/public). Quem tem `templates.export` lia o nome do funil privado de outro usuário no inventory — e depois exportava o conteúdo serializado por id. Mesma classe de furo que o CRM-205 fechou para macros, uma camada ao lado.

Os **dois** pontos de enumeração foram corrigidos, porque qualquer um sozinho ainda vaza:
- `ExportService.exportable_inventory` — a lista do wizard
- `BundleBuilder#base_relation` — cobre `all` **e** um id explícito forjado a partir de um UUID vazado

## Sobre a 1ª pergunta da nota de review: os dois pontos viram um só?

**Viram** — e é o segundo exemplo que decide isso.

Com uma categoria escopada, a regra ficou em dois lugares de propósito: desenhar a abstração com um exemplo na mão seria chute. Com duas, ela passa a viver em **quatro**, e o modo de falha é silencioso — um fix aplicado no inventory mas não no `base_relation` continua vazando pelo id explícito, e a tela parece correta.

Mas `Templates::VisibilityScope` é um **roteador, não uma policy**. Ele diz *qual* regra governa cada categoria; os modelos continuam dizendo *o que* a regra é. E os formatos seguem diferentes, como a nota previu:

| Categoria | Regra | Onde decide userless/service |
|---|---|---|
| `macros` | `Macro.with_visibility(user, {})` | dentro do próprio método |
| `pipelines` | `Pipeline.accessible_by(user)` | em `PipelinePolicy::Scope` |

Unificar as **regras** seria o movimento errado. O export não pode arbitrar sobre elas — arbitrar por conta própria foi exatamente o achado Alto da review do CRM-205, e os exemplos de caller sem usuário fixam isso nos dois sentidos.

## Sobre a nota de escopo do card: admin enxerga todas?

**Não.** A `PipelinePolicy::Scope` diz isso explicitamente:

> *"No administrator bypass here, deliberately: admins never reached other users' private pipelines."*

O export herda essa decisão em vez de inventar uma segunda.

**Service token vê tudo**, e esse ramo não é cosmético: ele autentica **sem usuário** e já vem elevado pelo `check_permission!`, então escopar por um user nil encolheria silenciosamente bundles que hoje saem completos.

## Sobre a 2ª pergunta: copiar o formato do spec

`spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb` — **12 examples**, no formato do spec do CRM-205:

- os **três caminhos** em examples separados: inventory, `all`, id explícito
- um example de **`team` visibility**
- guardas provando que categorias account-wide (`labels`, `agents`) continuam exportando inteiras
- **os dois** callers sem usuário (bare e service token)

O example de `team` merece o lugar dele: ali o acesso vem de **participação em time**, não de posse. Um fix que se apoiasse no formato da macro passaria em todos os outros examples do arquivo e falharia só nesse.

## Prova negativa

Removendo o ramo de pipelines do roteador, **6 dos 12 falham** — os três caminhos, o caso de team, o caller sem usuário e a delegação do roteador.

As guardas de over-scoping **continuam passando nos dois estados**, que é justamente para isso que existem: elas pegam o erro oposto, o de escopar demais.

O spec do CRM-205 segue verde através do roteador — **19 examples** somando os dois arquivos.

## Summary by Sourcery

Enforce pipeline visibility rules across every template export enumeration path.

Bug Fixes:
- Scope pipeline inventory and export selection by the existing pipeline visibility rules, preventing unauthorized users from discovering or exporting private pipelines through either `all` or explicit IDs.

Enhancements:
- Centralize export visibility routing for macros and pipelines while preserving existing account-wide category behavior and service-token access semantics.

CI:
- Extend the spec staleness guard and its tracked request specs to cover template export visibility changes.

Tests:
- Add RBAC coverage for inventory, bulk export, explicit pipeline IDs, team visibility, userless callers, service tokens, default pipelines, and protection against over-scoping account-wide categories.

---

## Lane RBAC inteira — rodada, com baseline

O card pede a lane inteira, então:

| Run | Examples | Failures |
|---|---|---|
| `develop` | 261 | **1** — `whatsapp_channel_management_rbac_spec.rb:157` |
| **com este PR** | **273** | **1** — a mesma |

**+12 examples (os deste PR), zero falhas novas.** A que resta é pré-existente: `WebMock::NetConnectNotAllowedError` num `PUT https://api.z-api.io/.../update-webhook-delivery` sem stub. Reproduz igual em develop rodando o arquivo isolado (102 examples, 1 failure, mesma linha).

### Um susto que vale registrar

Numa primeira comparação a lane deu **2** falhas contra 1 do baseline, e a extra era `whatsapp_channel_management_rbac_spec.rb:117` — um 401 inesperado. Como o spec deste PR roda antes daquele por ordem alfabética, a suspeita óbvia era vazamento meu.

Não é. A suíte roda com `config.order = :random` e cada execução sorteia um seed novo, então aquela comparação era entre ordens diferentes. Rodando **os dois lados com `--seed 4206`**, a falha não aparece em nenhum deles — os números da tabela acima são desse par.

Rodar meu spec seguido do de WhatsApp em `--order defined` também não reproduz (114 examples, só a 157).

Fica o registro de que existe uma **dependência de ordem pré-existente** ali: sob certas ordens, `:117` responde 401. Não é deste card e não foi tocada aqui, mas é o tipo de coisa que reaparece e faz perder tempo — vale um card próprio se incomodar de novo.


---

## Auto-revisão antes de pedir review

Fui procurar a mesma classe de furo uma camada ao lado — foi assim que este card nasceu do CRM-205. O que verifiquei:

| Verificação | Resultado |
|---|---|
| Outra categoria do export tem visibilidade por usuário? | **Não.** `AgentBot`, `Team`, `Label`, `CannedResponse`, `Inbox`, `MessageTemplate` e `CustomAttributeDefinition` não têm — só `macros` e `pipelines` |
| Alguma categoria referencia pipeline no serializer? | **Nenhuma** |
| O `PipelinesSerializer` segue associações que escapem do escopo? | **Não** — serializa `pipeline_stages` e `pipeline_service_definitions` do próprio record, que já vem da relation escopada. Não inclui `PipelineTasks` |
| Outro ponto do export enumera `Pipeline`? | Só o `MODEL_MAP` (roteado) e o `pipelines_importer` (fluxo de **import**, que cria — não lê dado alheio) |
| O controller tem outro endpoint de leitura? | Só `exportable_inventory`, `export` e `import` |

### Uma consequência herdada que ninguém documentava

`Pipeline.accessible_by` faz `OR where(is_default: true)`. Ou seja: uma pipeline **private E default** é legível — e portanto exportável — por todos.

Isso é herdado de propósito. Se for julgado errado, é errado para a **listagem** de pipelines também, e o conserto pertence ao `accessible_by`, não a uma regra mais estrita inventada aqui (inventar é justamente o que a review do CRM-205 apontou).

Acrescentei um example que fixa os dois lados: o funil aparece no inventory **e** o `accessible_by` concorda. Se a regra do modelo mudar, ele falha e diz por quê.

**13 examples** no arquivo, **20** somando os dois specs de visibilidade do export.

### Trade-off consciente: custo da query

O inventory era um `pluck` direto na tabela. Agora passa pelo `accessible_by`, que adiciona uma subquery aninhada (`PipelineTeam` ⟵ `TeamMember`) para resolver a visibilidade `team`.

É o mesmo custo que a listagem de pipelines do CRM já paga em toda requisição, e o comentário do próprio scope registra a escolha de subquery aninhada em vez de `user.team_ids` justamente para ficar em uma ida ao banco. Aceito conscientemente: o inventory é uma tela de wizard, não um caminho quente.
