### PR TITLE
fix(pipeline_stages): preserve and validate the stage automation_rules (CRM-254, CRM-255)

### DIFF
--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PipelineStagesController < Api::V1::BaseController
+  DESCRIPTION_MAX_LENGTH = 500
+
   require_permissions({
     index: 'pipeline_stages.read',
     show: 'pipeline_stages.read',
@@ -13,6 +15,8 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   before_action :fetch_pipeline
   
   before_action :fetch_pipeline_stage, only: [:show, :update, :destroy, :move_up, :move_down]
+  before_action :reject_invalid_stage_type, only: [:create, :update]
+  before_action :reject_invalid_automation_rules, only: [:create, :update]
 
   def index
     @pipeline_stages = @pipeline.pipeline_stages.ordered.includes(pipeline_items: [:conversation])
@@ -157,6 +161,77 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     @pipeline_stage = @pipeline.pipeline_stages.find(params[:id])
   end
 
+  # stage_type is an enum: an unknown value raises ArgumentError on assignment, which the
+  # global StandardError rescue turns into a 500. Callers that guess the value (the copilot
+  # among them) deserve a 422 naming the accepted ones.
+  def reject_invalid_stage_type
+    submitted = params.dig(:pipeline_stage, :stage_type)
+    return if submitted.blank? || PipelineStage.stage_types.key?(submitted.to_s)
+
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: ["stage_type must be one of: #{PipelineStage.stage_types.keys.join(', ')}"],
+      status: :unprocessable_entity
+    )
+  end
+
+  # normalize_automation_rules drops what it cannot recognise, so a typo in a trigger used to
+  # come back 200 with the rule silently gone. Reject the payload instead, naming what failed.
+  def reject_invalid_automation_rules
+    raw = params.dig(:pipeline_stage, :automation_rules)
+    return if raw.blank?
+
+    details = if raw.is_a?(ActionController::Parameters) || raw.is_a?(Hash)
+                automation_rules_errors(raw.to_unsafe_h.with_indifferent_access)
+              else
+                ['automation_rules must be an object']
+              end
+    return if details.empty?
+
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: details,
+      status: :unprocessable_entity
+    )
+  end
+
+  def automation_rules_errors(ar)
+    details = []
+
+    if ar.key?('description') && ar['description'].to_s.length > DESCRIPTION_MAX_LENGTH
+      details << "automation_rules.description must be at most #{DESCRIPTION_MAX_LENGTH} characters"
+    end
+
+    Array(ar['rules']).each_with_index do |rule, index|
+      unless rule.respond_to?(:to_h)
+        details << "automation_rules.rules[#{index}] must be an object"
+        next
+      end
+
+      r = rule.to_h.with_indifferent_access
+      trigger = r[:trigger].to_s
+      action  = r[:action].to_s
+
+      unless Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.include?(trigger)
+        details << "automation_rules.rules[#{index}].trigger must be one of: " \
+                   "#{Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.join(', ')}"
+      end
+
+      unless Pipelines::StageAutomationService::SUPPORTED_ACTIONS.include?(action)
+        details << "automation_rules.rules[#{index}].action must be one of: " \
+                   "#{Pipelines::StageAutomationService::SUPPORTED_ACTIONS.join(', ')}"
+      end
+    end
+
+    details
+  end
+
+  # There is no `description` column on pipeline_stages: the stage description lives at
+  # automation_rules.description, and a top-level `description` is dropped by this permit.
+  # The copilot catalog (evo-skyway-service, stageFields) mirrors this shape — keep both in
+  # step when the accepted fields change.
   def pipeline_stage_params
     permitted = params.require(:pipeline_stage).permit(
       :name,
@@ -226,7 +301,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     ar = raw.to_unsafe_h.with_indifferent_access
     result = {}
 
-    result['description'] = ar['description'].to_s.slice(0, 500) if ar.key?('description')
+    result['description'] = ar['description'].to_s.slice(0, DESCRIPTION_MAX_LENGTH) if ar.key?('description')
 
     if ar['rules'].is_a?(Array)
       valid_triggers = Pipelines::StageAutomationService::SUPPORTED_TRIGGERS

--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -215,13 +215,13 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
       action  = r[:action].to_s
 
       unless Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.include?(trigger)
-        details << "automation_rules.rules[#{index}].trigger must be one of: " \
-                   "#{Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.join(', ')}"
+        details << "automation_rules.rules[#{index}].trigger #{trigger.inspect} is not supported; " \
+                   "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.join(', ')}"
       end
 
       unless Pipelines::StageAutomationService::SUPPORTED_ACTIONS.include?(action)
-        details << "automation_rules.rules[#{index}].action must be one of: " \
-                   "#{Pipelines::StageAutomationService::SUPPORTED_ACTIONS.join(', ')}"
+        details << "automation_rules.rules[#{index}].action #{action.inspect} is not supported; " \
+                   "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_ACTIONS.join(', ')}"
       end
     end
 

--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::PipelineStagesController < Api::V1::BaseController
   DESCRIPTION_MAX_LENGTH = 500
+  INACTIVITY_BASES = %w[no_customer_reply stage_stagnation].freeze
 
   require_permissions({
     index: 'pipeline_stages.read',
@@ -204,28 +205,57 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
       details << "automation_rules.description must be at most #{DESCRIPTION_MAX_LENGTH} characters"
     end
 
-    Array(ar['rules']).each_with_index do |rule, index|
-      unless rule.respond_to?(:to_h)
-        details << "automation_rules.rules[#{index}] must be an object"
-        next
-      end
-
-      r = rule.to_h.with_indifferent_access
-      trigger = r[:trigger].to_s
-      action  = r[:action].to_s
-
-      unless Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.include?(trigger)
-        details << "automation_rules.rules[#{index}].trigger #{trigger.inspect} is not supported; " \
-                   "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.join(', ')}"
-      end
-
-      unless Pipelines::StageAutomationService::SUPPORTED_ACTIONS.include?(action)
-        details << "automation_rules.rules[#{index}].action #{action.inspect} is not supported; " \
-                   "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_ACTIONS.join(', ')}"
-      end
-    end
+    Array(ar['rules']).each_with_index { |rule, index| details.concat(rule_errors(rule, index)) }
 
     details
+  end
+
+  def rule_errors(rule, index)
+    return ["automation_rules.rules[#{index}] must be an object"] unless rule.respond_to?(:to_h)
+
+    r       = rule.to_h.with_indifferent_access
+    trigger = r[:trigger].to_s
+    action  = r[:action].to_s
+    errors  = []
+
+    unless Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.include?(trigger)
+      errors << "automation_rules.rules[#{index}].trigger #{trigger.inspect} is not supported; " \
+                "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_TRIGGERS.join(', ')}"
+    end
+
+    unless Pipelines::StageAutomationService::SUPPORTED_ACTIONS.include?(action)
+      errors << "automation_rules.rules[#{index}].action #{action.inspect} is not supported; " \
+                "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_ACTIONS.join(', ')}"
+    end
+
+    errors.concat(inactivity_trigger_value_errors(r[:trigger_value], index)) if trigger == 'inactivity'
+    errors
+  end
+
+  # normalize_trigger_value coerces this object into shape rather than refusing it: an
+  # unknown base becomes no_customer_reply, and a minutes the sweeper cannot read becomes 0,
+  # which makes the rule fire on the next pass instead of after the delay that was asked for.
+  def inactivity_trigger_value_errors(value, index)
+    prefix = "automation_rules.rules[#{index}].trigger_value"
+    return ["#{prefix} must be an object for the inactivity trigger"] unless value.is_a?(Hash)
+
+    tv      = value.with_indifferent_access
+    base    = tv[:base]
+    minutes = tv[:minutes]
+    errors  = []
+
+    if base.present? && !INACTIVITY_BASES.include?(base.to_s)
+      errors << "#{prefix}.base #{base.to_s.inspect} is not supported; " \
+                "must be one of: #{INACTIVITY_BASES.join(', ')}"
+    end
+
+    if minutes.blank?
+      errors << "#{prefix}.minutes is required for the inactivity trigger"
+    elsif !minutes.to_s.match?(/\A[1-9]\d*\z/)
+      errors << "#{prefix}.minutes #{minutes.to_s.inspect} is not a positive whole number of minutes"
+    end
+
+    errors
   end
 
   # There is no `description` column on pipeline_stages: the stage description lives at
@@ -338,7 +368,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
 
     v = value.respond_to?(:to_h) ? value.to_h.with_indifferent_access : {}
     base = v[:base].to_s
-    base = 'no_customer_reply' unless %w[no_customer_reply stage_stagnation].include?(base)
+    base = 'no_customer_reply' unless INACTIVITY_BASES.include?(base)
     { 'minutes' => v[:minutes].to_i, 'base' => base }
   end
 

--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -166,7 +166,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     )
 
     raw_ar = params.dig(:pipeline_stage, :automation_rules)
-    permitted[:automation_rules] = normalize_automation_rules(raw_ar) if raw_ar.present?
+    permitted[:automation_rules] = merge_automation_rules(raw_ar) if raw_ar.present?
 
     allowed_display_types = %w[text number currency percent link date list checkbox].freeze
 
@@ -207,6 +207,17 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     end
 
     permitted
+  end
+
+  # automation_rules is a single jsonb column, so assigning it replaces the whole object.
+  # An update that carries only `rules` would drop the stage description (and one that
+  # carries only `description` would drop the rules), so the incoming keys are merged over
+  # what is stored. Sending a key explicitly still overwrites it: `description: ''` clears
+  # the description, `rules: []` clears the rules.
+  def merge_automation_rules(raw)
+    stored = @pipeline_stage&.automation_rules || {}
+
+    stored.to_h.stringify_keys.merge(normalize_automation_rules(raw))
   end
 
   def normalize_automation_rules(raw)

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
     allow(controller).to receive(:authenticate_request!).and_return(true)
     allow(controller).to receive(:authorize).and_return(true)
     allow(controller).to receive(:pundit_user).and_return({ user: user, account_user: nil })
+    # Current is reset by the executor between requests, so the service-token grant in
+    # check_permission! does not survive an example that issues more than one request.
+    allow(controller).to receive(:check_permission!).and_return(true)
   end
 
   after do
@@ -87,7 +90,132 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
       expect(stage.reload.automation_rules['rules']).to eq([])
       expect(stage.reload.automation_rules['description']).to eq('Primeiro contato com o lead')
     end
+
+    # Omitting a key and sending it empty must mean different things: the copilot updates
+    # one key at a time and expects the other to survive, the UI sends the empty value to
+    # clear. A client that clears BY OMISSION cannot be served by both at once.
+    it 'leaves an omitted key untouched rather than clearing it' do
+      update_stage(rules: [rule])
+
+      expect(stage.reload.automation_rules['description']).to eq('Primeiro contato com o lead')
+
+      update_stage(description: 'Outra descricao')
+
+      expect(stage.reload.automation_rules['rules']).to eq([rule])
+    end
   end
+
+  describe 'reading the stage back' do
+    let(:rule) do
+      {
+        'trigger' => 'label_added',
+        'trigger_value' => 'lead qualificado',
+        'action' => 'move_to_stage',
+        'action_value' => 'stage-uuid'
+      }
+    end
+
+    it 'returns description and rules together on show and index' do
+      post :create,
+           params: {
+             pipeline_id: pipeline.id,
+             pipeline_stage: {
+               name: 'Lead',
+               color: '#60A5FA',
+               automation_rules: { description: 'Primeiro contato', rules: [rule] }
+             }
+           },
+           as: :json
+      expect(response).to have_http_status(:created)
+      stage_id = JSON.parse(response.body).dig('data', 'id')
+
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage_id,
+            pipeline_stage: { automation_rules: { rules: [rule.merge('action_value' => 'outro-stage')] } }
+          },
+          as: :json
+      expect(response).to have_http_status(:ok)
+
+      get :show, params: { pipeline_id: pipeline.id, id: stage_id }
+
+      expect(response).to have_http_status(:ok)
+      shown = JSON.parse(response.body).dig('data', 'automation_rules')
+      expect(shown['description']).to eq('Primeiro contato')
+      expect(shown['rules'].first['action_value']).to eq('outro-stage')
+
+      get :index, params: { pipeline_id: pipeline.id }
+
+      expect(response).to have_http_status(:ok)
+      listed = JSON.parse(response.body)['data'].find { |s| s['id'] == stage_id }
+      expect(listed['automation_rules']['description']).to eq('Primeiro contato')
+      expect(listed['automation_rules']['rules'].first['action_value']).to eq('outro-stage')
+    end
+  end
+
+  describe 'rejected payloads' do
+    let!(:stage) do
+      pipeline.pipeline_stages.create!(name: 'Lead', position: 1, color: '#60A5FA')
+    end
+
+    it 'rejects an unknown stage_type instead of blowing up' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { stage_type: 'em_negociacao' }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body)['error']).to be_present
+      expect(stage.reload.stage_type).to eq('active')
+    end
+
+    it 'rejects a rule with an unknown trigger instead of dropping it' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'stage_entered', 'action' => 'apply_label', 'action_value' => 'x' }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(stage.reload.automation_rules['rules']).to be_nil
+    end
+
+    it 'rejects automation_rules that is not an object' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: 'nao sou um objeto' }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'rejects a description longer than the stored limit instead of truncating it' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: { description: 'a' * 501 } }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(stage.reload.automation_rules['description']).to be_nil
+    end
+  end
+
 
   describe 'POST #create' do
     it 'stores the description sent inside automation_rules' do

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -228,6 +228,104 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
       )
     end
 
+    it 'rejects an inactivity base outside the enum instead of silently defaulting it' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{
+                  'trigger' => 'inactivity',
+                  'trigger_value' => { 'minutes' => 30, 'base' => 'last_activity' },
+                  'action' => 'apply_label',
+                  'action_value' => 'frio'
+                }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('trigger_value.base "last_activity" is not supported')
+      )
+      expect(stage.reload.automation_rules['rules']).to be_nil
+    end
+
+    it 'rejects inactivity minutes that would collapse to zero and fire at once' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{
+                  'trigger' => 'inactivity',
+                  'trigger_value' => { 'minutes' => 'trinta', 'base' => 'stage_stagnation' },
+                  'action' => 'apply_label',
+                  'action_value' => 'frio'
+                }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('trigger_value.minutes "trinta" is not a positive whole number')
+      )
+      expect(stage.reload.automation_rules['rules']).to be_nil
+    end
+
+    it 'rejects an inactivity rule with no minutes at all' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{
+                  'trigger' => 'inactivity',
+                  'trigger_value' => { 'base' => 'stage_stagnation' },
+                  'action' => 'apply_label',
+                  'action_value' => 'frio'
+                }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].trigger_value.minutes is required for the inactivity trigger'
+      )
+    end
+
+    it 'stores an inactivity rule whose base and minutes are both valid' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{
+                  'trigger' => 'inactivity',
+                  'trigger_value' => { 'minutes' => '30', 'base' => 'stage_stagnation' },
+                  'action' => 'apply_label',
+                  'action_value' => 'frio'
+                }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(stage.reload.automation_rules['rules'].first['trigger_value']).to eq(
+        'minutes' => 30, 'base' => 'stage_stagnation'
+      )
+    end
+
     it 'rejects a description longer than the stored limit instead of truncating it' do
       put :update,
           params: {

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::PipelineStagesController, type: :controller do
+  let(:user) { User.create!(email: 'stage-spec@example.com', name: 'Stage Spec') }
+  let(:pipeline) do
+    Pipeline.create!(name: 'Sales Pipeline', pipeline_type: 'sales', created_by: user)
+  end
+
+  before do
+    Current.user = user
+    Current.service_authenticated = true
+    Current.authentication_method = 'service_token'
+
+    allow(controller).to receive(:authenticate_request!).and_return(true)
+    allow(controller).to receive(:authorize).and_return(true)
+    allow(controller).to receive(:pundit_user).and_return({ user: user, account_user: nil })
+  end
+
+  after do
+    Current.reset
+  end
+
+  describe 'automation_rules on update' do
+    let(:rule) do
+      {
+        'trigger' => 'label_added',
+        'trigger_value' => 'lead qualificado',
+        'action' => 'apply_label',
+        'action_value' => 'em negociacao'
+      }
+    end
+
+    let!(:stage) do
+      pipeline.pipeline_stages.create!(
+        name: 'Lead',
+        position: 1,
+        color: '#60A5FA',
+        automation_rules: { 'description' => 'Primeiro contato com o lead', 'rules' => [rule] }
+      )
+    end
+
+    # as: :json so an empty `rules: []` survives the round trip — form encoding drops it,
+    # which is not how the copilot or the frontend call the endpoint.
+    def update_stage(automation_rules)
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: automation_rules }
+          },
+          as: :json
+    end
+
+    it 'keeps the description when only the rules are sent' do
+      new_rule = rule.merge('action_value' => 'proposta enviada')
+
+      update_stage(rules: [new_rule])
+
+      expect(response).to have_http_status(:ok)
+      automation_rules = JSON.parse(response.body).dig('data', 'automation_rules')
+      expect(automation_rules['description']).to eq('Primeiro contato com o lead')
+      expect(automation_rules['rules'].first['action_value']).to eq('proposta enviada')
+      expect(stage.reload.automation_rules['description']).to eq('Primeiro contato com o lead')
+    end
+
+    it 'keeps the rules when only the description is sent' do
+      update_stage(description: 'Lead recem-chegado')
+
+      expect(response).to have_http_status(:ok)
+      automation_rules = stage.reload.automation_rules
+      expect(automation_rules['description']).to eq('Lead recem-chegado')
+      expect(automation_rules['rules']).to eq([rule])
+    end
+
+    it 'clears the description when it is sent empty' do
+      update_stage(description: '')
+
+      expect(stage.reload.automation_rules['description']).to eq('')
+      expect(stage.reload.automation_rules['rules']).to eq([rule])
+    end
+
+    it 'clears the rules when an empty list is sent' do
+      update_stage(rules: [])
+
+      expect(stage.reload.automation_rules['rules']).to eq([])
+      expect(stage.reload.automation_rules['description']).to eq('Primeiro contato com o lead')
+    end
+  end
+
+  describe 'POST #create' do
+    it 'stores the description sent inside automation_rules' do
+      post :create,
+           params: {
+             pipeline_id: pipeline.id,
+             pipeline_stage: {
+               name: 'Qualified',
+               color: '#F59E0B',
+               automation_rules: { description: 'Lead com fit confirmado' }
+             }
+           }
+
+      expect(response).to have_http_status(:created)
+      automation_rules = JSON.parse(response.body).dig('data', 'automation_rules')
+      expect(automation_rules['description']).to eq('Lead com fit confirmado')
+    end
+  end
+end

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -187,6 +187,29 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
           as: :json
 
       expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('trigger "stage_entered" is not supported')
+      )
+      expect(stage.reload.automation_rules['rules']).to be_nil
+    end
+
+    it 'rejects a rule with an unknown action instead of dropping it' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'action' => 'send_pigeon', 'action_value' => 'x' }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('action "send_pigeon" is not supported')
+      )
       expect(stage.reload.automation_rules['rules']).to be_nil
     end
 
@@ -200,6 +223,9 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
           as: :json
 
       expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules must be an object'
+      )
     end
 
     it 'rejects a description longer than the stored limit instead of truncating it' do


### PR DESCRIPTION
Dois cards entram aqui, no mesmo controller de estágio de pipeline. O primeiro abriu o PR; o segundo saiu da revisão dele, e separá-lo em um PR próprio conflitaria linha a linha com este.

## CRM-254 — a descrição do estágio some no update

`automation_rules` é uma coluna `jsonb` única, então atribuir substitui o objeto inteiro. `normalize_automation_rules` montava o payload do zero a cada chamada, então um update que carregava só `rules` voltava — e era gravado — sem `description`, perdendo a descrição do estágio. O caso espelhado também estava quebrado: um update com só `description` derrubava as regras.

O payload normalizado agora é mesclado sobre o `automation_rules` já gravado no registro em edição. No create não há objeto gravado, então o comportamento não muda. Mandar uma chave explicitamente continua sobrescrevendo — `description: ""` limpa a descrição, `rules: []` limpa as regras.

## CRM-255 — escrita inválida respondia 200 e sumia

A revisão do primeiro commit encontrou três caminhos em que a API respondia errado e ninguém ficava sabendo:

- `stage_type` desconhecido levantava `ArgumentError` na atribuição do enum e virava **500** pelo `rescue_from StandardError` global. O catálogo do copiloto anunciava o campo como "texto livre", então isso era alcançável só pedindo um funil ao Darwin.
- Regra com gatilho ou ação inválidos era descartada pelo `filter_map` do normalizador e voltava **200**, como se tivesse sido salva.
- Descrição acima do limite gravado era truncada em silêncio.

Os três agora falham com **422**. `automation_rules` que não seja objeto também vira 422 em vez de ser ignorado — e esse caso era o pior dos quatro: uma string JSON zerava o objeto inteiro, levando a descrição junto.

A mensagem passou a nomear **o valor recusado**, não só os aceitos: `automation_rules.rules[0].trigger "stage_entered" is not supported; must be one of: ...`. Quem lê o erro não precisa mais diferenciar o próprio payload contra a lista para achar o typo.

O último commit fecha a mesma família de defeito num subcampo. O `trigger_value` do gatilho `inactivity` era moldado à força: base fora do enum virava `no_customer_reply` e um `minutes` ilegível virava `0` — e `0` faz `StageInactivityActionsService#evaluate_rule` disparar na primeira varredura em vez de esperar. Quem configurava "avisar depois de 30 minutos parado" ganhava um disparo imediato, com 200. Base inválida, `minutes` ausente ou não-inteiro e `trigger_value` não-objeto agora respondem 422 nomeando o valor.

As checagens por regra saíram para um `rule_errors` próprio, senão o coletor de erros passava dos limites de complexidade.

## Ordem de merge

evolution-foundation/evo-ai-frontend-community#322 precisa entrar **antes** deste PR. O formulário de edição de estágio limpa por omissão (não manda a chave quando o campo fica vazio), e isso só funciona enquanto a API substitui o objeto inteiro. Com a mesclagem e sem o #322, o usuário deixa de conseguir apagar a descrição de um estágio.

A metade do copiloto é o evolution-foundation/evo-skyway-service#9, e a ordem dele tem duas pressões opostas. Entrar **antes** deste PR expõe a descrição no catálogo enquanto a API ainda substitui o objeto: o copiloto escreve a descrição no create e a apaga no update seguinte, em silêncio e com perda de dado. Entrar **depois** abre uma janela em que a validação nova recusa com 422 a regra de inatividade que o catálogo do #9 ainda não sabe montar — barulhento, mas sem perda.

A recomendação é manter #322 → #298 → #9 e mesclar os dois últimos juntos, encurtando a janela para perto de zero.

## Testes

`spec/requests/api/v1/pipeline_stages_spec.rb` é novo — o controller não tinha spec. Cobre preservação e limpeza das duas chaves, o padrão de omissão, leitura por `GET` no `show` e no `index`, e os payloads agora rejeitados, incluindo os quatro do `trigger_value` de inatividade. Sem o primeiro commit, 4 exemplos falham.

`bundle exec rspec spec/requests/api/v1/pipeline*.rb spec/services/pipelines/ spec/models/pipeline*_spec.rb` → 196 exemplos, 0 falhas.

Validado também com a API de pé, contra o Postgres community, comparando o mesmo estágio na `develop` e com o patch. Na `develop` os três payloads ruins voltam 200: gatilho e ação fora do enum viram `{"rules": []}`, e a string JSON zera tudo para `{}`. Com o patch os três viram 422 e o estado gravado não muda; regra válida continua gravando com a descrição preservada.

## Summary by Sourcery

Preserve pipeline stage automation rule data during partial updates and reject invalid automation rule payloads with actionable validation errors.

Bug Fixes:
- Preserve existing `automation_rules` keys when partially updating a pipeline stage while still allowing explicit clearing of descriptions and rules.
- Return 422 validation errors for invalid stage types, malformed automation rules, unsupported triggers or actions, invalid inactivity values, and overlong descriptions instead of silently dropping or truncating data.

Enhancements:
- Add comprehensive request coverage for automation rule preservation, clearing, retrieval, creation, and rejected payloads.

Tests:
- Add controller request specs covering pipeline stage automation rule updates, reads, creates, and validation failures.
