### PR TITLE
fix(pipeline_stages): rules fora de forma volta 422 em vez de 500 (CRM-254)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -140,6 +140,12 @@ on:
       - 'app/services/templates/**'
       - 'spec/requests/api/v1/templates_export_visibility_rbac_spec.rb'
       - 'spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb'
+      # CRM-254/CRM-255: automation_rules is one jsonb column, so this controller decides
+      # whether an update merges over what is stored or replaces it. Replacing drops the
+      # stage description on a rules-only write — data loss that answers 200. The same
+      # guard is what keeps a malformed write at 422 instead of 500. No other lane runs it.
+      - 'app/controllers/api/v1/pipeline_stages_controller.rb'
+      - 'spec/requests/api/v1/pipeline_stages_spec.rb'
 
 permissions:
   contents: read
@@ -240,4 +246,5 @@ jobs:
             spec/services/automation_rules/contact_action_service_spec.rb \
             spec/requests/api/v1/templates_export_visibility_rbac_spec.rb \
             spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb \
+            spec/requests/api/v1/pipeline_stages_spec.rb \
             --format progress

--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -183,7 +183,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     raw = params.dig(:pipeline_stage, :automation_rules)
     return if raw.blank?
 
-    details = if raw.is_a?(ActionController::Parameters) || raw.is_a?(Hash)
+    details = if raw.respond_to?(:to_unsafe_h)
                 automation_rules_errors(raw.to_unsafe_h.with_indifferent_access)
               else
                 ['automation_rules must be an object']
@@ -204,6 +204,11 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     if ar.key?('description') && ar['description'].to_s.length > DESCRIPTION_MAX_LENGTH
       details << "automation_rules.description must be at most #{DESCRIPTION_MAX_LENGTH} characters"
     end
+
+    # `rules` as anything but an array (an object keyed by index, say) is what a caller that
+    # guesses the shape sends. Array() would turn it into pairs and rule_errors would raise
+    # on them — a 500 out of the guard whose whole job is to answer 422.
+    return details << 'automation_rules.rules must be an array' if ar.key?('rules') && !ar['rules'].is_a?(Array)
 
     Array(ar['rules']).each_with_index { |rule, index| details.concat(rule_errors(rule, index)) }
 
@@ -326,7 +331,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   end
 
   def normalize_automation_rules(raw)
-    return {} unless raw.respond_to?(:to_h)
+    return {} unless raw.respond_to?(:to_unsafe_h)
 
     ar = raw.to_unsafe_h.with_indifferent_access
     result = {}

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -228,6 +228,43 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
       )
     end
 
+    # A caller that guesses the shape sends `rules` as an object keyed by index. Walking it
+    # as a list of pairs raises TypeError, which the global rescue turns into a 500 — the
+    # very answer this guard exists to replace.
+    it 'rejects rules sent as an object instead of raising' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: { '0' => { 'trigger' => 'label_added', 'action' => 'apply_label', 'action_value' => 'x' } }
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules must be an array'
+      )
+    end
+
+    it 'rejects automation_rules sent as a list' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: [{ 'description' => 'x' }] }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules must be an object'
+      )
+    end
+
     it 'rejects an inactivity base outside the enum instead of silently defaulting it' do
       put :update,
           params: {


### PR DESCRIPTION
`Array(ar['rules'])` sobre um **objeto** vira lista de pares, e `rule_errors` chama `to_h` em cada par — `TypeError`, que o `rescue_from StandardError` global entrega como **500**. Ou seja: o guard que existe para trocar 500 por 422 respondia 500 numa forma de entrada plausível.

Alcançável pelo copiloto: o `evo-skyway-service` repassa o argumento do modelo para o corpo sem coagir forma (`internal/agent/tools.go`, `buildBody`). O catálogo declara `rules` como array, mas nada valida — e "modelo mandando objeto onde o schema pede array" é a classe de bug do CRM-254.

Comprovado contra a `develop` (`0dbe0088`), mesmo payload:

| payload | antes | depois |
|---|---|---|
| `automation_rules: { rules: { "0": {...} } }` | **500** `INTERNAL_ERROR` | **422** `automation_rules.rules must be an array` |

## Dois guards que nunca disparavam

`raw.is_a?(Hash)` em `reject_invalid_automation_rules` nunca é verdade — `ActionController::Parameters` não herda de `Hash` desde o Rails 5 — e, se fosse, `Hash` não responde a `to_unsafe_h`, então o ramo estouraria `NoMethodError`. `normalize_automation_rules` tinha a mesma inversão (`respond_to?(:to_h)` seguido de `to_unsafe_h`). Os dois passam a checar `to_unsafe_h`.

## spec-staleness-guard

O par controller/spec entrou no `spec-staleness-guard.yml`. Não há lane de rspec geral neste repo — o guard é o que roda spec — e ele **não disparou** nem na #298 nem nas PRs do CRM-255, porque `app/controllers/api/v1/pipeline_stages_controller.rb` não estava nos `paths:`. Sem isso o `pipeline_stages_spec.rb` é documentação, não trava.

## Testes

Dois exemplos novos em `spec/requests/api/v1/pipeline_stages_spec.rb`: `rules` como objeto e `automation_rules` como lista. Sem o fix, o primeiro falha com 500.

`bundle exec rspec spec/requests/api/v1/pipeline_stages_spec.rb spec/requests/api/v1/pipelines_activation_spec.rb spec/requests/api/v1/pipeline_items_archived_spec.rb spec/services/pipelines/ spec/models/pipeline_spec.rb spec/models/pipeline_item_spec.rb spec/listeners/pipeline_stage_automation_listener_spec.rb` → 101 exemplos, 0 falhas.

## Summary by Sourcery

Reject malformed pipeline-stage automation rules with clear validation errors and ensure the associated request spec runs in CI.

Bug Fixes:
- Return HTTP 422 validation errors when pipeline-stage automation rules are provided in invalid shapes instead of allowing them to become HTTP 500 errors.

Enhancements:
- Correct automation-rules parameter handling for Rails parameter objects during validation and normalization.

CI:
- Add the pipeline stages controller and request spec to the spec staleness guard so relevant changes run their regression tests.

Tests:
- Add request coverage for rules provided as an object and automation_rules provided as a list.