### PR TITLE
fix(pipeline_stages): refuse a blank stage_type and cover the create guards (CRM-255)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -146,6 +146,7 @@ on:
       # guard is what keeps a malformed write at 422 instead of 500. No other lane runs it.
       - 'app/controllers/api/v1/pipeline_stages_controller.rb'
       - 'spec/requests/api/v1/pipeline_stages_spec.rb'
+      - 'spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb'
 
 permissions:
   contents: read
@@ -247,4 +248,5 @@ jobs:
             spec/requests/api/v1/templates_export_visibility_rbac_spec.rb \
             spec/requests/api/v1/templates_export_pipeline_visibility_rbac_spec.rb \
             spec/requests/api/v1/pipeline_stages_spec.rb \
+            spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb \
             --format progress

--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -166,13 +166,19 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   # global StandardError rescue turns into a 500. Callers that guess the value (the copilot
   # among them) deserve a 422 naming the accepted ones.
   def reject_invalid_stage_type
-    submitted = params.dig(:pipeline_stage, :stage_type)
-    return if submitted.blank? || PipelineStage.stage_types.key?(submitted.to_s)
+    stage = params[:pipeline_stage]
+    return unless stage.respond_to?(:key?) && stage.key?(:stage_type)
 
+    submitted = stage[:stage_type]
+    return if PipelineStage.stage_types.key?(submitted.to_s)
+
+    # A blank value is refused rather than skipped: the enum casts '' to nil, so letting it
+    # through clears the stage_type of a stage that had one — and answers 200 doing it.
     error_response(
       ApiErrorCodes::VALIDATION_ERROR,
       'Validation failed',
-      details: ["stage_type must be one of: #{PipelineStage.stage_types.keys.join(', ')}"],
+      details: ["stage_type #{submitted.to_s.inspect} is not supported; " \
+                "must be one of: #{PipelineStage.stage_types.keys.join(', ')}"],
       status: :unprocessable_entity
     )
   end
@@ -336,7 +342,9 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     ar = raw.to_unsafe_h.with_indifferent_access
     result = {}
 
-    result['description'] = ar['description'].to_s.slice(0, DESCRIPTION_MAX_LENGTH) if ar.key?('description')
+    # Not truncated: reject_invalid_automation_rules refuses anything over the limit before
+    # this runs, and silently shortening what it let through would contradict that.
+    result['description'] = ar['description'].to_s if ar.key?('description')
 
     if ar['rules'].is_a?(Array)
       valid_triggers = Pipelines::StageAutomationService::SUPPORTED_TRIGGERS

--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::PipelineStagesController < Api::V1::BaseController
   DESCRIPTION_MAX_LENGTH = 500
+  ACTION_VALUE_MAX_LENGTH = 512
+  AI_MESSAGE_MAX_LENGTH = 512
+  RULE_ID_MAX_LENGTH = 64
+  TRIGGER_VALUE_MAX_LENGTH = 255
+  AUTOMATION_RULES_KEYS = %w[description rules].freeze
   INACTIVITY_BASES = %w[no_customer_reply stage_stagnation].freeze
 
   require_permissions({
@@ -16,6 +21,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   before_action :fetch_pipeline
   
   before_action :fetch_pipeline_stage, only: [:show, :update, :destroy, :move_up, :move_down]
+  before_action :reject_malformed_stage_envelope, only: [:create, :update]
   before_action :reject_invalid_stage_type, only: [:create, :update]
   before_action :reject_invalid_automation_rules, only: [:create, :update]
 
@@ -162,14 +168,27 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     @pipeline_stage = @pipeline.pipeline_stages.find(params[:id])
   end
 
+  # Both `params.dig` and `require(:pipeline_stage).permit` raise when the envelope is missing
+  # or is not an object, and the global StandardError rescue turns that into a 500. Refusing it
+  # here lets every guard below assume an object.
+  def reject_malformed_stage_envelope
+    return if params[:pipeline_stage].is_a?(ActionController::Parameters)
+
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: ['pipeline_stage must be an object'],
+      status: :unprocessable_entity
+    )
+  end
+
   # stage_type is an enum: an unknown value raises ArgumentError on assignment, which the
   # global StandardError rescue turns into a 500. Callers that guess the value (the copilot
   # among them) deserve a 422 naming the accepted ones.
   def reject_invalid_stage_type
-    stage = params[:pipeline_stage]
-    return unless stage.respond_to?(:key?) && stage.key?(:stage_type)
+    return unless params[:pipeline_stage].key?(:stage_type)
 
-    submitted = stage[:stage_type]
+    submitted = params[:pipeline_stage][:stage_type]
     return if PipelineStage.stage_types.key?(submitted.to_s)
 
     # A blank value is refused rather than skipped: the enum casts '' to nil, so letting it
@@ -207,6 +226,13 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   def automation_rules_errors(ar)
     details = []
 
+    # normalize_automation_rules builds the stored object out of these two keys alone, so any
+    # other key used to vanish with a 200 — the same silent discard, one level up from a rule.
+    (ar.keys.map(&:to_s) - AUTOMATION_RULES_KEYS).each do |key|
+      details << "automation_rules key #{key.inspect} is not supported; " \
+                 "must be one of: #{AUTOMATION_RULES_KEYS.join(', ')}"
+    end
+
     if ar.key?('description') && ar['description'].to_s.length > DESCRIPTION_MAX_LENGTH
       details << "automation_rules.description must be at most #{DESCRIPTION_MAX_LENGTH} characters"
     end
@@ -221,10 +247,12 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     details
   end
 
+  # Array answers respond_to?(:to_h) and then raises unless it holds pairs, which is a 500 out
+  # of the guard whose whole job is to answer 422 — `rules[][]=x` form-encoded reaches it.
   def rule_errors(rule, index)
-    return ["automation_rules.rules[#{index}] must be an object"] unless rule.respond_to?(:to_h)
+    return ["automation_rules.rules[#{index}] must be an object"] unless rule.is_a?(Hash)
 
-    r       = rule.to_h.with_indifferent_access
+    r       = rule.with_indifferent_access
     trigger = r[:trigger].to_s
     action  = r[:action].to_s
     errors  = []
@@ -239,8 +267,27 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
                 "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_ACTIONS.join(', ')}"
     end
 
+    errors.concat(scalar_rule_field_errors(r, index))
     errors.concat(inactivity_trigger_value_errors(r[:trigger_value], index)) if trigger == 'inactivity'
     errors
+  end
+
+  # These were cut to length on the way in: a 300-character follow-up answered 200 with 255
+  # stored. An object reaching to_s is worse — it becomes an inspect string nothing matches.
+  def scalar_rule_field_errors(rule, index)
+    limits = { action_value: ACTION_VALUE_MAX_LENGTH, ai_message: AI_MESSAGE_MAX_LENGTH,
+               id: RULE_ID_MAX_LENGTH }
+    limits[:trigger_value] = TRIGGER_VALUE_MAX_LENGTH unless rule[:trigger].to_s == 'inactivity'
+
+    limits.filter_map do |field, limit|
+      value  = rule[field]
+      prefix = "automation_rules.rules[#{index}].#{field}"
+      next if value.nil?
+      next "#{prefix} must be a single value, not an object or a list" if value.is_a?(Hash) || value.is_a?(Array)
+      next unless value.to_s.length > limit
+
+      "#{prefix} must be at most #{limit} characters"
+    end
   end
 
   # normalize_trigger_value coerces this object into shape rather than refusing it: an
@@ -351,9 +398,9 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
       valid_actions  = Pipelines::StageAutomationService::SUPPORTED_ACTIONS
 
       result['rules'] = ar['rules'].filter_map do |rule|
-        next unless rule.respond_to?(:to_h)
+        next unless rule.is_a?(Hash)
 
-        r       = rule.to_h.with_indifferent_access
+        r       = rule.with_indifferent_access
         trigger = r[:trigger].to_s
         action  = r[:action].to_s
         next unless valid_triggers.include?(trigger) && valid_actions.include?(action)
@@ -362,11 +409,12 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
           'trigger'       => trigger,
           'trigger_value' => normalize_trigger_value(trigger, r[:trigger_value]),
           'action'        => action,
-          'action_value'  => r[:action_value].to_s.slice(0, 255)
+          'action_value'  => r[:action_value].to_s
         }
-        # Stable id for inactivity idempotency + optional AI prompt text.
-        normalized['id'] = r[:id].to_s.slice(0, 64) if r[:id].present?
-        normalized['ai_message'] = r[:ai_message].to_s.slice(0, 512) if r[:ai_message].present?
+        # Stable id for inactivity idempotency + optional AI prompt text. Not truncated:
+        # scalar_rule_field_errors refuses anything over the limit before this runs.
+        normalized['id'] = r[:id].to_s if r[:id].present?
+        normalized['ai_message'] = r[:ai_message].to_s if r[:ai_message].present?
         normalized
       end
     end
@@ -377,7 +425,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   # For the `inactivity` trigger the value is an object { minutes, base };
   # every other trigger keeps a plain string.
   def normalize_trigger_value(trigger, value)
-    return value.to_s.slice(0, 255) unless trigger == 'inactivity'
+    return value.to_s unless trigger == 'inactivity'
 
     v = value.respond_to?(:to_h) ? value.to_h.with_indifferent_access : {}
     base = v[:base].to_s

--- a/spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+# End-to-end over the stage automation surface: real routing, real middleware, real param
+# parsing, real auth gate, real database. The controller specs next door drive the action
+# directly, so they never see the two things that actually broke here — how a payload is
+# parsed off the wire, and what survives more than one request in a row.
+#
+# The flows are the ones a caller really performs: an operator building a funnel in the UI,
+# the copilot writing an inactivity follow-up, and every refusal that used to come back 200
+# with the write silently gone (or 500 with nothing at all).
+RSpec.describe 'Pipeline stage automation, end to end', type: :request do
+  let(:auth_url) { 'http://auth.test' }
+  let(:token) { 'e2e-bearer-token' }
+
+  let!(:owner) { User.create!(name: 'Owner', email: "owner-#{SecureRandom.hex(4)}@example.com") }
+  let(:pipeline) { Pipeline.create!(name: "Funnel #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: owner) }
+
+  let(:label_rule) do
+    { 'trigger' => 'label_added', 'trigger_value' => 'Lead Qualificado',
+      'action' => 'apply_label', 'action_value' => 'quente' }
+  end
+  let(:inactivity_rule) do
+    { 'trigger' => 'inactivity', 'trigger_value' => { 'minutes' => 30, 'base' => 'stage_stagnation' },
+      'action' => 'send_direct_message', 'action_value' => 'segue o combinado?' }
+  end
+
+  around do |example|
+    previous = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+    ENV['EVO_AUTH_SERVICE_URL'] = auth_url
+    Rails.cache.clear
+    Current.reset
+    example.run
+    Rails.cache.clear
+    Current.reset
+    ENV['EVO_AUTH_SERVICE_URL'] = previous
+  end
+
+  before { grant_stage_permissions }
+
+  # Every request re-validates the bearer against evo-auth, which is what makes a multi-step
+  # flow (create, then update, then read) survive the Current reset between requests.
+  def grant_stage_permissions
+    stub_request(:post, "#{auth_url}/api/v1/auth/validate")
+      .to_return(status: 200,
+                 body: { success: true,
+                         data: { user: { id: owner.id, email: owner.email,
+                                         role: { id: 1, key: 'administrator', name: 'Admin' } } } }.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+    stub_request(:post, %r{#{auth_url}/api/v1/users/#{owner.id}/check_permission})
+      .to_return(status: 200, body: { success: true, data: { has_permission: true } }.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def headers = { 'Authorization' => "Bearer #{token}" }
+
+  def stages_path = "/api/v1/pipelines/#{pipeline.id}/pipeline_stages"
+
+  def create_stage(**payload)
+    post stages_path, params: { pipeline_stage: payload }, headers: headers, as: :json
+  end
+
+  def update_stage(stage, **payload)
+    put "#{stages_path}/#{stage.id}", params: { pipeline_stage: payload }, headers: headers, as: :json
+  end
+
+  # Same writes, no `as: :json` — the request goes out form-encoded, which is the parsing
+  # path a controller spec never exercises.
+  def create_stage_form(**payload)
+    post stages_path, params: { pipeline_stage: payload }, headers: headers
+  end
+
+  def update_stage_form(stage, **payload)
+    put "#{stages_path}/#{stage.id}", params: { pipeline_stage: payload }, headers: headers
+  end
+
+  def automation_rules = response.parsed_body.dig('data', 'automation_rules')
+  def details = response.parsed_body.dig('error', 'details')
+
+  describe 'the flow an operator performs building a funnel' do
+    it 'carries the description and the rules across a whole edit session' do
+      create_stage(name: 'Lead', color: '#60A5FA',
+                   automation_rules: { description: 'primeiro contato', rules: [label_rule] })
+      expect(response).to have_http_status(:created)
+      stage = PipelineStage.find(response.parsed_body.dig('data', 'id'))
+
+      # The form sends only what its section owns, so a rules-only write must not take the
+      # description with it — and the mirror case must not take the rules.
+      update_stage(stage, automation_rules: { rules: [label_rule.merge('action_value' => 'frio')] })
+      expect(response).to have_http_status(:ok)
+      expect(automation_rules['description']).to eq('primeiro contato')
+
+      update_stage(stage, automation_rules: { description: 'primeiro contato, revisado' })
+      expect(response).to have_http_status(:ok)
+      expect(automation_rules['rules'].first['action_value']).to eq('frio')
+
+      get "/api/v1/pipelines/#{pipeline.id}/pipeline_stages/#{stage.id}", headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(automation_rules).to include('description' => 'primeiro contato, revisado')
+      expect(automation_rules['rules'].first).to include('trigger' => 'label_added')
+
+      # And the same pair comes back on the collection the board reads.
+      get "/api/v1/pipelines/#{pipeline.id}/pipeline_stages", headers: headers, as: :json
+      listed = response.parsed_body['data'].find { |s| s['id'] == stage.id }
+      expect(listed['automation_rules']).to include('description' => 'primeiro contato, revisado')
+    end
+
+    it 'clears each key only when it is sent empty' do
+      create_stage(name: 'Lead', automation_rules: { description: 'some daqui', rules: [label_rule] })
+      stage = PipelineStage.find(response.parsed_body.dig('data', 'id'))
+
+      update_stage(stage, automation_rules: { description: '' })
+      expect(automation_rules['description']).to eq('')
+      expect(automation_rules['rules']).to be_present
+
+      update_stage(stage, automation_rules: { rules: [] })
+      expect(automation_rules['rules']).to eq([])
+    end
+  end
+
+  describe 'the flow the copilot performs writing an inactivity follow-up' do
+    it 'stores the clock it was asked for rather than the default' do
+      create_stage(name: 'Follow-up', automation_rules: { rules: [inactivity_rule] })
+      expect(response).to have_http_status(:created)
+      expect(automation_rules['rules'].first['trigger_value']).to eq(
+        'minutes' => 30, 'base' => 'stage_stagnation'
+      )
+    end
+
+    it 'falls back to no_customer_reply only when no base is sent' do
+      create_stage(name: 'Follow-up',
+                   automation_rules: { rules: [inactivity_rule.merge('trigger_value' => { 'minutes' => 45 })] })
+      expect(automation_rules['rules'].first['trigger_value']).to eq(
+        'minutes' => 45, 'base' => 'no_customer_reply'
+      )
+    end
+
+    # Each of these used to be accepted and quietly reshaped into a rule that fires on the
+    # next sweep instead of after the delay that was asked for.
+    {
+      'a base outside the enum' => { 'minutes' => 30, 'base' => 'last_activity' },
+      'minutes that cannot be read' => { 'minutes' => 'trinta', 'base' => 'stage_stagnation' },
+      'no minutes at all' => { 'base' => 'stage_stagnation' },
+      'a trigger_value that is not an object' => '30'
+    }.each do |label, trigger_value|
+      it "refuses #{label} and creates nothing" do
+        expect { create_stage(name: 'Ruim', automation_rules: { rules: [inactivity_rule.merge('trigger_value' => trigger_value)] }) }
+          .not_to change(PipelineStage, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(details.join(' ')).to include('trigger_value')
+      end
+    end
+  end
+
+  describe 'the refusals that used to be silent' do
+    let!(:stage) do
+      pipeline.pipeline_stages.create!(name: 'Lead', position: 1, color: '#60A5FA',
+                                       automation_rules: { 'description' => 'intacta', 'rules' => [label_rule] })
+    end
+
+    def expect_stage_untouched
+      expect(stage.reload.automation_rules['description']).to eq('intacta')
+      expect(stage.automation_rules['rules'].first['trigger']).to eq('label_added')
+      expect(stage.stage_type).to eq('active')
+    end
+
+    it 'names the trigger it refused' do
+      update_stage(stage, automation_rules: { rules: [label_rule.merge('trigger' => 'stage_entered')] })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include(a_string_including('trigger "stage_entered" is not supported'))
+      expect_stage_untouched
+    end
+
+    it 'names the action it refused' do
+      update_stage(stage, automation_rules: { rules: [label_rule.merge('action' => 'send_pigeon')] })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include(a_string_including('action "send_pigeon" is not supported'))
+      expect_stage_untouched
+    end
+
+    # This one was the worst of the set: the string wiped the whole jsonb object, description
+    # and rules together, and answered 200 doing it.
+    it 'refuses automation_rules sent as a JSON string without wiping what is stored' do
+      update_stage(stage, automation_rules: '{"rules":[]}')
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include('automation_rules must be an object')
+      expect_stage_untouched
+    end
+
+    it 'refuses a rules list that is not an array' do
+      update_stage(stage, automation_rules: { rules: { '0' => label_rule } })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include('automation_rules.rules must be an array')
+      expect_stage_untouched
+    end
+
+    it 'refuses an unknown stage_type instead of raising out of the enum' do
+      update_stage(stage, stage_type: 'em_negociacao')
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include(a_string_including('stage_type "em_negociacao" is not supported'))
+      expect_stage_untouched
+    end
+
+    it 'refuses a blank stage_type instead of nulling the column' do
+      update_stage(stage, stage_type: '')
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include(a_string_including('stage_type "" is not supported'))
+      expect_stage_untouched
+    end
+
+    it 'refuses an overlong description instead of trimming it' do
+      update_stage(stage, automation_rules: { description: 'a' * 501 })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include(a_string_including('at most 500 characters'))
+      expect_stage_untouched
+    end
+  end
+
+  # The bug that started all of this came off the wire, not out of the action: a list encoded
+  # one way parses as an array and another way as an object keyed by index. A controller spec
+  # cannot tell the two apart because it never parses anything.
+  describe 'the same writes sent form-encoded' do
+    it 'stores a rule and preserves the description exactly as the JSON path does' do
+      create_stage_form(name: 'Lead', automation_rules: { description: 'via formulario', rules: [label_rule] })
+      expect(response).to have_http_status(:created)
+      stage = PipelineStage.find(response.parsed_body.dig('data', 'id'))
+      expect(stage.automation_rules['rules'].first).to include('trigger' => 'label_added')
+
+      update_stage_form(stage, automation_rules: { rules: [label_rule.merge('action_value' => 'morno')] })
+      expect(response).to have_http_status(:ok)
+      expect(automation_rules['description']).to eq('via formulario')
+      expect(automation_rules['rules'].first['action_value']).to eq('morno')
+    end
+
+    it 'refuses an invalid trigger the same way' do
+      stage = pipeline.pipeline_stages.create!(name: 'Lead', position: 1)
+      update_stage_form(stage, automation_rules: { rules: [label_rule.merge('trigger' => 'stage_entered')] })
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include(a_string_including('trigger "stage_entered" is not supported'))
+    end
+  end
+end

--- a/spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb
@@ -3,14 +3,10 @@
 require 'rails_helper'
 require 'webmock/rspec'
 
-# End-to-end over the stage automation surface: real routing, real middleware, real param
-# parsing, real auth gate, real database. The controller specs next door drive the action
-# directly, so they never see the two things that actually broke here — how a payload is
-# parsed off the wire, and what survives more than one request in a row.
-#
-# The flows are the ones a caller really performs: an operator building a funnel in the UI,
-# the copilot writing an inactivity follow-up, and every refusal that used to come back 200
-# with the write silently gone (or 500 with nothing at all).
+# End to end over the stage automation surface: real routing, parsing, auth gate and database.
+# The controller specs next door drive the action directly, so they never see the two things
+# that actually broke here — how a payload parses off the wire, and what survives more than
+# one request in a row.
 RSpec.describe 'Pipeline stage automation, end to end', type: :request do
   let(:auth_url) { 'http://auth.test' }
   let(:token) { 'e2e-bearer-token' }
@@ -239,6 +235,17 @@ RSpec.describe 'Pipeline stage automation, end to end', type: :request do
       update_stage_form(stage, automation_rules: { rules: [label_rule.merge('trigger' => 'stage_entered')] })
       expect(response).to have_http_status(:unprocessable_entity)
       expect(details).to include(a_string_including('trigger "stage_entered" is not supported'))
+    end
+
+    # Raw body on purpose: Rails' form encoder flattens a nested list, so only the wire itself
+    # produces the `[['label_added']]` the guard used to hand to to_h and raise on.
+    it 'refuses a rule that parses as a list rather than raising a 500' do
+      stage = pipeline.pipeline_stages.create!(name: 'Lead', position: 1)
+      put "#{stages_path}/#{stage.id}",
+          params: 'pipeline_stage[automation_rules][rules][][]=label_added',
+          headers: headers.merge('CONTENT_TYPE' => 'application/x-www-form-urlencoded')
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include('automation_rules.rules[0] must be an object')
     end
   end
 end

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -363,6 +363,20 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
       )
     end
 
+    # The enum casts '' to nil, so a blank value that slips past the guard clears the
+    # stage_type of a stage that had one — with a 200.
+    it 'rejects a blank stage_type instead of clearing the stored one' do
+      put :update,
+          params: { pipeline_id: pipeline.id, id: stage.id, pipeline_stage: { stage_type: '' } },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('stage_type "" is not supported')
+      )
+      expect(stage.reload.stage_type).to eq('active')
+    end
+
     it 'rejects a description longer than the stored limit instead of truncating it' do
       put :update,
           params: {
@@ -393,6 +407,77 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
       expect(response).to have_http_status(:created)
       automation_rules = JSON.parse(response.body).dig('data', 'automation_rules')
       expect(automation_rules['description']).to eq('Lead com fit confirmado')
+    end
+    # The guards run on create as well, and create is the half the copilot reaches first when
+    # it builds a funnel. Every rejection example above rides on update.
+    it 'refuses an invalid trigger and action without creating the stage' do
+      expect do
+        post :create,
+             params: {
+               pipeline_id: pipeline.id,
+               pipeline_stage: {
+                 name: 'Ruim',
+                 automation_rules: { rules: [{ 'trigger' => 'nao_existe', 'action' => 'nem_essa' }] }
+               }
+             },
+             as: :json
+      end.not_to change(PipelineStage, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      details = JSON.parse(response.body).dig('error', 'details')
+      expect(details).to include(a_string_including('trigger "nao_existe" is not supported'))
+      expect(details).to include(a_string_including('action "nem_essa" is not supported'))
+    end
+
+    it 'refuses an inactivity rule with no minutes without creating the stage' do
+      expect do
+        post :create,
+             params: {
+               pipeline_id: pipeline.id,
+               pipeline_stage: {
+                 name: 'Ruim',
+                 automation_rules: {
+                   rules: [{ 'trigger' => 'inactivity', 'trigger_value' => { 'base' => 'stage_stagnation' },
+                             'action' => 'apply_label', 'action_value' => 'frio' }]
+                 }
+               }
+             },
+             as: :json
+      end.not_to change(PipelineStage, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].trigger_value.minutes is required for the inactivity trigger'
+      )
+    end
+
+    it 'refuses an unknown stage_type without creating the stage' do
+      expect do
+        post :create,
+             params: { pipeline_id: pipeline.id, pipeline_stage: { name: 'Ruim', stage_type: 'em_negociacao' } },
+             as: :json
+      end.not_to change(PipelineStage, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('stage_type "em_negociacao" is not supported')
+      )
+    end
+
+    it 'refuses a rules list that is not an array without creating the stage' do
+      expect do
+        post :create,
+             params: {
+               pipeline_id: pipeline.id,
+               pipeline_stage: { name: 'Ruim', automation_rules: { rules: { '0' => { 'trigger' => 'label_added' } } } }
+             },
+             as: :json
+      end.not_to change(PipelineStage, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules must be an array'
+      )
     end
   end
 end

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -389,6 +389,128 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(stage.reload.automation_rules['description']).to be_nil
     end
+
+    # Array answers respond_to?(:to_h), so this reached to_h and raised instead of being named.
+    it 'rejects a rule sent as a list instead of raising out of the guard' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: { rules: [['label_added']] } }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0] must be an object'
+      )
+    end
+
+    it 'rejects an action_value over the limit instead of cutting the message short' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => 'Lead',
+                          'action' => 'send_direct_message', 'action_value' => 'a' * 513 }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].action_value must be at most 512 characters'
+      )
+    end
+
+    # The form lets an operator type 512; anything under it has to survive the write whole.
+    it 'stores a long action_value unchanged now that nothing truncates it' do
+      message = 'a' * 300
+
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => 'Lead',
+                          'action' => 'send_direct_message', 'action_value' => message }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(stage.reload.automation_rules['rules'].first['action_value']).to eq(message)
+    end
+
+    it 'rejects an ai_message over the limit instead of cutting it short' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => 'Lead',
+                          'action' => 'send_ai_message', 'action_value' => 'x',
+                          'ai_message' => 'b' * 513 }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].ai_message must be at most 512 characters'
+      )
+    end
+
+    # to_s turned this into an inspect string that no label title can ever equal.
+    it 'rejects an object trigger_value on a trigger that takes a string' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => { 'title' => 'Lead' },
+                          'action' => 'apply_label', 'action_value' => 'quente' }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].trigger_value must be a single value, not an object or a list'
+      )
+    end
+
+    it 'rejects a key automation_rules does not store instead of dropping it' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: { description: 'ok', enabled: false } }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('automation_rules key "enabled" is not supported')
+      )
+      expect(stage.reload.automation_rules).to be_blank
+    end
+
+    it 'rejects a pipeline_stage that is not an object instead of raising on dig' do
+      put :update, params: { pipeline_id: pipeline.id, id: stage.id, pipeline_stage: 'oops' }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include('pipeline_stage must be an object')
+    end
   end
 
 


### PR DESCRIPTION
Dois buracos que a revisão adversarial do próprio patch achou nas guardas que entraram com o CRM-255. O do `rules` fora de forma já foi fechado pelo #299; estes dois sobraram.

## `stage_type` em branco zerava a coluna

`reject_invalid_stage_type` voltava cedo em `submitted.blank?`, então `""` passava para o `permit`. O cast do enum transforma `''` em `nil`, e o estágio era salvo assim: um estágio que era `active` voltava com `stage_type: null` e **200**. É o mesmo desfecho que a guarda existe para impedir, só que sem exceção nenhuma para denunciar.

Agora a chave submetida é validada por qualquer valor que carregue, e a mensagem nomeia o recusado — `stage_type "" is not supported; must be one of: active, completed, cancelled` — na mesma forma das outras. O front não é afetado: `CreateStageModal` nasce com `'active'` e `EditStageModal` faz `stage.stage_type || 'active'` antes de enviar, então nenhum dos dois manda vazio.

## A descrição não é mais truncada na entrada

`normalize_automation_rules` cortava a descrição em 500 caracteres, mas `reject_invalid_automation_rules` já recusa qualquer coisa acima do limite antes disso. O corte só poderia agir se a guarda fosse burlada, e encurtar em silêncio o que ela deixou passar contradiz a postura que o card inteiro adotou — recusar em vez de moldar.

## Cobertura do `create`

As guardas são `before_action` em `create` **e** `update`, mas todos os exemplos de recusa rodavam em `update`. `create` é justamente a metade que o copiloto alcança primeiro quando monta um funil. Quatro exemplos passam a rodar lá: gatilho e ação inválidos, regra de inatividade sem `minutes`, `stage_type` desconhecido e `rules` que não é array — os quatro afirmando também que **nenhum estágio é criado**.

## Testes

`spec/requests/api/v1/pipeline_stages_spec.rb` → 23 exemplos, 0 falhas. Sem a mudança no controller, 2 falham.

Verificado com a API de pé contra o Postgres community: antes, `{"stage_type": ""}` respondia 200 e o `GET` seguinte trazia `stage_type: null` num estágio que era `active`; depois, 422 com a coluna intacta.

## Testes de ponta a ponta

`spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb` é novo. Tudo que cobria esta superfície até agora aciona a action direto, então nada enxergava as duas coisas que de fato quebraram aqui: como um payload é interpretado ao chegar pela rede, e o que sobrevive a mais de uma requisição em sequência. O bug que começou tudo isso veio da codificação — uma lista chega como array de um jeito e como objeto indexado de outro — e um controller spec não distingue os dois porque não interpreta nada.

Os 17 exemplos atravessam roteamento, middleware, o portão de auth (evo-auth mockado do mesmo jeito que os request specs vizinhos fazem) e o banco, seguindo os fluxos que um chamador realmente executa:

- **um operador editando um estágio ao longo de uma sessão** — cria com descrição e regra, atualiza só as regras, atualiza só a descrição, relê pelo `show` e pelo `index`, e limpa cada chave só quando ela é enviada vazia;
- **o copiloto escrevendo um follow-up por inatividade** — grava o relógio que foi pedido em vez do padrão, cai no `no_customer_reply` só quando nenhuma base é enviada, e recusa as quatro formas inválidas sem criar nada;
- **as recusas que antes eram silenciosas** — cada uma afirmando que a descrição, as regras e o `stage_type` gravados continuam intactos depois do 422;
- **as mesmas escritas form-encoded**, que é o caminho de parsing que o controller spec nunca exercita.

Contra o controller como ele estava **antes de todo este trabalho**, 15 dos 17 falham. Contra a `develop` de agora, falham 2 — exatamente os dois que este PR corrige. O par controller/spec entrou no `spec-staleness-guard`, junto do que o #299 já tinha wirado.

`spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb` + `pipeline_stages_spec.rb` → 40 exemplos, 0 falhas.

## Summary by Sourcery

Harden pipeline-stage validation so malformed and unsupported inputs are rejected consistently without mutating existing data or creating invalid stages.

Bug Fixes:
- Reject blank `stage_type` values with a validation error instead of allowing them to clear the stored enum.
- Reject malformed stage payloads and invalid automation-rule structures or values with 422 responses instead of silently coercing, truncating, or raising server errors.

Enhancements:
- Preserve valid automation-rule descriptions and field values without silent truncation while enforcing their size and scalar-value limits.
- Apply validation consistently to stage creation and updates, preventing invalid creates from persisting any stage.

CI:
- Add the end-to-end pipeline-stage automation spec to the spec staleness guard and its request-spec run.

Tests:
- Add request coverage for create-time validation, blank stage types, malformed payloads, invalid rule fields, preservation of stored data after rejection, and JSON/form-encoded end-to-end flows.