### PR TITLE
fix(pipeline_stages): correções da revisão do #300 (CRM-255)

### DIFF
--- a/app/controllers/api/v1/pipeline_stages_controller.rb
+++ b/app/controllers/api/v1/pipeline_stages_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::PipelineStagesController < Api::V1::BaseController
   DESCRIPTION_MAX_LENGTH = 500
+  ACTION_VALUE_MAX_LENGTH = 512
+  AI_MESSAGE_MAX_LENGTH = 512
+  RULE_ID_MAX_LENGTH = 64
+  TRIGGER_VALUE_MAX_LENGTH = 255
+  AUTOMATION_RULES_KEYS = %w[description rules].freeze
   INACTIVITY_BASES = %w[no_customer_reply stage_stagnation].freeze
 
   require_permissions({
@@ -16,6 +21,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   before_action :fetch_pipeline
   
   before_action :fetch_pipeline_stage, only: [:show, :update, :destroy, :move_up, :move_down]
+  before_action :reject_malformed_stage_envelope, only: [:create, :update]
   before_action :reject_invalid_stage_type, only: [:create, :update]
   before_action :reject_invalid_automation_rules, only: [:create, :update]
 
@@ -162,14 +168,27 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     @pipeline_stage = @pipeline.pipeline_stages.find(params[:id])
   end
 
+  # Both `params.dig` and `require(:pipeline_stage).permit` raise when the envelope is missing
+  # or is not an object, and the global StandardError rescue turns that into a 500. Refusing it
+  # here lets every guard below assume an object.
+  def reject_malformed_stage_envelope
+    return if params[:pipeline_stage].is_a?(ActionController::Parameters)
+
+    error_response(
+      ApiErrorCodes::VALIDATION_ERROR,
+      'Validation failed',
+      details: ['pipeline_stage must be an object'],
+      status: :unprocessable_entity
+    )
+  end
+
   # stage_type is an enum: an unknown value raises ArgumentError on assignment, which the
   # global StandardError rescue turns into a 500. Callers that guess the value (the copilot
   # among them) deserve a 422 naming the accepted ones.
   def reject_invalid_stage_type
-    stage = params[:pipeline_stage]
-    return unless stage.respond_to?(:key?) && stage.key?(:stage_type)
+    return unless params[:pipeline_stage].key?(:stage_type)
 
-    submitted = stage[:stage_type]
+    submitted = params[:pipeline_stage][:stage_type]
     return if PipelineStage.stage_types.key?(submitted.to_s)
 
     # A blank value is refused rather than skipped: the enum casts '' to nil, so letting it
@@ -207,6 +226,13 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   def automation_rules_errors(ar)
     details = []
 
+    # normalize_automation_rules builds the stored object out of these two keys alone, so any
+    # other key used to vanish with a 200 — the same silent discard, one level up from a rule.
+    (ar.keys.map(&:to_s) - AUTOMATION_RULES_KEYS).each do |key|
+      details << "automation_rules key #{key.inspect} is not supported; " \
+                 "must be one of: #{AUTOMATION_RULES_KEYS.join(', ')}"
+    end
+
     if ar.key?('description') && ar['description'].to_s.length > DESCRIPTION_MAX_LENGTH
       details << "automation_rules.description must be at most #{DESCRIPTION_MAX_LENGTH} characters"
     end
@@ -221,10 +247,12 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
     details
   end
 
+  # Array answers respond_to?(:to_h) and then raises unless it holds pairs, which is a 500 out
+  # of the guard whose whole job is to answer 422 — `rules[][]=x` form-encoded reaches it.
   def rule_errors(rule, index)
-    return ["automation_rules.rules[#{index}] must be an object"] unless rule.respond_to?(:to_h)
+    return ["automation_rules.rules[#{index}] must be an object"] unless rule.is_a?(Hash)
 
-    r       = rule.to_h.with_indifferent_access
+    r       = rule.with_indifferent_access
     trigger = r[:trigger].to_s
     action  = r[:action].to_s
     errors  = []
@@ -239,8 +267,27 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
                 "must be one of: #{Pipelines::StageAutomationService::SUPPORTED_ACTIONS.join(', ')}"
     end
 
+    errors.concat(scalar_rule_field_errors(r, index))
     errors.concat(inactivity_trigger_value_errors(r[:trigger_value], index)) if trigger == 'inactivity'
     errors
+  end
+
+  # These were cut to length on the way in: a 300-character follow-up answered 200 with 255
+  # stored. An object reaching to_s is worse — it becomes an inspect string nothing matches.
+  def scalar_rule_field_errors(rule, index)
+    limits = { action_value: ACTION_VALUE_MAX_LENGTH, ai_message: AI_MESSAGE_MAX_LENGTH,
+               id: RULE_ID_MAX_LENGTH }
+    limits[:trigger_value] = TRIGGER_VALUE_MAX_LENGTH unless rule[:trigger].to_s == 'inactivity'
+
+    limits.filter_map do |field, limit|
+      value  = rule[field]
+      prefix = "automation_rules.rules[#{index}].#{field}"
+      next if value.nil?
+      next "#{prefix} must be a single value, not an object or a list" if value.is_a?(Hash) || value.is_a?(Array)
+      next unless value.to_s.length > limit
+
+      "#{prefix} must be at most #{limit} characters"
+    end
   end
 
   # normalize_trigger_value coerces this object into shape rather than refusing it: an
@@ -351,9 +398,9 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
       valid_actions  = Pipelines::StageAutomationService::SUPPORTED_ACTIONS
 
       result['rules'] = ar['rules'].filter_map do |rule|
-        next unless rule.respond_to?(:to_h)
+        next unless rule.is_a?(Hash)
 
-        r       = rule.to_h.with_indifferent_access
+        r       = rule.with_indifferent_access
         trigger = r[:trigger].to_s
         action  = r[:action].to_s
         next unless valid_triggers.include?(trigger) && valid_actions.include?(action)
@@ -362,11 +409,12 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
           'trigger'       => trigger,
           'trigger_value' => normalize_trigger_value(trigger, r[:trigger_value]),
           'action'        => action,
-          'action_value'  => r[:action_value].to_s.slice(0, 255)
+          'action_value'  => r[:action_value].to_s
         }
-        # Stable id for inactivity idempotency + optional AI prompt text.
-        normalized['id'] = r[:id].to_s.slice(0, 64) if r[:id].present?
-        normalized['ai_message'] = r[:ai_message].to_s.slice(0, 512) if r[:ai_message].present?
+        # Stable id for inactivity idempotency + optional AI prompt text. Not truncated:
+        # scalar_rule_field_errors refuses anything over the limit before this runs.
+        normalized['id'] = r[:id].to_s if r[:id].present?
+        normalized['ai_message'] = r[:ai_message].to_s if r[:ai_message].present?
         normalized
       end
     end
@@ -377,7 +425,7 @@ class Api::V1::PipelineStagesController < Api::V1::BaseController
   # For the `inactivity` trigger the value is an object { minutes, base };
   # every other trigger keeps a plain string.
   def normalize_trigger_value(trigger, value)
-    return value.to_s.slice(0, 255) unless trigger == 'inactivity'
+    return value.to_s unless trigger == 'inactivity'
 
     v = value.respond_to?(:to_h) ? value.to_h.with_indifferent_access : {}
     base = v[:base].to_s

--- a/spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_automation_e2e_spec.rb
@@ -3,14 +3,10 @@
 require 'rails_helper'
 require 'webmock/rspec'
 
-# End-to-end over the stage automation surface: real routing, real middleware, real param
-# parsing, real auth gate, real database. The controller specs next door drive the action
-# directly, so they never see the two things that actually broke here — how a payload is
-# parsed off the wire, and what survives more than one request in a row.
-#
-# The flows are the ones a caller really performs: an operator building a funnel in the UI,
-# the copilot writing an inactivity follow-up, and every refusal that used to come back 200
-# with the write silently gone (or 500 with nothing at all).
+# End to end over the stage automation surface: real routing, parsing, auth gate and database.
+# The controller specs next door drive the action directly, so they never see the two things
+# that actually broke here — how a payload parses off the wire, and what survives more than
+# one request in a row.
 RSpec.describe 'Pipeline stage automation, end to end', type: :request do
   let(:auth_url) { 'http://auth.test' }
   let(:token) { 'e2e-bearer-token' }
@@ -239,6 +235,17 @@ RSpec.describe 'Pipeline stage automation, end to end', type: :request do
       update_stage_form(stage, automation_rules: { rules: [label_rule.merge('trigger' => 'stage_entered')] })
       expect(response).to have_http_status(:unprocessable_entity)
       expect(details).to include(a_string_including('trigger "stage_entered" is not supported'))
+    end
+
+    # Raw body on purpose: Rails' form encoder flattens a nested list, so only the wire itself
+    # produces the `[['label_added']]` the guard used to hand to to_h and raise on.
+    it 'refuses a rule that parses as a list rather than raising a 500' do
+      stage = pipeline.pipeline_stages.create!(name: 'Lead', position: 1)
+      put "#{stages_path}/#{stage.id}",
+          params: 'pipeline_stage[automation_rules][rules][][]=label_added',
+          headers: headers.merge('CONTENT_TYPE' => 'application/x-www-form-urlencoded')
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(details).to include('automation_rules.rules[0] must be an object')
     end
   end
 end

--- a/spec/requests/api/v1/pipeline_stages_spec.rb
+++ b/spec/requests/api/v1/pipeline_stages_spec.rb
@@ -389,6 +389,128 @@ RSpec.describe Api::V1::PipelineStagesController, type: :controller do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(stage.reload.automation_rules['description']).to be_nil
     end
+
+    # Array answers respond_to?(:to_h), so this reached to_h and raised instead of being named.
+    it 'rejects a rule sent as a list instead of raising out of the guard' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: { rules: [['label_added']] } }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0] must be an object'
+      )
+    end
+
+    it 'rejects an action_value over the limit instead of cutting the message short' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => 'Lead',
+                          'action' => 'send_direct_message', 'action_value' => 'a' * 513 }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].action_value must be at most 512 characters'
+      )
+    end
+
+    # The form lets an operator type 512; anything under it has to survive the write whole.
+    it 'stores a long action_value unchanged now that nothing truncates it' do
+      message = 'a' * 300
+
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => 'Lead',
+                          'action' => 'send_direct_message', 'action_value' => message }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(stage.reload.automation_rules['rules'].first['action_value']).to eq(message)
+    end
+
+    it 'rejects an ai_message over the limit instead of cutting it short' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => 'Lead',
+                          'action' => 'send_ai_message', 'action_value' => 'x',
+                          'ai_message' => 'b' * 513 }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].ai_message must be at most 512 characters'
+      )
+    end
+
+    # to_s turned this into an inspect string that no label title can ever equal.
+    it 'rejects an object trigger_value on a trigger that takes a string' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: {
+              automation_rules: {
+                rules: [{ 'trigger' => 'label_added', 'trigger_value' => { 'title' => 'Lead' },
+                          'action' => 'apply_label', 'action_value' => 'quente' }]
+              }
+            }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        'automation_rules.rules[0].trigger_value must be a single value, not an object or a list'
+      )
+    end
+
+    it 'rejects a key automation_rules does not store instead of dropping it' do
+      put :update,
+          params: {
+            pipeline_id: pipeline.id,
+            id: stage.id,
+            pipeline_stage: { automation_rules: { description: 'ok', enabled: false } }
+          },
+          as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include(
+        a_string_including('automation_rules key "enabled" is not supported')
+      )
+      expect(stage.reload.automation_rules).to be_blank
+    end
+
+    it 'rejects a pipeline_stage that is not an object instead of raising on dig' do
+      put :update, params: { pipeline_id: pipeline.id, id: stage.id, pipeline_stage: 'oops' }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(JSON.parse(response.body).dig('error', 'details')).to include('pipeline_stage must be an object')
+    end
   end
 
 


### PR DESCRIPTION
Os achados da revisão do #300, fechados. Cinco buracos nas guardas que entraram com o CRM-255 — nenhum deles é regressão do #300, todos vieram junto com o #298/#299 e já estão na `develop`.

## Dois 500 saindo da guarda que existe para responder 422

`rule_errors` aceitava qualquer coisa que respondesse a `to_h`, e `Array` responde — e estoura se não guardar pares. `pipeline_stage[automation_rules][rules][][]=label_added` form-encoded chega como `[["label_added"]]` e virava `TypeError: wrong element type String at 0`. Agora é `is_a?(Hash)`.

`pipeline_stage` que não é objeto estourava no `params.dig` da guarda, e o `require(...).permit` estouraria logo atrás — blindar o `dig` sozinho não resolveria. Um `reject_malformed_stage_envelope` recusa o envelope na frente, e as guardas seguintes passam a poder assumir um objeto.

## Três coerções silenciosas que sobraram

`action_value`, `ai_message`, `id` e o `trigger_value` string eram cortados no `normalize_automation_rules`. O caso que importa: **o textarea de `send_direct_message` no front tem `maxLength={512}` e o back cortava em 255** — o operador digitava 300 caracteres de follow-up, a API respondia 200 e guardava 255. É a mesma truncagem que o #300 tirou da `description`, uma linha abaixo. Agora recusa acima do limite, e o teto do `action_value` subiu para 512 para casar com o que o formulário deixa digitar (`ai_message` já era 512 dos dois lados).

Objeto onde vai string também para: `trigger_value: {"title":"Lead"}` num `label_added` virava a string `"{\"title\" => \"Lead\"}"`, gravada com 200. A regra nascia impossível de casar e nunca disparava.

Chave que o `automation_rules` não guarda deixa de sumir: o objeto gravado é montado só a partir de `description` e `rules`, então qualquer outra chave era o mesmo descarte silencioso, um nível acima da regra.

## Testes

`pipeline_stages_spec.rb` + `pipeline_stages_automation_e2e_spec.rb` → **48 exemplos, 0 falhas**. Com o controller do #300 no lugar, **os 8 exemplos novos ficam vermelhos**.

O exemplo form-encoded manda o corpo cru de propósito: o encoder de formulário do Rails achata a lista aninhada (`[['label_added']]` sai como `rules[]=label_added`), então só o corpo cru produz a forma que estourava — com `params:` normal o exemplo passaria pelo motivo errado.

A lane inteira do `spec-staleness-guard` (45 arquivos) → **548 exemplos, 0 falhas**. Mais os 10 specs restantes que tocam `pipeline_stages` → **153 exemplos, 0 falhas**.

## Fica pendente

O `Input` genérico de `trigger_value` (`StageAutomationRules.tsx:261`, usado pelo `custom_attribute_updated`) não tem `maxLength`, e o back agora recusa acima de 255. Espelhar o limite no front é card do repo do frontend.

## Summary by Sourcery

Harden pipeline stage automation rule validation so malformed and lossy inputs are rejected with clear 422 responses.

Bug Fixes:
- Return validation errors instead of 500 responses for malformed pipeline stage envelopes and automation rules.
- Prevent silent truncation and coercion of automation rule values, including oversized fields, object-valued strings, and unsupported automation rule keys.

Enhancements:
- Align automation rule validation and persistence with supported field types and length limits.

Tests:
- Add request and end-to-end coverage for malformed payloads, validation limits, preservation of long values, and unsupported keys.