### PR TITLE
fix(automation_rules): dispara a automação de estágio em card sem conversa (CRM-258)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -21,6 +21,7 @@ on:
       - 'spec/services/pipelines/**'
       - 'spec/listeners/automation_rule_listener_attribute_changed_spec.rb'
       - 'spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb'
+      - 'spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb'
       - 'spec/listeners/pipeline_stage_automation_listener_spec.rb'
       - 'spec/listeners/action_cable_listener_conversation_update_spec.rb'
       - 'spec/jobs/action_cable_broadcast_job_spec.rb'
@@ -211,6 +212,7 @@ jobs:
             spec/services/pipelines/stage_automation_service_spec.rb \
             spec/listeners/automation_rule_listener_attribute_changed_spec.rb \
             spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb \
+            spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb \
             spec/listeners/pipeline_stage_automation_listener_spec.rb \
             spec/listeners/action_cable_listener_conversation_update_spec.rb \
             spec/jobs/action_cable_broadcast_job_spec.rb \

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -20,6 +20,7 @@ on:
       - 'spec/services/automation_rules/**'
       - 'spec/services/pipelines/**'
       - 'spec/listeners/automation_rule_listener_attribute_changed_spec.rb'
+      - 'spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb'
       - 'spec/listeners/pipeline_stage_automation_listener_spec.rb'
       - 'spec/listeners/action_cable_listener_conversation_update_spec.rb'
       - 'spec/jobs/action_cable_broadcast_job_spec.rb'
@@ -209,6 +210,7 @@ jobs:
             spec/services/automation_rules/conditions_filter_service_spec.rb \
             spec/services/pipelines/stage_automation_service_spec.rb \
             spec/listeners/automation_rule_listener_attribute_changed_spec.rb \
+            spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb \
             spec/listeners/pipeline_stage_automation_listener_spec.rb \
             spec/listeners/action_cable_listener_conversation_update_spec.rb \
             spec/jobs/action_cable_broadcast_job_spec.rb \

--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -4,6 +4,8 @@ class AutomationRuleListener < BaseListener
   # single contact). Both tunable via ENV; threshold high disables it.
   CONTACT_UPDATED_SPAM_THRESHOLD = (ENV.fetch('AUTOMATION_CONTACT_UPDATED_SPAM_THRESHOLD', 5).to_i)
   CONTACT_UPDATED_SPAM_WINDOW = (ENV.fetch('AUTOMATION_CONTACT_UPDATED_SPAM_WINDOW_SECONDS', 30).to_i)
+  CONTACT_CONDITION_ATTRIBUTES = %w[name email phone_number identifier country_code city company labels blocked].freeze
+  PIPELINE_CONDITION_ATTRIBUTES = %w[pipeline_id pipeline_stage_id].freeze
 
   def conversation_updated(event)
     process_conversation_event(event, 'conversation_updated')
@@ -62,13 +64,19 @@ class AutomationRuleListener < BaseListener
         next
       end
 
-      evaluate_and_execute_rule(
-        rule: rule,
-        conversation: conversation,
-        account: account,
-        changed_attributes: changed_attributes,
-        payload: { pipeline_item_id: pipeline_item&.id, conversation_id: conversation&.id, changed_attributes: changed_attributes }
-      )
+      if conversation.nil?
+        evaluate_and_execute_pipeline_contact_rule(rule, pipeline_item, changed_attributes)
+      elsif promoted_lead_card?(event) && pipeline_rule_executable_without_conversation?(rule)
+        record_promotion_replay_skip(rule, pipeline_item, current_stage_id, changed_attributes)
+      else
+        evaluate_and_execute_rule(
+          rule: rule,
+          conversation: conversation,
+          account: account,
+          changed_attributes: changed_attributes,
+          payload: { pipeline_item_id: pipeline_item&.id, conversation_id: conversation&.id, changed_attributes: changed_attributes }
+        )
+      end
 
       mark_pipeline_item_rule_fired(rule.id, pipeline_item&.id, current_stage_id)
     end
@@ -309,11 +317,91 @@ class AutomationRuleListener < BaseListener
     }
   end
 
+  def execute_contact_rule_actions(rule, contact, recorder)
+    if rule.mode == 'flow' && rule.flow_data.present?
+      recorder.add_step('Executing flow', data: { mode: 'flow' })
+      AutomationRules::FlowExecutionService.new(rule, nil, nil, contact, recorder: recorder).perform
+    else
+      AutomationRules::ContactActionService.new(rule, contact, recorder: recorder).perform
+    end
+  end
+
+  def promoted_lead_card?(event)
+    event.data[:promoted_from_lead_card].present?
+  end
+
+  # Condição de conversa precisa da conversa no FROM da query; as de contato e
+  # de pipeline resolvem sem ela.
+  def pipeline_rule_executable_without_conversation?(rule)
+    Array(rule.conditions).all? do |condition|
+      attribute_key = condition['attribute_key']
+
+      CONTACT_CONDITION_ATTRIBUTES.include?(attribute_key) || PIPELINE_CONDITION_ATTRIBUTES.include?(attribute_key)
+    end
+  end
+
+  # Card criado a partir de contato: avalia com o contato no lugar da conversa e
+  # executa pelo mesmo ContactActionService de contact_created/contact_updated.
+  def evaluate_and_execute_pipeline_contact_rule(rule, pipeline_item, changed_attributes)
+    contact = pipeline_item&.contact
+    recorder = ::AutomationRules::RunRecorder.new(
+      rule: rule,
+      event_name: 'pipeline_stage_updated',
+      payload: { pipeline_item_id: pipeline_item&.id, conversation_id: nil, contact_id: contact&.id,
+                 changed_attributes: changed_attributes }
+    )
+    recorder.add_step('Event received', data: { event_name: 'pipeline_stage_updated', changed_attributes: changed_attributes })
+
+    if contact.nil?
+      recorder.skipped!('No conversation linked to event (pipeline_item without conversation, etc.)')
+      return recorder.persist!
+    end
+
+    unless pipeline_rule_executable_without_conversation?(rule)
+      recorder.skipped!('Rule has conversation-scoped conditions and this pipeline item has no conversation')
+      return recorder.persist!
+    end
+
+    conditions_match = ::AutomationRules::ConditionsFilterService.new(
+      rule, nil, { contact: contact, changed_attributes: changed_attributes }
+    ).perform
+    recorder.add_step(
+      'Conditions evaluated',
+      level: conditions_match ? 'success' : 'info',
+      data: { matched: !!conditions_match, conditions: rule.conditions }
+    )
+
+    unless conditions_match
+      recorder.no_match!
+      return recorder.persist!
+    end
+
+    execute_contact_rule_actions(rule, contact, recorder)
+
+    recorder.matched!
+    recorder.persist!
+  rescue StandardError => e
+    Rails.logger.error "[AutomationRuleListener] evaluate_and_execute_pipeline_contact_rule failed rule=#{rule&.id}: #{e.class}: #{e.message}"
+    recorder.error!(e)
+    recorder.persist!
+  end
+
+  # O replay da promoção serve às regras que ficaram skipped por falta de
+  # conversa; a que já rodou no eixo do contato rodaria dobrado.
+  def record_promotion_replay_skip(rule, pipeline_item, stage_id, changed_attributes)
+    recorder = ::AutomationRules::RunRecorder.new(
+      rule: rule,
+      event_name: 'pipeline_stage_updated',
+      payload: { pipeline_item_id: pipeline_item&.id, stage_id: stage_id, changed_attributes: changed_attributes }
+    )
+    recorder.add_step('Event received', data: { event_name: 'pipeline_stage_updated', changed_attributes: changed_attributes })
+    recorder.skipped!('Already executed on the contact axis when the card entered this stage')
+    recorder.persist!
+  end
+
   def rule_has_only_contact_conditions?(rule)
-    # Verifica se todas as condições são de contato
-    contact_attributes = %w[name email phone_number identifier country_code city company labels blocked]
     rule.conditions.all? do |condition|
-      contact_attributes.include?(condition['attribute_key'])
+      CONTACT_CONDITION_ATTRIBUTES.include?(condition['attribute_key'])
     end
   end
 
@@ -349,12 +437,7 @@ class AutomationRuleListener < BaseListener
       return
     end
 
-    if rule.mode == 'flow' && rule.flow_data.present?
-      recorder.add_step('Executing flow', data: { mode: 'flow' })
-      AutomationRules::FlowExecutionService.new(rule, nil, nil, contact, recorder: recorder).perform
-    else
-      AutomationRules::ContactActionService.new(rule, contact, recorder: recorder).perform
-    end
+    execute_contact_rule_actions(rule, contact, recorder)
 
     recorder.matched!
     recorder.persist!

--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -77,6 +77,7 @@ class AutomationRuleListener < BaseListener
           conversation: conversation,
           account: account,
           changed_attributes: changed_attributes,
+          pipeline_item: pipeline_item,
           payload: { pipeline_item_id: pipeline_item&.id, conversation_id: conversation&.id, changed_attributes: changed_attributes }
         )
       end
@@ -261,7 +262,8 @@ class AutomationRuleListener < BaseListener
     end
   end
 
-  def evaluate_and_execute_rule(rule:, conversation:, account:, changed_attributes:, payload: {}, message: nil, contact: nil)
+  def evaluate_and_execute_rule(rule:, conversation:, account:, changed_attributes:, payload: {}, message: nil, contact: nil,
+                                pipeline_item: nil)
     recorder = ::AutomationRules::RunRecorder.new(rule: rule, event_name: rule.event_name, payload: payload)
     recorder.add_step('Event received', data: { event_name: rule.event_name, changed_attributes: changed_attributes })
 
@@ -274,6 +276,7 @@ class AutomationRuleListener < BaseListener
     options = { changed_attributes: changed_attributes }
     options[:message] = message if message
     options[:contact] = contact if contact
+    options[:pipeline_item] = pipeline_item if pipeline_item
 
     conditions_match = ::AutomationRules::ConditionsFilterService.new(rule, conversation, options).perform
     recorder.add_step(
@@ -333,8 +336,8 @@ class AutomationRuleListener < BaseListener
     event.data[:promoted_from_lead_card].present?
   end
 
-  # Condição de conversa precisa da conversa no FROM da query; as de contato, de
-  # pipeline e de custom attribute de contato resolvem sem ela.
+  # A conversation condition needs the conversation in the query's FROM; contact,
+  # pipeline and contact custom attribute conditions resolve without it.
   def pipeline_rule_executable_without_conversation?(rule)
     Array(rule.conditions).all? do |condition|
       attribute_key = condition['attribute_key']
@@ -345,8 +348,8 @@ class AutomationRuleListener < BaseListener
     end
   end
 
-  # Card criado a partir de contato: avalia com o contato no lugar da conversa e
-  # executa pelo mesmo ContactActionService de contact_created/contact_updated.
+  # Card born from a contact: evaluate with the contact in place of the conversation
+  # and execute through the same ContactActionService contact_created already uses.
   def evaluate_and_execute_pipeline_contact_rule(rule, pipeline_item, changed_attributes)
     contact = pipeline_item&.contact
     recorder = ::AutomationRules::RunRecorder.new(
@@ -391,8 +394,8 @@ class AutomationRuleListener < BaseListener
     recorder&.persist!
   end
 
-  # O replay da promoção serve às regras que ficaram skipped por falta de
-  # conversa; a que já rodou no eixo do contato rodaria dobrado.
+  # The promotion replay serves the rules left skipped for want of a conversation;
+  # one that already ran on the contact axis would run twice.
   def record_promotion_replay_skip(rule, pipeline_item, conversation, changed_attributes)
     recorder = ::AutomationRules::RunRecorder.new(
       rule: rule,
@@ -401,7 +404,7 @@ class AutomationRuleListener < BaseListener
                  changed_attributes: changed_attributes }
     )
     recorder.add_step('Event received', data: { event_name: 'pipeline_stage_updated', changed_attributes: changed_attributes })
-    recorder.skipped!('Already executed on the contact axis when the card entered this stage')
+    recorder.skipped!('Runs on the contact axis, where this card already had its turn when it entered the stage')
     recorder.persist!
   end
 

--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -6,6 +6,7 @@ class AutomationRuleListener < BaseListener
   CONTACT_UPDATED_SPAM_WINDOW = (ENV.fetch('AUTOMATION_CONTACT_UPDATED_SPAM_WINDOW_SECONDS', 30).to_i)
   CONTACT_CONDITION_ATTRIBUTES = %w[name email phone_number identifier country_code city company labels blocked].freeze
   PIPELINE_CONDITION_ATTRIBUTES = %w[pipeline_id pipeline_stage_id].freeze
+  CONTACT_CUSTOM_ATTRIBUTE_MODEL = 'contact_attribute'.freeze
 
   def conversation_updated(event)
     process_conversation_event(event, 'conversation_updated')
@@ -57,8 +58,10 @@ class AutomationRuleListener < BaseListener
     rules = current_account_rules('pipeline_stage_updated', account)
     current_stage_id = pipeline_item&.pipeline_stage_id
 
+    replay = promoted_lead_card?(event)
+
     rules.each do |rule|
-      if pipeline_item_rule_recently_fired?(rule.id, pipeline_item&.id, current_stage_id)
+      if !replay && pipeline_item_rule_recently_fired?(rule.id, pipeline_item&.id, current_stage_id)
         Rails.logger.info "[AutomationRuleListener] rule #{rule.id} skipped (dedup): pipeline_item=#{pipeline_item&.id} stage=#{current_stage_id} already fired in last #{PIPELINE_STAGE_DEDUP_WINDOW}s"
         record_dedup_skip(rule, pipeline_item, current_stage_id, changed_attributes)
         next
@@ -66,8 +69,8 @@ class AutomationRuleListener < BaseListener
 
       if conversation.nil?
         evaluate_and_execute_pipeline_contact_rule(rule, pipeline_item, changed_attributes)
-      elsif promoted_lead_card?(event) && pipeline_rule_executable_without_conversation?(rule)
-        record_promotion_replay_skip(rule, pipeline_item, current_stage_id, changed_attributes)
+      elsif replay && pipeline_rule_executable_without_conversation?(rule)
+        record_promotion_replay_skip(rule, pipeline_item, conversation, changed_attributes)
       else
         evaluate_and_execute_rule(
           rule: rule,
@@ -330,13 +333,15 @@ class AutomationRuleListener < BaseListener
     event.data[:promoted_from_lead_card].present?
   end
 
-  # Condição de conversa precisa da conversa no FROM da query; as de contato e
-  # de pipeline resolvem sem ela.
+  # Condição de conversa precisa da conversa no FROM da query; as de contato, de
+  # pipeline e de custom attribute de contato resolvem sem ela.
   def pipeline_rule_executable_without_conversation?(rule)
     Array(rule.conditions).all? do |condition|
       attribute_key = condition['attribute_key']
 
-      CONTACT_CONDITION_ATTRIBUTES.include?(attribute_key) || PIPELINE_CONDITION_ATTRIBUTES.include?(attribute_key)
+      CONTACT_CONDITION_ATTRIBUTES.include?(attribute_key) ||
+        PIPELINE_CONDITION_ATTRIBUTES.include?(attribute_key) ||
+        condition['custom_attribute_type'].to_s == CONTACT_CUSTOM_ATTRIBUTE_MODEL
     end
   end
 
@@ -363,7 +368,7 @@ class AutomationRuleListener < BaseListener
     end
 
     conditions_match = ::AutomationRules::ConditionsFilterService.new(
-      rule, nil, { contact: contact, changed_attributes: changed_attributes }
+      rule, nil, { contact: contact, pipeline_item: pipeline_item, changed_attributes: changed_attributes }
     ).perform
     recorder.add_step(
       'Conditions evaluated',
@@ -382,17 +387,18 @@ class AutomationRuleListener < BaseListener
     recorder.persist!
   rescue StandardError => e
     Rails.logger.error "[AutomationRuleListener] evaluate_and_execute_pipeline_contact_rule failed rule=#{rule&.id}: #{e.class}: #{e.message}"
-    recorder.error!(e)
-    recorder.persist!
+    recorder&.error!(e)
+    recorder&.persist!
   end
 
   # O replay da promoção serve às regras que ficaram skipped por falta de
   # conversa; a que já rodou no eixo do contato rodaria dobrado.
-  def record_promotion_replay_skip(rule, pipeline_item, stage_id, changed_attributes)
+  def record_promotion_replay_skip(rule, pipeline_item, conversation, changed_attributes)
     recorder = ::AutomationRules::RunRecorder.new(
       rule: rule,
       event_name: 'pipeline_stage_updated',
-      payload: { pipeline_item_id: pipeline_item&.id, stage_id: stage_id, changed_attributes: changed_attributes }
+      payload: { pipeline_item_id: pipeline_item&.id, conversation_id: conversation&.id,
+                 changed_attributes: changed_attributes }
     )
     recorder.add_step('Event received', data: { event_name: 'pipeline_stage_updated', changed_attributes: changed_attributes })
     recorder.skipped!('Already executed on the contact axis when the card entered this stage')

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -486,6 +486,7 @@ class Conversation < ApplicationRecord
 
     lead_item.update!(conversation_id: id, contact_id: nil)
     Rails.logger.info "[Pipeline] Conversation #{id} promoted onto existing lead card #{lead_item.id}"
+    replay_stage_entry_for_promoted_card(lead_item)
     true
   rescue ActiveRecord::RecordNotUnique
     # Race: outra conversa já promoveu este lead-card (índice único conversation_id). Resolvido.
@@ -496,6 +497,20 @@ class Conversation < ApplicationRecord
     # cai no add_conversation normal (cria o card). Um dup-card é aceitável; zero-card NÃO é.
     Rails.logger.warn "[Pipeline] Lead card promotion failed for conversation #{id} (#{e.class}: #{e.message}) — fallback to add_conversation"
     false
+  end
+
+  # A promoção não toca em `pipeline_stage_id`, então nenhum evento de estágio
+  # nasce dela e a entrada ficava perdida para sempre.
+  def replay_stage_entry_for_promoted_card(lead_item)
+    Rails.configuration.dispatcher.dispatch(
+      'pipeline_stage_updated',
+      Time.zone.now,
+      pipeline_item: lead_item,
+      changed_attributes: { 'pipeline_stage_id' => [nil, lead_item.pipeline_stage_id] },
+      promoted_from_lead_card: true
+    )
+  rescue StandardError => e
+    Rails.logger.error "[Pipeline] Failed to replay stage entry for promoted card #{lead_item.id}: #{e.class}: #{e.message}"
   end
 
   def resolve_target_pipeline

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -499,8 +499,8 @@ class Conversation < ApplicationRecord
     false
   end
 
-  # A promoção não toca em `pipeline_stage_id`, então nenhum evento de estágio
-  # nasce dela e a entrada ficava perdida para sempre.
+  # The promotion never touches `pipeline_stage_id`, so no stage event is born
+  # from it and the stage entry stayed lost for good.
   def replay_stage_entry_for_promoted_card(lead_item)
     Rails.configuration.dispatcher.dispatch(
       'pipeline_stage_updated',

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -329,6 +329,10 @@ class AutomationRules::ConditionsFilterService < FilterService
   end
 
   def build_query_string(filters, query_hash, current_index)
+    # `pipeline_id` também está na seção `conversations` do filter_keys.yml, e o
+    # ramo de conversa gerava `conversations.pipeline_id`, coluna inexistente.
+    return pipeline_query_string(query_hash.with_indifferent_access, current_index) if pipeline_filter?(query_hash['attribute_key'])
+
     # EVO-1642: some keys (e.g. country_code, labels) live in BOTH the
     # conversations and contacts filter sections. With no conversation in the
     # base relation, resolve them against contacts — otherwise the query would
@@ -358,6 +362,12 @@ class AutomationRules::ConditionsFilterService < FilterService
     attribute_key = query_hash['attribute_key']
     query_operator = query_hash['query_operator']
     filter_operator_value = filter_operation(query_hash, current_index)
+
+    # Base relation é `contacts` e não há JOIN de pipeline_items para referenciar.
+    if @conversation.nil?
+      return ' EXISTS (SELECT 1 FROM pipeline_items WHERE pipeline_items.contact_id = contacts.id ' \
+             "AND pipeline_items.#{attribute_key} #{filter_operator_value}) #{query_operator} "
+    end
 
     " pipeline_items.#{attribute_key} #{filter_operator_value} #{query_operator} "
   end

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -330,8 +330,8 @@ class AutomationRules::ConditionsFilterService < FilterService
   end
 
   def build_query_string(filters, query_hash, current_index)
-    # `pipeline_id` também está na seção `conversations` do filter_keys.yml, e o
-    # ramo de conversa gerava `conversations.pipeline_id`, coluna inexistente.
+    # `pipeline_id` also sits in the `conversations` section of filter_keys.yml, so
+    # the conversation branch emitted `conversations.pipeline_id` — a missing column.
     return pipeline_query_string(query_hash.with_indifferent_access, current_index) if pipeline_filter?(query_hash['attribute_key'])
 
     # EVO-1642: some keys (e.g. country_code, labels) live in BOTH the
@@ -346,8 +346,6 @@ class AutomationRules::ConditionsFilterService < FilterService
       contact_query_string(filters[:contact], query_hash.with_indifferent_access, current_index)
     elsif filters[:message]
       message_query_string(filters[:message], query_hash.with_indifferent_access, current_index)
-    elsif pipeline_filter?(query_hash['attribute_key'])
-      pipeline_query_string(query_hash.with_indifferent_access, current_index)
     elsif custom_attribute(query_hash['attribute_key'], query_hash['custom_attribute_type'])
       custom_attribute_query(query_hash.with_indifferent_access, query_hash['custom_attribute_type'], current_index)
     else
@@ -364,16 +362,16 @@ class AutomationRules::ConditionsFilterService < FilterService
     query_operator = query_hash['query_operator']
     filter_operator_value = filter_operation(query_hash, current_index)
 
-    # Base relation é `contacts` e não há JOIN de pipeline_items para referenciar.
-    # A subquery é escalar e presa ao card que disparou o evento: alcançar
-    # qualquer card do contato faria `pipeline_id != A` casar por causa de um
-    # card em B, e `is_not_present` nunca casar.
-    if @conversation.nil?
+    # Scoped to the card that fired, on either axis. The joined `pipeline_items`
+    # row set holds every card of the contact/conversation, so `pipeline_id != A`
+    # would match on a card in B and `is_not_present` could never match.
+    if @pipeline_item || @conversation.nil?
       @filter_values['scoped_pipeline_item_id'] = @pipeline_item&.id
       return " (SELECT pipeline_items.#{attribute_key} FROM pipeline_items " \
              "WHERE pipeline_items.id = :scoped_pipeline_item_id) #{filter_operator_value} #{query_operator} "
     end
 
+    # No card in scope (events that are not pipeline events): conversation-wide.
     " pipeline_items.#{attribute_key} #{filter_operator_value} #{query_operator} "
   end
 

--- a/app/services/automation_rules/conditions_filter_service.rb
+++ b/app/services/automation_rules/conditions_filter_service.rb
@@ -18,6 +18,7 @@ class AutomationRules::ConditionsFilterService < FilterService
     # EVO-1642: contact-triggered rules with only-contact conditions run with
     # no conversation in scope; the base relation falls back to the contact.
     @contact = options[:contact]
+    @pipeline_item = options[:pipeline_item]
 
     # setup filters from json file
     file = File.read('./lib/filters/filter_keys.yml')
@@ -364,9 +365,13 @@ class AutomationRules::ConditionsFilterService < FilterService
     filter_operator_value = filter_operation(query_hash, current_index)
 
     # Base relation é `contacts` e não há JOIN de pipeline_items para referenciar.
+    # A subquery é escalar e presa ao card que disparou o evento: alcançar
+    # qualquer card do contato faria `pipeline_id != A` casar por causa de um
+    # card em B, e `is_not_present` nunca casar.
     if @conversation.nil?
-      return ' EXISTS (SELECT 1 FROM pipeline_items WHERE pipeline_items.contact_id = contacts.id ' \
-             "AND pipeline_items.#{attribute_key} #{filter_operator_value}) #{query_operator} "
+      @filter_values['scoped_pipeline_item_id'] = @pipeline_item&.id
+      return " (SELECT pipeline_items.#{attribute_key} FROM pipeline_items " \
+             "WHERE pipeline_items.id = :scoped_pipeline_item_id) #{filter_operator_value} #{query_operator} "
     end
 
     " pipeline_items.#{attribute_key} #{filter_operator_value} #{query_operator} "

--- a/spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb
+++ b/spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
+  include ActiveJob::TestHelper
+
+  let(:listener) { described_class.instance }
+
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://crm258.example.com') }
+  let(:inbox) { Inbox.create!(name: "Inbox #{SecureRandom.hex(3)}", channel: channel) }
+  let(:contact) do
+    Contact.create!(name: 'Lead Checkout', email: "lead-#{SecureRandom.hex(4)}@test.com",
+                    phone_number: "+5571#{rand(100_000_000..999_999_999)}")
+  end
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let(:pipeline) { Pipeline.create!(name: "funil-#{SecureRandom.hex(3)}", pipeline_type: 'custom', created_by: user) }
+  let!(:entry_stage) { PipelineStage.create!(pipeline: pipeline, name: 'Entrada', position: 1) }
+  let!(:next_stage) { PipelineStage.create!(pipeline: pipeline, name: 'Qualificado', position: 2) }
+  let!(:ia_label) { Label.create!(title: "ia-#{SecureRandom.hex(3)}", color: '#00aabb') }
+
+  def build_rule(conditions: [], actions: nil)
+    rule = AutomationRule.new(
+      name: "entrada-#{SecureRandom.hex(4)}",
+      event_name: 'pipeline_stage_updated',
+      active: true,
+      mode: 'simple',
+      conditions: conditions,
+      actions: actions || [{ 'action_name' => 'add_label', 'action_params' => [ia_label.title] }]
+    )
+    rule.save!(validate: false)
+    rule
+  end
+
+  def entered_entry_stage
+    { 'pipeline_stage_id' => [nil, entry_stage.id] }
+  end
+
+  def entered_stage_condition
+    { 'attribute_key' => 'pipeline_stage_id', 'filter_operator' => 'attribute_changed',
+      'values' => { 'from' => [], 'to' => [entry_stage.id] }, 'query_operator' => nil }
+  end
+
+  def conversation_condition
+    { 'attribute_key' => 'status', 'filter_operator' => 'equal_to', 'values' => ['open'], 'query_operator' => nil }
+  end
+
+  def contact_card
+    PipelineItem.create!(pipeline: pipeline, pipeline_stage: entry_stage, contact: contact, entered_at: Time.current)
+  end
+
+  def conversation_card
+    PipelineItem.create!(pipeline: pipeline, pipeline_stage: entry_stage, conversation: conversation, entered_at: Time.current)
+  end
+
+  StageEvent = Struct.new(:data) unless defined?(StageEvent)
+
+  def dispatch(pipeline_item, changed_attributes = entered_entry_stage, extra = {})
+    listener.pipeline_stage_updated(
+      StageEvent.new({ pipeline_item: pipeline_item, changed_attributes: changed_attributes }.merge(extra))
+    )
+  end
+
+  def runs_for(rule)
+    AutomationRuleRun.where(automation_rule_id: rule.id).order(:started_at)
+  end
+
+  def step_labels(run)
+    run.steps.map { |s| s['label'] }.join(' | ')
+  end
+
+  after { Current.reset }
+
+  describe 'card criado a partir de contato' do
+    it 'avalia as condicoes e aplica a acao no contato' do
+      rule = build_rule(conditions: [entered_stage_condition])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      expect { dispatch(item) }.to change { runs_for(rule).count }.by(1)
+
+      run = runs_for(rule).last
+      expect(run.status).to eq('matched')
+      expect(step_labels(run)).to include('Conditions evaluated')
+      expect(contact.reload.label_list).to include(ia_label.title)
+    end
+
+    it 'registra o pipeline_item e o contato no payload do run' do
+      rule = build_rule
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.payload).to include(
+        'pipeline_item_id' => item.id, 'conversation_id' => nil, 'contact_id' => contact.id
+      )
+    end
+
+    it 'nao dispara quando a condicao aponta para outro estagio' do
+      rule = build_rule(conditions: [entered_stage_condition])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item, { 'pipeline_stage_id' => [entry_stage.id, next_stage.id] })
+
+      expect(runs_for(rule).last.status).to eq('no_match')
+      expect(contact.reload.label_list).to be_empty
+    end
+
+    it 'dispara tambem na movimentacao entre estagios' do
+      rule = build_rule
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item, { 'pipeline_stage_id' => [entry_stage.id, next_stage.id] })
+
+      expect(runs_for(rule).last.status).to eq('matched')
+      expect(contact.reload.label_list).to include(ia_label.title)
+    end
+
+    it 'recusa a regra de condicao de conversa com o motivo especifico' do
+      rule = build_rule(conditions: [conversation_condition])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      run = runs_for(rule).last
+      expect(run.status).to eq('skipped')
+      expect(step_labels(run)).to include('conversation-scoped conditions')
+      expect(step_labels(run)).not_to include('Conditions evaluated')
+    end
+
+    it 'registra a acao presa a conversa como skipped em vez de some-la' do
+      rule = build_rule(actions: [{ 'action_name' => 'send_message', 'action_params' => ['oi'] }])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(step_labels(runs_for(rule).last)).to include('Action skipped: send_message')
+    end
+
+    it 'aceita condicao de pipeline_id resolvida pelos cards do contato' do
+      rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'equal_to',
+                                       'values' => [pipeline.id], 'query_operator' => nil }])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('matched')
+    end
+  end
+
+  describe 'card de conversa (comportamento preservado)' do
+    it 'casa e aplica a label na conversa' do
+      rule = build_rule
+      item = conversation_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('matched')
+      expect(conversation.reload.label_list).to include(ia_label.title)
+    end
+
+    it 'condicao de conversa continua sendo avaliada' do
+      rule = build_rule(conditions: [conversation_condition])
+      item = conversation_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('matched')
+    end
+
+    it 'filtro pipeline_id casa em vez de quebrar em conversations.pipeline_id' do
+      rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'equal_to',
+                                       'values' => [pipeline.id], 'query_operator' => nil }])
+      item = conversation_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('matched')
+    end
+  end
+
+  describe 'promocao do card de lead' do
+    it 'redispara a entrada no estagio quando a conversa chega' do
+      rule = build_rule(conditions: [conversation_condition])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      perform_enqueued_jobs { conversation }
+
+      expect(item.reload.conversation_id).to eq(conversation.id)
+      expect(runs_for(rule).map(&:status)).to include('matched')
+      expect(conversation.reload.label_list).to include(ia_label.title)
+    end
+
+    it 'nao repete a regra que ja rodou no eixo do contato' do
+      rule = build_rule
+      item = contact_card
+      item.update!(conversation_id: conversation.id, contact_id: nil)
+      runs_for(rule).delete_all
+
+      dispatch(item, entered_entry_stage, { promoted_from_lead_card: true })
+
+      expect(runs_for(rule).last.status).to eq('skipped')
+      expect(step_labels(runs_for(rule).last)).to include('Already executed on the contact axis')
+    end
+  end
+
+  describe 'predicado de roteamento' do
+    it 'aceita condicao de contato, de estagio e de pipeline' do
+      rule = build_rule(conditions: [entered_stage_condition,
+                                     { 'attribute_key' => 'name', 'filter_operator' => 'equal_to',
+                                       'values' => ['Lead Checkout'], 'query_operator' => nil }])
+
+      expect(listener.send(:pipeline_rule_executable_without_conversation?, rule)).to be(true)
+    end
+
+    it 'recusa condicao de conversa' do
+      rule = build_rule(conditions: [entered_stage_condition, conversation_condition])
+
+      expect(listener.send(:pipeline_rule_executable_without_conversation?, rule)).to be(false)
+    end
+  end
+end

--- a/spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb
+++ b/spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb
@@ -56,11 +56,19 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
     PipelineItem.create!(pipeline: pipeline, pipeline_stage: entry_stage, conversation: conversation, entered_at: Time.current)
   end
 
-  StageEvent = Struct.new(:data) unless defined?(StageEvent)
+  # A conversation may hold one card per pipeline (unique index is per pipeline).
+  def conversation_card_in_other_pipeline
+    other = Pipeline.create!(name: "outro-#{SecureRandom.hex(3)}", pipeline_type: 'custom', created_by: user)
+    stage = PipelineStage.create!(pipeline: other, name: 'Entrada', position: 1)
+    [other, PipelineItem.create!(pipeline: other, pipeline_stage: stage, conversation: conversation, entered_at: Time.current)]
+  end
+
+  # Anonymous so the suite does not carry a top-level StageEvent constant.
+  let(:stage_event) { Struct.new(:data) }
 
   def dispatch(pipeline_item, changed_attributes = entered_entry_stage, extra = {})
     listener.pipeline_stage_updated(
-      StageEvent.new({ pipeline_item: pipeline_item, changed_attributes: changed_attributes }.merge(extra))
+      stage_event.new({ pipeline_item: pipeline_item, changed_attributes: changed_attributes }.merge(extra))
     )
   end
 
@@ -182,16 +190,16 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
       expect(runs_for(rule).last.status).to eq('matched')
     end
 
-    it 'pipeline_id is_not_present casa quando nao ha card no escopo' do
+    it 'pipeline_id is_not_present nao casa enquanto o card do evento existe' do
       rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'is_not_present',
                                        'values' => [], 'query_operator' => nil }])
-      contact_card
+      item = contact_card
+      runs_for(rule).delete_all
 
-      matched = AutomationRules::ConditionsFilterService.new(
-        rule, nil, { contact: contact, pipeline_item: nil, changed_attributes: entered_entry_stage }
-      ).perform
+      dispatch(item)
 
-      expect(matched).to be_truthy
+      expect(runs_for(rule).last.status).to eq('no_match')
+      expect(contact.reload.label_list).to be_empty
     end
 
     it 'aceita condicao de custom attribute de contato' do
@@ -245,6 +253,32 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
       dispatch(item)
 
       expect(runs_for(rule).last.status).to eq('matched')
+    end
+
+    it 'nao casa pipeline_id por causa de um card da conversa em outro funil' do
+      other_pipeline, = conversation_card_in_other_pipeline
+      rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'equal_to',
+                                       'values' => [other_pipeline.id], 'query_operator' => nil }])
+      item = conversation_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('no_match')
+      expect(conversation.reload.label_list).to be_empty
+    end
+
+    it 'pipeline_id not_equal_to olha so o card que disparou o evento' do
+      conversation_card_in_other_pipeline
+      rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'not_equal_to',
+                                       'values' => [pipeline.id], 'query_operator' => nil }])
+      item = conversation_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('no_match')
+      expect(conversation.reload.label_list).to be_empty
     end
   end
 
@@ -306,7 +340,7 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
 
       run = runs_for(rule).last
       expect(run.status).to eq('skipped')
-      expect(step_labels(run)).to include('Already executed on the contact axis')
+      expect(step_labels(run)).to include('Runs on the contact axis')
       expect(run.payload).to include('pipeline_item_id' => item.id, 'conversation_id' => conversation.id)
     end
   end

--- a/spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb
+++ b/spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
       expect(step_labels(runs_for(rule).last)).to include('Action skipped: send_message')
     end
 
-    it 'aceita condicao de pipeline_id resolvida pelos cards do contato' do
+    it 'aceita condicao de pipeline_id resolvida pelo card do evento' do
       rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'equal_to',
                                        'values' => [pipeline.id], 'query_operator' => nil }])
       item = contact_card
@@ -154,6 +154,63 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
       dispatch(item)
 
       expect(runs_for(rule).last.status).to eq('matched')
+    end
+
+    it 'nao casa pipeline_id por causa de um card do contato em outro funil' do
+      other_pipeline = Pipeline.create!(name: "outro-#{SecureRandom.hex(3)}", pipeline_type: 'custom', created_by: user)
+      other_stage = PipelineStage.create!(pipeline: other_pipeline, name: 'Entrada', position: 1)
+      PipelineItem.create!(pipeline: other_pipeline, pipeline_stage: other_stage, contact: contact, entered_at: Time.current)
+      rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'not_equal_to',
+                                       'values' => [pipeline.id], 'query_operator' => nil }])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('no_match')
+      expect(contact.reload.label_list).to be_empty
+    end
+
+    it 'casa pipeline_id is_present pelo card do evento' do
+      rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'is_present',
+                                       'values' => [], 'query_operator' => nil }])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('matched')
+    end
+
+    it 'pipeline_id is_not_present casa quando nao ha card no escopo' do
+      rule = build_rule(conditions: [{ 'attribute_key' => 'pipeline_id', 'filter_operator' => 'is_not_present',
+                                       'values' => [], 'query_operator' => nil }])
+      contact_card
+
+      matched = AutomationRules::ConditionsFilterService.new(
+        rule, nil, { contact: contact, pipeline_item: nil, changed_attributes: entered_entry_stage }
+      ).perform
+
+      expect(matched).to be_truthy
+    end
+
+    it 'aceita condicao de custom attribute de contato' do
+      definition = CustomAttributeDefinition.create!(
+        attribute_key: "plano_#{SecureRandom.hex(3)}", attribute_display_name: 'Plano',
+        attribute_model: 'contact_attribute', attribute_display_type: 'text'
+      )
+      key = definition.attribute_key
+      contact.update!(custom_attributes: { key => 'gold' })
+      Current.reset
+      rule = build_rule(conditions: [{ 'attribute_key' => key, 'custom_attribute_type' => 'contact_attribute',
+                                       'filter_operator' => 'equal_to', 'values' => ['gold'], 'query_operator' => nil }])
+      item = contact_card
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(runs_for(rule).last.status).to eq('matched')
+      expect(contact.reload.label_list).to include(ia_label.title)
     end
   end
 
@@ -204,6 +261,41 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
       expect(conversation.reload.label_list).to include(ia_label.title)
     end
 
+    it 'nao aplica a acao duas vezes no fluxo real de promocao' do
+      rule = build_rule
+      item = contact_card
+      runs_for(rule).delete_all
+
+      perform_enqueued_jobs { conversation }
+
+      expect(item.reload.conversation_id).to eq(conversation.id)
+      expect(conversation.reload.label_list).to be_empty
+      expect(runs_for(rule).map(&:status)).to eq(%w[skipped])
+    end
+
+    it 'o replay nao e engolido pela janela de dedup' do
+      rule = build_rule(conditions: [conversation_condition])
+      item = contact_card
+      item.update!(conversation_id: conversation.id, contact_id: nil)
+      allow(Rails.cache).to receive(:exist?).and_return(true)
+      runs_for(rule).delete_all
+
+      dispatch(item, entered_entry_stage, { promoted_from_lead_card: true })
+
+      expect(runs_for(rule).last.status).to eq('matched')
+    end
+
+    it 'o evento normal continua respeitando a janela de dedup' do
+      rule = build_rule
+      item = conversation_card
+      allow(Rails.cache).to receive(:exist?).and_return(true)
+      runs_for(rule).delete_all
+
+      dispatch(item)
+
+      expect(step_labels(runs_for(rule).last)).to include('Duplicate event')
+    end
+
     it 'nao repete a regra que ja rodou no eixo do contato' do
       rule = build_rule
       item = contact_card
@@ -212,8 +304,10 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
 
       dispatch(item, entered_entry_stage, { promoted_from_lead_card: true })
 
-      expect(runs_for(rule).last.status).to eq('skipped')
-      expect(step_labels(runs_for(rule).last)).to include('Already executed on the contact axis')
+      run = runs_for(rule).last
+      expect(run.status).to eq('skipped')
+      expect(step_labels(run)).to include('Already executed on the contact axis')
+      expect(run.payload).to include('pipeline_item_id' => item.id, 'conversation_id' => conversation.id)
     end
   end
 
@@ -222,6 +316,13 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
       rule = build_rule(conditions: [entered_stage_condition,
                                      { 'attribute_key' => 'name', 'filter_operator' => 'equal_to',
                                        'values' => ['Lead Checkout'], 'query_operator' => nil }])
+
+      expect(listener.send(:pipeline_rule_executable_without_conversation?, rule)).to be(true)
+    end
+
+    it 'aceita custom attribute de contato' do
+      rule = build_rule(conditions: [{ 'attribute_key' => 'plano', 'custom_attribute_type' => 'contact_attribute',
+                                       'filter_operator' => 'equal_to', 'values' => ['gold'], 'query_operator' => nil }])
 
       expect(listener.send(:pipeline_rule_executable_without_conversation?, rule)).to be(true)
     end

--- a/spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb
+++ b/spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
+  include ActiveJob::TestHelper
+
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://e2e.example.com') }
+  let(:inbox) { Inbox.create!(name: "Inbox #{SecureRandom.hex(3)}", channel: channel) }
+  let!(:ia_label) { Label.create!(title: "ia-#{SecureRandom.hex(3)}", color: '#00aabb') }
+  let!(:pipeline) do
+    Pipeline.create!(name: "funil-#{SecureRandom.hex(3)}", pipeline_type: 'custom', created_by: user, is_default: true)
+  end
+  let!(:entry_stage) { PipelineStage.create!(pipeline: pipeline, name: 'Entrada', position: 1) }
+  let!(:won_stage) { PipelineStage.create!(pipeline: pipeline, name: 'Ganho', position: 2) }
+
+  def rule!(conditions:, actions:)
+    rule = AutomationRule.new(name: "r-#{SecureRandom.hex(4)}", event_name: 'pipeline_stage_updated',
+                              active: true, mode: 'simple', conditions: conditions, actions: actions)
+    rule.save!(validate: false)
+    rule
+  end
+
+  def entry_rule
+    rule!(conditions: [{ 'attribute_key' => 'pipeline_stage_id', 'filter_operator' => 'attribute_changed',
+                         'values' => { 'from' => [], 'to' => [entry_stage.id] }, 'query_operator' => nil }],
+          actions: [{ 'action_name' => 'add_label', 'action_params' => [ia_label.title] }])
+  end
+
+  def runs(rule) = AutomationRuleRun.where(automation_rule_id: rule.id).order(:started_at)
+
+  # Só os jobs do caminho de automação: avatar e ip lookup fazem HTTP real, que
+  # o WebMock de outros specs da mesma lane bloqueia.
+  def run_automation_jobs(&)
+    perform_enqueued_jobs(only: [EventDispatcherJob, AutomationContactEventJob], &)
+  end
+
+  after { Current.reset }
+
+  it 'contato criado cai no funil default e a automacao de entrada roda' do
+    r = entry_rule
+    contact = nil
+    run_automation_jobs do
+      contact = Contact.create!(name: 'Pedro', email: "p-#{SecureRandom.hex(4)}@t.com",
+                                phone_number: "+5571#{rand(100_000_000..999_999_999)}")
+    end
+    item = PipelineItem.find_by(contact_id: contact.id)
+    expect(item).to be_present
+    expect(item.conversation_id).to be_nil
+    expect(runs(r).map(&:status)).to eq(['matched'])
+    expect(contact.reload.label_list).to include(ia_label.title)
+  end
+
+  it 'lead via API publica (checkout) dispara a automacao de entrada' do
+    r = entry_rule
+    contact = Contact.create!(name: 'Checkout', email: "c-#{SecureRandom.hex(4)}@t.com",
+                              phone_number: "+5571#{rand(100_000_000..999_999_999)}",
+                              skip_default_pipeline_assignment: true)
+    Current.reset
+    runs(r).delete_all
+    item = nil
+    run_automation_jobs do
+      item = pipeline.pipeline_items.create!(contact: contact, conversation: nil, pipeline_stage: entry_stage,
+                                             entered_at: Time.current,
+                                             custom_fields: { 'lead_source' => 'public_api' })
+    end
+    expect(runs(r).map(&:status)).to eq(['matched'])
+    expect(contact.reload.label_list).to include(ia_label.title)
+  end
+
+  it 'mover o card de contato entre estagios dispara a regra do estagio destino' do
+    won_label = Label.create!(title: "ganho-#{SecureRandom.hex(3)}", color: '#00ff00')
+    r = rule!(conditions: [{ 'attribute_key' => 'pipeline_stage_id', 'filter_operator' => 'attribute_changed',
+                             'values' => { 'from' => [], 'to' => [won_stage.id] }, 'query_operator' => nil }],
+              actions: [{ 'action_name' => 'add_label', 'action_params' => [won_label.title] }])
+    contact = Contact.create!(name: 'Move', email: "m-#{SecureRandom.hex(4)}@t.com",
+                              phone_number: "+5571#{rand(100_000_000..999_999_999)}",
+                              skip_default_pipeline_assignment: true)
+    Current.reset
+    item = pipeline.pipeline_items.create!(contact: contact, pipeline_stage: entry_stage, entered_at: Time.current)
+    runs(r).delete_all
+    run_automation_jobs { item.update!(pipeline_stage: won_stage) }
+    expect(runs(r).map(&:status)).to eq(['matched'])
+    expect(contact.reload.label_list).to include(won_label.title)
+  end
+
+  it 'promocao roda a regra de conversa e nao repete a de contato' do
+    contact_rule = entry_rule
+    conv_label = Label.create!(title: "conv-#{SecureRandom.hex(3)}", color: '#0000ff')
+    conv_rule = rule!(conditions: [{ 'attribute_key' => 'status', 'filter_operator' => 'equal_to',
+                                     'values' => ['open'], 'query_operator' => nil }],
+                      actions: [{ 'action_name' => 'add_label', 'action_params' => [conv_label.title] }])
+    contact = nil
+    run_automation_jobs do
+      contact = Contact.create!(name: 'Promo', email: "pr-#{SecureRandom.hex(4)}@t.com",
+                                phone_number: "+5571#{rand(100_000_000..999_999_999)}")
+    end
+    item = PipelineItem.find_by(contact_id: contact.id)
+    labels_after_entry = contact.reload.label_list
+
+    ci = ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4))
+    conversation = nil
+    run_automation_jobs { conversation = Conversation.create!(inbox: inbox, contact: contact, contact_inbox: ci) }
+
+    item.reload
+
+    expect(item.conversation_id).to eq(conversation.id)
+    expect(labels_after_entry).to include(ia_label.title)
+    expect(runs(contact_rule).map(&:status)).to eq(%w[matched skipped])
+    expect(runs(conv_rule).map(&:status)).to eq(%w[skipped matched])
+    expect(conversation.reload.label_list).to include(conv_label.title)
+    expect(conversation.reload.label_list).not_to include(ia_label.title)
+  end
+
+  it 'regra de condicao de conversa em card sem conversa fica skipped com motivo' do
+    r = rule!(conditions: [{ 'attribute_key' => 'status', 'filter_operator' => 'equal_to',
+                             'values' => ['open'], 'query_operator' => nil }],
+              actions: [{ 'action_name' => 'add_label', 'action_params' => [ia_label.title] }])
+    contact = nil
+    run_automation_jobs do
+      contact = Contact.create!(name: 'Skip', email: "s-#{SecureRandom.hex(4)}@t.com",
+                                phone_number: "+5571#{rand(100_000_000..999_999_999)}")
+    end
+    run = runs(r).last
+    expect(run.status).to eq('skipped')
+    expect(run.steps.map { |s| s['label'] }.join).to include('conversation-scoped conditions')
+    expect(contact.reload.label_list).to be_empty
+  end
+
+  it 'card de conversa segue igual (nao-regressao)' do
+    r = entry_rule
+    contact = Contact.create!(name: 'Conv', email: "cv-#{SecureRandom.hex(4)}@t.com",
+                              phone_number: "+5571#{rand(100_000_000..999_999_999)}",
+                              skip_default_pipeline_assignment: true)
+    Current.reset
+    ci = ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4))
+    conversation = nil
+    run_automation_jobs { conversation = Conversation.create!(inbox: inbox, contact: contact, contact_inbox: ci) }
+    item = PipelineItem.find_by(conversation_id: conversation.id)
+    expect(item.read_attribute(:contact_id)).to be_nil
+    expect(runs(r).map(&:status)).to eq(['matched'])
+    expect(conversation.reload.label_list).to include(ia_label.title)
+  end
+end

--- a/spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb
+++ b/spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe AutomationRuleListener, '#pipeline_stage_updated' do
 
   def runs(rule) = AutomationRuleRun.where(automation_rule_id: rule.id).order(:started_at)
 
-  # Só os jobs do caminho de automação: avatar e ip lookup fazem HTTP real, que
-  # o WebMock de outros specs da mesma lane bloqueia.
+  # Automation-path jobs only: avatar and ip lookup make real HTTP calls, which the
+  # WebMock of other specs in the same lane blocks.
   def run_automation_jobs(&)
     perform_enqueued_jobs(only: [EventDispatcherJob, AutomationContactEventJob], &)
   end


### PR DESCRIPTION
## Problema

Card criado a partir de um **contato** mantém `pipeline_items.conversation_id` NULL. O `pipeline_stage_updated` chegava em `evaluate_and_execute_rule` com conversa nil e morria em `skipped` antes de ler qualquer condição — a automação de entrada no estágio (a que liga a IA no lead) nunca rodava.

Não é só o caminho de checkout por API: `Contact#assign_to_default_pipeline` põe **todo contato criado** no funil default como card de contato. O `Public::Leads::CreationService` e o `POST /pipeline_items` com `type: contact` são mais dois. É o caminho majoritário de entrada de lead.

E a perda era permanente. `Conversation#promote_lead_card` troca o eixo do card sem tocar em `pipeline_stage_id`, então nenhum evento nascia da promoção e a entrada não se recuperava quando a conversa chegava.

## Solução

Eventos de card sem conversa vão para o executor de contato que `contact_created` já usa: as condições são avaliadas com o contato no lugar da conversa e as ações rodam pelo `ContactActionService`, que aplica as nativas de contato e registra as presas à conversa como `skipped`. Regra que pede atributo de conversa continua `skipped`, agora com o motivo que diz isso em vez do genérico.

A promoção redispara o evento marcado, e o listener recusa as regras que já rodaram no eixo do contato — o replay serve às que ficaram sem conversa, sem executar nada duas vezes.

A label de contato resolve o caso do card ponta a ponta: `AgentBotInbox#resolve_label_ids_for_conversation` lê labels da conversa **e** do contato, então o bot é liberado quando a conversa chega.

## `pipeline_id` quebrado (achado no caminho)

`pipeline_id` também está declarado na seção `conversations` do `filter_keys.yml`, então o ramo de conversa vencia e a query saía como `conversations.pipeline_id` — coluna que não existe, erro levantado e engolido pelo `rescue` do `#perform`. As chaves de pipeline agora resolvem contra `pipeline_items` antes de qualquer seção, por subquery escalar presa ao card do evento quando não há conversa.

**Atenção no deploy:** condições com `pipeline_id` nunca casaram em produção. Depois deste merge elas passam a casar, e regras que existiam mortas começam a disparar. No banco de dev são 0 regras nessa forma; vale conferir produção antes de mesclar.

## Testes

`automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb` (22 exemplos) cobre o roteamento, o escopo da condição de pipeline, o custom attribute de contato, a janela de dedup e o replay da promoção.

`automation_rule_listener_pipeline_stage_updated_e2e_spec.rb` (6 exemplos) roda a reprodução do card pelos callbacks reais: contato criado caindo no funil default, lead do jeito que a API pública cria, movimentação de estágio, promoção, a recusa da regra de conversa e o card de conversa como controle intocado.

Lane completa do `spec-staleness-guard`: **576 exemplos, 0 falhas**. Os dois specs novos dão **24/28 falhas contra `origin/develop`** — os 4 que passam são justamente os controles do eixo de conversa. Suítes vizinhas idênticas à baseline, sem regressão. Ambos registrados no guard nos `paths:` e na lista do `rspec`.

## Summary by Sourcery

Enable pipeline stage automations to run reliably for contact-originated cards and recover skipped stage-entry rules when conversations are created.

New Features:
- Execute stage-entry automation rules for pipeline cards created from contacts, evaluating contact, pipeline, and contact custom-attribute conditions.
- Replay stage-entry automation when a lead card is promoted to a conversation and prevent duplicate execution across contact and conversation axes.

Bug Fixes:
- Fix pipeline condition evaluation so pipeline identifiers are resolved against the event's pipeline card instead of the conversations table.
- Preserve conversation-card behavior while allowing conversation-scoped rules to remain skipped with an explicit reason on contact-only cards.

Enhancements:
- Run contact-card actions through the contact automation service and record conversation-bound actions as skipped.
- Resolve contact labels from both the conversation and its associated contact so automation agents can use labels applied before promotion.

CI:
- Register the new contact-card and end-to-end listener specs in the spec-staleness-guard workflow.

Tests:
- Add focused and end-to-end coverage for contact-card routing, pipeline scoping, custom attributes, deduplication, promotion replay, and conversation-card regression behavior.