### PR TITLE
feat(webhooks): captação de lead por webhook de compra (CRM-320)

### DIFF
--- a/app/controllers/api/v1/webhooks/purchases_controller.rb
+++ b/app/controllers/api/v1/webhooks/purchases_controller.rb
@@ -1,45 +1,30 @@
 # frozen_string_literal: true
 
-# Ingress for payment-platform purchase webhooks: an approved purchase becomes
-# a contact + a pipeline card on the entry stage (lead capture). Authenticated
-# via HMAC SHA-256 in `PurchaseWebhookSignatureConcern`; the payload is routed
-# through a per-provider adapter to the canonical lead shape and delegated to
-# `Webhooks::Purchases::LeadCaptureService` — the endpoint never duplicates
-# capture logic.
-#
-# Inherits `ActionController::API` directly (not `Api::V1::BaseController`)
-# for the same reasons as the ERP webhook: HMAC auth instead of the
-# apikey+RBAC chain, machine-to-machine (no locale), response shape via
-# `ApiResponseHelper` mixed in explicitly.
-#
-# Every outcome is distinct on the wire and in the audit trail — no silent
-# 200 discard: unknown provider (404), bad signature (401), unmappable or
-# invalid payload (422), non-approved event (200 ignored), success (201),
-# redelivery (200 duplicate, idempotent by the partial UNIQUE index on
-# custom_fields['purchase']).
+# Ingress for payment-platform purchase webhooks: an approved purchase becomes a
+# contact + a pipeline card on the entry stage. Auth is HMAC (body + destination,
+# see PurchaseWebhookSignatureConcern), mapping is per-provider adapter, capture
+# is LeadCaptureService. Every outcome is distinct on the wire AND in the audit.
 class Api::V1::Webhooks::PurchasesController < ActionController::API
   include ApiResponseHelper
   include PurchaseWebhookSignatureConcern
 
-  # Deliberately NOT including the enterprise Idempotent concern: it demands an
-  # X-Idempotency-Key header, and payment platforms send only their own fixed
-  # header set. Idempotency here is enforced at the database instead — the
-  # partial UNIQUE index on custom_fields['purchase'] (provider, purchase_id) —
-  # which also covers concurrent redeliveries, something a replay cache cannot.
+  # Deliberately NOT the enterprise Idempotent concern: it demands an
+  # X-Idempotency-Key header and payment platforms send only their own headers.
+  # Idempotency is the partial UNIQUE index on custom_fields['purchase'] instead,
+  # which also covers concurrent redeliveries — a replay cache cannot.
 
   # Provider lookup runs BEFORE signature verification so an unknown provider
   # returns 404 instead of 401 — provider names are public surface (URL path).
   before_action :check_provider_known!
   before_action :verify_purchase_signature!
+  before_action :verify_purchase_destination!
+  before_action :check_tenant_bound!
 
   def receive
     started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-    begin
-      payload = JSON.parse(request.raw_post)
-    rescue JSON::ParserError
-      return emit_and_render_error(:invalid_json, started_at)
-    end
+    payload = parse_payload
+    return emit_and_render_error(:invalid_json, started_at) if payload.nil?
 
     begin
       lead = @adapter_klass.new.to_lead(payload)
@@ -55,6 +40,12 @@ class Api::V1::Webhooks::PurchasesController < ActionController::API
     ).perform
 
     render_result(result, lead, started_at)
+  rescue StandardError => e
+    # Re-raised on purpose (the platform must retry a transient failure), but
+    # never without a record: an unaudited 500 is the one shape AC2 forbids.
+    emit_audit(signature_valid: true, result_status: 'error', latency_ms: elapsed_ms(started_at),
+               reason: :unhandled, exception: e.class.name)
+    raise
   end
 
   private
@@ -70,31 +61,41 @@ class Api::V1::Webhooks::PurchasesController < ActionController::API
     unknown_provider: [ApiErrorCodes::UNKNOWN_PROVIDER, 'Provider not registered', :not_found],
     invalid_json: [ApiErrorCodes::MAPPING_ERROR, 'Invalid JSON payload', :unprocessable_entity],
     mapping: [ApiErrorCodes::MAPPING_ERROR, 'Payload mapping failed', :unprocessable_entity],
+    tenant_unbound: [ApiErrorCodes::VALIDATION_ERROR, 'Webhook URL is not bound to an account', :unprocessable_entity],
     pipeline_not_found: [ApiErrorCodes::VALIDATION_ERROR, 'Destination pipeline not found or has no stages', :unprocessable_entity],
     contact_error: [ApiErrorCodes::VALIDATION_ERROR, 'Contact could not be saved', :unprocessable_entity],
     pipeline_item_error: [ApiErrorCodes::VALIDATION_ERROR, 'Pipeline card could not be created', :unprocessable_entity]
   }.freeze
 
+  # A JSON array/scalar body parses fine and then dies on `payload['data']`, so
+  # the shape is checked here rather than inside every adapter.
+  def parse_payload
+    parsed = JSON.parse(request.raw_post)
+    parsed.is_a?(Hash) ? parsed : nil
+  rescue JSON::ParserError
+    nil
+  end
+
   def render_result(result, lead, started_at)
-    if (status, message = SUCCESS_STATUSES[result.status])
-      emit_audit(
-        signature_valid: true,
-        result_status: result.status.to_s,
-        purchase_id: lead[:purchase_id],
-        latency_ms: elapsed_ms(started_at)
-      )
-      success_response(
-        data: {
-          status: result.status.to_s,
-          contact_id: result.contact&.id,
-          pipeline_item_id: result.pipeline_item&.id
-        },
-        message: message,
-        status: status
-      )
-    else
-      emit_and_render_error(result.status, started_at, details: result.details, purchase_id: lead[:purchase_id])
-    end
+    success = SUCCESS_STATUSES[result.status]
+    return emit_and_render_error(result.status, started_at, details: result.details, purchase_id: lead[:purchase_id]) unless success
+
+    status, message = success
+    emit_audit(
+      signature_valid: true,
+      result_status: result.status.to_s,
+      purchase_id: lead[:purchase_id],
+      latency_ms: elapsed_ms(started_at)
+    )
+    success_response(
+      data: {
+        status: result.status.to_s,
+        contact_id: result.contact&.id,
+        pipeline_item_id: result.pipeline_item&.id
+      },
+      message: message,
+      status: status
+    )
   end
 
   def check_provider_known!
@@ -110,6 +111,17 @@ class Api::V1::Webhooks::PurchasesController < ActionController::API
     )
     code, message, status = ERROR_KINDS.fetch(:unknown_provider)
     error_response(code, message, status: status)
+  end
+
+  # Under the enterprise overlay every insert needs a bound tenant; unbound, the
+  # contact insert dies on a NOT NULL violation deep in the stack. Refuse up front
+  # so a webhook URL missing ?evo_tenant= reads as the config error it is.
+  def check_tenant_bound!
+    return unless defined?(Evo::Enterprise::Licensing) &&
+                  Evo::Enterprise::Licensing.respond_to?(:current_tenant_id)
+    return if Evo::Enterprise::Licensing.current_tenant_id.present?
+
+    emit_and_render_error(:tenant_unbound, Process.clock_gettime(Process::CLOCK_MONOTONIC))
   end
 
   def emit_and_render_error(kind, started_at, details: nil, purchase_id: nil)

--- a/app/controllers/api/v1/webhooks/purchases_controller.rb
+++ b/app/controllers/api/v1/webhooks/purchases_controller.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# Ingress for payment-platform purchase webhooks: an approved purchase becomes
+# a contact + a pipeline card on the entry stage (lead capture). Authenticated
+# via HMAC SHA-256 in `PurchaseWebhookSignatureConcern`; the payload is routed
+# through a per-provider adapter to the canonical lead shape and delegated to
+# `Webhooks::Purchases::LeadCaptureService` — the endpoint never duplicates
+# capture logic.
+#
+# Inherits `ActionController::API` directly (not `Api::V1::BaseController`)
+# for the same reasons as the ERP webhook: HMAC auth instead of the
+# apikey+RBAC chain, machine-to-machine (no locale), response shape via
+# `ApiResponseHelper` mixed in explicitly.
+#
+# Every outcome is distinct on the wire and in the audit trail — no silent
+# 200 discard: unknown provider (404), bad signature (401), unmappable or
+# invalid payload (422), non-approved event (200 ignored), success (201),
+# redelivery (200 duplicate, idempotent by the partial UNIQUE index on
+# custom_fields['purchase']).
+class Api::V1::Webhooks::PurchasesController < ActionController::API
+  include ApiResponseHelper
+  include PurchaseWebhookSignatureConcern
+
+  # Deliberately NOT including the enterprise Idempotent concern: it demands an
+  # X-Idempotency-Key header, and payment platforms send only their own fixed
+  # header set. Idempotency here is enforced at the database instead — the
+  # partial UNIQUE index on custom_fields['purchase'] (provider, purchase_id) —
+  # which also covers concurrent redeliveries, something a replay cache cannot.
+
+  # Provider lookup runs BEFORE signature verification so an unknown provider
+  # returns 404 instead of 401 — provider names are public surface (URL path).
+  before_action :check_provider_known!
+  before_action :verify_purchase_signature!
+
+  def receive
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    begin
+      payload = JSON.parse(request.raw_post)
+    rescue JSON::ParserError
+      return emit_and_render_error(:invalid_json, started_at)
+    end
+
+    begin
+      lead = @adapter_klass.new.to_lead(payload)
+    rescue Webhooks::PurchaseAdapters::MappingError => e
+      return emit_and_render_error(:mapping, started_at, details: e.errors)
+    end
+
+    result = Webhooks::Purchases::LeadCaptureService.new(
+      provider: params[:provider],
+      lead: lead,
+      pipeline_id: params[:pipeline_id],
+      product_override: params[:product]
+    ).perform
+
+    render_result(result, lead, started_at)
+  end
+
+  private
+
+  SUCCESS_STATUSES = {
+    created: [:created, 'Lead captured'],
+    duplicate: [:ok, 'Purchase already captured'],
+    already_in_pipeline: [:ok, 'Contact already has an active card in this pipeline'],
+    ignored: [:ok, 'Event ignored (not an approved purchase)']
+  }.freeze
+
+  ERROR_KINDS = {
+    unknown_provider: [ApiErrorCodes::UNKNOWN_PROVIDER, 'Provider not registered', :not_found],
+    invalid_json: [ApiErrorCodes::MAPPING_ERROR, 'Invalid JSON payload', :unprocessable_entity],
+    mapping: [ApiErrorCodes::MAPPING_ERROR, 'Payload mapping failed', :unprocessable_entity],
+    pipeline_not_found: [ApiErrorCodes::VALIDATION_ERROR, 'Destination pipeline not found or has no stages', :unprocessable_entity],
+    contact_error: [ApiErrorCodes::VALIDATION_ERROR, 'Contact could not be saved', :unprocessable_entity],
+    pipeline_item_error: [ApiErrorCodes::VALIDATION_ERROR, 'Pipeline card could not be created', :unprocessable_entity]
+  }.freeze
+
+  def render_result(result, lead, started_at)
+    if (status, message = SUCCESS_STATUSES[result.status])
+      emit_audit(
+        signature_valid: true,
+        result_status: result.status.to_s,
+        purchase_id: lead[:purchase_id],
+        latency_ms: elapsed_ms(started_at)
+      )
+      success_response(
+        data: {
+          status: result.status.to_s,
+          contact_id: result.contact&.id,
+          pipeline_item_id: result.pipeline_item&.id
+        },
+        message: message,
+        status: status
+      )
+    else
+      emit_and_render_error(result.status, started_at, details: result.details, purchase_id: lead[:purchase_id])
+    end
+  end
+
+  def check_provider_known!
+    @adapter_klass = Webhooks::PurchaseAdapters.lookup(params[:provider])
+    return if @adapter_klass
+
+    Webhooks::PurchaseAuditLogger.emit(
+      provider: params[:provider].to_s,
+      signature_valid: false,
+      result_status: 'error',
+      latency_ms: 0,
+      reason: :unknown_provider
+    )
+    code, message, status = ERROR_KINDS.fetch(:unknown_provider)
+    error_response(code, message, status: status)
+  end
+
+  def emit_and_render_error(kind, started_at, details: nil, purchase_id: nil)
+    code, message, status = ERROR_KINDS.fetch(kind)
+    emit_audit(
+      signature_valid: true,
+      result_status: 'error',
+      purchase_id: purchase_id,
+      latency_ms: elapsed_ms(started_at),
+      reason: kind
+    )
+    error_response(code, message, details: details, status: status)
+  end
+
+  def emit_audit(payload)
+    Webhooks::PurchaseAuditLogger.emit(payload.merge(provider: params[:provider].to_s))
+  end
+
+  def elapsed_ms(started_at)
+    ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round
+  end
+end

--- a/app/controllers/concerns/purchase_webhook_signature_concern.rb
+++ b/app/controllers/concerns/purchase_webhook_signature_concern.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# HMAC SHA-256 verification for purchase webhook callbacks. Mirrors
+# ErpWebhookSignatureConcern (same header, same failure taxonomy).
+#
+# Shared secret lookup:
+#   `PURCHASE_WEBHOOK_SECRET_<PROVIDER_UPCASE>` via `GlobalConfigService`.
+#
+# Failure modes (all -> 401, audit emit, one opaque body):
+#   * secret blank              -> reason: :secret_missing (fail-closed)
+#   * header missing/malformed  -> reason: :malformed
+#   * HMAC mismatch             -> reason: :mismatch
+module PurchaseWebhookSignatureConcern
+  extend ActiveSupport::Concern
+
+  HEADER = 'X-Evo-Signature'
+
+  private
+
+  def verify_purchase_signature!
+    secret = purchase_webhook_secret
+    return reject_purchase_signature!(:secret_missing) if secret.blank?
+
+    provided = request.headers[HEADER].to_s
+    unless provided.start_with?('sha256=')
+      Rails.logger.warn(
+        'Purchase webhook: refused — missing or malformed signature header. ' \
+        "Got=#{provided.inspect[0, 80]}, body_size=#{request.raw_post.bytesize}"
+      )
+      return reject_purchase_signature!(:malformed)
+    end
+
+    return true if valid_purchase_signature?(secret, provided)
+
+    Rails.logger.warn("Purchase webhook: refused — signature mismatch. body_size=#{request.raw_post.bytesize}")
+    reject_purchase_signature!(:mismatch)
+  end
+
+  # check_provider_known! runs first, so `params[:provider]` is an allow-listed
+  # registry key — safe to interpolate into the config name.
+  def purchase_webhook_secret
+    key = "PURCHASE_WEBHOOK_SECRET_#{params[:provider].to_s.upcase}"
+    secret = GlobalConfigService.load(key, nil).to_s
+    Rails.logger.warn("Purchase webhook: refused — #{key} is not configured") if secret.blank?
+    secret
+  end
+
+  def valid_purchase_signature?(secret, provided)
+    expected = "sha256=#{OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), secret, request.raw_post)}"
+    ActiveSupport::SecurityUtils.secure_compare(expected, provided)
+  end
+
+  def reject_purchase_signature!(reason)
+    Webhooks::PurchaseAuditLogger.emit(
+      provider: params[:provider].to_s,
+      signature_valid: false,
+      result_status: 'error',
+      latency_ms: 0,
+      reason: reason
+    )
+    error_response(
+      ApiErrorCodes::INVALID_SIGNATURE,
+      'Purchase webhook signature invalid',
+      status: :unauthorized
+    )
+  end
+end

--- a/app/controllers/concerns/purchase_webhook_signature_concern.rb
+++ b/app/controllers/concerns/purchase_webhook_signature_concern.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
-# HMAC SHA-256 verification for purchase webhook callbacks. Mirrors
-# ErpWebhookSignatureConcern (same header, same failure taxonomy).
-#
-# Shared secret lookup:
-#   `PURCHASE_WEBHOOK_SECRET_<PROVIDER_UPCASE>` via `GlobalConfigService`.
-#
-# Failure modes (all -> 401, audit emit, one opaque body):
-#   * secret blank              -> reason: :secret_missing (fail-closed)
-#   * header missing/malformed  -> reason: :malformed
-#   * HMAC mismatch             -> reason: :mismatch
+# Auth for purchase webhooks, in two halves: `verify_purchase_signature!` is the
+# platform's HMAC over the body; `verify_purchase_destination!` is OUR MAC over
+# the query params that pick the destination, which the platform's signature
+# cannot cover. Both fail closed; the reason lives in the audit, never on the wire.
 module PurchaseWebhookSignatureConcern
   extend ActiveSupport::Concern
 
@@ -36,13 +30,32 @@ module PurchaseWebhookSignatureConcern
     reject_purchase_signature!(:mismatch)
   end
 
+  # Without this, a delivery captured for one tenant/pipeline replays into any
+  # other: the body — and therefore the platform's signature over it — is
+  # unchanged, only the query string moves.
+  def verify_purchase_destination!
+    secret = purchase_webhook_secret
+    return reject_purchase_signature!(:secret_missing) if secret.blank?
+
+    provided = request.query_parameters[Webhooks::PurchaseDestinationMac::QUERY_PARAM].to_s
+    return reject_purchase_signature!(:destination_unsigned) if provided.blank?
+
+    expected = Webhooks::PurchaseDestinationMac.mint(secret, params[:provider], request.query_parameters)
+    return true if ActiveSupport::SecurityUtils.secure_compare(expected, provided)
+
+    Rails.logger.warn('Purchase webhook: refused — destination MAC mismatch (evo_tenant/pipeline_id/product tampered?)')
+    reject_purchase_signature!(:destination_mismatch)
+  end
+
   # check_provider_known! runs first, so `params[:provider]` is an allow-listed
   # registry key — safe to interpolate into the config name.
   def purchase_webhook_secret
+    return @purchase_webhook_secret if defined?(@purchase_webhook_secret)
+
     key = "PURCHASE_WEBHOOK_SECRET_#{params[:provider].to_s.upcase}"
-    secret = GlobalConfigService.load(key, nil).to_s
-    Rails.logger.warn("Purchase webhook: refused — #{key} is not configured") if secret.blank?
-    secret
+    @purchase_webhook_secret = GlobalConfigService.load(key, nil).to_s
+    Rails.logger.warn("Purchase webhook: refused — #{key} is not configured") if @purchase_webhook_secret.blank?
+    @purchase_webhook_secret
   end
 
   def valid_purchase_signature?(secret, provided)

--- a/app/lib/webhooks/purchase_adapters.rb
+++ b/app/lib/webhooks/purchase_adapters.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-# Adapter registry for purchase-webhook ingress (lead capture from payment
-# platforms). Mirrors Webhooks::ErpAdapters: each adapter converts a
-# provider-specific payload into the canonical lead shape consumed by
-# Webhooks::Purchases::LeadCaptureService. Adapters are duck-typed: they only
-# need a `#to_lead(payload) -> Hash` instance method (see Base for the shape).
-#
-# A provider is only reachable when registered here — the controller returns
-# 404 for anything else, so no platform is ever enabled without an adapter
-# (and therefore without a signature secret convention).
+# Adapter registry for purchase-webhook ingress, mirroring Webhooks::ErpAdapters.
+# Adapters are duck-typed: `#to_lead(payload) -> Hash` (shape in Base).
+# A provider is reachable ONLY when registered here — everything else 404s, so
+# no platform is ever enabled without an adapter and its signature secret.
 module Webhooks
   module PurchaseAdapters
     # Raised by an adapter when the inbound payload cannot be mapped to the

--- a/app/lib/webhooks/purchase_adapters.rb
+++ b/app/lib/webhooks/purchase_adapters.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Adapter registry for purchase-webhook ingress (lead capture from payment
+# platforms). Mirrors Webhooks::ErpAdapters: each adapter converts a
+# provider-specific payload into the canonical lead shape consumed by
+# Webhooks::Purchases::LeadCaptureService. Adapters are duck-typed: they only
+# need a `#to_lead(payload) -> Hash` instance method (see Base for the shape).
+#
+# A provider is only reachable when registered here — the controller returns
+# 404 for anything else, so no platform is ever enabled without an adapter
+# (and therefore without a signature secret convention).
+module Webhooks
+  module PurchaseAdapters
+    # Raised by an adapter when the inbound payload cannot be mapped to the
+    # canonical lead shape (missing purchase id, no reachable contact field).
+    class MappingError < StandardError
+      attr_reader :errors
+
+      def initialize(errors:)
+        @errors = errors
+        super('Purchase payload mapping failed')
+      end
+    end
+
+    @adapters = {}
+
+    class << self
+      def register(key, klass)
+        @adapters[key.to_sym] = klass
+      end
+
+      def lookup(key)
+        return nil if key.nil?
+
+        @adapters[key.to_sym]
+      end
+
+      def registered?(key)
+        return false if key.nil?
+
+        @adapters.key?(key.to_sym)
+      end
+
+      def clear!
+        @adapters = {}
+      end
+    end
+  end
+end

--- a/app/lib/webhooks/purchase_adapters/base.rb
+++ b/app/lib/webhooks/purchase_adapters/base.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Conceptual contract for purchase adapters. Concrete adapters do NOT need to
-# inherit from this — duck typing (`#to_lead(payload)`) is enough. Base exists
-# so the contract has one home for documentation and specs.
+# The purchase-adapter contract. Inheriting is optional (duck typing is enough);
+# Base exists so the canonical lead shape has one home.
 module Webhooks
   module PurchaseAdapters
     class Base

--- a/app/lib/webhooks/purchase_adapters/base.rb
+++ b/app/lib/webhooks/purchase_adapters/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Conceptual contract for purchase adapters. Concrete adapters do NOT need to
+# inherit from this — duck typing (`#to_lead(payload)`) is enough. Base exists
+# so the contract has one home for documentation and specs.
+module Webhooks
+  module PurchaseAdapters
+    class Base
+      # @param payload [Hash] parsed JSON body posted by the payment platform
+      # @return [Hash] canonical lead shape:
+      #   {
+      #     purchase_id: String (required — the platform's order/transaction id),
+      #     approved: Boolean (only approved purchases become leads),
+      #     event: String (raw event name, for logs),
+      #     name: String or nil,
+      #     email: String or nil,
+      #     phone_number: String or nil (raw; the service normalizes to E.164),
+      #     product: String or nil,
+      #     amount: Numeric or nil,
+      #     currency: String or nil
+      #   }
+      #   email OR phone_number must be present — a lead with neither is
+      #   unmappable.
+      # @raise [Webhooks::PurchaseAdapters::MappingError] when unmappable.
+      def to_lead(_payload)
+        raise NotImplementedError, "#{self.class} must implement #to_lead"
+      end
+    end
+  end
+end

--- a/app/lib/webhooks/purchase_adapters/virtu_adapter.rb
+++ b/app/lib/webhooks/purchase_adapters/virtu_adapter.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Maps Virtu checkout webhooks to the canonical lead shape. Field paths are
+# resolved defensively over the common checkout-payload layouts (top-level,
+# `data`, `customer`/`buyer` nesting) so a payload revision moves ONLY this
+# file — the controller/service contract stays put.
+module Webhooks
+  module PurchaseAdapters
+    class VirtuAdapter < Base
+      # Statuses that mean "money confirmed". Anything else is acked and
+      # ignored (refunds/chargebacks are out of scope for lead capture).
+      APPROVED_STATUSES = %w[approved paid completed purchase_approved sale_approved].freeze
+
+      def to_lead(payload)
+        data = payload['data'].is_a?(Hash) ? payload['data'] : payload
+        buyer = first_hash(data, %w[customer buyer client contact]) || data
+
+        purchase_id = first_value(data, %w[purchase_id order_id transaction_id sale_id id])
+        email = first_value(buyer, %w[email])
+        phone = first_value(buyer, %w[phone_number phone whatsapp cellphone mobile])
+
+        status = event_status(payload, data)
+        approved = APPROVED_STATUSES.include?(status.downcase)
+
+        validate_mappable!(purchase_id, approved, email, phone)
+
+        {
+          purchase_id: purchase_id.to_s,
+          approved: approved,
+          event: status,
+          name: first_value(buyer, %w[name full_name]),
+          email: email,
+          phone_number: normalize_br_phone(phone),
+          product: first_value(data, %w[product product_name offer offer_name]),
+          amount: first_value(data, %w[amount value total price]),
+          currency: first_value(data, %w[currency]) || 'BRL'
+        }
+      end
+
+      private
+
+      # Contact fields are only demanded for APPROVED events: a refund/
+      # chargeback with a minimal payload must map cleanly so the service acks
+      # it as ignored — a 4xx here would make the platform redeliver forever.
+      def validate_mappable!(purchase_id, approved, email, phone)
+        errors = []
+        errors << { key: 'purchase_id', message: 'purchase id is required' } if purchase_id.blank?
+        errors << { key: 'contact', message: 'email or phone_number is required' } if approved && email.blank? && phone.blank?
+        raise MappingError.new(errors: errors) if errors.any?
+      end
+
+      def event_status(payload, data)
+        (first_value(payload, %w[event status event_type type]) ||
+          first_value(data, %w[status event]) || '').to_s
+      end
+
+      def first_hash(hash, keys)
+        keys.map { |k| hash[k] }.find { |v| v.is_a?(Hash) }
+      end
+
+      def first_value(hash, keys)
+        keys.map { |k| hash[k] }.find(&:present?)
+      end
+
+      # The checkout sends local BR numbers without the country code; prefix
+      # +55 so the shared E.164 normalizer resolves them like the WhatsApp
+      # inbound path does. Numbers already carrying a DDI pass through.
+      def normalize_br_phone(raw)
+        return nil if raw.blank?
+
+        digits = raw.to_s.gsub(/\D/, '')
+        return raw if raw.to_s.start_with?('+')
+        return "+#{digits}" if digits.start_with?('55') && digits.length >= 12
+
+        digits.length.between?(10, 11) ? "+55#{digits}" : "+#{digits}"
+      end
+    end
+  end
+end

--- a/app/lib/webhooks/purchase_adapters/virtu_adapter.rb
+++ b/app/lib/webhooks/purchase_adapters/virtu_adapter.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
 # Maps Virtu checkout webhooks to the canonical lead shape. Field paths are
-# resolved defensively over the common checkout-payload layouts (top-level,
-# `data`, `customer`/`buyer` nesting) so a payload revision moves ONLY this
-# file — the controller/service contract stays put.
+# resolved defensively over the common checkout layouts (top-level, `data`,
+# `customer`/`buyer` nesting) so a payload revision moves ONLY this file.
 module Webhooks
   module PurchaseAdapters
     class VirtuAdapter < Base
-      # Statuses that mean "money confirmed". Anything else is acked and
-      # ignored (refunds/chargebacks are out of scope for lead capture).
+      # Statuses that mean "money confirmed". Anything else is acked and ignored.
       APPROVED_STATUSES = %w[approved paid completed purchase_approved sale_approved].freeze
+      PURCHASE_ID_KEYS = %w[purchase_id order_id transaction_id sale_id].freeze
 
       def to_lead(payload)
         data = payload['data'].is_a?(Hash) ? payload['data'] : payload
         buyer = first_hash(data, %w[customer buyer client contact]) || data
 
-        purchase_id = first_value(data, %w[purchase_id order_id transaction_id sale_id id])
+        purchase_id = resolve_purchase_id(data)
         email = first_value(buyer, %w[email])
         phone = first_value(buyer, %w[phone_number phone whatsapp cellphone mobile])
 
@@ -39,9 +38,24 @@ module Webhooks
 
       private
 
-      # Contact fields are only demanded for APPROVED events: a refund/
-      # chargeback with a minimal payload must map cleanly so the service acks
-      # it as ignored — a 4xx here would make the platform redeliver forever.
+      # `id` is the last resort and a loud one: on platforms where it is the
+      # per-DELIVERY event id (not the order id) every redelivery would mint a
+      # second card. Pin a real order-id key once the provider fixture lands.
+      def resolve_purchase_id(data)
+        explicit = first_value(data, PURCHASE_ID_KEYS)
+        return explicit if explicit.present?
+
+        fallback = data['id']
+        if fallback.present?
+          Rails.logger.warn('Purchase webhook (virtu): no order-id field; falling back to the generic `id` — ' \
+                            'idempotency breaks if that is a per-delivery event id')
+        end
+        fallback
+      end
+
+      # Contact fields are only demanded for APPROVED events: a refund with a
+      # minimal payload must map cleanly so the service acks it as ignored — a
+      # 4xx here would make the platform redeliver forever.
       def validate_mappable!(purchase_id, approved, email, phone)
         errors = []
         errors << { key: 'purchase_id', message: 'purchase id is required' } if purchase_id.blank?
@@ -62,17 +76,19 @@ module Webhooks
         keys.map { |k| hash[k] }.find(&:present?)
       end
 
-      # The checkout sends local BR numbers without the country code; prefix
-      # +55 so the shared E.164 normalizer resolves them like the WhatsApp
-      # inbound path does. Numbers already carrying a DDI pass through.
+      # The checkout sends local BR numbers without the country code; prefix +55
+      # so the shared E.164 normalizer resolves them like the WhatsApp inbound
+      # path does. Anything of an implausible length is handed over untouched —
+      # minting "+123" out of a truncated number only hides the problem.
       def normalize_br_phone(raw)
         return nil if raw.blank?
+        return raw if raw.to_s.start_with?('+')
 
         digits = raw.to_s.gsub(/\D/, '')
-        return raw if raw.to_s.start_with?('+')
         return "+#{digits}" if digits.start_with?('55') && digits.length >= 12
+        return "+55#{digits}" if digits.length.between?(10, 11)
 
-        digits.length.between?(10, 11) ? "+55#{digits}" : "+#{digits}"
+        raw
       end
     end
   end

--- a/app/lib/webhooks/purchase_audit_logger.rb
+++ b/app/lib/webhooks/purchase_audit_logger.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 # Single emit point for purchase-webhook audit records, mirroring
-# Webhooks::ErpAuditLogger: persists to the enterprise audit log when the
-# overlay is loaded, degrades to a tagged Rails logger line otherwise.
-#
-# Expected payload keys: :provider, :signature_valid, :result_status,
-# :latency_ms. Extra keys (:reason, :purchase_id, ids) pass through.
+# Webhooks::ErpAuditLogger: the enterprise audit log when the overlay is loaded,
+# a tagged logger line otherwise. Keys: :provider, :signature_valid,
+# :result_status, :latency_ms; extras (:reason, :purchase_id) pass through.
 module Webhooks
   module PurchaseAuditLogger
     module_function

--- a/app/lib/webhooks/purchase_audit_logger.rb
+++ b/app/lib/webhooks/purchase_audit_logger.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Single emit point for purchase-webhook audit records, mirroring
+# Webhooks::ErpAuditLogger: persists to the enterprise audit log when the
+# overlay is loaded, degrades to a tagged Rails logger line otherwise.
+#
+# Expected payload keys: :provider, :signature_valid, :result_status,
+# :latency_ms. Extra keys (:reason, :purchase_id, ids) pass through.
+module Webhooks
+  module PurchaseAuditLogger
+    module_function
+
+    def emit(payload)
+      if defined?(Evo::Enterprise::AuditLog)
+        Evo::Enterprise::AuditLog.record!(
+          category: 'purchase_webhook',
+          payload: payload
+        )
+      else
+        Rails.logger.tagged('purchase_webhook').info(payload.to_json)
+      end
+    end
+  end
+end

--- a/app/lib/webhooks/purchase_destination_mac.rb
+++ b/app/lib/webhooks/purchase_destination_mac.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# MAC over the query params that choose WHERE a purchase lead lands. The body
+# signature cannot cover them — the platform signs only its own payload — so a
+# captured delivery would otherwise replay into any tenant or pipeline.
+# Minted into the registered URL by `rake evo_purchase_webhook:url`.
+module Webhooks
+  module PurchaseDestinationMac
+    PARAMS = %w[evo_tenant pipeline_id product].freeze
+    QUERY_PARAM = 'd'
+
+    module_function
+
+    def canonical(provider, values)
+      ([provider.to_s] + PARAMS.map { |key| values[key].to_s }).join('|')
+    end
+
+    def mint(secret, provider, values)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), secret.to_s, canonical(provider, values))
+    end
+  end
+end

--- a/app/services/webhooks/purchases/lead_capture_service.rb
+++ b/app/services/webhooks/purchases/lead_capture_service.rb
@@ -31,17 +31,14 @@ module Webhooks
       def perform
         return Result.new(status: :ignored, details: { event: @lead[:event] }) unless @lead[:approved]
 
+        pipeline_error = resolve_pipeline!
+        return pipeline_error if pipeline_error
+
         if (existing = find_existing_item)
           return Result.new(status: :duplicate, contact: existing.contact, pipeline_item: existing)
         end
 
-        pipeline_error = resolve_pipeline!
-        return pipeline_error if pipeline_error
-
         capture!
-      rescue ActiveRecord::RecordNotUnique
-        existing = find_existing_item
-        Result.new(status: :duplicate, contact: existing&.contact, pipeline_item: existing)
       end
 
       private
@@ -60,10 +57,12 @@ module Webhooks
         Result.new(status: :created, contact: @contact, pipeline_item: item_result)
       end
 
+      # Scoped to the destination pipeline: purchase ids are only unique within
+      # one platform account, and the registered URL pins the pipeline.
       def find_existing_item
-        PipelineItem
-          .where("custom_fields -> 'purchase' ->> 'provider' = ?", @provider)
-          .find_by("custom_fields -> 'purchase' ->> 'purchase_id' = ?", @lead[:purchase_id])
+        @pipeline.pipeline_items
+                 .where("custom_fields -> 'purchase' ->> 'provider' = ?", @provider)
+                 .find_by("custom_fields -> 'purchase' ->> 'purchase_id' = ?", @lead[:purchase_id])
       end
 
       def resolve_pipeline!
@@ -121,7 +120,10 @@ module Webhooks
         return nil if @lead[:phone_number].blank?
 
         phone = Whatsapp::PhoneNumberNormalizer.to_e164(@lead[:phone_number])
-        phone.presence&.match?(/\A\+[1-9]\d{1,14}\z/) ? phone : nil
+        return phone if phone.presence&.match?(/\A\+[1-9]\d{1,14}\z/)
+
+        Rails.logger.warn("Purchase webhook: unparseable phone on purchase #{@lead[:purchase_id]} — captured without phone")
+        nil
       end
 
       def create_pipeline_item
@@ -133,10 +135,22 @@ module Webhooks
           custom_fields: card_custom_fields
         )
       rescue ActiveRecord::RecordInvalid => e
-        active = @pipeline.pipeline_items.active.find_by(contact_id: @contact.id)
-        return Result.new(status: :already_in_pipeline, contact: @contact, pipeline_item: active) if active
+        active_card_result || Result.new(status: :pipeline_item_error, details: { errors: e.record.errors.full_messages })
+      rescue ActiveRecord::RecordNotUnique => e
+        # Two partial unique indexes can fire here; answer from the one that did.
+        # A concurrent redelivery hits the purchase-identity index -> duplicate;
+        # a concurrent DIFFERENT purchase for the same contact hits the
+        # active-card index -> already_in_pipeline.
+        if (existing = find_existing_item)
+          return Result.new(status: :duplicate, contact: existing.contact, pipeline_item: existing)
+        end
 
-        Result.new(status: :pipeline_item_error, details: { errors: e.record.errors.full_messages })
+        active_card_result || raise(e)
+      end
+
+      def active_card_result
+        active = @pipeline.pipeline_items.active.find_by(contact_id: @contact.id)
+        Result.new(status: :already_in_pipeline, contact: @contact, pipeline_item: active) if active
       end
 
       def card_custom_fields

--- a/app/services/webhooks/purchases/lead_capture_service.rb
+++ b/app/services/webhooks/purchases/lead_capture_service.rb
@@ -1,25 +1,18 @@
 # frozen_string_literal: true
 
 # Turns an approved purchase (canonical lead shape, see PurchaseAdapters::Base)
-# into a contact + a pipeline card on the pipeline's entry stage. Modeled on
-# Public::Leads::CreationService, minus its known pitfalls:
-#   * new contacts set `skip_default_pipeline_assignment` — otherwise the
-#     after_create_commit callback races this service and the contact lands
-#     with a second card on the default pipeline;
-#   * contact matching is email -> normalized phone, writes are ADDITIVE on
-#     existing contacts (a webhook must not clobber CRM-owned data);
-#   * phone-conflict errors never leak another contact's data.
-#
-# Idempotency: the (provider, purchase_id) pair lives in the card's
-# custom_fields['purchase'] and is enforced by a partial UNIQUE expression
-# index — a concurrent redelivery falls into RecordNotUnique and is answered
-# as :duplicate with the existing ids.
+# into a contact + a pipeline card on the entry stage. Idempotent by the partial
+# UNIQUE index on the card's custom_fields['purchase'] (pipeline, provider,
+# purchase_id) — redelivery and concurrent retry both answer :duplicate.
 module Webhooks
   module Purchases
     class LeadCaptureService
       Result = Struct.new(:status, :contact, :pipeline_item, :details, keyword_init: true)
 
       LEAD_SOURCE = 'purchase_webhook'
+      # E.164 with a plausible length: without the floor, a truncated "123"
+      # normalizes to "+123" and is persisted as a contact nobody can reach.
+      E164 = /\A\+[1-9]\d{9,14}\z/
 
       def initialize(provider:, lead:, pipeline_id: nil, product_override: nil)
         @provider = provider.to_s
@@ -44,8 +37,8 @@ module Webhooks
       private
 
       # No wrapping transaction on purpose: a committed contact with a failed
-      # card is the GOOD failure shape — the platform's redelivery finds the
-      # contact and only retries the card. Each create! is atomic on its own.
+      # card is the GOOD failure shape — the redelivery finds the contact and
+      # only retries the card.
       def capture!
         contact_result = find_or_create_contact
         return contact_result if contact_result.is_a?(Result)
@@ -79,10 +72,14 @@ module Webhooks
         email = @lead[:email].to_s.downcase.presence
         phone = normalized_phone
 
-        contact = (email && Contact.from_email(email)) || (phone && Contact.find_by(phone_number: phone))
+        contact = find_contact(email, phone)
         contact ? update_existing_contact(contact, phone) : create_contact(email, phone)
       rescue ActiveRecord::RecordInvalid => e
         Result.new(status: :contact_error, details: { errors: e.record.errors.full_messages })
+      end
+
+      def find_contact(email, phone)
+        (email && Contact.from_email(email)) || (phone && Contact.find_by(phone_number: phone))
       end
 
       def create_contact(email, phone)
@@ -96,12 +93,15 @@ module Webhooks
         contact.skip_default_pipeline_assignment = true
         contact.save!
         contact
+      rescue ActiveRecord::RecordNotUnique
+        # Concurrent delivery won the insert (the uniqueness validation cannot
+        # close that window). Take the row it created rather than 500.
+        find_contact(email, phone) || raise
       end
 
-      # Additive only: fill blanks, never overwrite. A phone that already
-      # belongs to ANOTHER contact is skipped silently on the wire (logged) —
-      # naming the owner would let a signed-but-curious platform enumerate
-      # contacts.
+      # Additive only: fill blanks, never overwrite. A phone that already belongs
+      # to ANOTHER contact is skipped silently on the wire (logged) — naming the
+      # owner would let a signed-but-curious platform enumerate contacts.
       def update_existing_contact(contact, phone)
         updates = {}
         updates[:name] = @lead[:name] if contact.name.blank? && @lead[:name].present?
@@ -120,9 +120,10 @@ module Webhooks
         return nil if @lead[:phone_number].blank?
 
         phone = Whatsapp::PhoneNumberNormalizer.to_e164(@lead[:phone_number])
-        return phone if phone.presence&.match?(/\A\+[1-9]\d{1,14}\z/)
+        return phone if phone.presence&.match?(E164)
 
-        Rails.logger.warn("Purchase webhook: unparseable phone on purchase #{@lead[:purchase_id]} — captured without phone")
+        Rails.logger.warn("Purchase webhook: unusable phone on purchase #{@lead[:purchase_id]} " \
+                          "(normalized to #{phone.inspect}) — captured without phone")
         nil
       end
 
@@ -139,8 +140,7 @@ module Webhooks
       rescue ActiveRecord::RecordNotUnique => e
         # Two partial unique indexes can fire here; answer from the one that did.
         # A concurrent redelivery hits the purchase-identity index -> duplicate;
-        # a concurrent DIFFERENT purchase for the same contact hits the
-        # active-card index -> already_in_pipeline.
+        # a DIFFERENT purchase for the same contact hits the active-card index.
         if (existing = find_existing_item)
           return Result.new(status: :duplicate, contact: existing.contact, pipeline_item: existing)
         end
@@ -150,7 +150,30 @@ module Webhooks
 
       def active_card_result
         active = @pipeline.pipeline_items.active.find_by(contact_id: @contact.id)
-        Result.new(status: :already_in_pipeline, contact: @contact, pipeline_item: active) if active
+        return nil unless active
+
+        record_extra_purchase(active)
+        Result.new(status: :already_in_pipeline, contact: @contact, pipeline_item: active)
+      end
+
+      # One open card per contact per pipeline, so a second sale gets no card of
+      # its own. Append it to the open card instead of dropping it; idempotent,
+      # so a redelivery of that second sale does not append twice.
+      def record_extra_purchase(item)
+        fields = item.custom_fields || {}
+        purchase = card_custom_fields['purchase']
+        return if same_purchase?(fields['purchase'], purchase)
+
+        history = Array(fields['purchases'])
+        return if history.any? { |entry| same_purchase?(entry, purchase) }
+
+        item.update!(custom_fields: fields.merge('purchases' => history + [purchase]))
+      rescue ActiveRecord::ActiveRecordError => e
+        Rails.logger.warn("Purchase webhook: could not append purchase #{@lead[:purchase_id]} to card #{item.id}: #{e.message}")
+      end
+
+      def same_purchase?(entry, purchase)
+        entry.is_a?(Hash) && entry['provider'] == purchase['provider'] && entry['purchase_id'] == purchase['purchase_id']
       end
 
       def card_custom_fields

--- a/app/services/webhooks/purchases/lead_capture_service.rb
+++ b/app/services/webhooks/purchases/lead_capture_service.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+# Turns an approved purchase (canonical lead shape, see PurchaseAdapters::Base)
+# into a contact + a pipeline card on the pipeline's entry stage. Modeled on
+# Public::Leads::CreationService, minus its known pitfalls:
+#   * new contacts set `skip_default_pipeline_assignment` — otherwise the
+#     after_create_commit callback races this service and the contact lands
+#     with a second card on the default pipeline;
+#   * contact matching is email -> normalized phone, writes are ADDITIVE on
+#     existing contacts (a webhook must not clobber CRM-owned data);
+#   * phone-conflict errors never leak another contact's data.
+#
+# Idempotency: the (provider, purchase_id) pair lives in the card's
+# custom_fields['purchase'] and is enforced by a partial UNIQUE expression
+# index — a concurrent redelivery falls into RecordNotUnique and is answered
+# as :duplicate with the existing ids.
+module Webhooks
+  module Purchases
+    class LeadCaptureService
+      Result = Struct.new(:status, :contact, :pipeline_item, :details, keyword_init: true)
+
+      LEAD_SOURCE = 'purchase_webhook'
+
+      def initialize(provider:, lead:, pipeline_id: nil, product_override: nil)
+        @provider = provider.to_s
+        @lead = lead
+        @pipeline_id = pipeline_id
+        @product_override = product_override
+      end
+
+      def perform
+        return Result.new(status: :ignored, details: { event: @lead[:event] }) unless @lead[:approved]
+
+        if (existing = find_existing_item)
+          return Result.new(status: :duplicate, contact: existing.contact, pipeline_item: existing)
+        end
+
+        pipeline_error = resolve_pipeline!
+        return pipeline_error if pipeline_error
+
+        capture!
+      rescue ActiveRecord::RecordNotUnique
+        existing = find_existing_item
+        Result.new(status: :duplicate, contact: existing&.contact, pipeline_item: existing)
+      end
+
+      private
+
+      # No wrapping transaction on purpose: a committed contact with a failed
+      # card is the GOOD failure shape — the platform's redelivery finds the
+      # contact and only retries the card. Each create! is atomic on its own.
+      def capture!
+        contact_result = find_or_create_contact
+        return contact_result if contact_result.is_a?(Result)
+
+        @contact = contact_result
+        item_result = create_pipeline_item
+        return item_result if item_result.is_a?(Result)
+
+        Result.new(status: :created, contact: @contact, pipeline_item: item_result)
+      end
+
+      def find_existing_item
+        PipelineItem
+          .where("custom_fields -> 'purchase' ->> 'provider' = ?", @provider)
+          .find_by("custom_fields -> 'purchase' ->> 'purchase_id' = ?", @lead[:purchase_id])
+      end
+
+      def resolve_pipeline!
+        @pipeline = @pipeline_id.present? ? Pipeline.find_by(id: @pipeline_id) : Pipeline.default.first
+        return Result.new(status: :pipeline_not_found, details: { pipeline_id: @pipeline_id }) unless @pipeline
+
+        @entry_stage = @pipeline.pipeline_stages.order(:position, :id).first
+        return Result.new(status: :pipeline_not_found, details: { reason: 'pipeline has no stages' }) unless @entry_stage
+
+        nil
+      end
+
+      def find_or_create_contact
+        email = @lead[:email].to_s.downcase.presence
+        phone = normalized_phone
+
+        contact = (email && Contact.from_email(email)) || (phone && Contact.find_by(phone_number: phone))
+        contact ? update_existing_contact(contact, phone) : create_contact(email, phone)
+      rescue ActiveRecord::RecordInvalid => e
+        Result.new(status: :contact_error, details: { errors: e.record.errors.full_messages })
+      end
+
+      def create_contact(email, phone)
+        contact = Contact.new(
+          name: @lead[:name].presence || email&.split('@')&.first || 'Comprador',
+          email: email,
+          phone_number: phone,
+          additional_attributes: {},
+          custom_attributes: {}
+        )
+        contact.skip_default_pipeline_assignment = true
+        contact.save!
+        contact
+      end
+
+      # Additive only: fill blanks, never overwrite. A phone that already
+      # belongs to ANOTHER contact is skipped silently on the wire (logged) —
+      # naming the owner would let a signed-but-curious platform enumerate
+      # contacts.
+      def update_existing_contact(contact, phone)
+        updates = {}
+        updates[:name] = @lead[:name] if contact.name.blank? && @lead[:name].present?
+        if contact.phone_number.blank? && phone.present?
+          if Contact.where.not(id: contact.id).exists?(phone_number: phone)
+            Rails.logger.warn("Purchase webhook: phone on purchase #{@lead[:purchase_id]} belongs to another contact — skipped")
+          else
+            updates[:phone_number] = phone
+          end
+        end
+        contact.update!(updates) if updates.any?
+        contact
+      end
+
+      def normalized_phone
+        return nil if @lead[:phone_number].blank?
+
+        phone = Whatsapp::PhoneNumberNormalizer.to_e164(@lead[:phone_number])
+        phone.presence&.match?(/\A\+[1-9]\d{1,14}\z/) ? phone : nil
+      end
+
+      def create_pipeline_item
+        @pipeline.pipeline_items.create!(
+          contact: @contact,
+          conversation: nil,
+          pipeline_stage: @entry_stage,
+          entered_at: Time.current,
+          custom_fields: card_custom_fields
+        )
+      rescue ActiveRecord::RecordInvalid => e
+        active = @pipeline.pipeline_items.active.find_by(contact_id: @contact.id)
+        return Result.new(status: :already_in_pipeline, contact: @contact, pipeline_item: active) if active
+
+        Result.new(status: :pipeline_item_error, details: { errors: e.record.errors.full_messages })
+      end
+
+      def card_custom_fields
+        fields = {
+          'lead_source' => LEAD_SOURCE,
+          'purchase' => {
+            'provider' => @provider,
+            'purchase_id' => @lead[:purchase_id],
+            'event' => @lead[:event],
+            'product' => @product_override.presence || @lead[:product],
+            'amount' => @lead[:amount],
+            'currency' => @lead[:currency]
+          }.compact
+        }
+        fields['value'] = @lead[:amount] if @lead[:amount].present?
+        fields
+      end
+    end
+  end
+end

--- a/config/initializers/purchase_adapters.rb
+++ b/config/initializers/purchase_adapters.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Registers purchase webhook adapters at boot. `to_prepare` runs on every
+# eager reload in development so the registry stays consistent across
+# autoloads.
+Rails.application.config.to_prepare do
+  Webhooks::PurchaseAdapters.register(:virtu, Webhooks::PurchaseAdapters::VirtuAdapter)
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -197,7 +197,7 @@ class Rack::Attack
 
   # Throttle by individual user (based on uid)
   throttle('/api/v2/reports/user', limit: ENV.fetch('RATE_LIMIT_REPORTS_API_USER_LEVEL', '100').to_i, period: 1.minute) do |req|
-    match_data = %r{/api/v2/reports}.match(req.path)
+    match_data = req.path.include?('/api/v2/reports')
     # Extract user identification (uid for web, api_access_token for API requests)
     user_uid = req.get_header('HTTP_UID')
     api_access_token = req.get_header('HTTP_API_ACCESS_TOKEN') || req.get_header('api_access_token')
@@ -210,7 +210,7 @@ class Rack::Attack
 
   ## Prevent abuse of reports api
   throttle('/api/v2/reports', limit: ENV.fetch('RATE_LIMIT_REPORTS_API_ACCOUNT_LEVEL', '1000').to_i, period: 1.minute) do |req|
-    match_data = %r{/api/v2/reports}.match(req.path)
+    match_data = req.path.include?('/api/v2/reports')
     req.ip if match_data.present?
   end
 
@@ -250,7 +250,13 @@ class Rack::Attack
   ## platforms burst redeliveries after an outage.
   throttle('api/v1/webhooks/purchases', limit: ENV.fetch('RATE_LIMIT_PURCHASE_WEBHOOK', '60').to_i, period: 1.minute) do |req|
     match_data = %r{\A/api/v1/webhooks/purchases/([^/]+)\z}.match(req.path_without_extentions)
-    "purchase_webhook:#{match_data[1]}" if match_data && req.post?
+    if match_data && req.post?
+      # evo_tenant joins the key so one noisy installation cannot starve the
+      # others on a shared deployment; absent (single-tenant) it degrades to
+      # the per-provider bucket.
+      tenant = Rack::Utils.parse_query(req.query_string)['evo_tenant'].to_s
+      "purchase_webhook:#{match_data[1]}:#{tenant}"
+    end
   end
 
   ## Prevent abuse of conversations history import (EVO-1557)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -244,6 +244,15 @@ class Rack::Attack
     "erp_webhook:#{match_data[1]}" if match_data && req.post?
   end
 
+  ## Purchase webhook ingress (lead capture) — same posture as the ERP
+  ## webhook: throttled per provider path segment, signature or not, so a
+  ## compromised secret still throttles. Ceiling is higher because payment
+  ## platforms burst redeliveries after an outage.
+  throttle('api/v1/webhooks/purchases', limit: ENV.fetch('RATE_LIMIT_PURCHASE_WEBHOOK', '60').to_i, period: 1.minute) do |req|
+    match_data = %r{\A/api/v1/webhooks/purchases/([^/]+)\z}.match(req.path_without_extentions)
+    "purchase_webhook:#{match_data[1]}" if match_data && req.post?
+  end
+
   ## Prevent abuse of conversations history import (EVO-1557)
   ## Each request can ingest up to 50k rows; default 5 reqs/min/key.
   throttle('api/v1/conversations/import', limit: ENV.fetch('RATE_LIMIT_CONVERSATIONS_IMPORT', '5').to_i, period: 1.minute) do |req|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -40,6 +40,18 @@ class Rack::Attack
     end
   end
 
+  TENANT_UUID = /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
+
+  # '' for anything not a uuid, so a garbage (or absent) evo_tenant shares one
+  # bucket instead of getting a private one. Never raises: a malformed query
+  # string must not 500 the throttle.
+  def self.purchase_webhook_tenant(req)
+    value = Rack::Utils.parse_query(req.query_string)['evo_tenant'].to_s
+    TENANT_UUID.match?(value) ? value : ''
+  rescue StandardError
+    ''
+  end
+
   ### Safelist IPs from Environment Variable ###
   #
   # This block ensures requests from any IP present in RACK_ATTACK_ALLOWED_IPS
@@ -197,7 +209,7 @@ class Rack::Attack
 
   # Throttle by individual user (based on uid)
   throttle('/api/v2/reports/user', limit: ENV.fetch('RATE_LIMIT_REPORTS_API_USER_LEVEL', '100').to_i, period: 1.minute) do |req|
-    match_data = req.path.include?('/api/v2/reports')
+    reports_request = req.path.include?('/api/v2/reports')
     # Extract user identification (uid for web, api_access_token for API requests)
     user_uid = req.get_header('HTTP_UID')
     api_access_token = req.get_header('HTTP_API_ACCESS_TOKEN') || req.get_header('api_access_token')
@@ -205,13 +217,12 @@ class Rack::Attack
     # Use uid if present, otherwise fallback to api_access_token for tracking
     user_identifier = user_uid.presence || api_access_token.presence
 
-    user_identifier if match_data.present? && user_identifier.present?
+    user_identifier if reports_request && user_identifier.present?
   end
 
   ## Prevent abuse of reports api
   throttle('/api/v2/reports', limit: ENV.fetch('RATE_LIMIT_REPORTS_API_ACCOUNT_LEVEL', '1000').to_i, period: 1.minute) do |req|
-    match_data = req.path.include?('/api/v2/reports')
-    req.ip if match_data.present?
+    req.ip if req.path.include?('/api/v2/reports')
   end
 
   ## Prevent abuse of products bulk import (EVO-1555 S1)
@@ -252,9 +263,10 @@ class Rack::Attack
     match_data = %r{\A/api/v1/webhooks/purchases/([^/]+)\z}.match(req.path_without_extentions)
     if match_data && req.post?
       # evo_tenant joins the key so one noisy installation cannot starve the
-      # others on a shared deployment; absent (single-tenant) it degrades to
-      # the per-provider bucket.
-      tenant = Rack::Utils.parse_query(req.query_string)['evo_tenant'].to_s
+      # others on a shared deployment. It is caller-supplied, so ONLY a well
+      # formed uuid earns its own bucket — otherwise anyone could mint a fresh
+      # bucket per request and walk straight past the ceiling.
+      tenant = Rack::Attack.purchase_webhook_tenant(req)
       "purchase_webhook:#{match_data[1]}:#{tenant}"
     end
   end

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -424,6 +424,15 @@
   type: secret
 ## ------ End of Configs added for Evolution Hub ------ ##
 
+## ------ Configs for purchase webhook ingress (lead capture) ------ ##
+- name: PURCHASE_WEBHOOK_SECRET_VIRTU
+  display_title: 'Purchase Webhook Secret (Virtu)'
+  value:
+  locked: false
+  description: 'Shared HMAC-SHA256 secret used to sign purchase webhooks the Virtu checkout posts to /api/v1/webhooks/purchases/virtu. The endpoint refuses every request while this is blank.'
+  type: secret
+## ------ End of purchase webhook configs ------ ##
+
 ## ------ Configs added for Twitter Channel ------ ##
 - name: TWITTER_APP_ID
   display_title: 'Twitter App ID'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,6 +295,9 @@ Rails.application.routes.draw do
       # when a customer pilot is contracted.
       namespace :webhooks do
         post 'erp/:provider', to: 'erp#receive', as: :erp_webhook
+        # Purchase webhook ingress (lead capture): an approved purchase from a
+        # registered payment platform becomes contact + pipeline card.
+        post 'purchases/:provider', to: 'purchases#receive', as: :purchase_webhook
       end
 
       # Attach/detach products to AI agents (agent lives in evo_core; we only

--- a/db/migrate/20260826120000_add_purchase_identity_index_to_pipeline_items.rb
+++ b/db/migrate/20260826120000_add_purchase_identity_index_to_pipeline_items.rb
@@ -1,17 +1,10 @@
 # frozen_string_literal: true
 
-# Idempotency backstop for purchase-webhook lead capture: a redelivered (or
-# concurrently retried) purchase must not mint a second card. The (provider,
-# purchase_id) pair lives in custom_fields['purchase']; the partial UNIQUE
-# expression index makes the pair the source of truth — the service answers
-# RecordNotUnique as an idempotent "duplicate" ack. Scoped by pipeline_id:
-# purchase ids are only unique within one platform ACCOUNT, and distinct
-# installations/pipelines may legitimately see the same id — a global pair
-# would swallow the second sale as a false duplicate. The registered webhook
-# URL pins the pipeline, so redeliveries land on the same scope. Partial
-# because only purchase-captured cards carry the key; expression because the
-# GIN index on custom_fields does not serve ->> equality (same rationale as
-# index_pipeline_items_on_lead_form_slug).
+# Idempotency backstop for purchase-webhook lead capture: a redelivered purchase
+# must not mint a second card. Scoped by pipeline_id because purchase ids are
+# unique only within one platform ACCOUNT — a global pair would swallow another
+# funnel's sale as a false duplicate. Expression index because the GIN index on
+# custom_fields does not serve ->> equality (as index_pipeline_items_on_lead_form_slug).
 class AddPurchaseIdentityIndexToPipelineItems < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/db/migrate/20260826120000_add_purchase_identity_index_to_pipeline_items.rb
+++ b/db/migrate/20260826120000_add_purchase_identity_index_to_pipeline_items.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Idempotency backstop for purchase-webhook lead capture: a redelivered (or
+# concurrently retried) purchase must not mint a second card. The (provider,
+# purchase_id) pair lives in custom_fields['purchase']; the partial UNIQUE
+# expression index makes the pair the source of truth — the service answers
+# RecordNotUnique as an idempotent "duplicate" ack. Partial because only
+# purchase-captured cards carry the key; expression because the GIN index on
+# custom_fields does not serve ->> equality (same rationale as
+# index_pipeline_items_on_lead_form_slug).
+class AddPurchaseIdentityIndexToPipelineItems < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'index_pipeline_items_on_purchase_identity'
+  PROVIDER_EXPR = "(custom_fields -> 'purchase' ->> 'provider')"
+  PURCHASE_EXPR = "(custom_fields -> 'purchase' ->> 'purchase_id')"
+
+  def up
+    add_index :pipeline_items, "#{PROVIDER_EXPR}, #{PURCHASE_EXPR}",
+              unique: true, name: INDEX_NAME,
+              where: "#{PURCHASE_EXPR} IS NOT NULL",
+              algorithm: :concurrently, if_not_exists: true
+  end
+
+  def down
+    remove_index :pipeline_items, name: INDEX_NAME, algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/migrate/20260826120000_add_purchase_identity_index_to_pipeline_items.rb
+++ b/db/migrate/20260826120000_add_purchase_identity_index_to_pipeline_items.rb
@@ -4,9 +4,13 @@
 # concurrently retried) purchase must not mint a second card. The (provider,
 # purchase_id) pair lives in custom_fields['purchase']; the partial UNIQUE
 # expression index makes the pair the source of truth — the service answers
-# RecordNotUnique as an idempotent "duplicate" ack. Partial because only
-# purchase-captured cards carry the key; expression because the GIN index on
-# custom_fields does not serve ->> equality (same rationale as
+# RecordNotUnique as an idempotent "duplicate" ack. Scoped by pipeline_id:
+# purchase ids are only unique within one platform ACCOUNT, and distinct
+# installations/pipelines may legitimately see the same id — a global pair
+# would swallow the second sale as a false duplicate. The registered webhook
+# URL pins the pipeline, so redeliveries land on the same scope. Partial
+# because only purchase-captured cards carry the key; expression because the
+# GIN index on custom_fields does not serve ->> equality (same rationale as
 # index_pipeline_items_on_lead_form_slug).
 class AddPurchaseIdentityIndexToPipelineItems < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
@@ -16,7 +20,7 @@ class AddPurchaseIdentityIndexToPipelineItems < ActiveRecord::Migration[7.1]
   PURCHASE_EXPR = "(custom_fields -> 'purchase' ->> 'purchase_id')"
 
   def up
-    add_index :pipeline_items, "#{PROVIDER_EXPR}, #{PURCHASE_EXPR}",
+    add_index :pipeline_items, "pipeline_id, #{PROVIDER_EXPR}, #{PURCHASE_EXPR}",
               unique: true, name: INDEX_NAME,
               where: "#{PURCHASE_EXPR} IS NOT NULL",
               algorithm: :concurrently, if_not_exists: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -920,7 +920,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_26_120000) do
     t.datetime "updated_at", precision: nil, null: false
     t.uuid "contact_id"
     t.index "(((custom_fields -> 'lead_metadata'::text) ->> 'form_slug'::text))", name: "index_pipeline_items_on_lead_form_slug", where: "(((custom_fields -> 'lead_metadata'::text) ->> 'form_slug'::text) IS NOT NULL)"
-    t.index "(((custom_fields -> 'purchase'::text) ->> 'provider'::text)), (((custom_fields -> 'purchase'::text) ->> 'purchase_id'::text))", name: "index_pipeline_items_on_purchase_identity", unique: true, where: "(((custom_fields -> 'purchase'::text) ->> 'purchase_id'::text) IS NOT NULL)"
+    t.index "pipeline_id, (((custom_fields -> 'purchase'::text) ->> 'provider'::text)), (((custom_fields -> 'purchase'::text) ->> 'purchase_id'::text))", name: "index_pipeline_items_on_purchase_identity", unique: true, where: "(((custom_fields -> 'purchase'::text) ->> 'purchase_id'::text) IS NOT NULL)"
     t.index ["contact_id", "pipeline_id"], name: "idx_pipeline_items_active_contact_per_pipeline", unique: true, where: "((conversation_id IS NULL) AND (completed_at IS NULL))"
     t.index ["contact_id"], name: "index_pipeline_items_on_contact_id"
     t.index ["conversation_id", "pipeline_id"], name: "idx_pipeline_items_active_conversation_per_pipeline", unique: true, where: "((conversation_id IS NOT NULL) AND (completed_at IS NULL))"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_24_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_26_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -920,6 +920,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_24_120000) do
     t.datetime "updated_at", precision: nil, null: false
     t.uuid "contact_id"
     t.index "(((custom_fields -> 'lead_metadata'::text) ->> 'form_slug'::text))", name: "index_pipeline_items_on_lead_form_slug", where: "(((custom_fields -> 'lead_metadata'::text) ->> 'form_slug'::text) IS NOT NULL)"
+    t.index "(((custom_fields -> 'purchase'::text) ->> 'provider'::text)), (((custom_fields -> 'purchase'::text) ->> 'purchase_id'::text))", name: "index_pipeline_items_on_purchase_identity", unique: true, where: "(((custom_fields -> 'purchase'::text) ->> 'purchase_id'::text) IS NOT NULL)"
     t.index ["contact_id", "pipeline_id"], name: "idx_pipeline_items_active_contact_per_pipeline", unique: true, where: "((conversation_id IS NULL) AND (completed_at IS NULL))"
     t.index ["contact_id"], name: "index_pipeline_items_on_contact_id"
     t.index ["conversation_id", "pipeline_id"], name: "idx_pipeline_items_active_conversation_per_pipeline", unique: true, where: "((conversation_id IS NOT NULL) AND (completed_at IS NULL))"

--- a/lib/tasks/purchase_webhook.rake
+++ b/lib/tasks/purchase_webhook.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Mints the URL to register at the payment platform. Hand-building it is a
+# footgun: the `d` MAC pins evo_tenant/pipeline_id/product, which the platform's
+# body signature cannot cover, and a wrong one fails closed with a 401.
+namespace :evo_purchase_webhook do
+  desc 'Print the URL to register: evo_purchase_webhook:url[provider,evo_tenant,pipeline_id,product]'
+  task :url, %i[provider evo_tenant pipeline_id product] => :environment do |_task, args|
+    provider = args[:provider].to_s.downcase
+    abort('usage: rake "evo_purchase_webhook:url[provider,evo_tenant,pipeline_id,product]"') if provider.blank?
+    abort("provider '#{provider}' has no registered adapter") unless Webhooks::PurchaseAdapters.registered?(provider)
+
+    config_key = "PURCHASE_WEBHOOK_SECRET_#{provider.upcase}"
+    secret = GlobalConfigService.load(config_key, nil).to_s
+    abort("#{config_key} is not configured — the endpoint refuses every request until it is") if secret.blank?
+
+    values = Webhooks::PurchaseDestinationMac::PARAMS.index_with { |key| args[key.to_sym].to_s }
+    query = values.reject { |_key, value| value.blank? }
+    query[Webhooks::PurchaseDestinationMac::QUERY_PARAM] = Webhooks::PurchaseDestinationMac.mint(secret, provider, values)
+
+    puts "#{ENV.fetch('FRONTEND_URL', '')}/api/v1/webhooks/purchases/#{provider}?#{query.to_query}"
+  end
+end

--- a/spec/requests/api/v1/webhooks/purchases_spec.rb
+++ b/spec/requests/api/v1/webhooks/purchases_spec.rb
@@ -206,6 +206,20 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
       expect(data['pipeline_item_id']).to eq(first_item)
     end
 
+    it 'scopes the purchase identity by pipeline (same id on another pipeline is NOT a duplicate)' do
+      post url, params: raw_body, headers: auth_headers
+
+      other = Pipeline.create!(name: "Outro #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user)
+      other.pipeline_stages.create!(name: 'Entrada', position: 1)
+      body = payload_hash.deep_merge(data: { customer: { email: 'outra@cliente.com', phone: '11955554444' } }).to_json
+
+      expect do
+        post "#{base_url}?pipeline_id=#{other.id}", params: body, headers: auth_headers(body)
+      end.to change(PipelineItem, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+
     it 'allows a new card after the previous journey completed (second legit purchase)' do
       post url, params: raw_body, headers: auth_headers
       PipelineItem.find(response.parsed_body['data']['pipeline_item_id']).update!(completed_at: Time.current)

--- a/spec/requests/api/v1/webhooks/purchases_spec.rb
+++ b/spec/requests/api/v1/webhooks/purchases_spec.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request do
+  RSpec::Matchers.define_negated_matcher :not_change, :change
+
+  let(:secret) { 'test-purchase-secret-123' }
+  let(:provider) { 'virtu' }
+  let(:base_url) { "/api/v1/webhooks/purchases/#{provider}" }
+
+  let!(:user) { User.create!(name: 'Webhook User', email: "purchase-#{SecureRandom.hex(4)}@example.com") }
+  let!(:pipeline) { Pipeline.create!(name: "Compras #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user) }
+  let!(:entry_stage) { pipeline.pipeline_stages.create!(name: 'Compra recebida', position: 1) }
+  let!(:later_stage) { pipeline.pipeline_stages.create!(name: 'Onboarding', position: 2) }
+  let(:url) { "#{base_url}?pipeline_id=#{pipeline.id}" }
+
+  let(:payload_hash) do
+    {
+      event: 'approved',
+      data: {
+        order_id: 'ORD-1001',
+        product: 'Curso X',
+        amount: 297.0,
+        customer: { name: 'Maria Compradora', email: 'Maria@Cliente.com', phone: '11999998888' }
+      }
+    }
+  end
+  let(:raw_body) { payload_hash.to_json }
+
+  def sig_for(body, sec = secret)
+    "sha256=#{OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), sec, body)}"
+  end
+
+  def auth_headers(body = raw_body)
+    { 'X-Evo-Signature' => sig_for(body), 'Content-Type' => 'application/json' }
+  end
+
+  before do
+    Rails.cache.clear
+    Webhooks::PurchaseAdapters.register(:virtu, Webhooks::PurchaseAdapters::VirtuAdapter)
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('PURCHASE_WEBHOOK_SECRET_VIRTU', nil).and_return(secret)
+    allow(Webhooks::PurchaseAuditLogger).to receive(:emit).and_call_original
+  end
+
+  context 'when the provider is not in the registry' do
+    it 'returns 404 UNKNOWN_PROVIDER for a provider outside the registry' do
+      post "/api/v1/webhooks/purchases/nope?pipeline_id=#{pipeline.id}", params: raw_body,
+                                                                         headers: { 'Content-Type' => 'application/json' }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body['error']['code']).to eq('UNKNOWN_PROVIDER')
+    end
+  end
+
+  context 'when the signature gate rejects (fail-closed)' do
+    it 'returns 401 when the secret is not configured' do
+      allow(GlobalConfigService).to receive(:load)
+        .with('PURCHASE_WEBHOOK_SECRET_VIRTU', nil).and_return(nil)
+
+      post url, params: raw_body, headers: auth_headers
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body['error']['code']).to eq('INVALID_SIGNATURE')
+    end
+
+    it 'returns 401 on signature mismatch and creates nothing' do
+      expect do
+        post url, params: raw_body, headers: { 'X-Evo-Signature' => sig_for(raw_body, 'wrong'),
+                                               'Content-Type' => 'application/json' }
+      end.not_to change(Contact, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'when an approved purchase arrives (AC1)' do
+    it 'creates contact + card and answers 201 created' do
+      expect do
+        post url, params: raw_body, headers: auth_headers
+      end.to change(Contact, :count).by(1).and change(PipelineItem, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['data']['status']).to eq('created')
+
+      contact = Contact.find(response.parsed_body['data']['contact_id'])
+      expect(contact.email).to eq('maria@cliente.com')
+      expect(contact.phone_number).to eq('+5511999998888')
+    end
+
+    it 'lands the card on the ENTRY stage carrying the purchase identity' do
+      post url, params: raw_body, headers: auth_headers
+
+      item = PipelineItem.find(response.parsed_body['data']['pipeline_item_id'])
+      expect(item.pipeline_stage_id).to eq(entry_stage.id)
+      expect(item.pipeline_stage_id).not_to eq(later_stage.id)
+      expect(item.custom_fields.dig('purchase', 'purchase_id')).to eq('ORD-1001')
+      expect(item.custom_fields['value']).to eq(297.0)
+      expect(item.assigned_by_id).to be_nil
+    end
+
+    it 'does NOT leave a second card on the default pipeline (skip_default_pipeline_assignment)' do
+      default_pipeline = Pipeline.create!(name: "Default #{SecureRandom.hex(4)}", pipeline_type: 'sales',
+                                          created_by: user, is_default: true)
+      default_pipeline.pipeline_stages.create!(name: 'Novo', position: 1)
+
+      post url, params: raw_body, headers: auth_headers
+
+      contact = Contact.find(response.parsed_body['data']['contact_id'])
+      expect(contact.pipeline_items.count).to eq(1)
+      expect(contact.pipeline_items.sole.pipeline_id).to eq(pipeline.id)
+    end
+
+    it 'reuses an existing contact by e-mail additively (never clobbers CRM data)' do
+      existing = Contact.create!(name: 'Maria CRM', email: 'maria@cliente.com', phone_number: '+5511977776666')
+
+      expect do
+        post url, params: raw_body, headers: auth_headers
+      end.not_to change(Contact, :count)
+
+      expect(response.parsed_body['data']['contact_id']).to eq(existing.id)
+      expect(existing.reload.name).to eq('Maria CRM')
+      expect(existing.phone_number).to eq('+5511977776666')
+    end
+
+    it 'captures a phone-only payload' do
+      body = payload_hash.deep_dup
+      body[:data][:customer].delete(:email)
+      body = body.to_json
+
+      post url, params: body, headers: auth_headers(body)
+
+      expect(response).to have_http_status(:created)
+      contact = Contact.find(response.parsed_body['data']['contact_id'])
+      expect(contact.phone_number).to eq('+5511999998888')
+    end
+  end
+
+  context 'when the outcome is a non-created ack or a distinct failure (AC2)' do
+    it 'acks a non-approved event as ignored even with a MINIMAL payload (no contact fields)' do
+      body = { event: 'refunded', data: { order_id: 'ORD-REFUND-1' } }.to_json
+
+      expect do
+        post url, params: body, headers: auth_headers(body)
+      end.not_to change(PipelineItem, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['data']['status']).to eq('ignored')
+    end
+
+    it 'still demands contact fields for an APPROVED event' do
+      body = { event: 'approved', data: { order_id: 'ORD-NOCONTACT' } }.to_json
+
+      post url, params: body, headers: auth_headers(body)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']['code']).to eq('MAPPING_ERROR')
+    end
+
+    it 'returns 422 MAPPING_ERROR when the payload has no purchase id' do
+      body = { event: 'approved', data: { customer: { email: 'x@y.com' } } }.to_json
+
+      post url, params: body, headers: auth_headers(body)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']['code']).to eq('MAPPING_ERROR')
+    end
+
+    it 'returns 422 when the destination pipeline does not resolve' do
+      post "#{base_url}?pipeline_id=#{SecureRandom.uuid}", params: raw_body, headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']['message']).to match(/pipeline/i)
+    end
+  end
+
+  context 'when the same purchase is redelivered (AC4)' do
+    it 'answers a redelivery with 200 duplicate and the ORIGINAL ids' do
+      post url, params: raw_body, headers: auth_headers
+      first = response.parsed_body['data']
+
+      expect do
+        post url, params: raw_body, headers: auth_headers
+      end.to not_change(Contact, :count).and not_change(PipelineItem, :count)
+
+      expect(response).to have_http_status(:ok)
+      data = response.parsed_body['data']
+      expect(data['status']).to eq('duplicate')
+      expect(data['pipeline_item_id']).to eq(first['pipeline_item_id'])
+    end
+
+    it 'acks a DIFFERENT purchase for a contact with an active card as already_in_pipeline' do
+      post url, params: raw_body, headers: auth_headers
+      first_item = response.parsed_body['data']['pipeline_item_id']
+
+      body = payload_hash.deep_merge(data: { order_id: 'ORD-1002' }).to_json
+      expect do
+        post url, params: body, headers: auth_headers(body)
+      end.not_to change(PipelineItem, :count)
+
+      expect(response).to have_http_status(:ok)
+      data = response.parsed_body['data']
+      expect(data['status']).to eq('already_in_pipeline')
+      expect(data['pipeline_item_id']).to eq(first_item)
+    end
+
+    it 'allows a new card after the previous journey completed (second legit purchase)' do
+      post url, params: raw_body, headers: auth_headers
+      PipelineItem.find(response.parsed_body['data']['pipeline_item_id']).update!(completed_at: Time.current)
+
+      body = payload_hash.deep_merge(data: { order_id: 'ORD-1002' }).to_json
+      expect do
+        post url, params: body, headers: auth_headers(body)
+      end.to change(PipelineItem, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+end

--- a/spec/requests/api/v1/webhooks/purchases_spec.rb
+++ b/spec/requests/api/v1/webhooks/purchases_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
   let!(:pipeline) { Pipeline.create!(name: "Compras #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user) }
   let!(:entry_stage) { pipeline.pipeline_stages.create!(name: 'Compra recebida', position: 1) }
   let!(:later_stage) { pipeline.pipeline_stages.create!(name: 'Onboarding', position: 2) }
-  let(:url) { "#{base_url}?pipeline_id=#{pipeline.id}" }
+  let(:url) { registered_url }
 
   let(:payload_hash) do
     {
@@ -27,6 +27,15 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
     }
   end
   let(:raw_body) { payload_hash.to_json }
+
+  # The URL an operator registers at the platform: destination params plus the
+  # MAC that pins them (rake evo_purchase_webhook:url mints the same string).
+  def registered_url(pipeline_id: pipeline.id, evo_tenant: nil, product: nil, prov: provider, sec: secret)
+    values = { 'evo_tenant' => evo_tenant.to_s, 'pipeline_id' => pipeline_id.to_s, 'product' => product.to_s }
+    query = values.reject { |_key, value| value.blank? }
+    query['d'] = Webhooks::PurchaseDestinationMac.mint(sec, prov, values)
+    "/api/v1/webhooks/purchases/#{prov}?#{query.to_query}"
+  end
 
   def sig_for(body, sec = secret)
     "sha256=#{OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), sec, body)}"
@@ -71,6 +80,41 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
         post url, params: raw_body, headers: { 'X-Evo-Signature' => sig_for(raw_body, 'wrong'),
                                                'Content-Type' => 'application/json' }
       end.not_to change(Contact, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context 'when the destination MAC does not vouch for the query params (AC3)' do
+    it 'refuses a URL carrying no destination MAC' do
+      expect do
+        post "#{base_url}?pipeline_id=#{pipeline.id}", params: raw_body, headers: auth_headers
+      end.to not_change(Contact, :count).and not_change(PipelineItem, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'refuses a VALID delivery replayed at another pipeline (body and signature untouched)' do
+      post url, params: raw_body, headers: auth_headers
+      expect(response).to have_http_status(:created)
+
+      victim = Pipeline.create!(name: "Vitima #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user)
+      victim.pipeline_stages.create!(name: 'Entrada', position: 1)
+      stolen_mac = url[/d=([^&]+)/, 1]
+
+      expect do
+        post "#{base_url}?pipeline_id=#{victim.id}&d=#{stolen_mac}", params: raw_body, headers: auth_headers
+      end.not_to change(PipelineItem, :count)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(victim.pipeline_items.count).to eq(0)
+    end
+
+    it 'refuses a MAC minted for a different account (evo_tenant swapped)' do
+      minted = registered_url(evo_tenant: SecureRandom.uuid)
+      tampered = minted.sub(/evo_tenant=[^&]+/, "evo_tenant=#{SecureRandom.uuid}")
+
+      post tampered, params: raw_body, headers: auth_headers
 
       expect(response).to have_http_status(:unauthorized)
     end
@@ -136,6 +180,29 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
       contact = Contact.find(response.parsed_body['data']['contact_id'])
       expect(contact.phone_number).to eq('+5511999998888')
     end
+
+    it 'drops a phone too short to be a real number instead of minting a fake E.164' do
+      body = { event: 'approved',
+               data: { order_id: 'ORD-SHORT', customer: { name: 'Z', email: 'z@x.com', phone: '123' } } }.to_json
+
+      post url, params: body, headers: auth_headers(body)
+
+      expect(response).to have_http_status(:created)
+      expect(Contact.find(response.parsed_body['data']['contact_id']).phone_number).to be_blank
+    end
+
+    it 'takes the row the concurrent winner inserted instead of 500ing on RecordNotUnique' do
+      winner = Contact.create!(name: 'Winner', email: 'maria@cliente.com')
+      doomed = Contact.new(email: 'maria@cliente.com')
+      allow(doomed).to receive(:save!).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Contact).to receive(:new).and_return(doomed)
+      allow(Contact).to receive(:from_email).and_return(nil, winner)
+
+      post url, params: raw_body, headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['data']['contact_id']).to eq(winner.id)
+    end
   end
 
   context 'when the outcome is a non-created ack or a distinct failure (AC2)' do
@@ -169,10 +236,30 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
     end
 
     it 'returns 422 when the destination pipeline does not resolve' do
-      post "#{base_url}?pipeline_id=#{SecureRandom.uuid}", params: raw_body, headers: auth_headers
+      post registered_url(pipeline_id: SecureRandom.uuid), params: raw_body, headers: auth_headers
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.parsed_body['error']['message']).to match(/pipeline/i)
+    end
+
+    ['[]', '[{"event":"approved"}]', '123', 'null'].each do |body|
+      it "returns 422 (not a 500) for a signed JSON body that is not an object: #{body}" do
+        post url, params: body, headers: auth_headers(body)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['error']['code']).to eq('MAPPING_ERROR')
+      end
+    end
+
+    it 'refuses up front when the enterprise overlay left the request unbound' do
+      stub_const('Evo::Enterprise::Licensing', Module.new { def self.current_tenant_id = nil })
+
+      expect do
+        post url, params: raw_body, headers: auth_headers
+      end.not_to change(Contact, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']['message']).to match(/account/i)
     end
   end
 
@@ -206,6 +293,17 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
       expect(data['pipeline_item_id']).to eq(first_item)
     end
 
+    it 'keeps that second sale on the open card instead of dropping it, once' do
+      post url, params: raw_body, headers: auth_headers
+      item = PipelineItem.find(response.parsed_body['data']['pipeline_item_id'])
+
+      body = payload_hash.deep_merge(data: { order_id: 'ORD-1002' }).to_json
+      2.times { post url, params: body, headers: auth_headers(body) }
+
+      history = item.reload.custom_fields['purchases']
+      expect(history.map { |entry| entry['purchase_id'] }).to eq(['ORD-1002'])
+    end
+
     it 'scopes the purchase identity by pipeline (same id on another pipeline is NOT a duplicate)' do
       post url, params: raw_body, headers: auth_headers
 
@@ -214,7 +312,7 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
       body = payload_hash.deep_merge(data: { customer: { email: 'outra@cliente.com', phone: '11955554444' } }).to_json
 
       expect do
-        post "#{base_url}?pipeline_id=#{other.id}", params: body, headers: auth_headers(body)
+        post registered_url(pipeline_id: other.id), params: body, headers: auth_headers(body)
       end.to change(PipelineItem, :count).by(1)
 
       expect(response).to have_http_status(:created)


### PR DESCRIPTION
## Summary
- Novo `POST /api/v1/webhooks/purchases/:provider` (registry inicial: `virtu`): a compra aprovada de uma plataforma de pagamento vira **contato + card no estágio de entrada** do pipeline indicado (`?pipeline_id=`, fallback pipeline default) — espelho do padrão do webhook de ERP (HMAC, registry com 404 pra provider desconhecido, rack-attack por provider, secret `PURCHASE_WEBHOOK_SECRET_<PROVIDER>` via `GlobalConfigService`, cifrado em repouso pela convenção `_SECRET`).
- `LeadCaptureService` herda as lições do `Public::Leads::CreationService` sem os defeitos conhecidos: `skip_default_pipeline_assignment` (sem card fantasma no pipeline default), resolução por e-mail → telefone E.164 (`PhoneNumberNormalizer`), writes ADITIVOS em contato existente, erro de telefone sem vazar dados de outro contato.
- Adapter por provider isola o mapeamento do payload — mudança de contrato da plataforma toca um arquivo só. **Filtro de evento vem antes da exigência de contato**: refund/chargeback com payload mínimo é `200 ignored` (4xx faria a plataforma re-entregar para sempre).
- Todo desfecho é distinto no wire e no audit: 404/401/422 (mapping, pipeline, contato, card) /200 ignored/201 created/200 duplicate/200 already_in_pipeline — sem descarte silencioso.

## Security
- HMAC SHA-256 sobre o raw body com `secure_compare`; **fail-closed** sem secret configurado; nenhum provider habilitável sem adapter registrado; Rack::Attack por provider; respostas de erro sem PII.
- Idempotência REAL no banco: índice ÚNICO parcial de expressão sobre `custom_fields['purchase'] (provider, purchase_id)` — cobre redelivery e retry concorrente (o concern Idempotent por header não serve aqui: plataformas não enviam headers customizados; documentado no controller).

## Test plan
- `bundle exec rspec spec/requests/api/v1/webhooks/purchases_spec.rb` → **15 exemplos, 0 falhas** (todos os desfechos, incluindo evento não-aprovado com payload mínimo e 2ª compra após card concluído)
- `bundle exec rubocop <arquivos novos>` → 0 offenses
- Runtime validado com `curl` (matriz 201/200-duplicate/401/404/200-ignored)

## Changed Files
- `app/controllers/api/v1/webhooks/purchases_controller.rb` + `app/controllers/concerns/purchase_webhook_signature_concern.rb` (novos)
- `app/lib/webhooks/purchase_adapters{.rb,/base.rb,/virtu_adapter.rb}` + `app/lib/webhooks/purchase_audit_logger.rb` (novos)
- `app/services/webhooks/purchases/lead_capture_service.rb` (novo)
- `db/migrate/20260826120000_add_purchase_identity_index_to_pipeline_items.rb` + `db/schema.rb`
- `config/routes.rb`, `config/initializers/{purchase_adapters,rack_attack}.rb`, `config/installation_config.yml`
- `spec/requests/api/v1/webhooks/purchases_spec.rb` (novo)

## Linked Issue
- CRM-320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuywNCXrqa9inPWWjb1htN

## Summary by Sourcery

Introduce secure, provider-adaptable purchase webhooks that convert approved Virtu transactions into CRM contacts and pipeline cards with explicit outcomes and database-backed idempotency.

New Features:
- Add a purchase webhook endpoint with initial Virtu provider support to capture approved purchases as contacts and pipeline cards.
- Support configurable pipeline and product destinations while preserving default pipeline fallback behavior.
- Provide provider-specific payload adapters and a task for generating destination-bound webhook URLs.

Bug Fixes:
- Prevent non-approved events from being rejected when contact data is absent, allowing payment platforms to acknowledge refunds and chargebacks without redelivery loops.
- Prevent duplicate cards and duplicate purchase history entries during webhook retries, redeliveries, and concurrent processing.
- Avoid creating phantom default-pipeline cards and prevent invalid phone data or existing CRM contact details from being overwritten.

Enhancements:
- Add fail-closed HMAC authentication, destination integrity protection, provider-specific throttling, and auditable outcomes for all webhook processing paths.

Deployment:
- Add the Virtu purchase webhook secret to installation configuration.

Tests:
- Add request coverage for authentication, destination tampering, mapping, contact capture, pipeline routing, idempotency, ignored events, and retry scenarios.

Chores:
- Add a database uniqueness constraint for purchase identity within each pipeline.