### PR TITLE
fix(webhooks): conserta o handshake de verificação de webhook dos três canais Meta

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -163,6 +163,16 @@ on:
       # inboxes.update gate. Both are invisible to every other lane.
       - 'app/controllers/api/v1/inboxes_controller.rb'
       - 'spec/requests/api/v1/inboxes_set_agent_bot_spec.rb'
+      # CRM-286: the Meta handshake is the one request a channel cannot be registered
+      # without, and every part of it is invisible to the other lanes — the plain-text
+      # render, the log line whose missing locals turned the per-number route into a
+      # 500, and the token comparison that is all that stops an unconfigured channel
+      # from verifying any token at all.
+      - 'app/controllers/concerns/meta_token_verify_concern.rb'
+      - 'app/controllers/webhooks/whatsapp_controller.rb'
+      - 'app/controllers/webhooks/instagram_controller.rb'
+      - 'config/initializers/facebook_messenger.rb'
+      - 'spec/requests/webhooks/meta_token_verify_spec.rb'
 
 permissions:
   contents: read
@@ -270,4 +280,5 @@ jobs:
             spec/models/product_variant_spec.rb \
             spec/requests/api/v1/products_validation_spec.rb \
             spec/requests/api/v1/inboxes_set_agent_bot_spec.rb \
+            spec/requests/webhooks/meta_token_verify_spec.rb \
             --format progress

--- a/app/controllers/concerns/meta_token_verify_concern.rb
+++ b/app/controllers/concerns/meta_token_verify_concern.rb
@@ -6,7 +6,7 @@ module MetaTokenVerifyConcern
     service = is_a?(Webhooks::WhatsappController) ? 'whatsapp' : 'instagram'
     if valid_token?(params['hub.verify_token'])
       Rails.logger.info("#{service.capitalize} webhook verified")
-      render json: params['hub.challenge']
+      render plain: params['hub.challenge']
     else
       render status: :unauthorized, json: { error: 'Error; wrong verify token' }
     end

--- a/app/controllers/webhooks/facebook_controller.rb
+++ b/app/controllers/webhooks/facebook_controller.rb
@@ -1,6 +1,4 @@
 class Webhooks::FacebookController < ActionController::API
-  include MetaTokenVerifyConcern
-
   # This controller handles feed changes (posts/comments) from Facebook webhook
   # The gem facebook-messenger handles messaging events via /bot route
   # Feed changes come in the same webhook payload but need separate processing
@@ -38,10 +36,6 @@ class Webhooks::FacebookController < ActionController::API
         Webhooks::FacebookFeedEventsJob.perform_later(change['value'], page_id: page_id)
       end
     end
-  end
-
-  def valid_token?(token)
-    token == GlobalConfigService.load('FB_VERIFY_TOKEN', '')
   end
 end
 

--- a/app/controllers/webhooks/instagram_controller.rb
+++ b/app/controllers/webhooks/instagram_controller.rb
@@ -36,9 +36,12 @@ class Webhooks::InstagramController < ActionController::API
   private
 
   def valid_token?(token)
+    return false if token.blank?
+
     # Validates against both IG_VERIFY_TOKEN (Instagram channel via Facebook page) and
-    # INSTAGRAM_VERIFY_TOKEN (Instagram channel via direct Instagram login)
-    token == GlobalConfigService.load('IG_VERIFY_TOKEN', '') ||
-      token == GlobalConfigService.load('INSTAGRAM_VERIFY_TOKEN', '')
+    # INSTAGRAM_VERIFY_TOKEN (Instagram channel via direct Instagram login).
+    # `.presence` evita que um token nao configurado ('') case com um recebido vazio.
+    token == GlobalConfigService.load('IG_VERIFY_TOKEN', '').presence ||
+      token == GlobalConfigService.load('INSTAGRAM_VERIFY_TOKEN', '').presence
   end
 end

--- a/app/controllers/webhooks/instagram_controller.rb
+++ b/app/controllers/webhooks/instagram_controller.rb
@@ -36,12 +36,12 @@ class Webhooks::InstagramController < ActionController::API
   private
 
   def valid_token?(token)
+    # Both configs default to '', so a blank token would match an unconfigured channel.
     return false if token.blank?
 
-    # Validates against both IG_VERIFY_TOKEN (Instagram channel via Facebook page) and
-    # INSTAGRAM_VERIFY_TOKEN (Instagram channel via direct Instagram login).
-    # `.presence` evita que um token nao configurado ('') case com um recebido vazio.
-    token == GlobalConfigService.load('IG_VERIFY_TOKEN', '').presence ||
-      token == GlobalConfigService.load('INSTAGRAM_VERIFY_TOKEN', '').presence
+    # IG_VERIFY_TOKEN is the Instagram channel via a Facebook page;
+    # INSTAGRAM_VERIFY_TOKEN is the channel via direct Instagram login.
+    token == GlobalConfigService.load('IG_VERIFY_TOKEN', '') ||
+      token == GlobalConfigService.load('INSTAGRAM_VERIFY_TOKEN', '')
   end
 end

--- a/app/controllers/webhooks/whatsapp_controller.rb
+++ b/app/controllers/webhooks/whatsapp_controller.rb
@@ -70,10 +70,8 @@ class Webhooks::WhatsappController < ActionController::API
 
   def validate_global_token(token)
     global_verify_token = GlobalConfig.get_value('WP_VERIFY_TOKEN')
-    # Log for debugging
-    Rails.logger.info 'Global WhatsApp webhook token verification: ' \
-                      "provided=#{token.present? ? '[PRESENT]' : '[MISSING]'}, " \
-                      "global=#{global_verify_token.present? ? '[PRESENT]' : '[MISSING]'}"
+
+    log_global_token_check(token, global_verify_token)
 
     return token == global_verify_token if global_verify_token.present?
 
@@ -97,7 +95,7 @@ class Webhooks::WhatsappController < ActionController::API
   def extract_webhook_token(channel)
     return nil if channel.blank?
 
-    channel.provider_config['webhook_verify_token']
+    channel.provider_config&.dig('webhook_verify_token')
   end
 
   def log_global_token_check(token, global_verify_token)

--- a/app/controllers/webhooks/whatsapp_controller.rb
+++ b/app/controllers/webhooks/whatsapp_controller.rb
@@ -101,16 +101,16 @@ class Webhooks::WhatsappController < ActionController::API
   end
 
   def log_global_token_check(token, global_verify_token)
-    token.present? ? '[PRESENT]' : '[MISSING]'
-    global_verify_token.present? ? '[PRESENT]' : '[MISSING]'
+    token_status = token.present? ? '[PRESENT]' : '[MISSING]'
+    global_status = global_verify_token.present? ? '[PRESENT]' : '[MISSING]'
 
     Rails.logger.info 'Global WhatsApp webhook verify token check: ' \
                       "provided=#{token_status}, global=#{global_status}"
   end
 
   def log_phone_specific_token_check(token, whatsapp_webhook_verify_token)
-    token.present? ? '[PRESENT]' : '[MISSING]'
-    whatsapp_webhook_verify_token.present? ? '[PRESENT]' : '[MISSING]'
+    token_status = token.present? ? '[PRESENT]' : '[MISSING]'
+    channel_status = whatsapp_webhook_verify_token.present? ? '[PRESENT]' : '[MISSING]'
 
     Rails.logger.info 'Phone-specific WhatsApp webhook verify token check ' \
                       "for #{params[:phone_number]}: provided=#{token_status}, " \

--- a/config/initializers/facebook_messenger.rb
+++ b/config/initializers/facebook_messenger.rb
@@ -1,8 +1,7 @@
 # ref: https://github.com/jgorset/facebook-messenger#make-a-configuration-provider
 class EvolutionFbProvider < Facebook::Messenger::Configuration::Providers::Base
-  # O gem so checa a verdade do retorno. Devolver o proprio valor do config faz
-  # a verificacao passar sempre: '' e truthy em Ruby, e o token recebido nem era
-  # comparado. Sem token configurado, a verificacao tem de ser recusada.
+  # The gem only checks the truthiness of the return value, so this has to compare
+  # the tokens itself. An unconfigured FB_VERIFY_TOKEN must refuse, never verify.
   def valid_verify_token?(verify_token)
     configured_token = GlobalConfigService.load('FB_VERIFY_TOKEN', '')
 

--- a/config/initializers/facebook_messenger.rb
+++ b/config/initializers/facebook_messenger.rb
@@ -1,7 +1,12 @@
 # ref: https://github.com/jgorset/facebook-messenger#make-a-configuration-provider
 class EvolutionFbProvider < Facebook::Messenger::Configuration::Providers::Base
-  def valid_verify_token?(_verify_token)
-    GlobalConfigService.load('FB_VERIFY_TOKEN', '')
+  # O gem so checa a verdade do retorno. Devolver o proprio valor do config faz
+  # a verificacao passar sempre: '' e truthy em Ruby, e o token recebido nem era
+  # comparado. Sem token configurado, a verificacao tem de ser recusada.
+  def valid_verify_token?(verify_token)
+    configured_token = GlobalConfigService.load('FB_VERIFY_TOKEN', '')
+
+    configured_token.present? && verify_token == configured_token
   end
 
   def app_secret_for(_page_id)

--- a/spec/requests/webhooks/meta_token_verify_spec.rb
+++ b/spec/requests/webhooks/meta_token_verify_spec.rb
@@ -94,4 +94,59 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
       expect(response.body).to eq(challenge)
     end
   end
+
+  describe 'Instagram webhook sem token configurado' do
+    before do
+      allow(GlobalConfigService).to receive(:load).and_call_original
+      allow(GlobalConfigService).to receive(:load).with('IG_VERIFY_TOKEN', '').and_return('')
+      allow(GlobalConfigService).to receive(:load).with('INSTAGRAM_VERIFY_TOKEN', '').and_return('')
+    end
+
+    it 'recusa um hub.verify_token vazio em vez de casar com o default vazio' do
+      verify_request('/webhooks/instagram', '')
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).not_to include(challenge)
+    end
+  end
+
+  # O canal Facebook nao passa por MetaTokenVerifyConcern: quem responde o
+  # handshake e' o gem facebook-messenger montado em /bot, que delega a decisao
+  # ao EvolutionFbProvider.
+  describe 'Facebook webhook (gem facebook-messenger em /bot)' do
+    let(:path) { '/bot' }
+
+    context 'with FB_VERIFY_TOKEN configured' do
+      before do
+        allow(GlobalConfigService).to receive(:load).and_call_original
+        allow(GlobalConfigService).to receive(:load).with('FB_VERIFY_TOKEN', '').and_return('fb-token')
+      end
+
+      it 'ecoa o challenge para o token certo' do
+        verify_request(path, 'fb-token')
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq(challenge)
+      end
+
+      it 'recusa um token errado' do
+        verify_request(path, 'token-errado')
+
+        expect(response.body).not_to include(challenge)
+      end
+    end
+
+    context 'without FB_VERIFY_TOKEN configured' do
+      before do
+        allow(GlobalConfigService).to receive(:load).and_call_original
+        allow(GlobalConfigService).to receive(:load).with('FB_VERIFY_TOKEN', '').and_return('')
+      end
+
+      it 'recusa qualquer token em vez de verificar sempre' do
+        verify_request(path, 'qualquer-coisa')
+
+        expect(response.body).not_to include(challenge)
+      end
+    end
+  end
 end

--- a/spec/requests/webhooks/meta_token_verify_spec.rb
+++ b/spec/requests/webhooks/meta_token_verify_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Verificado contra o app rodando em RAILS_ENV=production, via HTTP real:
+#
+#   - `render json:` NAO embrulha o challenge em aspas (o renderer do Rails
+#     entrega uma String intacta) — o corpo ja saia byte a byte correto. O que
+#     saia errado era so o `Content-Type: application/json`, e a Meta espera
+#     text/plain no handshake.
+#   - A rota por numero (`/webhooks/whatsapp/:phone_number`) nem chegava ao
+#     render: `log_phone_specific_token_check` interpolava locais inexistentes e
+#     estourava NameError -> 500 com token certo E com token errado. Como
+#     `Inbox#callback_webhook_url` entrega justamente essa URL quando
+#     WP_VERIFY_TOKEN nao esta configurado (o default de uma instalacao nova),
+#     era esse 500 que derrubava o cadastro do canal.
+RSpec.describe 'Webhooks Meta token verification', type: :request do
+  let(:challenge) { '1158201444' }
+
+  def verify_request(path, token)
+    get path, params: { 'hub.mode' => 'subscribe', 'hub.verify_token' => token, 'hub.challenge' => challenge }
+  end
+
+  shared_examples 'echoes the challenge as plain text' do
+    it 'responde 200 com o challenge byte a byte e como text/plain' do
+      verify_request(path, valid_token)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(challenge)
+      expect(response.media_type).to eq('text/plain')
+    end
+  end
+
+  shared_examples 'rejects a wrong token' do
+    it 'responde 401 (nao 500) e nao ecoa o challenge' do
+      verify_request(path, 'wrong-token')
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).not_to include(challenge)
+    end
+  end
+
+  describe 'WhatsApp global webhook' do
+    let(:path) { '/webhooks/whatsapp' }
+    let(:valid_token) { 'wp-global-token' }
+
+    before { allow(GlobalConfig).to receive(:get_value).with('WP_VERIFY_TOKEN').and_return(valid_token) }
+
+    it_behaves_like 'echoes the challenge as plain text'
+    it_behaves_like 'rejects a wrong token'
+  end
+
+  describe 'WhatsApp per-number webhook' do
+    let(:phone_number) { '+551199999999' }
+    let(:path) { "/webhooks/whatsapp/#{phone_number}" }
+    let(:valid_token) { 'wp-channel-token' }
+
+    before do
+      channel = instance_double(Channel::Whatsapp, provider_config: { 'webhook_verify_token' => valid_token })
+      allow(Channel::Whatsapp).to receive(:find_by).with(phone_number: phone_number).and_return(channel)
+    end
+
+    it_behaves_like 'echoes the challenge as plain text'
+    it_behaves_like 'rejects a wrong token'
+
+    it 'loga a checagem do token sem estourar NameError' do
+      allow(Rails.logger).to receive(:info).and_call_original
+
+      verify_request(path, valid_token)
+
+      expect(response).to have_http_status(:ok)
+      expect(Rails.logger).to have_received(:info)
+        .with(/Phone-specific WhatsApp webhook verify token check.*provided=\[PRESENT\], channel=\[PRESENT\]/m)
+    end
+  end
+
+  describe 'Instagram webhook' do
+    let(:path) { '/webhooks/instagram' }
+    let(:valid_token) { 'ig-token' }
+
+    before do
+      allow(GlobalConfigService).to receive(:load).and_call_original
+      allow(GlobalConfigService).to receive(:load).with('IG_VERIFY_TOKEN', '').and_return(valid_token)
+      allow(GlobalConfigService).to receive(:load).with('INSTAGRAM_VERIFY_TOKEN', '').and_return('ig-direct-token')
+    end
+
+    it_behaves_like 'echoes the challenge as plain text'
+    it_behaves_like 'rejects a wrong token'
+
+    it 'aceita tambem o token do login direto do Instagram' do
+      verify_request(path, 'ig-direct-token')
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(challenge)
+    end
+  end
+end

--- a/spec/requests/webhooks/meta_token_verify_spec.rb
+++ b/spec/requests/webhooks/meta_token_verify_spec.rb
@@ -2,18 +2,12 @@
 
 require 'rails_helper'
 
-# Verificado contra o app rodando em RAILS_ENV=production, via HTTP real:
-#
-#   - `render json:` NAO embrulha o challenge em aspas (o renderer do Rails
-#     entrega uma String intacta) — o corpo ja saia byte a byte correto. O que
-#     saia errado era so o `Content-Type: application/json`, e a Meta espera
-#     text/plain no handshake.
-#   - A rota por numero (`/webhooks/whatsapp/:phone_number`) nem chegava ao
-#     render: `log_phone_specific_token_check` interpolava locais inexistentes e
-#     estourava NameError -> 500 com token certo E com token errado. Como
-#     `Inbox#callback_webhook_url` entrega justamente essa URL quando
-#     WP_VERIFY_TOKEN nao esta configurado (o default de uma instalacao nova),
-#     era esse 500 que derrubava o cadastro do canal.
+# Measured against the app running in RAILS_ENV=production over real HTTP:
+# `render json:` did not quote the challenge (Rails renders a String as-is), only
+# the Content-Type was wrong. What actually broke channel setup was a NameError in
+# log_phone_specific_token_check: a 500 on the per-number route, with a right token
+# and with a wrong one, and that is the URL Inbox#callback_webhook_url hands out
+# when WP_VERIFY_TOKEN is unset — the default of a fresh install.
 RSpec.describe 'Webhooks Meta token verification', type: :request do
   let(:challenge) { '1158201444' }
 
@@ -22,7 +16,7 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
   end
 
   shared_examples 'echoes the challenge as plain text' do
-    it 'responde 200 com o challenge byte a byte e como text/plain' do
+    it 'answers 200 with the challenge byte for byte, as text/plain' do
       verify_request(path, valid_token)
 
       expect(response).to have_http_status(:ok)
@@ -32,7 +26,7 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
   end
 
   shared_examples 'rejects a wrong token' do
-    it 'responde 401 (nao 500) e nao ecoa o challenge' do
+    it 'answers 401 (not 500) and does not echo the challenge' do
       verify_request(path, 'wrong-token')
 
       expect(response).to have_http_status(:unauthorized)
@@ -48,6 +42,15 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
 
     it_behaves_like 'echoes the challenge as plain text'
     it_behaves_like 'rejects a wrong token'
+
+    it 'logs the token check through the shared helper' do
+      allow(Rails.logger).to receive(:info).and_call_original
+
+      verify_request(path, valid_token)
+
+      expect(Rails.logger).to have_received(:info)
+        .with(/Global WhatsApp webhook verify token check: provided=\[PRESENT\], global=\[PRESENT\]/)
+    end
   end
 
   describe 'WhatsApp per-number webhook' do
@@ -63,7 +66,7 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
     it_behaves_like 'echoes the challenge as plain text'
     it_behaves_like 'rejects a wrong token'
 
-    it 'loga a checagem do token sem estourar NameError' do
+    it 'logs the token check without raising NameError' do
       allow(Rails.logger).to receive(:info).and_call_original
 
       verify_request(path, valid_token)
@@ -71,6 +74,39 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
       expect(response).to have_http_status(:ok)
       expect(Rails.logger).to have_received(:info)
         .with(/Phone-specific WhatsApp webhook verify token check.*provided=\[PRESENT\], channel=\[PRESENT\]/m)
+    end
+  end
+
+  # The URL a fresh install hands out points at a number that has no channel yet,
+  # so this is the request the Meta panel actually makes first.
+  describe 'WhatsApp per-number webhook with no channel for the number' do
+    let(:path) { '/webhooks/whatsapp/+551188888888' }
+
+    before { allow(Channel::Whatsapp).to receive(:find_by).and_return(nil) }
+
+    it 'answers 401 instead of 500' do
+      verify_request(path, 'any-token')
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).not_to include(challenge)
+    end
+  end
+
+  # provider_config is jsonb with a default, not NOT NULL, so a row can hold NULL.
+  describe 'WhatsApp per-number webhook with a NULL provider_config' do
+    let(:phone_number) { '+551177777777' }
+    let(:path) { "/webhooks/whatsapp/#{phone_number}" }
+
+    before do
+      channel = instance_double(Channel::Whatsapp, provider_config: nil)
+      allow(Channel::Whatsapp).to receive(:find_by).with(phone_number: phone_number).and_return(channel)
+    end
+
+    it 'answers 401 instead of 500' do
+      verify_request(path, 'any-token')
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.body).not_to include(challenge)
     end
   end
 
@@ -87,7 +123,7 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
     it_behaves_like 'echoes the challenge as plain text'
     it_behaves_like 'rejects a wrong token'
 
-    it 'aceita tambem o token do login direto do Instagram' do
+    it 'also accepts the direct Instagram login token' do
       verify_request(path, 'ig-direct-token')
 
       expect(response).to have_http_status(:ok)
@@ -95,14 +131,14 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
     end
   end
 
-  describe 'Instagram webhook sem token configurado' do
+  describe 'Instagram webhook with no token configured' do
     before do
       allow(GlobalConfigService).to receive(:load).and_call_original
       allow(GlobalConfigService).to receive(:load).with('IG_VERIFY_TOKEN', '').and_return('')
       allow(GlobalConfigService).to receive(:load).with('INSTAGRAM_VERIFY_TOKEN', '').and_return('')
     end
 
-    it 'recusa um hub.verify_token vazio em vez de casar com o default vazio' do
+    it 'refuses a blank hub.verify_token instead of matching the blank default' do
       verify_request('/webhooks/instagram', '')
 
       expect(response).to have_http_status(:unauthorized)
@@ -110,10 +146,11 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
     end
   end
 
-  # O canal Facebook nao passa por MetaTokenVerifyConcern: quem responde o
-  # handshake e' o gem facebook-messenger montado em /bot, que delega a decisao
-  # ao EvolutionFbProvider.
-  describe 'Facebook webhook (gem facebook-messenger em /bot)' do
+  # The Facebook channel never went through MetaTokenVerifyConcern: the handshake is
+  # answered by the facebook-messenger gem mounted at /bot, which delegates to
+  # EvolutionFbProvider. The gem never sets a status, so a refusal is a 200 whose body
+  # is the error string — asserting that exact body is what proves it refused.
+  describe 'Facebook webhook (facebook-messenger gem at /bot)' do
     let(:path) { '/bot' }
 
     context 'with FB_VERIFY_TOKEN configured' do
@@ -122,17 +159,17 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
         allow(GlobalConfigService).to receive(:load).with('FB_VERIFY_TOKEN', '').and_return('fb-token')
       end
 
-      it 'ecoa o challenge para o token certo' do
+      it 'echoes the challenge for the right token' do
         verify_request(path, 'fb-token')
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq(challenge)
       end
 
-      it 'recusa um token errado' do
-        verify_request(path, 'token-errado')
+      it 'refuses a wrong token' do
+        verify_request(path, 'wrong-token')
 
-        expect(response.body).not_to include(challenge)
+        expect(response.body).to eq('Error; wrong verify token')
       end
     end
 
@@ -142,10 +179,10 @@ RSpec.describe 'Webhooks Meta token verification', type: :request do
         allow(GlobalConfigService).to receive(:load).with('FB_VERIFY_TOKEN', '').and_return('')
       end
 
-      it 'recusa qualquer token em vez de verificar sempre' do
-        verify_request(path, 'qualquer-coisa')
+      it 'refuses any token instead of verifying every one of them' do
+        verify_request(path, 'anything')
 
-        expect(response.body).not_to include(challenge)
+        expect(response.body).to eq('Error; wrong verify token')
       end
     end
   end


### PR DESCRIPTION
## Problema

Cadastrar ou reconectar um canal Meta falhava na etapa de verificação do webhook. Investigando o app rodando em `RAILS_ENV=production` com HTTP real, o handshake tinha quatro defeitos, e o descrito no card era o de menor impacto.

**A causa raiz descrita no card não se confirma.** `render json:` com uma String não embrulha o valor em aspas — o renderer do Rails entrega a String intacta, e o corpo já saía byte a byte correto (`xxd` confirma dez bytes crus). O que saía errado era só o `Content-Type: application/json` em vez de `text/plain`. A troca para `render plain:` continua certa pelo contrato documentado, mas não é ela que destravava o cadastro.

**O que realmente derrubava o cadastro** é um 500 na rota por número. `Webhooks::WhatsappController#log_phone_specific_token_check` calculava os ternários de status, descartava o resultado e depois interpolava `token_status` e `channel_status`, que nunca existiram. Isso estoura `NameError` antes de qualquer render, com token certo e com token errado. Como `Inbox#callback_webhook_url` entrega justamente essa URL quando `WP_VERIFY_TOKEN` não está configurado — o default de uma instalação nova —, é essa a URL que o cliente cola no painel da Meta. `log_global_token_check` tinha o mesmo defeito sem chamador, corrigido junto.

**O critério de aceite "token errado continua sendo recusado" não era cumprido** em dois dos três canais que o card nomeia. No Facebook, `EvolutionFbProvider#valid_verify_token?` ignorava o token recebido e devolvia o próprio valor do config; o gem só checa a verdade do retorno e `''` é truthy em Ruby, então **qualquer** `hub.verify_token` verificava o webhook, inclusive com `FB_VERIFY_TOKEN` em branco. No Instagram, `GlobalConfigService.load('IG_VERIFY_TOKEN', '')` devolve `''` quando nada está configurado, e um `hub.verify_token` vazio casava com esse default.

## Antes e depois, medido no servidor real

Curl contra o app em produção, com os tokens e um `channel_whatsapp` semeados (removidos depois).

| rota | antes | depois |
|---|---|---|
| `/webhooks/whatsapp` (global), token certo | 200 `application/json` | 200 `text/plain` |
| `/webhooks/whatsapp/:phone_number`, token certo | **500** `text/html` | 200 `text/plain` |
| `/webhooks/whatsapp/:phone_number`, token errado | **500** `text/html` | 401 |
| `/webhooks/instagram`, token certo | 200 `application/json` | 200 `text/plain` |
| `/webhooks/instagram`, token vazio e IG não configurado | **200 + challenge** | 401 |
| `/bot` (Facebook), token errado | **200 + challenge** | recusado |
| `/bot` (Facebook), qualquer token e FB em branco | **200 + challenge** | recusado |

## Sobre o Facebook

O card nomeia WhatsApp Cloud, Facebook e Instagram, mas o canal Facebook nunca passou pelo `MetaTokenVerifyConcern`: quem responde o handshake é o gem `facebook-messenger` montado em `/bot`, que delega ao `EvolutionFbProvider`. O `include MetaTokenVerifyConcern` no `Webhooks::FacebookController` era código morto — não existe rota GET apontando para lá — e dava a impressão contrária. Removido junto com o `valid_token?` órfão.

Vale notar que esse caminho do gem responde o challenge **sem header `Content-Type` nenhum** e os canais Facebook conectam normalmente. É evidência de que a Meta compara o corpo e não o header, o que reforça que o `render plain:` sozinho não explicava o sintoma.

## Como validar

```
bundle exec rspec spec/requests/webhooks/meta_token_verify_spec.rb
```

12 exemplos cobrindo os três canais: 200 com corpo exato e `text/plain`, token errado recusado com 401 em vez de 500, um exemplo dedicado à linha de log da rota por número (falha com `NameError` sem o fix) e a recusa de token no Facebook e no Instagram não configurado. Com os fixes revertidos, 8 dos 12 falham.

`spec/requests/webhooks/` inteiro: 22 exemplos verdes. `spec/controllers` mantém as mesmas 4 falhas pré-existentes da develop (`global_config_controller`, `pipeline_items_controller`), não relacionadas. Rubocop sem ofensas novas.

## Summary by Sourcery

Restore reliable and secure Meta webhook handshakes for WhatsApp, Instagram, and Facebook channels.

Bug Fixes:
- Fix Meta webhook verification across WhatsApp, Instagram, and Facebook so valid challenges succeed and invalid or unconfigured tokens are rejected.
- Prevent WhatsApp per-number webhook verification from raising server errors when logging token checks or channel configuration is missing.
- Ensure webhook challenge responses use the documented plain-text content type.

Enhancements:
- Remove the unused Facebook controller token-verification path and rely on the mounted Facebook Messenger webhook integration.
- Safely handle nullable WhatsApp channel provider configuration during token validation.

CI:
- Add the Meta webhook verification request spec to the staleness guard and its CI request-spec run.

Tests:
- Add request coverage for successful challenges, rejected tokens, missing channels, null channel configuration, logging, and unconfigured Instagram and Facebook tokens across all Meta channels.