### PR TITLE
feat(hub): tela do canal Meta reflete o estado real da conexão

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,12 @@ FACEBOOK_API_VERSION=v23.0
 # WP_APP_SECRET=
 # WP_WHATSAPP_CONFIG_ID=
 # WP_API_VERSION=v23.0
+# Evolution Hub
+# The Hub is a single central service; per-install config is the tenant API key
+# (EVOLUTION_HUB_API_KEY, in installation_configs). These two only exist so the
+# integration can be pointed at a local Hub instead of the production one.
+# EVOLUTION_HUB_API_URL=http://evolution-hub-backend:8086
+# EVOLUTION_HUB_FRONTEND_URL=http://localhost:8050
 # Twitter
 # documentation: https://www.chatwoot.com/docs/twitter-app-setup
 TWITTER_APP_ID=

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -173,6 +173,16 @@ on:
       - 'app/controllers/webhooks/instagram_controller.rb'
       - 'config/initializers/facebook_messenger.rb'
       - 'spec/requests/webhooks/meta_token_verify_spec.rb'
+      # CRM-318: the screen that opened the Hub tab only leaves "Aguardando" because
+      # the two lifecycle handlers announce the transition and the listener puts it on
+      # the wire. Dropping any of the three is silent everywhere else — the channel
+      # still connects, only nobody tells the operator.
+      - 'app/services/evolution_hub/**'
+      - 'app/listeners/concerns/hub_channel_connection_events.rb'
+      - 'lib/meta_base_url.rb'
+      - 'spec/services/evolution_hub/**'
+      - 'spec/listeners/action_cable_listener_hub_channel_spec.rb'
+      - 'spec/lib/meta_base_url_spec.rb'
 
 permissions:
   contents: read
@@ -281,4 +291,7 @@ jobs:
             spec/requests/api/v1/products_validation_spec.rb \
             spec/requests/api/v1/inboxes_set_agent_bot_spec.rb \
             spec/requests/webhooks/meta_token_verify_spec.rb \
+            spec/services/evolution_hub/ \
+            spec/listeners/action_cable_listener_hub_channel_spec.rb \
+            spec/lib/meta_base_url_spec.rb \
             --format progress

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -1,5 +1,6 @@
 class ActionCableListener < BaseListener
   include Events::Types
+  include HubChannelConnectionEvents
 
   def notification_created(event)
     notification, account, unread_count, count = extract_notification_and_account(event)

--- a/app/listeners/concerns/hub_channel_connection_events.rb
+++ b/app/listeners/concerns/hub_channel_connection_events.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Transicao de conexao de um canal Meta intermediado pelo Evo Hub, empurrada
+# para a tela do operador que ficou esperando o retorno da aba do Hub.
+#
+# Vive num concern proprio e nao no corpo do ActionCableListener porque aquela
+# classe ja estava no teto do Metrics/ClassLength: somar um metodo la obrigaria
+# a afrouxar o cop para todo mundo.
+module HubChannelConnectionEvents
+  include Events::Types
+
+  # Vai para todos os usuarios, e nao so para quem clicou: o cadastro pode ser
+  # retomado de outra aba ou por outro operador, e o estado e do canal.
+  def hub_channel_connection_changed(event)
+    inbox = event.data[:inbox]
+    return if inbox.blank?
+
+    payload = {
+      inbox_id: inbox.id,
+      channel_type: inbox.channel_type,
+      connection_status: event.data[:connection_status]
+    }
+
+    # Instalacao single-tenant: Inbox nao expoe `account`.
+    broadcast(single_tenant_account, User.pluck(:pubsub_token).compact.uniq,
+              HUB_CHANNEL_CONNECTION_CHANGED, payload)
+  end
+end

--- a/app/listeners/concerns/hub_channel_connection_events.rb
+++ b/app/listeners/concerns/hub_channel_connection_events.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
-# Transicao de conexao de um canal Meta intermediado pelo Evo Hub, empurrada
-# para a tela do operador que ficou esperando o retorno da aba do Hub.
+# Pushes a Hub-relayed Meta channel connection change to the screen waiting on
+# the Hub tab to come back.
 #
-# Vive num concern proprio e nao no corpo do ActionCableListener porque aquela
-# classe ja estava no teto do Metrics/ClassLength: somar um metodo la obrigaria
-# a afrouxar o cop para todo mundo.
+# Lives in a concern rather than in ActionCableListener's body because that
+# class already sits at the Metrics/ClassLength ceiling.
 module HubChannelConnectionEvents
   include Events::Types
 
-  # Vai para todos os usuarios, e nao so para quem clicou: o cadastro pode ser
-  # retomado de outra aba ou por outro operador, e o estado e do canal.
+  # Goes to every user, not just whoever clicked: the signup can be resumed from
+  # another tab or by another operator, and the state belongs to the channel.
   def hub_channel_connection_changed(event)
     inbox = event.data[:inbox]
     return if inbox.blank?
@@ -21,7 +20,7 @@ module HubChannelConnectionEvents
       connection_status: event.data[:connection_status]
     }
 
-    # Instalacao single-tenant: Inbox nao expoe `account`.
+    # Single-tenant install: Inbox does not expose `account`.
     broadcast(single_tenant_account, User.pluck(:pubsub_token).compact.uniq,
               HUB_CHANNEL_CONNECTION_CHANGED, payload)
   end

--- a/app/services/evolution_hub/channel_connected_handler.rb
+++ b/app/services/evolution_hub/channel_connected_handler.rb
@@ -8,6 +8,8 @@
 # Channel record as fully connected.
 module EvolutionHub
   class ChannelConnectedHandler
+    include ConnectionBroadcast
+
     def initialize(payload)
       @payload = payload
     end
@@ -27,7 +29,10 @@ module EvolutionHub
       when Channel::Instagram    then mark_instagram_connected(channel)
       else
         Rails.logger.warn("EvolutionHub::ChannelConnected: unsupported channel class #{channel.class}")
+        return
       end
+
+      broadcast_connection_change(channel, ConnectionBroadcast::CONNECTED)
     end
 
     private

--- a/app/services/evolution_hub/channel_disconnected_handler.rb
+++ b/app/services/evolution_hub/channel_disconnected_handler.rb
@@ -5,6 +5,8 @@
 # revoked at Meta, etc).
 module EvolutionHub
   class ChannelDisconnectedHandler
+    include ConnectionBroadcast
+
     def initialize(payload)
       @payload = payload
     end
@@ -19,6 +21,15 @@ module EvolutionHub
         return
       end
 
+      mark_inactive(record)
+
+      Rails.logger.info("EvolutionHub::ChannelDisconnected: #{record.class.name}##{record.id} marked inactive")
+      broadcast_connection_change(record, ConnectionBroadcast::DISCONNECTED)
+    end
+
+    private
+
+    def mark_inactive(record)
       if record.is_a?(Channel::Whatsapp)
         provider_config = (record.provider_config || {}).deep_dup
         hub_block = provider_config['evolution_hub'] || {}
@@ -29,11 +40,7 @@ module EvolutionHub
         hub_meta = (record.evolution_hub_meta || {}).merge('status' => 'inactive')
         record.update!(evolution_hub_meta: hub_meta)
       end
-
-      Rails.logger.info("EvolutionHub::ChannelDisconnected: #{record.class.name}##{record.id} marked inactive")
     end
-
-    private
 
     def external_id
       (@payload['external_id'] || @payload.dig('channel', 'external_id')).to_s

--- a/app/services/evolution_hub/connection_broadcast.rb
+++ b/app/services/evolution_hub/connection_broadcast.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Anuncia para a tela a mudanca de estado de conexao de um canal Meta
+# intermediado pelo Hub. Compartilhado pelos handlers de `channel_connected` e
+# `channel_disconnected`, que sao simetricos: manter uma copia em cada um
+# convidava a divergencia entre os dois sentidos.
+#
+# Sem este empurrao, a tela que abriu a aba do Hub so descobre a conexao num
+# refresh manual — a dor que originou o card.
+#
+# Falha aqui NAO desfaz a persistencia: o canal ja mudou de estado de fato, e
+# nao avisar a tela e menos grave do que estourar e reprocessar o webhook.
+module EvolutionHub
+  module ConnectionBroadcast
+    CONNECTED = 'connected'
+    DISCONNECTED = 'disconnected'
+
+    private
+
+    def broadcast_connection_change(channel, status)
+      inbox = channel.inbox
+      return if inbox.blank?
+
+      Rails.configuration.dispatcher.dispatch(
+        Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+        Time.zone.now,
+        inbox: inbox,
+        channel: channel,
+        connection_status: status
+      )
+    rescue StandardError => e
+      Rails.logger.error(
+        "EvolutionHub: falha ao anunciar #{status} do canal #{channel.id}: #{e.class}: #{e.message}"
+      )
+    end
+  end
+end

--- a/app/services/evolution_hub/connection_broadcast.rb
+++ b/app/services/evolution_hub/connection_broadcast.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 
-# Anuncia para a tela a mudanca de estado de conexao de um canal Meta
-# intermediado pelo Hub. Compartilhado pelos handlers de `channel_connected` e
-# `channel_disconnected`, que sao simetricos: manter uma copia em cada um
-# convidava a divergencia entre os dois sentidos.
-#
-# Sem este empurrao, a tela que abriu a aba do Hub so descobre a conexao num
-# refresh manual — a dor que originou o card.
-#
-# Falha aqui NAO desfaz a persistencia: o canal ja mudou de estado de fato, e
-# nao avisar a tela e menos grave do que estourar e reprocessar o webhook.
+# Announces a Hub-relayed Meta channel connection change to the operator's
+# screen. Shared by the channel_connected/channel_disconnected handlers so the
+# two directions cannot drift apart.
 module EvolutionHub
   module ConnectionBroadcast
     CONNECTED = 'connected'
@@ -17,6 +10,8 @@ module EvolutionHub
 
     private
 
+    # A failed announcement must not undo the persistence: the channel already
+    # changed state, and not telling the screen beats reprocessing the webhook.
     def broadcast_connection_change(channel, status)
       inbox = channel.inbox
       return if inbox.blank?
@@ -25,12 +20,11 @@ module EvolutionHub
         Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
         Time.zone.now,
         inbox: inbox,
-        channel: channel,
         connection_status: status
       )
     rescue StandardError => e
       Rails.logger.error(
-        "EvolutionHub: falha ao anunciar #{status} do canal #{channel.id}: #{e.class}: #{e.message}"
+        "EvolutionHub: failed to announce #{status} for channel #{channel.id}: #{e.class}: #{e.message}"
       )
     end
   end

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -51,11 +51,8 @@ module Events::Types
   INBOX_CREATED = 'inbox.created'
   INBOX_UPDATED = 'inbox.updated'
 
-  # Estado da conexao de um canal Meta intermediado pelo Evo Hub. Evento
-  # proprio, e nao INBOX_UPDATED, porque aquele fica atras de
-  # ENV['ENABLE_INBOX_EVENTS'] e dispara em QUALQUER atualizacao de inbox:
-  # ligar o global para empurrar esta transicao especifica transformaria um
-  # aviso pontual em broadcast de tudo.
+  # Its own event rather than INBOX_UPDATED, which sits behind
+  # ENV['ENABLE_INBOX_EVENTS'] and fires on ANY inbox update.
   HUB_CHANNEL_CONNECTION_CHANGED = 'hub_channel.connection_changed'
 
   # notification events

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -51,6 +51,13 @@ module Events::Types
   INBOX_CREATED = 'inbox.created'
   INBOX_UPDATED = 'inbox.updated'
 
+  # Estado da conexao de um canal Meta intermediado pelo Evo Hub. Evento
+  # proprio, e nao INBOX_UPDATED, porque aquele fica atras de
+  # ENV['ENABLE_INBOX_EVENTS'] e dispara em QUALQUER atualizacao de inbox:
+  # ligar o global para empurrar esta transicao especifica transformaria um
+  # aviso pontual em broadcast de tudo.
+  HUB_CHANNEL_CONNECTION_CHANGED = 'hub_channel.connection_changed'
+
   # notification events
   NOTIFICATION_CREATED = 'notification.created'
   NOTIFICATION_DELETED = 'notification.deleted'

--- a/lib/meta_base_url.rb
+++ b/lib/meta_base_url.rb
@@ -59,16 +59,21 @@ module MetaBaseUrl
     HUB_API_URL = 'https://api.evohub.ai'
     HUB_FRONTEND_URL = 'https://app.evohub.evolutionfoundation.com.br'
 
-    # Bare Hub URL (no /meta suffix) — used by Evolution Hub admin client
-    # to hit /api/v1/channels, /api/v1/auth/me, etc.
+    # Override para desenvolvimento e teste. O Hub central continua sendo o
+    # default; sem um override nao havia como exercitar a integracao sem bater
+    # no Hub de producao — nem o backend (chamadas de API) nem o frontend (o
+    # public_link que o operador abre no browser).
+    #
+    # Precedencia: ENV primeiro, para que o ambiente local nao dependa de uma
+    # linha no banco, e valor em branco cai no default.
     def hub_url
-      HUB_API_URL
+      ENV['EVOLUTION_HUB_API_URL'].presence || HUB_API_URL
     end
 
     # Frontend URL pra construir public_link (/connect/:token) que abre
     # a UI Pronta do Hub no browser do operador.
     def hub_frontend_url
-      HUB_FRONTEND_URL
+      ENV['EVOLUTION_HUB_FRONTEND_URL'].presence || HUB_FRONTEND_URL
     end
 
     private

--- a/lib/meta_base_url.rb
+++ b/lib/meta_base_url.rb
@@ -19,6 +19,16 @@ module MetaBaseUrl
   # :facebook so the URL is consistent with how Meta themselves namespace it.
   KINDS = %i[whatsapp facebook instagram].freeze
 
+  # The Hub is a single Evolution Foundation service: every self-hosted CRM
+  # talks to the central one, and what changes per install is the tenant API key
+  # (EVOLUTION_HUB_API_KEY in GlobalConfigService). The ENV overrides below only
+  # exist so the integration can be exercised against a local Hub.
+  #
+  # Declared on the module, not inside `class << self`, so they are reachable as
+  # MetaBaseUrl::HUB_API_URL the way META_API_VERSION and KINDS are.
+  HUB_API_URL = 'https://api.evohub.ai'
+  HUB_FRONTEND_URL = 'https://app.evohub.evolutionfoundation.com.br'
+
   class << self
     # Returns the base URL prefix.
     #
@@ -51,21 +61,8 @@ module MetaBaseUrl
       ActiveModel::Type::Boolean.new.cast(flag) && IntegrationRequirements.configured?('evolution_hub')
     end
 
-    # Hub URLs são FIXAS — o Hub é um serviço único da Evolution Foundation,
-    # não muda por instalação do CRM. Cada CRM open-source self-hosted bate
-    # nesse Hub central; o que muda por instalação é só a API key do tenant
-    # (EVOLUTION_HUB_API_KEY no GlobalConfigService).
-
-    HUB_API_URL = 'https://api.evohub.ai'
-    HUB_FRONTEND_URL = 'https://app.evohub.evolutionfoundation.com.br'
-
-    # Override para desenvolvimento e teste. O Hub central continua sendo o
-    # default; sem um override nao havia como exercitar a integracao sem bater
-    # no Hub de producao — nem o backend (chamadas de API) nem o frontend (o
-    # public_link que o operador abre no browser).
-    #
-    # Precedencia: ENV primeiro, para que o ambiente local nao dependa de uma
-    # linha no banco, e valor em branco cai no default.
+    # ENV takes precedence over the DB so a local environment needs no row in
+    # installation_configs; a blank value falls back to the central Hub.
     def hub_url
       ENV['EVOLUTION_HUB_API_URL'].presence || HUB_API_URL
     end

--- a/spec/lib/meta_base_url_spec.rb
+++ b/spec/lib/meta_base_url_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MetaBaseUrl do
+  describe '.hub_url e .hub_frontend_url' do
+    it 'usa o Hub central quando nao ha override' do
+      expect(described_class.hub_url).to eq(described_class::HUB_API_URL)
+      expect(described_class.hub_frontend_url).to eq(described_class::HUB_FRONTEND_URL)
+    end
+
+    it 'respeita o override de ambiente' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('EVOLUTION_HUB_API_URL').and_return('http://evolution-hub-backend:8086')
+      allow(ENV).to receive(:[]).with('EVOLUTION_HUB_FRONTEND_URL').and_return('http://localhost:8050')
+
+      expect(described_class.hub_url).to eq('http://evolution-hub-backend:8086')
+      expect(described_class.hub_frontend_url).to eq('http://localhost:8050')
+    end
+
+    it 'ignora override em branco e cai no default' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('EVOLUTION_HUB_API_URL').and_return('')
+      allow(ENV).to receive(:[]).with('EVOLUTION_HUB_FRONTEND_URL').and_return('  ')
+
+      expect(described_class.hub_url).to eq(described_class::HUB_API_URL)
+      expect(described_class.hub_frontend_url).to eq(described_class::HUB_FRONTEND_URL)
+    end
+  end
+end

--- a/spec/listeners/action_cable_listener_hub_channel_spec.rb
+++ b/spec/listeners/action_cable_listener_hub_channel_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActionCableListener do
+  describe '#hub_channel_connection_changed' do
+    let(:inbox) { instance_double(Inbox, id: 'inbox-1', channel_type: 'Channel::Whatsapp', blank?: false) }
+    let(:event) do
+      Events::Base.new(
+        Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+        Time.zone.now,
+        { inbox: inbox, connection_status: 'connected' }
+      )
+    end
+
+    before do
+      allow(User).to receive(:pluck).with(:pubsub_token).and_return(%w[tok-a tok-b tok-a])
+      allow(described_class.instance).to receive(:single_tenant_account).and_return(nil)
+      allow(ActionCableBroadcastJob).to receive(:perform_later)
+    end
+
+    it 'transmite inbox, tipo de canal e estado para os tokens da conta' do
+      described_class.instance.hub_channel_connection_changed(event)
+
+      expect(ActionCableBroadcastJob).to have_received(:perform_later) do |tokens, name, payload|
+        expect(tokens).to contain_exactly('tok-a', 'tok-b')
+        expect(name).to eq(Events::Types::HUB_CHANNEL_CONNECTION_CHANGED)
+        expect(payload[:inbox_id]).to eq('inbox-1')
+        expect(payload[:channel_type]).to eq('Channel::Whatsapp')
+        expect(payload[:connection_status]).to eq('connected')
+      end
+    end
+
+    it 'nao transmite evento sem inbox' do
+      sem_inbox = Events::Base.new(Events::Types::HUB_CHANNEL_CONNECTION_CHANGED, Time.zone.now, { connection_status: 'connected' })
+
+      described_class.instance.hub_channel_connection_changed(sem_inbox)
+
+      expect(ActionCableBroadcastJob).not_to have_received(:perform_later)
+    end
+  end
+end

--- a/spec/services/evolution_hub/channel_connected_handler_spec.rb
+++ b/spec/services/evolution_hub/channel_connected_handler_spec.rb
@@ -138,4 +138,35 @@ RSpec.describe EvolutionHub::ChannelConnectedHandler do
       end.not_to have_enqueued_job(Channels::Whatsapp::TemplatesSyncJob)
     end
   end
+
+  # The announcement is the whole point of the feature: without an example here,
+  # dropping the broadcast_connection_change call leaves the suite green.
+  describe '#perform — announces the transition' do
+    let(:inbox) { instance_double(Inbox, id: 77, channel_type: 'Channel::Whatsapp', blank?: false) }
+    let(:dispatcher) { instance_double(Dispatcher, dispatch: true) }
+
+    before do
+      allow(channel).to receive(:inbox).and_return(inbox)
+      allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher)
+    end
+
+    it 'dispatches the connection change with the inbox and the connected state' do
+      described_class.new(payload).perform
+
+      expect(dispatcher).to have_received(:dispatch).with(
+        Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+        kind_of(ActiveSupport::TimeWithZone),
+        hash_including(inbox: inbox, connection_status: 'connected')
+      )
+    end
+
+    it 'does not dispatch when no local channel matches the payload' do
+      allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(nil)
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.new(payload).perform
+
+      expect(dispatcher).not_to have_received(:dispatch)
+    end
+  end
 end

--- a/spec/services/evolution_hub/channel_disconnected_handler_spec.rb
+++ b/spec/services/evolution_hub/channel_disconnected_handler_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EvolutionHub::ChannelDisconnectedHandler do
+  let(:channel_uuid) { SecureRandom.uuid }
+  let(:inbox) { instance_double(Inbox, id: 77, channel_type: 'Channel::Whatsapp', blank?: false) }
+  let(:dispatcher) { instance_double(Dispatcher, dispatch: true) }
+
+  let(:channel) do
+    ch = Channel::Whatsapp.new(phone_number: "+5511#{rand(10**9)}", provider: 'whatsapp_cloud')
+    ch.id = channel_uuid
+    ch.provider_config = { 'evolution_hub' => { 'channel_id' => 'hub-ch-abc', 'status' => 'active' } }
+    allow(ch).to receive_messages(new_record?: false, persisted?: true, inbox: inbox)
+    allow(ch).to receive(:update!) do |attrs|
+      ch.provider_config = attrs[:provider_config] if attrs.key?(:provider_config)
+      true
+    end
+    ch
+  end
+
+  let(:payload) { { 'external_id' => channel_uuid, 'channel_id' => 'hub-ch-abc' } }
+
+  before do
+    allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(channel)
+    allow(Channel::FacebookPage).to receive(:find_by).and_return(nil)
+    allow(Channel::Instagram).to receive(:find_by).and_return(nil)
+    allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  it 'flips the hub status to inactive and announces the disconnection' do
+    described_class.new(payload).perform
+
+    expect(channel.provider_config.dig('evolution_hub', 'status')).to eq('inactive')
+    expect(dispatcher).to have_received(:dispatch).with(
+      Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+      kind_of(ActiveSupport::TimeWithZone),
+      hash_including(inbox: inbox, connection_status: 'disconnected')
+    )
+  end
+
+  it 'does not announce when no local channel matches the payload' do
+    allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(nil)
+    allow(Rails.logger).to receive(:warn)
+
+    described_class.new(payload).perform
+
+    expect(dispatcher).not_to have_received(:dispatch)
+  end
+
+  # Persistence already happened; failing to tell the screen must not make the
+  # Hub replay the webhook.
+  it 'keeps the channel inactive when the announcement blows up' do
+    allow(dispatcher).to receive(:dispatch).and_raise(StandardError, 'cable down')
+    allow(Rails.logger).to receive(:error)
+
+    expect { described_class.new(payload).perform }.not_to raise_error
+    expect(channel.provider_config.dig('evolution_hub', 'status')).to eq('inactive')
+  end
+end

--- a/spec/services/evolution_hub/connection_broadcast_spec.rb
+++ b/spec/services/evolution_hub/connection_broadcast_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# A tela que abriu a aba do Hub so descobria a conexao num refresh manual. Os
+# handlers passam a anunciar a transicao; estes exemplos prendem o contrato do
+# anuncio nos dois sentidos e a garantia de que uma falha no anuncio nao desfaz
+# a persistencia do canal.
+RSpec.describe EvolutionHub::ConnectionBroadcast do
+  let(:inbox) { instance_double(Inbox, id: 'inbox-1', blank?: false) }
+  let(:channel) { instance_double(Channel::Whatsapp, id: 'chan-1', inbox: inbox) }
+  let(:dispatcher) { instance_double(Dispatcher, dispatch: true) }
+
+  let(:host) do
+    Class.new do
+      include EvolutionHub::ConnectionBroadcast
+      def announce(channel, status) = broadcast_connection_change(channel, status)
+    end.new
+  end
+
+  before { allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher) }
+
+  it 'anuncia a conexao com a inbox, o canal e o estado' do
+    host.announce(channel, described_class::CONNECTED)
+
+    expect(dispatcher).to have_received(:dispatch).with(
+      Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+      kind_of(ActiveSupport::TimeWithZone),
+      hash_including(inbox: inbox, channel: channel, connection_status: 'connected')
+    )
+  end
+
+  it 'anuncia a desconexao pelo mesmo caminho' do
+    host.announce(channel, described_class::DISCONNECTED)
+
+    expect(dispatcher).to have_received(:dispatch).with(
+      Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+      kind_of(ActiveSupport::TimeWithZone),
+      hash_including(connection_status: 'disconnected')
+    )
+  end
+
+  it 'nao anuncia canal sem inbox' do
+    orfao = instance_double(Channel::Whatsapp, id: 'chan-2', inbox: nil)
+
+    host.announce(orfao, described_class::CONNECTED)
+
+    expect(dispatcher).not_to have_received(:dispatch)
+  end
+
+  it 'engole a falha do anuncio para nao desfazer a persistencia do canal' do
+    allow(dispatcher).to receive(:dispatch).and_raise(StandardError, 'cable fora do ar')
+
+    expect { host.announce(channel, described_class::CONNECTED) }.not_to raise_error
+  end
+end

--- a/spec/services/evolution_hub/connection_broadcast_spec.rb
+++ b/spec/services/evolution_hub/connection_broadcast_spec.rb
@@ -2,10 +2,8 @@
 
 require 'rails_helper'
 
-# A tela que abriu a aba do Hub so descobria a conexao num refresh manual. Os
-# handlers passam a anunciar a transicao; estes exemplos prendem o contrato do
-# anuncio nos dois sentidos e a garantia de que uma falha no anuncio nao desfaz
-# a persistencia do canal.
+# Pins the announcement contract in both directions, plus the guarantee that a
+# failed announcement does not undo the channel persistence.
 RSpec.describe EvolutionHub::ConnectionBroadcast do
   let(:inbox) { instance_double(Inbox, id: 'inbox-1', blank?: false) }
   let(:channel) { instance_double(Channel::Whatsapp, id: 'chan-1', inbox: inbox) }
@@ -20,13 +18,13 @@ RSpec.describe EvolutionHub::ConnectionBroadcast do
 
   before { allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher) }
 
-  it 'anuncia a conexao com a inbox, o canal e o estado' do
+  it 'anuncia a conexao com a inbox e o estado' do
     host.announce(channel, described_class::CONNECTED)
 
     expect(dispatcher).to have_received(:dispatch).with(
       Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
       kind_of(ActiveSupport::TimeWithZone),
-      hash_including(inbox: inbox, channel: channel, connection_status: 'connected')
+      hash_including(inbox: inbox, connection_status: 'connected')
     )
   end
 


### PR DESCRIPTION
## Problema

O operador clica em conectar, o CRM cria o canal no Evo Hub e abre outra aba com o `public_link`. Ele conclui o signup da Meta e volta — e a tela continua em "Aguardando conexão Meta no Hub…" indefinidamente, até um F5. Sem sinal de sucesso e sem sinal de falha.

O caminho de volta já ia até o banco: o Hub posta `channel_connected`, o `EvolutionHubEventsJob` despacha para o `ChannelConnectedHandler`, que grava as credenciais, ativa o canal e reenfileira o sync de templates. O que não existia era qualquer empurrão para a tela — nenhum handler do Hub chamava o dispatcher.

## Backend

Evento próprio, `hub_channel.connection_changed`. Não reusei o `INBOX_UPDATED` que já existe: ele fica atrás de `ENABLE_INBOX_EVENTS` e dispara em qualquer atualização de inbox, então ligá-lo para empurrar esta transição transformaria um aviso pontual em broadcast de tudo.

O despacho vive num módulo compartilhado (`EvolutionHub::ConnectionBroadcast`) usado pelos dois handlers do par. Eles são simétricos, e o próprio repositório avisa, no `ChannelReconciler`, que "credential-drift entre cópias é a classe de bug mais cara aqui". Escrevi duplicado primeiro e extraí.

Falha no anúncio não desfaz a persistência: o canal já mudou de estado de fato, e não avisar a tela é menos grave do que estourar e reprocessar o webhook.

No `ActionCableListener` o handler entra por concern (`app/listeners/concerns/hub_channel_connection_events.rb`) porque aquela classe já estava no teto do `Metrics/ClassLength`; somar um método no corpo obrigaria a afrouxar o cop para todo mundo. O diff no arquivo da classe é **uma linha**.

## Frontend

Case no `actionCableService` para o evento novo, e o `HubConnectButton` escutando enquanto espera, casando pelo id da inbox. Conectado virou estado próprio; desconectado volta para a espera, já que o par de eventos do Hub é simétrico.

O erro do Hub passa a sair pelo `apiErrorMessage`, que lê o envelope estruturado. Ler `data.message` cru descartava a tradução que o client já faz de `PLAN_FORBIDS_SHARED` e `QUOTA_EXCEEDED` e devolvia o texto técnico ao operador — é o critério de aceite de não regredir para "HTTP 403".

Um detalhe que estava enganando: a espera mostrava um `CheckCircle2` **verde** ao lado de "Aguardando conexão Meta no Hub…". Um check de sucesso enquanto nada tinha acontecido. Virou spinner.

## Validação no ambiente

Com o Hub local e o CRM reconstruído, postei um `channel_connected` assinado por HMAC no `POST /webhooks/evolution_hub` (o Hub local não consegue entregar sozinho: o guard anti-SSRF em `webhook_service.go:530` recusa destino em IP privado). O evento percorreu o caminho inteiro:

```
Enqueued EventDispatcherJob ... "hub_channel.connection_changed",
  {inbox: gid://…/Inbox/b33b9313…, connection_status: "connected"}
ActionCable broadcast start ... event=hub_channel.connection_changed recipients=3
ActionCable broadcast done
```

## Como validar

```
bundle exec rspec spec/services/evolution_hub/ spec/listeners/action_cable_listener_hub_channel_spec.rb
```

11 exemplos: o contrato do anúncio nos dois sentidos, canal sem inbox, falha do anúncio não derrubando a persistência, e o listener transmitindo `inbox_id`/`channel_type`/`connection_status` com deduplicação de tokens.

As 8 falhas em `spec/listeners/` são pré-existentes na develop — medidas com e sem estas mudanças. Rubocop sem ofensas novas, conferido por diff de ofensas por cop.

## Fora de escopo

Embedded signup dentro do CRM, que é a CRM-314. Nada aqui afrouxa `hubAllowExistingChannels` nem o 403 `HUB_EXISTING_CHANNELS_DISABLED`.

## Summary by Sourcery

Synchronize the Meta channel connection screen with the actual Evolution Hub connection state.

New Features:
- Propagate Meta channel connection and disconnection changes from Evolution Hub to the CRM interface through a dedicated event and ActionCable broadcast.
- Update the Hub connection screen to reflect connected, disconnected, and error states while a connection is in progress.

Bug Fixes:
- Prevent the Meta connection screen from remaining indefinitely in the waiting state after the Hub completes signup.
- Preserve translated Hub error messages instead of exposing raw technical responses to operators.
- Replace the misleading success check icon with a loading indicator during connection waiting.

Enhancements:
- Share connection-state broadcasting between both Hub lifecycle handlers and keep announcement failures from interrupting channel state persistence.
- Allow Hub API and frontend URLs to be overridden through environment variables for local integration testing.

CI:
- Expand the spec staleness guard and workflow coverage for Evolution Hub connection events and Meta Hub URL configuration.

Tests:
- Add coverage for connection and disconnection event dispatch, ActionCable payloads and token deduplication, missing inboxes, announcement failures, and Hub URL overrides.