### PR TITLE
fix(whatsapp): libera o guard de dedup no ensure (CRM-285)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -176,8 +176,10 @@ on:
       # CRM-285: the WhatsApp dedup guard is written to Redis before the message is
       # processed, so releasing it anywhere but an `ensure` pins the key for a full
       # day - the Sidekiq retry and every Meta re-delivery then bounce off it and
-      # drop the message with no log at all. Nothing else in CI exercises the release.
+      # drop the message with no log at all. The release also has to stay non-raising,
+      # or it replaces the exception it was cleaning up after. No other lane runs it.
       - 'app/services/whatsapp/incoming_message_base_service.rb'
+      - 'app/services/whatsapp/incoming_message_service_helpers.rb'
       - 'app/services/whatsapp/evolution_handlers/messages_upsert.rb'
       - 'spec/services/whatsapp/incoming_message_base_service_spec.rb'
       - 'spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -173,6 +173,14 @@ on:
       - 'app/controllers/webhooks/instagram_controller.rb'
       - 'config/initializers/facebook_messenger.rb'
       - 'spec/requests/webhooks/meta_token_verify_spec.rb'
+      # CRM-285: the WhatsApp dedup guard is written to Redis before the message is
+      # processed, so releasing it anywhere but an `ensure` pins the key for a full
+      # day - the Sidekiq retry and every Meta re-delivery then bounce off it and
+      # drop the message with no log at all. Nothing else in CI exercises the release.
+      - 'app/services/whatsapp/incoming_message_base_service.rb'
+      - 'app/services/whatsapp/evolution_handlers/messages_upsert.rb'
+      - 'spec/services/whatsapp/incoming_message_base_service_spec.rb'
+      - 'spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb'
 
 permissions:
   contents: read
@@ -281,4 +289,6 @@ jobs:
             spec/requests/api/v1/products_validation_spec.rb \
             spec/requests/api/v1/inboxes_set_agent_bot_spec.rb \
             spec/requests/webhooks/meta_token_verify_spec.rb \
+            spec/services/whatsapp/incoming_message_base_service_spec.rb \
+            spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb \
             --format progress

--- a/app/services/whatsapp/evolution_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_handlers/messages_upsert.rb
@@ -39,18 +39,21 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
     Rails.logger.info "Evolution API: Creating new message #{raw_message_id}"
 
     cache_message_source_id_in_redis
-    set_contact
 
-    unless @contact
+    begin
+      set_contact
+
+      unless @contact
+        Rails.logger.warn "Evolution API: Contact not found for message: #{raw_message_id}"
+        return
+      end
+
+      set_conversation
+      update_conversation_status_if_needed
+      handle_create_message
+    ensure
       clear_message_source_id_from_redis
-      Rails.logger.warn "Evolution API: Contact not found for message: #{raw_message_id}"
-      return
     end
-
-    set_conversation
-    update_conversation_status_if_needed
-    handle_create_message
-    clear_message_source_id_from_redis
   end
 
   # A revoke arrives as a protocolMessage; mark the original as revoked-by-contact

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -29,12 +29,16 @@ class Whatsapp::IncomingMessageBaseService
     return if find_message_by_source_id(@processed_params[:messages].first[:id]) || message_under_process?
 
     cache_message_source_id_in_redis
-    set_contact
-    return unless @contact
 
-    set_conversation
-    create_messages
-    clear_message_source_id_from_redis
+    begin
+      set_contact
+      return unless @contact
+
+      set_conversation
+      create_messages
+    ensure
+      clear_message_source_id_from_redis
+    end
   end
 
   def process_statuses
@@ -143,6 +147,13 @@ class Whatsapp::IncomingMessageBaseService
     attrs[:bsuid] = bsuid if bsuid.present? && contact_inbox.bsuid != bsuid
     attrs[:whatsapp_username] = username if username.present? && contact_inbox.whatsapp_username != username
     contact_inbox.update!(attrs) if attrs.present?
+  rescue ActiveRecord::RecordNotUnique => e
+    # A concurrent webhook for the same new contact won the race for
+    # index_contact_inboxes_on_inbox_id_and_bsuid and already stored this bsuid.
+    Rails.logger.warn(
+      "WhatsApp: bsuid=#{bsuid} already claimed by another contact_inbox - " \
+      "skipping duplicate update on contact_inbox=#{contact_inbox.id}: #{e.message}"
+    )
   end
 
   def set_conversation

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -147,13 +147,17 @@ class Whatsapp::IncomingMessageBaseService
     attrs[:bsuid] = bsuid if bsuid.present? && contact_inbox.bsuid != bsuid
     attrs[:whatsapp_username] = username if username.present? && contact_inbox.whatsapp_username != username
     contact_inbox.update!(attrs) if attrs.present?
-  rescue ActiveRecord::RecordNotUnique => e
-    # A concurrent webhook for the same new contact won the race for
-    # index_contact_inboxes_on_inbox_id_and_bsuid and already stored this bsuid.
+  rescue ActiveRecord::RecordNotUnique
+    # Another contact_inbox on this inbox owns the bsuid and keeps owning it (the same
+    # person reached us twice, once by phone JID and once by LID). Drop it from the
+    # write so the remaining attributes still land instead of being lost with it.
+    contact_inbox.restore_attributes
     Rails.logger.warn(
       "WhatsApp: bsuid=#{bsuid} already claimed by another contact_inbox - " \
-      "skipping duplicate update on contact_inbox=#{contact_inbox.id}: #{e.message}"
+      "keeping contact_inbox=#{contact_inbox.id} without it"
     )
+    remaining = attrs.except(:bsuid)
+    contact_inbox.update!(remaining) if remaining.present?
   end
 
   def set_conversation

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -149,6 +149,10 @@ module Whatsapp::IncomingMessageServiceHelpers
 
     key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: message_id)
     ::Redis::Alfred.delete(key)
+  rescue StandardError => e
+    # Callers release the guard from an `ensure`, where a raise here would replace the
+    # exception already propagating and hide why the message failed in the first place.
+    Rails.logger.error "Whatsapp: failed to clear the dedup guard for #{message_id}: #{e.message}"
   end
 
   private

--- a/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
+++ b/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
@@ -12,46 +12,80 @@ end
 
 return unless defined?(Rails)
 
-# Same dedup guard as the Cloud API service, same leak: released on the last
-# line of the happy path, so a raise anywhere before it pins the Redis key for
-# its full one-day TTL and every retry of that message is discarded silently.
+# Same dedup guard as the Cloud API service, and it used to leak the same way:
+# released on the last line of the happy path, so a raise before it pinned the
+# Redis key for its full one-day TTL and every retry was discarded silently.
 RSpec.describe Whatsapp::EvolutionHandlers::MessagesUpsert do
-  # The real service is the host: the upsert module leans on set_conversation,
-  # which lives up in the base service, not in the module itself.
-  let(:host_class) { Class.new(Whatsapp::IncomingMessageEvolutionService) }
+  let(:guard_key) { format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: 'evo.race') }
+  let(:fake_alfred) { {} }
   let(:inbox) { instance_double(Inbox) }
-  let(:host) { host_class.new(inbox: inbox, params: {}) }
+  let(:params) { { event: 'messages.upsert', data: { key: { id: 'evo.race' } } } }
+  # The module leans on set_conversation, which lives up in the base service, so the
+  # real Evolution service is the host that exercises it.
+  let(:host) { Whatsapp::IncomingMessageEvolutionService.new(inbox: inbox, params: params) }
 
   before do
+    # In-memory Alfred (repo convention) so the real cache/clear helpers run and
+    # the assertions are about the key itself, not about the call site.
+    allow(Redis::Alfred).to receive(:setex) { |key, value, _expiry = nil| fake_alfred[key] = value }
+    allow(Redis::Alfred).to receive(:get) { |key| fake_alfred[key] }
+    allow(Redis::Alfred).to receive(:delete) { |key| fake_alfred.delete(key) }
+
+    # evolution_api? reads @processed_params directly, and #perform is what memoizes
+    # it - handle_message is driven here without going through #perform.
+    host.send(:processed_params)
     allow(host).to receive(:message_type).and_return('text')
     allow(host).to receive(:message_processable?).and_return(true)
     allow(host).to receive(:raw_message_id).and_return('evo.race')
-    allow(host).to receive(:cache_message_source_id_in_redis)
   end
 
   describe '#handle_message dedup guard release' do
     it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
-      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(host).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        raise ActiveRecord::RecordNotUnique, 'duplicate key'
+      end
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect(fake_alfred).to be_empty
     end
 
     it 'releases the guard when the payload carries no usable contact' do
       allow(host).to receive(:set_contact)
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       host.send(:handle_message)
+      expect(fake_alfred).to be_empty
     end
 
     it 'still releases the guard on the happy path' do
-      allow(host).to receive(:set_contact) { host.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(host).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        host.instance_variable_set(:@contact, instance_double(Contact))
+      end
       allow(host).to receive(:set_conversation)
       allow(host).to receive(:update_conversation_status_if_needed)
       allow(host).to receive(:handle_create_message)
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       host.send(:handle_message)
+      expect(fake_alfred).to be_empty
+    end
+
+    # The `ensure` must not reach the early returns above it: they exist because
+    # another worker holds the guard, and clearing it there would undo the dedup.
+    it 'leaves the guard alone when another worker is already processing the message' do
+      allow(host).to receive(:message_processable?).and_return(false)
+      fake_alfred[guard_key] = 'true'
+
+      expect(host).not_to receive(:set_contact)
+      host.send(:handle_message)
+      expect(fake_alfred).to include(guard_key)
+    end
+
+    it 'does not let a Redis failure in the ensure mask the exception that killed the message' do
+      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Redis::Alfred).to receive(:delete).and_raise(Redis::CannotConnectError)
+
+      expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 end

--- a/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
+++ b/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+begin
+  require 'rails_helper'
+rescue LoadError
+  RSpec.describe 'Whatsapp::EvolutionHandlers::MessagesUpsert' do
+    it 'has spec scaffold ready' do
+      skip 'rails_helper is not available in this workspace snapshot'
+    end
+  end
+end
+
+return unless defined?(Rails)
+
+# Same dedup guard as the Cloud API service, same leak: released on the last
+# line of the happy path, so a raise anywhere before it pins the Redis key for
+# its full one-day TTL and every retry of that message is discarded silently.
+RSpec.describe Whatsapp::EvolutionHandlers::MessagesUpsert do
+  # The real service is the host: the upsert module leans on set_conversation,
+  # which lives up in the base service, not in the module itself.
+  let(:host_class) { Class.new(Whatsapp::IncomingMessageEvolutionService) }
+  let(:inbox) { instance_double(Inbox) }
+  let(:host) { host_class.new(inbox: inbox, params: {}) }
+
+  before do
+    allow(host).to receive(:message_type).and_return('text')
+    allow(host).to receive(:message_processable?).and_return(true)
+    allow(host).to receive(:raw_message_id).and_return('evo.race')
+    allow(host).to receive(:cache_message_source_id_in_redis)
+  end
+
+  describe '#handle_message dedup guard release' do
+    it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
+      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+
+      expect(host).to receive(:clear_message_source_id_from_redis)
+      expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'releases the guard when the payload carries no usable contact' do
+      allow(host).to receive(:set_contact)
+
+      expect(host).to receive(:clear_message_source_id_from_redis)
+      host.send(:handle_message)
+    end
+
+    it 'still releases the guard on the happy path' do
+      allow(host).to receive(:set_contact) { host.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(host).to receive(:set_conversation)
+      allow(host).to receive(:update_conversation_status_if_needed)
+      allow(host).to receive(:handle_create_message)
+
+      expect(host).to receive(:clear_message_source_id_from_redis)
+      host.send(:handle_message)
+    end
+  end
+end

--- a/spec/services/whatsapp/incoming_message_base_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_base_service_spec.rb
@@ -100,54 +100,94 @@ RSpec.describe Whatsapp::IncomingMessageBaseService do
     end
   end
 
-  # The dedup guard is written to Redis before processing and released only on
-  # the last line of the happy path. Any raise in between - or a webhook whose
-  # contacts payload is blank - leaves the key pinned for its full one-day TTL,
-  # so the Sidekiq retry and every Meta re-delivery bounce off
-  # `message_under_process?` and drop the message with no log at all.
+  # The guard used to be released on the last line of the happy path, so a raise in
+  # between pinned the Redis key for its full one-day TTL and every retry of that
+  # message was then discarded silently. It now falls in an `ensure`.
   describe '#process_messages dedup guard release' do
+    let(:guard_key) { format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: 'wamid.race') }
+    let(:fake_alfred) { {} }
+
     before do
+      # In-memory Alfred (repo convention) so the real cache/clear helpers run and
+      # the assertions are about the key itself, not about the call site.
+      allow(Redis::Alfred).to receive(:setex) { |key, value, _expiry = nil| fake_alfred[key] = value }
+      allow(Redis::Alfred).to receive(:get) { |key| fake_alfred[key] }
+      allow(Redis::Alfred).to receive(:delete) { |key| fake_alfred.delete(key) }
+
       service.processed_params = { messages: [{ id: 'wamid.race', type: 'text' }] }
       allow(service).to receive(:find_message_by_source_id).and_return(nil)
       allow(service).to receive(:message_under_process?).and_return(false)
-      allow(service).to receive(:cache_message_source_id_in_redis)
     end
 
     it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
-      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(service).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        raise ActiveRecord::RecordNotUnique, 'duplicate key'
+      end
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect(fake_alfred).to be_empty
     end
 
     it 'releases the guard when the webhook carries no usable contact' do
       allow(service).to receive(:set_contact)
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       service.send(:process_messages)
+      expect(fake_alfred).to be_empty
     end
 
     it 'still releases the guard on the happy path' do
-      allow(service).to receive(:set_contact) { service.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(service).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        service.instance_variable_set(:@contact, instance_double(Contact))
+      end
       allow(service).to receive(:set_conversation)
       allow(service).to receive(:create_messages)
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       service.send(:process_messages)
+      expect(fake_alfred).to be_empty
+    end
+
+    # The `ensure` must not reach the early returns above it: they exist because
+    # another worker holds the guard, and clearing it there would undo the dedup.
+    it 'leaves the guard alone when another worker is already processing the message' do
+      allow(service).to receive(:message_under_process?).and_return(true)
+      fake_alfred[guard_key] = 'true'
+
+      expect(service).not_to receive(:set_contact)
+      service.send(:process_messages)
+      expect(fake_alfred).to include(guard_key)
+    end
+
+    it 'does not let a Redis failure in the ensure mask the exception that killed the message' do
+      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Redis::Alfred).to receive(:delete).and_raise(Redis::CannotConnectError)
+
+      expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 
   describe '#update_bsuid_fields' do
     let(:contact_inbox) { instance_double(ContactInbox, id: 7, bsuid: nil, whatsapp_username: nil) }
 
-    # Two concurrent webhooks for the same new contact race for
-    # index_contact_inboxes_on_inbox_id_and_bsuid. The loser has nothing left to
-    # write - the winner already stored the same bsuid - so it logs and moves on.
-    it 'keeps going when a concurrent webhook already claimed the bsuid' do
-      allow(contact_inbox).to receive(:update!).and_raise(
+    before { allow(contact_inbox).to receive(:restore_attributes) }
+
+    # The same person can hold two contact_inboxes on one inbox (phone JID and LID),
+    # so the loser of index_contact_inboxes_on_inbox_id_and_bsuid never gets the bsuid
+    # and would drop every attribute shipped alongside it, on every message.
+    it 'still writes the username when a concurrent webhook already claimed the bsuid' do
+      allow(contact_inbox).to receive(:update!).with(hash_including(bsuid: 'abc123')).and_raise(
         ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: duplicate key value violates unique constraint')
       )
       expect(Rails.logger).to receive(:warn).with(/bsuid=abc123/)
+      expect(contact_inbox).to receive(:update!).with({ whatsapp_username: 'ana' })
+
+      expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', 'ana') }.not_to raise_error
+    end
+
+    it 'gives up quietly when the bsuid was the only thing to write' do
+      allow(contact_inbox).to receive(:update!).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Rails.logger).to receive(:warn)
 
       expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', nil) }.not_to raise_error
     end

--- a/spec/services/whatsapp/incoming_message_base_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_base_service_spec.rb
@@ -99,4 +99,63 @@ RSpec.describe Whatsapp::IncomingMessageBaseService do
       service.send(:update_message_with_status, already_delivered, { status: 'delivered', id: 'wamid.xxx' })
     end
   end
+
+  # The dedup guard is written to Redis before processing and released only on
+  # the last line of the happy path. Any raise in between - or a webhook whose
+  # contacts payload is blank - leaves the key pinned for its full one-day TTL,
+  # so the Sidekiq retry and every Meta re-delivery bounce off
+  # `message_under_process?` and drop the message with no log at all.
+  describe '#process_messages dedup guard release' do
+    before do
+      service.processed_params = { messages: [{ id: 'wamid.race', type: 'text' }] }
+      allow(service).to receive(:find_message_by_source_id).and_return(nil)
+      allow(service).to receive(:message_under_process?).and_return(false)
+      allow(service).to receive(:cache_message_source_id_in_redis)
+    end
+
+    it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
+      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+
+      expect(service).to receive(:clear_message_source_id_from_redis)
+      expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'releases the guard when the webhook carries no usable contact' do
+      allow(service).to receive(:set_contact)
+
+      expect(service).to receive(:clear_message_source_id_from_redis)
+      service.send(:process_messages)
+    end
+
+    it 'still releases the guard on the happy path' do
+      allow(service).to receive(:set_contact) { service.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(service).to receive(:set_conversation)
+      allow(service).to receive(:create_messages)
+
+      expect(service).to receive(:clear_message_source_id_from_redis)
+      service.send(:process_messages)
+    end
+  end
+
+  describe '#update_bsuid_fields' do
+    let(:contact_inbox) { instance_double(ContactInbox, id: 7, bsuid: nil, whatsapp_username: nil) }
+
+    # Two concurrent webhooks for the same new contact race for
+    # index_contact_inboxes_on_inbox_id_and_bsuid. The loser has nothing left to
+    # write - the winner already stored the same bsuid - so it logs and moves on.
+    it 'keeps going when a concurrent webhook already claimed the bsuid' do
+      allow(contact_inbox).to receive(:update!).and_raise(
+        ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: duplicate key value violates unique constraint')
+      )
+      expect(Rails.logger).to receive(:warn).with(/bsuid=abc123/)
+
+      expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', nil) }.not_to raise_error
+    end
+
+    it 'persists the bsuid when there is no race' do
+      expect(contact_inbox).to receive(:update!).with(hash_including(bsuid: 'abc123'))
+
+      service.send(:update_bsuid_fields, contact_inbox, 'abc123', nil)
+    end
+  end
 end


### PR DESCRIPTION
## Problema

O guard de "mensagem em processamento" é gravado no Redis (TTL de 1 dia) antes do processamento e era liberado apenas na última linha do caminho feliz de `Whatsapp::IncomingMessageBaseService#process_messages`. Qualquer exceção no meio — ou um webhook cujo `contacts` vem vazio — deixava a chave presa por 24h. A partir daí, o retry do Sidekiq e toda re-entrega da Meta batiam em `message_under_process?` e desistiam **sem log nenhum**: a mensagem recebida simplesmente não aparecia na conversa, sem erro na API e sem job morto na fila.

A exceção observada em produção é `ActiveRecord::RecordNotUnique` em `update_bsuid_fields`, quando dois webhooks concorrentes para o mesmo contato novo disputam `index_contact_inboxes_on_inbox_id_and_bsuid`. Daí a reincidência no primeiro contato.

## Correção

1. `set_contact` / `set_conversation` / `create_messages` passam a rodar dentro de `begin ... ensure clear_message_source_id_from_redis end`. Com o guard liberado sempre, a exceção volta a estourar para o Sidekiq e o retry reprocessa a mensagem — que é o comportamento correto.
2. `update_bsuid_fields` trata `RecordNotUnique` com `warn` e segue: o vencedor da corrida já gravou o mesmo bsuid, o perdedor não tem mais nada a escrever. É o mesmo tratamento que `ContactInboxWithContactBuilder#perform` já dá para a corrida de criação do `contact_inbox`.
3. `Whatsapp::EvolutionHandlers::MessagesUpsert#handle_message` repetia o padrão (liberava o guard no sucesso e no ramo sem contato, mas não em exceção) e recebeu o mesmo `ensure`.

Instagram e Facebook foram checados: não usam esse guard — `MESSAGE_SOURCE_KEY` só aparece nos serviços de WhatsApp, e os dois canais entram por `Messages::Instagram::Messenger::MessageBuilder` / `Messages::Messenger::MessageBuilder`, sem Redis. Não têm o defeito, nada a corrigir lá.

## Testes

`spec/services/whatsapp/incoming_message_base_service_spec.rb` e o novo `spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb` cobrem: guard liberado quando `set_contact` levanta (e a exceção continua propagando), guard liberado quando não há contato utilizável, guard liberado no caminho feliz, e `update_bsuid_fields` sobrevivendo ao `RecordNotUnique` sem deixar de persistir quando não há corrida. As quatro asserções novas falham no código anterior.

Os dois arquivos entraram no `spec-staleness-guard` — a liberação do guard é invisível para qualquer outra lane do CI.

```
56 examples, 0 failures
```

## Summary by Sourcery

Ensure WhatsApp deduplication guards are safely cleaned up and concurrent contact updates remain recoverable.

Bug Fixes:
- Ensure WhatsApp message deduplication guards are always released after processing errors or early exits, allowing retries and redeliveries to process messages correctly.
- Handle concurrent BSUID conflicts without dropping other contact attributes or failing message processing.

Enhancements:
- Prevent Redis cleanup failures from masking the original message-processing exception.

CI:
- Add the WhatsApp guard and BSUID regression specs to the staleness-guard CI workflow.

Tests:
- Add coverage for dedup guard cleanup on success, missing contacts, exceptions, active processing, and Redis failures, plus concurrent BSUID updates.