### PR TITLE
fix(hub): achados do code review do CRM-318

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,6 +157,12 @@ FACEBOOK_API_VERSION=v23.0
 # WP_APP_SECRET=
 # WP_WHATSAPP_CONFIG_ID=
 # WP_API_VERSION=v23.0
+# Evolution Hub
+# The Hub is a single central service; per-install config is the tenant API key
+# (EVOLUTION_HUB_API_KEY, in installation_configs). These two only exist so the
+# integration can be pointed at a local Hub instead of the production one.
+# EVOLUTION_HUB_API_URL=http://evolution-hub-backend:8086
+# EVOLUTION_HUB_FRONTEND_URL=http://localhost:8050
 # Twitter
 # documentation: https://www.chatwoot.com/docs/twitter-app-setup
 TWITTER_APP_ID=

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -173,6 +173,16 @@ on:
       - 'app/controllers/webhooks/instagram_controller.rb'
       - 'config/initializers/facebook_messenger.rb'
       - 'spec/requests/webhooks/meta_token_verify_spec.rb'
+      # CRM-318: the screen that opened the Hub tab only leaves "Aguardando" because
+      # the two lifecycle handlers announce the transition and the listener puts it on
+      # the wire. Dropping any of the three is silent everywhere else — the channel
+      # still connects, only nobody tells the operator.
+      - 'app/services/evolution_hub/**'
+      - 'app/listeners/concerns/hub_channel_connection_events.rb'
+      - 'lib/meta_base_url.rb'
+      - 'spec/services/evolution_hub/**'
+      - 'spec/listeners/action_cable_listener_hub_channel_spec.rb'
+      - 'spec/lib/meta_base_url_spec.rb'
 
 permissions:
   contents: read
@@ -281,4 +291,7 @@ jobs:
             spec/requests/api/v1/products_validation_spec.rb \
             spec/requests/api/v1/inboxes_set_agent_bot_spec.rb \
             spec/requests/webhooks/meta_token_verify_spec.rb \
+            spec/services/evolution_hub/ \
+            spec/listeners/action_cable_listener_hub_channel_spec.rb \
+            spec/lib/meta_base_url_spec.rb \
             --format progress

--- a/app/listeners/concerns/hub_channel_connection_events.rb
+++ b/app/listeners/concerns/hub_channel_connection_events.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
-# Transicao de conexao de um canal Meta intermediado pelo Evo Hub, empurrada
-# para a tela do operador que ficou esperando o retorno da aba do Hub.
+# Pushes a Hub-relayed Meta channel connection change to the screen waiting on
+# the Hub tab to come back.
 #
-# Vive num concern proprio e nao no corpo do ActionCableListener porque aquela
-# classe ja estava no teto do Metrics/ClassLength: somar um metodo la obrigaria
-# a afrouxar o cop para todo mundo.
+# Lives in a concern rather than in ActionCableListener's body because that
+# class already sits at the Metrics/ClassLength ceiling.
 module HubChannelConnectionEvents
   include Events::Types
 
-  # Vai para todos os usuarios, e nao so para quem clicou: o cadastro pode ser
-  # retomado de outra aba ou por outro operador, e o estado e do canal.
+  # Goes to every user, not just whoever clicked: the signup can be resumed from
+  # another tab or by another operator, and the state belongs to the channel.
   def hub_channel_connection_changed(event)
     inbox = event.data[:inbox]
     return if inbox.blank?
@@ -21,7 +20,7 @@ module HubChannelConnectionEvents
       connection_status: event.data[:connection_status]
     }
 
-    # Instalacao single-tenant: Inbox nao expoe `account`.
+    # Single-tenant install: Inbox does not expose `account`.
     broadcast(single_tenant_account, User.pluck(:pubsub_token).compact.uniq,
               HUB_CHANNEL_CONNECTION_CHANGED, payload)
   end

--- a/app/services/evolution_hub/connection_broadcast.rb
+++ b/app/services/evolution_hub/connection_broadcast.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 
-# Anuncia para a tela a mudanca de estado de conexao de um canal Meta
-# intermediado pelo Hub. Compartilhado pelos handlers de `channel_connected` e
-# `channel_disconnected`, que sao simetricos: manter uma copia em cada um
-# convidava a divergencia entre os dois sentidos.
-#
-# Sem este empurrao, a tela que abriu a aba do Hub so descobre a conexao num
-# refresh manual — a dor que originou o card.
-#
-# Falha aqui NAO desfaz a persistencia: o canal ja mudou de estado de fato, e
-# nao avisar a tela e menos grave do que estourar e reprocessar o webhook.
+# Announces a Hub-relayed Meta channel connection change to the operator's
+# screen. Shared by the channel_connected/channel_disconnected handlers so the
+# two directions cannot drift apart.
 module EvolutionHub
   module ConnectionBroadcast
     CONNECTED = 'connected'
@@ -17,6 +10,8 @@ module EvolutionHub
 
     private
 
+    # A failed announcement must not undo the persistence: the channel already
+    # changed state, and not telling the screen beats reprocessing the webhook.
     def broadcast_connection_change(channel, status)
       inbox = channel.inbox
       return if inbox.blank?
@@ -25,12 +20,11 @@ module EvolutionHub
         Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
         Time.zone.now,
         inbox: inbox,
-        channel: channel,
         connection_status: status
       )
     rescue StandardError => e
       Rails.logger.error(
-        "EvolutionHub: falha ao anunciar #{status} do canal #{channel.id}: #{e.class}: #{e.message}"
+        "EvolutionHub: failed to announce #{status} for channel #{channel.id}: #{e.class}: #{e.message}"
       )
     end
   end

--- a/lib/events/types.rb
+++ b/lib/events/types.rb
@@ -51,11 +51,8 @@ module Events::Types
   INBOX_CREATED = 'inbox.created'
   INBOX_UPDATED = 'inbox.updated'
 
-  # Estado da conexao de um canal Meta intermediado pelo Evo Hub. Evento
-  # proprio, e nao INBOX_UPDATED, porque aquele fica atras de
-  # ENV['ENABLE_INBOX_EVENTS'] e dispara em QUALQUER atualizacao de inbox:
-  # ligar o global para empurrar esta transicao especifica transformaria um
-  # aviso pontual em broadcast de tudo.
+  # Its own event rather than INBOX_UPDATED, which sits behind
+  # ENV['ENABLE_INBOX_EVENTS'] and fires on ANY inbox update.
   HUB_CHANNEL_CONNECTION_CHANGED = 'hub_channel.connection_changed'
 
   # notification events

--- a/lib/meta_base_url.rb
+++ b/lib/meta_base_url.rb
@@ -19,6 +19,16 @@ module MetaBaseUrl
   # :facebook so the URL is consistent with how Meta themselves namespace it.
   KINDS = %i[whatsapp facebook instagram].freeze
 
+  # The Hub is a single Evolution Foundation service: every self-hosted CRM
+  # talks to the central one, and what changes per install is the tenant API key
+  # (EVOLUTION_HUB_API_KEY in GlobalConfigService). The ENV overrides below only
+  # exist so the integration can be exercised against a local Hub.
+  #
+  # Declared on the module, not inside `class << self`, so they are reachable as
+  # MetaBaseUrl::HUB_API_URL the way META_API_VERSION and KINDS are.
+  HUB_API_URL = 'https://api.evohub.ai'
+  HUB_FRONTEND_URL = 'https://app.evohub.evolutionfoundation.com.br'
+
   class << self
     # Returns the base URL prefix.
     #
@@ -51,21 +61,8 @@ module MetaBaseUrl
       ActiveModel::Type::Boolean.new.cast(flag) && IntegrationRequirements.configured?('evolution_hub')
     end
 
-    # Hub URLs são FIXAS — o Hub é um serviço único da Evolution Foundation,
-    # não muda por instalação do CRM. Cada CRM open-source self-hosted bate
-    # nesse Hub central; o que muda por instalação é só a API key do tenant
-    # (EVOLUTION_HUB_API_KEY no GlobalConfigService).
-
-    HUB_API_URL = 'https://api.evohub.ai'
-    HUB_FRONTEND_URL = 'https://app.evohub.evolutionfoundation.com.br'
-
-    # Override para desenvolvimento e teste. O Hub central continua sendo o
-    # default; sem um override nao havia como exercitar a integracao sem bater
-    # no Hub de producao — nem o backend (chamadas de API) nem o frontend (o
-    # public_link que o operador abre no browser).
-    #
-    # Precedencia: ENV primeiro, para que o ambiente local nao dependa de uma
-    # linha no banco, e valor em branco cai no default.
+    # ENV takes precedence over the DB so a local environment needs no row in
+    # installation_configs; a blank value falls back to the central Hub.
     def hub_url
       ENV['EVOLUTION_HUB_API_URL'].presence || HUB_API_URL
     end

--- a/spec/services/evolution_hub/channel_connected_handler_spec.rb
+++ b/spec/services/evolution_hub/channel_connected_handler_spec.rb
@@ -138,4 +138,35 @@ RSpec.describe EvolutionHub::ChannelConnectedHandler do
       end.not_to have_enqueued_job(Channels::Whatsapp::TemplatesSyncJob)
     end
   end
+
+  # The announcement is the whole point of the feature: without an example here,
+  # dropping the broadcast_connection_change call leaves the suite green.
+  describe '#perform — announces the transition' do
+    let(:inbox) { instance_double(Inbox, id: 77, channel_type: 'Channel::Whatsapp', blank?: false) }
+    let(:dispatcher) { instance_double(Dispatcher, dispatch: true) }
+
+    before do
+      allow(channel).to receive(:inbox).and_return(inbox)
+      allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher)
+    end
+
+    it 'dispatches the connection change with the inbox and the connected state' do
+      described_class.new(payload).perform
+
+      expect(dispatcher).to have_received(:dispatch).with(
+        Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+        kind_of(ActiveSupport::TimeWithZone),
+        hash_including(inbox: inbox, connection_status: 'connected')
+      )
+    end
+
+    it 'does not dispatch when no local channel matches the payload' do
+      allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(nil)
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.new(payload).perform
+
+      expect(dispatcher).not_to have_received(:dispatch)
+    end
+  end
 end

--- a/spec/services/evolution_hub/channel_disconnected_handler_spec.rb
+++ b/spec/services/evolution_hub/channel_disconnected_handler_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EvolutionHub::ChannelDisconnectedHandler do
+  let(:channel_uuid) { SecureRandom.uuid }
+  let(:inbox) { instance_double(Inbox, id: 77, channel_type: 'Channel::Whatsapp', blank?: false) }
+  let(:dispatcher) { instance_double(Dispatcher, dispatch: true) }
+
+  let(:channel) do
+    ch = Channel::Whatsapp.new(phone_number: "+5511#{rand(10**9)}", provider: 'whatsapp_cloud')
+    ch.id = channel_uuid
+    ch.provider_config = { 'evolution_hub' => { 'channel_id' => 'hub-ch-abc', 'status' => 'active' } }
+    allow(ch).to receive_messages(new_record?: false, persisted?: true, inbox: inbox)
+    allow(ch).to receive(:update!) do |attrs|
+      ch.provider_config = attrs[:provider_config] if attrs.key?(:provider_config)
+      true
+    end
+    ch
+  end
+
+  let(:payload) { { 'external_id' => channel_uuid, 'channel_id' => 'hub-ch-abc' } }
+
+  before do
+    allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(channel)
+    allow(Channel::FacebookPage).to receive(:find_by).and_return(nil)
+    allow(Channel::Instagram).to receive(:find_by).and_return(nil)
+    allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  it 'flips the hub status to inactive and announces the disconnection' do
+    described_class.new(payload).perform
+
+    expect(channel.provider_config.dig('evolution_hub', 'status')).to eq('inactive')
+    expect(dispatcher).to have_received(:dispatch).with(
+      Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
+      kind_of(ActiveSupport::TimeWithZone),
+      hash_including(inbox: inbox, connection_status: 'disconnected')
+    )
+  end
+
+  it 'does not announce when no local channel matches the payload' do
+    allow(Channel::Whatsapp).to receive(:find_by).with(id: channel_uuid).and_return(nil)
+    allow(Rails.logger).to receive(:warn)
+
+    described_class.new(payload).perform
+
+    expect(dispatcher).not_to have_received(:dispatch)
+  end
+
+  # Persistence already happened; failing to tell the screen must not make the
+  # Hub replay the webhook.
+  it 'keeps the channel inactive when the announcement blows up' do
+    allow(dispatcher).to receive(:dispatch).and_raise(StandardError, 'cable down')
+    allow(Rails.logger).to receive(:error)
+
+    expect { described_class.new(payload).perform }.not_to raise_error
+    expect(channel.provider_config.dig('evolution_hub', 'status')).to eq('inactive')
+  end
+end

--- a/spec/services/evolution_hub/connection_broadcast_spec.rb
+++ b/spec/services/evolution_hub/connection_broadcast_spec.rb
@@ -2,10 +2,8 @@
 
 require 'rails_helper'
 
-# A tela que abriu a aba do Hub so descobria a conexao num refresh manual. Os
-# handlers passam a anunciar a transicao; estes exemplos prendem o contrato do
-# anuncio nos dois sentidos e a garantia de que uma falha no anuncio nao desfaz
-# a persistencia do canal.
+# Pins the announcement contract in both directions, plus the guarantee that a
+# failed announcement does not undo the channel persistence.
 RSpec.describe EvolutionHub::ConnectionBroadcast do
   let(:inbox) { instance_double(Inbox, id: 'inbox-1', blank?: false) }
   let(:channel) { instance_double(Channel::Whatsapp, id: 'chan-1', inbox: inbox) }
@@ -20,13 +18,13 @@ RSpec.describe EvolutionHub::ConnectionBroadcast do
 
   before { allow(Rails.configuration).to receive(:dispatcher).and_return(dispatcher) }
 
-  it 'anuncia a conexao com a inbox, o canal e o estado' do
+  it 'anuncia a conexao com a inbox e o estado' do
     host.announce(channel, described_class::CONNECTED)
 
     expect(dispatcher).to have_received(:dispatch).with(
       Events::Types::HUB_CHANNEL_CONNECTION_CHANGED,
       kind_of(ActiveSupport::TimeWithZone),
-      hash_including(inbox: inbox, channel: channel, connection_status: 'connected')
+      hash_including(inbox: inbox, connection_status: 'connected')
     )
   end
 


### PR DESCRIPTION
Correções dos achados do code review do **CRM-318**. Alvo é o branch do card (`danilocarneiro/crm-313-demo-live-frente1`), não a `develop` — o PR original (#307) segue como está e este entra por baixo.

O achado crítico do review é do lado do frontend (o `actionCableService` lia o payload da chave errada do frame do ActionCable, e a tela nunca saía de "Aguardando"); está no PR par, `evo-ai-frontend-community#XXX`.

## O que muda aqui

**Dois exemplos de `meta_base_url_spec.rb` falhavam.** `HUB_API_URL`/`HUB_FRONTEND_URL` estavam dentro do `class << self`, então pertenciam à singleton class e `MetaBaseUrl::HUB_API_URL` levantava `uninitialized constant`. Passam para o corpo do módulo, onde `META_API_VERSION` e `KINDS` já moravam. O comando de "Como validar" do #307 omite esse arquivo, então o spec do segundo commit não chegou a rodar.

**Nada cobria os handlers.** O spec do módulo exercitava uma classe anônima; apagar `broadcast_connection_change` de `ChannelConnectedHandler` ou de `ChannelDisconnectedHandler` deixava a suíte inteira verde. Dois exemplos no handler de conexão e um spec novo para o de desconexão.

**Os specs novos não rodavam em CI.** O `spec-staleness-guard.yml` é allowlist dupla (`paths:` + lista fixa do `run:`) e `evolution_hub` não aparecia em nenhuma das duas. O guard disparava pelo `action_cable_listener.rb`, mas rodava só a lista fixa — e não há lane geral de rspec no repo.

**Comentário obsoleto e payload morto.** O bloco acima das constantes dizia que as URLs do Hub são FIXAS, o oposto do que o código passou a fazer; as duas ENVs novas não estavam documentadas em lugar nenhum. E o dispatch mandava `channel:` junto, que nenhum listener lê — como o `Dispatcher` fan-outa para o sync e para o async, era um round-trip de GlobalID por transição à toa. Comentários novos traduzidos para inglês e encurtados, conforme o CLAUDE.md.

## Como validar

```
bundle exec rspec spec/services/evolution_hub/ spec/listeners/action_cable_listener_hub_channel_spec.rb spec/lib/meta_base_url_spec.rb
```

**19 exemplos, 0 falhas** (antes: 14 exemplos, 2 falhas). Teste de mutação: apagando a chamada de broadcast em cada handler, os dois exemplos novos ficam vermelhos.

`spec/listeners/` inteiro: 185 exemplos com as mesmas 8 falhas pré-existentes de mascaramento de PII e evo_flow, intocadas. Rubocop com 0 ofensas novas, conferido ofensa a ofensa contra a `develop`.

## Fora de escopo

Não encostei nos guards do critério 4 (`hubAllowExistingChannels`, o 403 `HUB_EXISTING_CHANNELS_DISABLED`) nem no modo "vincular canal existente".

Registro de uma coisa que apareceu no caminho e não é deste card: o `_inbox.json.jbuilder` expõe `evolution_hub_meta` inteiro para Facebook e Instagram, e esse hash carrega o `channel_token` do Hub. É pré-existente.

## Summary by Sourcery

Harden Evolution Hub channel lifecycle notifications and ensure their specs run in CI.

Bug Fixes:
- Ensure Hub connection and disconnection handlers notify the operator interface of channel state changes.
- Correct Hub URL constant visibility so MetaBaseUrl defaults can be referenced and tested reliably.
- Remove unused channel data from Hub connection-change events.

Enhancements:
- Add focused coverage for connection and disconnection handler behavior, including missing channels and broadcast failures.
- Document Hub URL overrides and clarify the connection-change event behavior.

CI:
- Include Evolution Hub and MetaBaseUrl specs in the staleness guard allowlist and CI test command.

Tests:
- Expand Evolution Hub specs to cover both lifecycle transitions and persistence behavior when announcements fail.