### PR TITLE
fix(whatsapp): achados do code review do CRM-285

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -176,8 +176,10 @@ on:
       # CRM-285: the WhatsApp dedup guard is written to Redis before the message is
       # processed, so releasing it anywhere but an `ensure` pins the key for a full
       # day - the Sidekiq retry and every Meta re-delivery then bounce off it and
-      # drop the message with no log at all. Nothing else in CI exercises the release.
+      # drop the message with no log at all. The release also has to stay non-raising,
+      # or it replaces the exception it was cleaning up after. No other lane runs it.
       - 'app/services/whatsapp/incoming_message_base_service.rb'
+      - 'app/services/whatsapp/incoming_message_service_helpers.rb'
       - 'app/services/whatsapp/evolution_handlers/messages_upsert.rb'
       - 'spec/services/whatsapp/incoming_message_base_service_spec.rb'
       - 'spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb'

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -147,13 +147,17 @@ class Whatsapp::IncomingMessageBaseService
     attrs[:bsuid] = bsuid if bsuid.present? && contact_inbox.bsuid != bsuid
     attrs[:whatsapp_username] = username if username.present? && contact_inbox.whatsapp_username != username
     contact_inbox.update!(attrs) if attrs.present?
-  rescue ActiveRecord::RecordNotUnique => e
-    # A concurrent webhook for the same new contact won the race for
-    # index_contact_inboxes_on_inbox_id_and_bsuid and already stored this bsuid.
+  rescue ActiveRecord::RecordNotUnique
+    # Another contact_inbox on this inbox owns the bsuid and keeps owning it (the same
+    # person reached us twice, once by phone JID and once by LID). Drop it from the
+    # write so the remaining attributes still land instead of being lost with it.
+    contact_inbox.restore_attributes
     Rails.logger.warn(
       "WhatsApp: bsuid=#{bsuid} already claimed by another contact_inbox - " \
-      "skipping duplicate update on contact_inbox=#{contact_inbox.id}: #{e.message}"
+      "keeping contact_inbox=#{contact_inbox.id} without it"
     )
+    remaining = attrs.except(:bsuid)
+    contact_inbox.update!(remaining) if remaining.present?
   end
 
   def set_conversation

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -149,6 +149,10 @@ module Whatsapp::IncomingMessageServiceHelpers
 
     key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: message_id)
     ::Redis::Alfred.delete(key)
+  rescue StandardError => e
+    # Callers release the guard from an `ensure`, where a raise here would replace the
+    # exception already propagating and hide why the message failed in the first place.
+    Rails.logger.error "Whatsapp: failed to clear the dedup guard for #{message_id}: #{e.message}"
   end
 
   private

--- a/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
+++ b/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
@@ -12,46 +12,80 @@ end
 
 return unless defined?(Rails)
 
-# Same dedup guard as the Cloud API service, same leak: released on the last
-# line of the happy path, so a raise anywhere before it pins the Redis key for
-# its full one-day TTL and every retry of that message is discarded silently.
+# Same dedup guard as the Cloud API service, and it used to leak the same way:
+# released on the last line of the happy path, so a raise before it pinned the
+# Redis key for its full one-day TTL and every retry was discarded silently.
 RSpec.describe Whatsapp::EvolutionHandlers::MessagesUpsert do
-  # The real service is the host: the upsert module leans on set_conversation,
-  # which lives up in the base service, not in the module itself.
-  let(:host_class) { Class.new(Whatsapp::IncomingMessageEvolutionService) }
+  let(:guard_key) { format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: 'evo.race') }
+  let(:fake_alfred) { {} }
   let(:inbox) { instance_double(Inbox) }
-  let(:host) { host_class.new(inbox: inbox, params: {}) }
+  let(:params) { { event: 'messages.upsert', data: { key: { id: 'evo.race' } } } }
+  # The module leans on set_conversation, which lives up in the base service, so the
+  # real Evolution service is the host that exercises it.
+  let(:host) { Whatsapp::IncomingMessageEvolutionService.new(inbox: inbox, params: params) }
 
   before do
+    # In-memory Alfred (repo convention) so the real cache/clear helpers run and
+    # the assertions are about the key itself, not about the call site.
+    allow(Redis::Alfred).to receive(:setex) { |key, value, _expiry = nil| fake_alfred[key] = value }
+    allow(Redis::Alfred).to receive(:get) { |key| fake_alfred[key] }
+    allow(Redis::Alfred).to receive(:delete) { |key| fake_alfred.delete(key) }
+
+    # evolution_api? reads @processed_params directly, and #perform is what memoizes
+    # it - handle_message is driven here without going through #perform.
+    host.send(:processed_params)
     allow(host).to receive(:message_type).and_return('text')
     allow(host).to receive(:message_processable?).and_return(true)
     allow(host).to receive(:raw_message_id).and_return('evo.race')
-    allow(host).to receive(:cache_message_source_id_in_redis)
   end
 
   describe '#handle_message dedup guard release' do
     it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
-      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(host).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        raise ActiveRecord::RecordNotUnique, 'duplicate key'
+      end
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect(fake_alfred).to be_empty
     end
 
     it 'releases the guard when the payload carries no usable contact' do
       allow(host).to receive(:set_contact)
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       host.send(:handle_message)
+      expect(fake_alfred).to be_empty
     end
 
     it 'still releases the guard on the happy path' do
-      allow(host).to receive(:set_contact) { host.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(host).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        host.instance_variable_set(:@contact, instance_double(Contact))
+      end
       allow(host).to receive(:set_conversation)
       allow(host).to receive(:update_conversation_status_if_needed)
       allow(host).to receive(:handle_create_message)
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       host.send(:handle_message)
+      expect(fake_alfred).to be_empty
+    end
+
+    # The `ensure` must not reach the early returns above it: they exist because
+    # another worker holds the guard, and clearing it there would undo the dedup.
+    it 'leaves the guard alone when another worker is already processing the message' do
+      allow(host).to receive(:message_processable?).and_return(false)
+      fake_alfred[guard_key] = 'true'
+
+      expect(host).not_to receive(:set_contact)
+      host.send(:handle_message)
+      expect(fake_alfred).to include(guard_key)
+    end
+
+    it 'does not let a Redis failure in the ensure mask the exception that killed the message' do
+      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Redis::Alfred).to receive(:delete).and_raise(Redis::CannotConnectError)
+
+      expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 end

--- a/spec/services/whatsapp/incoming_message_base_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_base_service_spec.rb
@@ -100,54 +100,94 @@ RSpec.describe Whatsapp::IncomingMessageBaseService do
     end
   end
 
-  # The dedup guard is written to Redis before processing and released only on
-  # the last line of the happy path. Any raise in between - or a webhook whose
-  # contacts payload is blank - leaves the key pinned for its full one-day TTL,
-  # so the Sidekiq retry and every Meta re-delivery bounce off
-  # `message_under_process?` and drop the message with no log at all.
+  # The guard used to be released on the last line of the happy path, so a raise in
+  # between pinned the Redis key for its full one-day TTL and every retry of that
+  # message was then discarded silently. It now falls in an `ensure`.
   describe '#process_messages dedup guard release' do
+    let(:guard_key) { format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: 'wamid.race') }
+    let(:fake_alfred) { {} }
+
     before do
+      # In-memory Alfred (repo convention) so the real cache/clear helpers run and
+      # the assertions are about the key itself, not about the call site.
+      allow(Redis::Alfred).to receive(:setex) { |key, value, _expiry = nil| fake_alfred[key] = value }
+      allow(Redis::Alfred).to receive(:get) { |key| fake_alfred[key] }
+      allow(Redis::Alfred).to receive(:delete) { |key| fake_alfred.delete(key) }
+
       service.processed_params = { messages: [{ id: 'wamid.race', type: 'text' }] }
       allow(service).to receive(:find_message_by_source_id).and_return(nil)
       allow(service).to receive(:message_under_process?).and_return(false)
-      allow(service).to receive(:cache_message_source_id_in_redis)
     end
 
     it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
-      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(service).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        raise ActiveRecord::RecordNotUnique, 'duplicate key'
+      end
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect(fake_alfred).to be_empty
     end
 
     it 'releases the guard when the webhook carries no usable contact' do
       allow(service).to receive(:set_contact)
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       service.send(:process_messages)
+      expect(fake_alfred).to be_empty
     end
 
     it 'still releases the guard on the happy path' do
-      allow(service).to receive(:set_contact) { service.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(service).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        service.instance_variable_set(:@contact, instance_double(Contact))
+      end
       allow(service).to receive(:set_conversation)
       allow(service).to receive(:create_messages)
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       service.send(:process_messages)
+      expect(fake_alfred).to be_empty
+    end
+
+    # The `ensure` must not reach the early returns above it: they exist because
+    # another worker holds the guard, and clearing it there would undo the dedup.
+    it 'leaves the guard alone when another worker is already processing the message' do
+      allow(service).to receive(:message_under_process?).and_return(true)
+      fake_alfred[guard_key] = 'true'
+
+      expect(service).not_to receive(:set_contact)
+      service.send(:process_messages)
+      expect(fake_alfred).to include(guard_key)
+    end
+
+    it 'does not let a Redis failure in the ensure mask the exception that killed the message' do
+      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Redis::Alfred).to receive(:delete).and_raise(Redis::CannotConnectError)
+
+      expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 
   describe '#update_bsuid_fields' do
     let(:contact_inbox) { instance_double(ContactInbox, id: 7, bsuid: nil, whatsapp_username: nil) }
 
-    # Two concurrent webhooks for the same new contact race for
-    # index_contact_inboxes_on_inbox_id_and_bsuid. The loser has nothing left to
-    # write - the winner already stored the same bsuid - so it logs and moves on.
-    it 'keeps going when a concurrent webhook already claimed the bsuid' do
-      allow(contact_inbox).to receive(:update!).and_raise(
+    before { allow(contact_inbox).to receive(:restore_attributes) }
+
+    # The same person can hold two contact_inboxes on one inbox (phone JID and LID),
+    # so the loser of index_contact_inboxes_on_inbox_id_and_bsuid never gets the bsuid
+    # and would drop every attribute shipped alongside it, on every message.
+    it 'still writes the username when a concurrent webhook already claimed the bsuid' do
+      allow(contact_inbox).to receive(:update!).with(hash_including(bsuid: 'abc123')).and_raise(
         ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: duplicate key value violates unique constraint')
       )
       expect(Rails.logger).to receive(:warn).with(/bsuid=abc123/)
+      expect(contact_inbox).to receive(:update!).with({ whatsapp_username: 'ana' })
+
+      expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', 'ana') }.not_to raise_error
+    end
+
+    it 'gives up quietly when the bsuid was the only thing to write' do
+      allow(contact_inbox).to receive(:update!).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Rails.logger).to receive(:warn)
 
       expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', nil) }.not_to raise_error
     end


### PR DESCRIPTION
Achados do code review da #308. Três Medium e quatro Low, todos fechados.

## M1 — o `ensure` mascarava a exceção real

`clear_message_source_id_from_redis` chama `Redis::Alfred.delete` sem rescue, e roda dentro de um `ensure`. Em Ruby, exceção levantada num `ensure` **substitui** a que estava propagando: com o Redis fora do ar, o job morto no Sidekiq reportaria `Redis::CannotConnectError` no lugar do `RecordNotUnique` que de fato matou a mensagem — justamente a trilha de diagnóstico que este card existe para devolver. Era regressão nova (antes, no caminho de exceção, o `clear` nunca era chamado).

A liberação passa a ser non-raising no próprio helper, o que cobre os dois call sites de uma vez. É a segunda opção sugerida pelo Sourcery, que marcou o mesmo ponto como blocking.

## M2 — o rescue de `RecordNotUnique` levava o `whatsapp_username` junto

`attrs` carrega `:bsuid` **e** `:whatsapp_username` no mesmo `update!`, então a violação do índice abortava os dois e o rescue engolia o conjunto — o username sumia sem log próprio.

E não é transitório como a corrida do `ContactInboxWithContactBuilder` que o comentário citava como paralelo: aquele rescue *se recupera*, este não tinha recuperação. Quando outro `contact_inbox` do mesmo inbox detém o bsuid (a mesma pessoa chegando por phone JID e por LID — alcançável pelos dois ramos do próprio `set_contact`), o perdedor nunca o obtém, `attrs[:bsuid]` é remontado e o `update!` falha **de novo a cada mensagem recebida** daquele contato.

Agora restaura os atributos sujos e regrava o que sobrou sem o bsuid. Saiu também o `e.message` do warn, que despejava o SQL da falha no log a cada mensagem sem acrescentar nada além do `bsuid=` já interpolado.

## M3 — o invariante mais frágil do fix não tinha spec

Nada fixava que os early returns ficam **fora** do `ensure`. Um "simplifica esse begin redundante" futuro vira `ensure` de método, o `return if find_message_by_source_id(...) || message_under_process?` passa a apagar o guard de outro worker, o dedup cai em silêncio e a suíte continua verde. Novo exemplo nos dois arquivos.

## Low

- Os specs afirmavam `expect(...).to receive(:clear_message_source_id_from_redis)`, o que **substitui** a implementação: provavam o call site, não o efeito — e o bug que foi pra produção era literalmente "a chave fica no Redis por 24h". Passam a rodar os helpers reais contra um `Redis::Alfred` em memória (convenção do repo, como em `sendgrid/event_processor_spec.rb`) e afirmam que a chave é gravada durante o processamento e some depois.
- Os comentários descreviam o comportamento **pré-fix no presente** ("released on the last line of the happy path"), o que depois do merge lê como se o vazamento continuasse lá. Reescritos no passado e mais curtos.
- `Class.new(Whatsapp::IncomingMessageEvolutionService)` era subclasse anônima de corpo vazio, cópia do vizinho — lá ela existe para adicionar `attr_writer :processed_params`. Instancia o serviço direto.
- `incoming_message_service_helpers.rb` entra no `spec-staleness-guard`, já que o M1 mora nele.

## Verificação

Cada spec novo foi validado contra a regressão que guarda, revertendo o fix correspondente:

| revertido | falhas |
|---|---|
| M1 (release non-raising) | 2 |
| M2 (regrava sem o bsuid) | 1 |
| M3 (`begin` → `ensure` de método) | 1 |

```
# os dois arquivos do card
18 examples, 0 failures

# a lane inteira do spec-staleness-guard (52 arquivos)
630 examples, 0 failures
```

RuboCop nos 4 arquivos: nenhuma categoria de ofensa nova em relação à #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden WhatsApp message deduplication and contact attribute updates while preserving the original failure context.

Bug Fixes:
- Prevent Redis cleanup failures from masking the original message-processing exception.
- Preserve WhatsApp usernames when bsuid uniqueness conflicts occur by retrying the remaining attribute update.

Enhancements:
- Strengthen WhatsApp deduplication coverage to verify Redis guard lifecycle, early-return behavior, and exception propagation.

CI:
- Add the WhatsApp service helper to the spec staleness guard workflow.

Tests:
- Run deduplication specs against an in-memory Redis store and add regression coverage for Redis failures, concurrent bsuid ownership, and guard preservation.