### PR TITLE
merge: resolve o conflito do spec-staleness-guard contra a develop (CRM-318)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -176,8 +176,10 @@ on:
       # CRM-285: the WhatsApp dedup guard is written to Redis before the message is
       # processed, so releasing it anywhere but an `ensure` pins the key for a full
       # day - the Sidekiq retry and every Meta re-delivery then bounce off it and
-      # drop the message with no log at all. Nothing else in CI exercises the release.
+      # drop the message with no log at all. The release also has to stay non-raising,
+      # or it replaces the exception it was cleaning up after. No other lane runs it.
       - 'app/services/whatsapp/incoming_message_base_service.rb'
+      - 'app/services/whatsapp/incoming_message_service_helpers.rb'
       - 'app/services/whatsapp/evolution_handlers/messages_upsert.rb'
       - 'spec/services/whatsapp/incoming_message_base_service_spec.rb'
       - 'spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -173,6 +173,14 @@ on:
       - 'app/controllers/webhooks/instagram_controller.rb'
       - 'config/initializers/facebook_messenger.rb'
       - 'spec/requests/webhooks/meta_token_verify_spec.rb'
+      # CRM-285: the WhatsApp dedup guard is written to Redis before the message is
+      # processed, so releasing it anywhere but an `ensure` pins the key for a full
+      # day - the Sidekiq retry and every Meta re-delivery then bounce off it and
+      # drop the message with no log at all. Nothing else in CI exercises the release.
+      - 'app/services/whatsapp/incoming_message_base_service.rb'
+      - 'app/services/whatsapp/evolution_handlers/messages_upsert.rb'
+      - 'spec/services/whatsapp/incoming_message_base_service_spec.rb'
+      - 'spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb'
 
 permissions:
   contents: read
@@ -281,4 +289,6 @@ jobs:
             spec/requests/api/v1/products_validation_spec.rb \
             spec/requests/api/v1/inboxes_set_agent_bot_spec.rb \
             spec/requests/webhooks/meta_token_verify_spec.rb \
+            spec/services/whatsapp/incoming_message_base_service_spec.rb \
+            spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb \
             --format progress

--- a/app/services/whatsapp/evolution_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_handlers/messages_upsert.rb
@@ -39,18 +39,21 @@ module Whatsapp::EvolutionHandlers::MessagesUpsert
     Rails.logger.info "Evolution API: Creating new message #{raw_message_id}"
 
     cache_message_source_id_in_redis
-    set_contact
 
-    unless @contact
+    begin
+      set_contact
+
+      unless @contact
+        Rails.logger.warn "Evolution API: Contact not found for message: #{raw_message_id}"
+        return
+      end
+
+      set_conversation
+      update_conversation_status_if_needed
+      handle_create_message
+    ensure
       clear_message_source_id_from_redis
-      Rails.logger.warn "Evolution API: Contact not found for message: #{raw_message_id}"
-      return
     end
-
-    set_conversation
-    update_conversation_status_if_needed
-    handle_create_message
-    clear_message_source_id_from_redis
   end
 
   # A revoke arrives as a protocolMessage; mark the original as revoked-by-contact

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -29,12 +29,16 @@ class Whatsapp::IncomingMessageBaseService
     return if find_message_by_source_id(@processed_params[:messages].first[:id]) || message_under_process?
 
     cache_message_source_id_in_redis
-    set_contact
-    return unless @contact
 
-    set_conversation
-    create_messages
-    clear_message_source_id_from_redis
+    begin
+      set_contact
+      return unless @contact
+
+      set_conversation
+      create_messages
+    ensure
+      clear_message_source_id_from_redis
+    end
   end
 
   def process_statuses
@@ -143,6 +147,13 @@ class Whatsapp::IncomingMessageBaseService
     attrs[:bsuid] = bsuid if bsuid.present? && contact_inbox.bsuid != bsuid
     attrs[:whatsapp_username] = username if username.present? && contact_inbox.whatsapp_username != username
     contact_inbox.update!(attrs) if attrs.present?
+  rescue ActiveRecord::RecordNotUnique => e
+    # A concurrent webhook for the same new contact won the race for
+    # index_contact_inboxes_on_inbox_id_and_bsuid and already stored this bsuid.
+    Rails.logger.warn(
+      "WhatsApp: bsuid=#{bsuid} already claimed by another contact_inbox - " \
+      "skipping duplicate update on contact_inbox=#{contact_inbox.id}: #{e.message}"
+    )
   end
 
   def set_conversation

--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -147,13 +147,17 @@ class Whatsapp::IncomingMessageBaseService
     attrs[:bsuid] = bsuid if bsuid.present? && contact_inbox.bsuid != bsuid
     attrs[:whatsapp_username] = username if username.present? && contact_inbox.whatsapp_username != username
     contact_inbox.update!(attrs) if attrs.present?
-  rescue ActiveRecord::RecordNotUnique => e
-    # A concurrent webhook for the same new contact won the race for
-    # index_contact_inboxes_on_inbox_id_and_bsuid and already stored this bsuid.
+  rescue ActiveRecord::RecordNotUnique
+    # Another contact_inbox on this inbox owns the bsuid and keeps owning it (the same
+    # person reached us twice, once by phone JID and once by LID). Drop it from the
+    # write so the remaining attributes still land instead of being lost with it.
+    contact_inbox.restore_attributes
     Rails.logger.warn(
       "WhatsApp: bsuid=#{bsuid} already claimed by another contact_inbox - " \
-      "skipping duplicate update on contact_inbox=#{contact_inbox.id}: #{e.message}"
+      "keeping contact_inbox=#{contact_inbox.id} without it"
     )
+    remaining = attrs.except(:bsuid)
+    contact_inbox.update!(remaining) if remaining.present?
   end
 
   def set_conversation

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -149,6 +149,10 @@ module Whatsapp::IncomingMessageServiceHelpers
 
     key = format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: message_id)
     ::Redis::Alfred.delete(key)
+  rescue StandardError => e
+    # Callers release the guard from an `ensure`, where a raise here would replace the
+    # exception already propagating and hide why the message failed in the first place.
+    Rails.logger.error "Whatsapp: failed to clear the dedup guard for #{message_id}: #{e.message}"
   end
 
   private

--- a/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
+++ b/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
@@ -12,46 +12,80 @@ end
 
 return unless defined?(Rails)
 
-# Same dedup guard as the Cloud API service, same leak: released on the last
-# line of the happy path, so a raise anywhere before it pins the Redis key for
-# its full one-day TTL and every retry of that message is discarded silently.
+# Same dedup guard as the Cloud API service, and it used to leak the same way:
+# released on the last line of the happy path, so a raise before it pinned the
+# Redis key for its full one-day TTL and every retry was discarded silently.
 RSpec.describe Whatsapp::EvolutionHandlers::MessagesUpsert do
-  # The real service is the host: the upsert module leans on set_conversation,
-  # which lives up in the base service, not in the module itself.
-  let(:host_class) { Class.new(Whatsapp::IncomingMessageEvolutionService) }
+  let(:guard_key) { format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: 'evo.race') }
+  let(:fake_alfred) { {} }
   let(:inbox) { instance_double(Inbox) }
-  let(:host) { host_class.new(inbox: inbox, params: {}) }
+  let(:params) { { event: 'messages.upsert', data: { key: { id: 'evo.race' } } } }
+  # The module leans on set_conversation, which lives up in the base service, so the
+  # real Evolution service is the host that exercises it.
+  let(:host) { Whatsapp::IncomingMessageEvolutionService.new(inbox: inbox, params: params) }
 
   before do
+    # In-memory Alfred (repo convention) so the real cache/clear helpers run and
+    # the assertions are about the key itself, not about the call site.
+    allow(Redis::Alfred).to receive(:setex) { |key, value, _expiry = nil| fake_alfred[key] = value }
+    allow(Redis::Alfred).to receive(:get) { |key| fake_alfred[key] }
+    allow(Redis::Alfred).to receive(:delete) { |key| fake_alfred.delete(key) }
+
+    # evolution_api? reads @processed_params directly, and #perform is what memoizes
+    # it - handle_message is driven here without going through #perform.
+    host.send(:processed_params)
     allow(host).to receive(:message_type).and_return('text')
     allow(host).to receive(:message_processable?).and_return(true)
     allow(host).to receive(:raw_message_id).and_return('evo.race')
-    allow(host).to receive(:cache_message_source_id_in_redis)
   end
 
   describe '#handle_message dedup guard release' do
     it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
-      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(host).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        raise ActiveRecord::RecordNotUnique, 'duplicate key'
+      end
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect(fake_alfred).to be_empty
     end
 
     it 'releases the guard when the payload carries no usable contact' do
       allow(host).to receive(:set_contact)
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       host.send(:handle_message)
+      expect(fake_alfred).to be_empty
     end
 
     it 'still releases the guard on the happy path' do
-      allow(host).to receive(:set_contact) { host.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(host).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        host.instance_variable_set(:@contact, instance_double(Contact))
+      end
       allow(host).to receive(:set_conversation)
       allow(host).to receive(:update_conversation_status_if_needed)
       allow(host).to receive(:handle_create_message)
 
-      expect(host).to receive(:clear_message_source_id_from_redis)
       host.send(:handle_message)
+      expect(fake_alfred).to be_empty
+    end
+
+    # The `ensure` must not reach the early returns above it: they exist because
+    # another worker holds the guard, and clearing it there would undo the dedup.
+    it 'leaves the guard alone when another worker is already processing the message' do
+      allow(host).to receive(:message_processable?).and_return(false)
+      fake_alfred[guard_key] = 'true'
+
+      expect(host).not_to receive(:set_contact)
+      host.send(:handle_message)
+      expect(fake_alfred).to include(guard_key)
+    end
+
+    it 'does not let a Redis failure in the ensure mask the exception that killed the message' do
+      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Redis::Alfred).to receive(:delete).and_raise(Redis::CannotConnectError)
+
+      expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 end

--- a/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
+++ b/spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+begin
+  require 'rails_helper'
+rescue LoadError
+  RSpec.describe 'Whatsapp::EvolutionHandlers::MessagesUpsert' do
+    it 'has spec scaffold ready' do
+      skip 'rails_helper is not available in this workspace snapshot'
+    end
+  end
+end
+
+return unless defined?(Rails)
+
+# Same dedup guard as the Cloud API service, same leak: released on the last
+# line of the happy path, so a raise anywhere before it pins the Redis key for
+# its full one-day TTL and every retry of that message is discarded silently.
+RSpec.describe Whatsapp::EvolutionHandlers::MessagesUpsert do
+  # The real service is the host: the upsert module leans on set_conversation,
+  # which lives up in the base service, not in the module itself.
+  let(:host_class) { Class.new(Whatsapp::IncomingMessageEvolutionService) }
+  let(:inbox) { instance_double(Inbox) }
+  let(:host) { host_class.new(inbox: inbox, params: {}) }
+
+  before do
+    allow(host).to receive(:message_type).and_return('text')
+    allow(host).to receive(:message_processable?).and_return(true)
+    allow(host).to receive(:raw_message_id).and_return('evo.race')
+    allow(host).to receive(:cache_message_source_id_in_redis)
+  end
+
+  describe '#handle_message dedup guard release' do
+    it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
+      allow(host).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+
+      expect(host).to receive(:clear_message_source_id_from_redis)
+      expect { host.send(:handle_message) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'releases the guard when the payload carries no usable contact' do
+      allow(host).to receive(:set_contact)
+
+      expect(host).to receive(:clear_message_source_id_from_redis)
+      host.send(:handle_message)
+    end
+
+    it 'still releases the guard on the happy path' do
+      allow(host).to receive(:set_contact) { host.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(host).to receive(:set_conversation)
+      allow(host).to receive(:update_conversation_status_if_needed)
+      allow(host).to receive(:handle_create_message)
+
+      expect(host).to receive(:clear_message_source_id_from_redis)
+      host.send(:handle_message)
+    end
+  end
+end

--- a/spec/services/whatsapp/incoming_message_base_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_base_service_spec.rb
@@ -100,54 +100,94 @@ RSpec.describe Whatsapp::IncomingMessageBaseService do
     end
   end
 
-  # The dedup guard is written to Redis before processing and released only on
-  # the last line of the happy path. Any raise in between - or a webhook whose
-  # contacts payload is blank - leaves the key pinned for its full one-day TTL,
-  # so the Sidekiq retry and every Meta re-delivery bounce off
-  # `message_under_process?` and drop the message with no log at all.
+  # The guard used to be released on the last line of the happy path, so a raise in
+  # between pinned the Redis key for its full one-day TTL and every retry of that
+  # message was then discarded silently. It now falls in an `ensure`.
   describe '#process_messages dedup guard release' do
+    let(:guard_key) { format(Redis::RedisKeys::MESSAGE_SOURCE_KEY, id: 'wamid.race') }
+    let(:fake_alfred) { {} }
+
     before do
+      # In-memory Alfred (repo convention) so the real cache/clear helpers run and
+      # the assertions are about the key itself, not about the call site.
+      allow(Redis::Alfred).to receive(:setex) { |key, value, _expiry = nil| fake_alfred[key] = value }
+      allow(Redis::Alfred).to receive(:get) { |key| fake_alfred[key] }
+      allow(Redis::Alfred).to receive(:delete) { |key| fake_alfred.delete(key) }
+
       service.processed_params = { messages: [{ id: 'wamid.race', type: 'text' }] }
       allow(service).to receive(:find_message_by_source_id).and_return(nil)
       allow(service).to receive(:message_under_process?).and_return(false)
-      allow(service).to receive(:cache_message_source_id_in_redis)
     end
 
     it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
-      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(service).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        raise ActiveRecord::RecordNotUnique, 'duplicate key'
+      end
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect(fake_alfred).to be_empty
     end
 
     it 'releases the guard when the webhook carries no usable contact' do
       allow(service).to receive(:set_contact)
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       service.send(:process_messages)
+      expect(fake_alfred).to be_empty
     end
 
     it 'still releases the guard on the happy path' do
-      allow(service).to receive(:set_contact) { service.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(service).to receive(:set_contact) do
+        expect(fake_alfred).to include(guard_key)
+        service.instance_variable_set(:@contact, instance_double(Contact))
+      end
       allow(service).to receive(:set_conversation)
       allow(service).to receive(:create_messages)
 
-      expect(service).to receive(:clear_message_source_id_from_redis)
       service.send(:process_messages)
+      expect(fake_alfred).to be_empty
+    end
+
+    # The `ensure` must not reach the early returns above it: they exist because
+    # another worker holds the guard, and clearing it there would undo the dedup.
+    it 'leaves the guard alone when another worker is already processing the message' do
+      allow(service).to receive(:message_under_process?).and_return(true)
+      fake_alfred[guard_key] = 'true'
+
+      expect(service).not_to receive(:set_contact)
+      service.send(:process_messages)
+      expect(fake_alfred).to include(guard_key)
+    end
+
+    it 'does not let a Redis failure in the ensure mask the exception that killed the message' do
+      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Redis::Alfred).to receive(:delete).and_raise(Redis::CannotConnectError)
+
+      expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 
   describe '#update_bsuid_fields' do
     let(:contact_inbox) { instance_double(ContactInbox, id: 7, bsuid: nil, whatsapp_username: nil) }
 
-    # Two concurrent webhooks for the same new contact race for
-    # index_contact_inboxes_on_inbox_id_and_bsuid. The loser has nothing left to
-    # write - the winner already stored the same bsuid - so it logs and moves on.
-    it 'keeps going when a concurrent webhook already claimed the bsuid' do
-      allow(contact_inbox).to receive(:update!).and_raise(
+    before { allow(contact_inbox).to receive(:restore_attributes) }
+
+    # The same person can hold two contact_inboxes on one inbox (phone JID and LID),
+    # so the loser of index_contact_inboxes_on_inbox_id_and_bsuid never gets the bsuid
+    # and would drop every attribute shipped alongside it, on every message.
+    it 'still writes the username when a concurrent webhook already claimed the bsuid' do
+      allow(contact_inbox).to receive(:update!).with(hash_including(bsuid: 'abc123')).and_raise(
         ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: duplicate key value violates unique constraint')
       )
       expect(Rails.logger).to receive(:warn).with(/bsuid=abc123/)
+      expect(contact_inbox).to receive(:update!).with({ whatsapp_username: 'ana' })
+
+      expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', 'ana') }.not_to raise_error
+    end
+
+    it 'gives up quietly when the bsuid was the only thing to write' do
+      allow(contact_inbox).to receive(:update!).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+      allow(Rails.logger).to receive(:warn)
 
       expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', nil) }.not_to raise_error
     end

--- a/spec/services/whatsapp/incoming_message_base_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_base_service_spec.rb
@@ -99,4 +99,63 @@ RSpec.describe Whatsapp::IncomingMessageBaseService do
       service.send(:update_message_with_status, already_delivered, { status: 'delivered', id: 'wamid.xxx' })
     end
   end
+
+  # The dedup guard is written to Redis before processing and released only on
+  # the last line of the happy path. Any raise in between - or a webhook whose
+  # contacts payload is blank - leaves the key pinned for its full one-day TTL,
+  # so the Sidekiq retry and every Meta re-delivery bounce off
+  # `message_under_process?` and drop the message with no log at all.
+  describe '#process_messages dedup guard release' do
+    before do
+      service.processed_params = { messages: [{ id: 'wamid.race', type: 'text' }] }
+      allow(service).to receive(:find_message_by_source_id).and_return(nil)
+      allow(service).to receive(:message_under_process?).and_return(false)
+      allow(service).to receive(:cache_message_source_id_in_redis)
+    end
+
+    it 'releases the guard when set_contact raises, and still lets the exception reach Sidekiq' do
+      allow(service).to receive(:set_contact).and_raise(ActiveRecord::RecordNotUnique.new('duplicate key'))
+
+      expect(service).to receive(:clear_message_source_id_from_redis)
+      expect { service.send(:process_messages) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'releases the guard when the webhook carries no usable contact' do
+      allow(service).to receive(:set_contact)
+
+      expect(service).to receive(:clear_message_source_id_from_redis)
+      service.send(:process_messages)
+    end
+
+    it 'still releases the guard on the happy path' do
+      allow(service).to receive(:set_contact) { service.instance_variable_set(:@contact, instance_double(Contact)) }
+      allow(service).to receive(:set_conversation)
+      allow(service).to receive(:create_messages)
+
+      expect(service).to receive(:clear_message_source_id_from_redis)
+      service.send(:process_messages)
+    end
+  end
+
+  describe '#update_bsuid_fields' do
+    let(:contact_inbox) { instance_double(ContactInbox, id: 7, bsuid: nil, whatsapp_username: nil) }
+
+    # Two concurrent webhooks for the same new contact race for
+    # index_contact_inboxes_on_inbox_id_and_bsuid. The loser has nothing left to
+    # write - the winner already stored the same bsuid - so it logs and moves on.
+    it 'keeps going when a concurrent webhook already claimed the bsuid' do
+      allow(contact_inbox).to receive(:update!).and_raise(
+        ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: duplicate key value violates unique constraint')
+      )
+      expect(Rails.logger).to receive(:warn).with(/bsuid=abc123/)
+
+      expect { service.send(:update_bsuid_fields, contact_inbox, 'abc123', nil) }.not_to raise_error
+    end
+
+    it 'persists the bsuid when there is no race' do
+      expect(contact_inbox).to receive(:update!).with(hash_including(bsuid: 'abc123'))
+
+      service.send(:update_bsuid_fields, contact_inbox, 'abc123', nil)
+    end
+  end
 end


### PR DESCRIPTION
Destrava o conflito do #307. Alvo é o branch do card; mergeando isto, o #307 volta a ficar `MERGEABLE`.

## O conflito

Único, e aditivo. O `spec-staleness-guard.yml` recebeu duas entradas independentes nos **mesmos dois pontos**:

- **CRM-285** (#308, já na `develop`) — os specs do guard de dedup do WhatsApp
- **CRM-318** (#309, no branch do card) — os specs do Evo Hub

Os dois apendaram no fim da lista de `paths:` e no fim da lista fixa do `run:`. Git não tem como saber a ordem, então marcou conflito onde não há disputa de conteúdo.

## A resolução

Os dois blocos ficam, com o do CRM-285 primeiro (chegou antes na `develop`), preservando a ordem cronológica do resto do arquivo. **Nenhum dos dois gatilhos perde entrada** — nem os `paths:`, nem os specs da lista do `run:`.

Conferido com o YAML parseado, não por leitura do diff:

```
paths: 107 entradas
CRM-285 presente: True     CRM-318 presente: True
run tem CRM-285 spec: True  run tem CRM-318 spec: True
```

`git merge-tree` contra a `origin/develop` agora produz árvore limpa, sem conflito.

## O que NÃO mudou

O diff do CRM-318 contra a `develop` continua idêntico ao que o #307 já mostrava: **14 arquivos, +330/−16**. O merge não tocou em nenhum arquivo do card — só no workflow, e só para acomodar as duas listas.

O `spec-staleness-guard` não roda neste PR (ele dispara em `pull_request` para `main`/`develop`, e este mira o branch do card). A validação real acontece no **#307**, que re-dispara assim que isto entrar.

## Summary by Sourcery

Prevent WhatsApp message deduplication locks from becoming stale while retaining updates during concurrent BSUID assignments.

Bug Fixes:
- Ensure WhatsApp message deduplication guards are released when processing fails or exits early, without masking the original exception if Redis cleanup fails.
- Preserve other contact attributes when concurrent BSUID assignment conflicts occur.
- Add coverage for deduplication cleanup, Redis failure handling, and BSUID update races.

Tests:
- Expand the staleness-guard workflow to track the WhatsApp deduplication services and their regression specs.