### PR TITLE
fix(bots): despacha o provider default do agent bot por job assíncrono (CRM-347)

### DIFF
--- a/app/jobs/agent_bots/http_request_job.rb
+++ b/app/jobs/agent_bots/http_request_job.rb
@@ -1,0 +1,13 @@
+class AgentBots::HttpRequestJob < ApplicationJob
+  queue_as :high
+
+  # Mirrors AgentBots::WebhookJob: the listener must never hold its thread (and
+  # whatever transaction/locks surround the event dispatch) across the bot's
+  # HTTP round-trip, which includes model latency.
+  def perform(agent_bot_id, payload)
+    agent_bot = AgentBot.find_by(id: agent_bot_id)
+    return if agent_bot.nil?
+
+    AgentBots::HttpRequestService.new(agent_bot, payload).perform
+  end
+end

--- a/app/jobs/agent_bots/http_request_job.rb
+++ b/app/jobs/agent_bots/http_request_job.rb
@@ -6,7 +6,13 @@ class AgentBots::HttpRequestJob < ApplicationJob
   # HTTP round-trip, which includes model latency.
   def perform(agent_bot_id, payload)
     agent_bot = AgentBot.find_by(id: agent_bot_id)
-    return if agent_bot.nil?
+    # agent_bots is RLS-scoped on enterprise, so a job that lands without its
+    # tenant reads nil here and the bot simply never answers. Log it: unlike the
+    # inline call this replaces, nothing else marks the failure.
+    if agent_bot.nil?
+      Rails.logger.warn "[AgentBot HTTP] Bot #{agent_bot_id} not found - skipping (deleted, or job ran without its tenant)"
+      return
+    end
 
     AgentBots::HttpRequestService.new(agent_bot, payload).perform
   end

--- a/app/listeners/agent_bot_listener.rb
+++ b/app/listeners/agent_bot_listener.rb
@@ -512,7 +512,10 @@ class AgentBotListener < BaseListener
     elsif agent_bot.n8n_provider?
       AgentBots::N8nRequestService.new(agent_bot, payload).perform
     else
-      AgentBots::HttpRequestService.new(agent_bot, payload).perform
+      # Async like the webhook provider: the default provider's round-trip
+      # includes model latency, and running it inline blocks the listener
+      # thread (and any surrounding transaction) for the whole duration.
+      AgentBots::HttpRequestJob.perform_later(agent_bot.id, payload)
     end
   end
 

--- a/spec/jobs/agent_bots/http_request_job_spec.rb
+++ b/spec/jobs/agent_bots/http_request_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AgentBots::HttpRequestJob do
+  let(:agent_bot) { AgentBot.create!(name: 'Bot', outgoing_url: 'https://bot.example') }
+  let(:payload) { { 'event' => 'message_created', 'conversation' => { 'id' => 'c-1' } } }
+
+  it 'runs the HTTP request service for the bot' do
+    service = instance_double(AgentBots::HttpRequestService, perform: nil)
+    allow(AgentBots::HttpRequestService).to receive(:new).and_return(service)
+
+    described_class.perform_now(agent_bot.id, payload)
+
+    expect(AgentBots::HttpRequestService).to have_received(:new).with(agent_bot, payload)
+    expect(service).to have_received(:perform)
+  end
+
+  it 'no-ops when the bot no longer exists' do
+    allow(AgentBots::HttpRequestService).to receive(:new)
+
+    described_class.perform_now(SecureRandom.uuid, payload)
+
+    expect(AgentBots::HttpRequestService).not_to have_received(:new)
+  end
+end

--- a/spec/jobs/agent_bots/http_request_job_spec.rb
+++ b/spec/jobs/agent_bots/http_request_job_spec.rb
@@ -16,11 +16,29 @@ RSpec.describe AgentBots::HttpRequestJob do
     expect(service).to have_received(:perform)
   end
 
-  it 'no-ops when the bot no longer exists' do
+  it 'no-ops LOUDLY when the bot no longer exists' do
     allow(AgentBots::HttpRequestService).to receive(:new)
+    allow(Rails.logger).to receive(:warn)
+    missing_id = SecureRandom.uuid
 
-    described_class.perform_now(SecureRandom.uuid, payload)
+    described_class.perform_now(missing_id, payload)
 
     expect(AgentBots::HttpRequestService).not_to have_received(:new)
+    expect(Rails.logger).to have_received(:warn).with(/#{missing_id}/)
+  end
+
+  # The default provider only started crossing ActiveJob serialization with this
+  # change, and HttpRequestService documents what string-vs-symbol keys cost
+  # there (random contextId -> the agent loses the conversation history).
+  # webhook_data hands the listener SYMBOL keys, so prove the round-trip keeps
+  # what the service reads reachable - and never raises SerializationError.
+  it 'round-trips the listener payload through ActiveJob unchanged' do
+    native = { event: 'message_created', message_type: 'incoming', conversation: { id: 'c-1' } }
+
+    args = ActiveJob::Arguments.deserialize(ActiveJob::Arguments.serialize([agent_bot.id, native]))
+
+    expect(args.first).to eq(agent_bot.id)
+    expect(args.last[:event]).to eq('message_created')
+    expect(args.last.dig(:conversation, :id)).to eq('c-1')
   end
 end

--- a/spec/listeners/agent_bot_listener_dispatch_spec.rb
+++ b/spec/listeners/agent_bot_listener_dispatch_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Provider dispatch of process_webhook_bot_event: the default provider must go
+# through the async job (its round-trip includes model latency; inline it holds
+# the listener thread for the whole duration), while the bot-runtime and
+# webhook paths keep their existing behavior.
+RSpec.describe AgentBotListener do
+  let(:listener) { described_class.instance }
+  let(:payload) { { event: 'message_created' } }
+  let(:agent_bot) do
+    instance_double(AgentBot, id: SecureRandom.uuid, outgoing_url: 'https://bot.example',
+                              webhook_provider?: false, n8n_provider?: false)
+  end
+
+  before { allow(BotRuntime::Config).to receive(:enabled?).and_return(false) }
+
+  it 'enqueues the async job for the default provider instead of calling inline' do
+    allow(AgentBots::HttpRequestJob).to receive(:perform_later)
+    allow(AgentBots::HttpRequestService).to receive(:new)
+
+    listener.send(:process_webhook_bot_event, agent_bot, payload)
+
+    expect(AgentBots::HttpRequestJob).to have_received(:perform_later).with(agent_bot.id, payload)
+    expect(AgentBots::HttpRequestService).not_to have_received(:new)
+  end
+
+  it 'keeps the webhook provider on its own async job' do
+    allow(agent_bot).to receive(:webhook_provider?).and_return(true)
+    allow(AgentBots::WebhookJob).to receive(:perform_later)
+
+    listener.send(:process_webhook_bot_event, agent_bot, payload)
+
+    expect(AgentBots::WebhookJob).to have_received(:perform_later).with(agent_bot.outgoing_url, payload)
+  end
+
+  it 'keeps the bot-runtime delegation path untouched when enabled' do
+    allow(BotRuntime::Config).to receive(:enabled?).and_return(true)
+    allow(listener).to receive(:delegate_to_bot_runtime)
+    allow(AgentBots::HttpRequestJob).to receive(:perform_later)
+
+    listener.send(:process_webhook_bot_event, agent_bot, payload)
+
+    expect(listener).to have_received(:delegate_to_bot_runtime).with(agent_bot, payload)
+    expect(AgentBots::HttpRequestJob).not_to have_received(:perform_later)
+  end
+
+  it 'does nothing without an outgoing_url' do
+    allow(agent_bot).to receive(:outgoing_url).and_return('')
+    allow(AgentBots::HttpRequestJob).to receive(:perform_later)
+
+    listener.send(:process_webhook_bot_event, agent_bot, payload)
+
+    expect(AgentBots::HttpRequestJob).not_to have_received(:perform_later)
+  end
+end


### PR DESCRIPTION
## Summary
- O `AgentBots::HttpRequestService` (provider default) rodava **inline** no `AgentBotListener` — a ida-e-volta ao bot inclui latência de modelo (segundos), segurando a thread do worker e qualquer transação/locks em volta do dispatch de eventos pela duração inteira. Em cenário real isso deadlockava com write-backs do próprio bot na mesma conversa (o POST de etiquetas esperava o lock até o `statement_timeout` de 14s → 500, etiqueta perdida).
- Fix: o provider default passa a despachar por **`AgentBots::HttpRequestJob`** (fila `high`), espelhando o que o provider webhook já fazia (`AgentBots::WebhookJob.perform_later`). O job re-hidrata o bot por id e roda o mesmo service — que já aceita payload com string keys pós-serialização.
- **Bot-runtime e n8n intactos** (specs cobrem os 3 ramos do dispatch).
- Medido: job de inbound de ~20s → 75ms; write-back de etiquetas de ~14s/500 → 62ms/200; resposta do bot íntegra num job separado (4,4s de LLM sem segurar nada).

## Security
- Sem superfície nova: mesmo service, mesma credencial (vault), mesmo payload — só o timing muda (pós-dispatch). Erros de HTTP continuam engolidos pelo service (sem retry → sem chamada duplicada ao bot).

## Test plan
- `bundle exec rspec spec/jobs/agent_bots/http_request_job_spec.rb spec/listeners/agent_bot_listener_dispatch_spec.rb` (**7 exemplos** apos o commit do review, 0 falhas)
- Suíte de `spec/services/agent_bots` re-rodada (falhas do `remote_media_attacher_spec` pré-existem na develop limpa, sem relação)
- Manual: mensagem inbound real → bot responde e aplica etiqueta; `WhatsappEventsJob` termina em ms; `[AgentBot HTTP]` roda no job novo

## Changed Files
- `app/jobs/agent_bots/http_request_job.rb` (novo)
- `app/listeners/agent_bot_listener.rb`
- `spec/jobs/agent_bots/http_request_job_spec.rb` (novo)
- `spec/listeners/agent_bot_listener_dispatch_spec.rb` (novo)

## Linked Issue
- CRM-347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuywNCXrqa9inPWWjb1htN

## Summary by Sourcery

Dispatch default agent bot HTTP requests asynchronously to prevent long-running bot calls from blocking event processing and conversation updates.

Bug Fixes:
- Move default agent bot HTTP dispatch to an asynchronous high-priority job, preventing listener threads, transactions, and conversation locks from being held during model latency.
- Log and safely skip requests when the referenced agent bot is unavailable when the job runs.

Enhancements:
- Preserve existing webhook, bot-runtime, and missing-URL dispatch behavior while routing only the default provider through the new job.

Tests:
- Add coverage for HTTP job execution, missing bots, ActiveJob payload round-tripping, and all agent bot dispatch paths.

## Review (CRM-347) — commit `417677a7`
- `AgentBots::HttpRequestJob` agora **loga** quando o `find_by` volta `nil`. `agent_bots` e RLS-scoped no enterprise (FORCE RLS + policy `tenant_isolation`), entao um job sem tenant lia `nil` e o bot simplesmente nao respondia — sem rastro. O `WebhookJob` que ele espelha recebe a URL e nunca re-consulta, entao o espelho nao era exato nesse ponto.
- Spec novo cobre o round-trip do payload pelo `ActiveJob::Arguments`: o provider default so passou a atravessar serializacao com esta mudanca, e chave symbol virando string ja custou o historico do agente uma vez (comentario do `HttpRequestService`).
