### PR TITLE
fix(admin): configuração de instalação passa a exigir a permissão granular (CRM-366)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -65,6 +65,15 @@ on:
       # keeps credentials out of the response. Neither shows up in another lane.
       - 'app/controllers/api/v1/admin/app_configs_controller.rb'
       - 'spec/controllers/api/v1/admin/app_configs_controller_spec.rb'
+      # CRM-366: this policy is the ONLY gate on /api/v1/admin/* (the controller
+      # declares no require_permissions), and re-admitting `administrator?` next to
+      # the grant hands SMTP, storage, OAuth and the Hub key to every account_owner
+      # while still answering 200. The base_controller is what keeps that denial a
+      # 403 instead of the 401 the SPA reads as a dead session. No other lane runs
+      # either file.
+      - 'app/policies/installation_config_policy.rb'
+      - 'app/controllers/api/v1/admin/base_controller.rb'
+      - 'spec/policies/installation_config_policy_spec.rb'
       # A macro only reports `failed` because ActionParamGuards validates the
       # param before delegating to the shared handler. Loosening that guard
       # brings back the silent success — and the junk label — invisibly to every
@@ -276,6 +285,7 @@ jobs:
             spec/initializers/active_storage_dynamic_service_spec.rb \
             spec/services/config_test/storage_test_service_spec.rb \
             spec/controllers/api/v1/admin/app_configs_controller_spec.rb \
+            spec/policies/installation_config_policy_spec.rb \
             spec/services/macros/execution_service_spec.rb \
             spec/requests/api/v1/macros_spec.rb \
             spec/presenters/conversations/event_data_presenter_spec.rb \

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -6,8 +6,15 @@ module Api
 
         private
 
+        # The Pundit error is rescued here, not left to the rescue_from in
+        # Api::BaseController: ApplicationController wraps every action in
+        # `around_action :handle_with_exception`, which catches it first and
+        # answers 401/UNAUTHORIZED — a code the SPA interceptor treats as a dead
+        # session and logs the user out. A permission denial must be 403.
         def authorize_admin!
           authorize :installation_config, :manage?
+        rescue Pundit::NotAuthorizedError => e
+          handle_not_authorized(e)
         end
 
         def handle_not_authorized(_exception)

--- a/app/policies/installation_config_policy.rb
+++ b/app/policies/installation_config_policy.rb
@@ -1,9 +1,9 @@
 class InstallationConfigPolicy < ApplicationPolicy
-  # Gate of /api/v1/admin/* — the controller declares no require_permissions.
-  # The grant alone: `administrator?` short-circuited it and is true for account_owner,
-  # whose role deliberately lacks installation_configs.manage in the auth seed.
+  # Sole gate of /api/v1/admin/* — that controller declares no require_permissions.
+  # The grant is the only term on purpose: `administrator?` short-circuited it and
+  # is true for account_owner, whose role deliberately lacks the grant in the auth seed.
   def manage?
-    @user&.has_permission?('installation_configs.manage') || false
+    !!@user&.has_permission?('installation_configs.manage')
   end
 
   def index?

--- a/app/policies/installation_config_policy.rb
+++ b/app/policies/installation_config_policy.rb
@@ -1,12 +1,9 @@
 class InstallationConfigPolicy < ApplicationPolicy
-  # This policy is the ONLY gate on Api::V1::Admin::BaseController (/api/v1/admin/*)
-  # — that controller declares no require_permissions of its own.
-  # While has_permission? was stubbed to `true`, manage? admitted ANY
-  # authenticated user; since story 4.2 it resolves for real, so access is
-  # administrator? (super_admin/account_owner/administrator/admin) or an
-  # explicit installation_configs.manage grant.
+  # Gate of /api/v1/admin/* — the controller declares no require_permissions.
+  # The grant alone: `administrator?` short-circuited it and is true for account_owner,
+  # whose role deliberately lacks installation_configs.manage in the auth seed.
   def manage?
-    @user&.administrator? || @user&.has_permission?('installation_configs.manage')
+    @user&.has_permission?('installation_configs.manage') || false
   end
 
   def index?

--- a/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
   let(:admin_user) do
     user = User.create!(email: 'admin@example.com', name: 'Admin User')
     allow(user).to receive(:administrator?).and_return(true)
+    allow(user).to receive(:has_permission?).with('installation_configs.manage').and_return(true)
     user
   end
 

--- a/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
+  # No `administrator?` stub on purpose: the grant is the whole gate, so the admin
+  # of this spec is defined by holding it. The catch-all `false` keeps any other
+  # permission key answering instead of raising on an unexpected argument.
   let(:admin_user) do
     user = User.create!(email: 'admin@example.com', name: 'Admin User')
-    allow(user).to receive(:administrator?).and_return(true)
+    allow(user).to receive(:has_permission?).and_return(false)
     allow(user).to receive(:has_permission?).with('installation_configs.manage').and_return(true)
     user
   end
@@ -11,6 +14,14 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
   let(:regular_user) do
     user = User.create!(email: 'agent@example.com', name: 'Agent User')
     allow(user).to receive(:administrator?).and_return(false)
+    allow(user).to receive(:has_permission?).and_return(false)
+    user
+  end
+
+  # The role that used to open this route through the old `administrator? ||` term.
+  let(:ungranted_admin_user) do
+    user = User.create!(email: 'owner@example.com', name: 'Account Owner')
+    allow(user).to receive(:administrator?).and_return(true)
     allow(user).to receive(:has_permission?).and_return(false)
     user
   end
@@ -43,6 +54,24 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
   end
 
+  shared_context 'authenticated administrator without the grant' do
+    before do
+      Current.user = ungranted_admin_user
+      allow(controller).to receive(:authenticate_request!).and_return(true)
+    end
+  end
+
+  # The denial must be 403/FORBIDDEN, never 401/UNAUTHORIZED: the SPA interceptor
+  # kills the session on the auth-invalidation codes, so a 401 here logs out an
+  # account_owner instead of telling them they lack the permission.
+  shared_examples 'a forbidden admin request' do
+    it 'answers 403 FORBIDDEN, not a session-invalidating 401' do
+      subject
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body.dig('error', 'code')).to eq(ApiErrorCodes::FORBIDDEN)
+    end
+  end
+
   describe 'GET #show' do
     context 'when not authenticated' do
       it 'returns 401' do
@@ -52,12 +81,19 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
 
     context 'when authenticated as non-admin' do
+      subject { get :show, params: { config_type: 'smtp' }, format: :json }
+
       include_context 'authenticated non-admin'
 
-      it 'returns unauthorized' do
-        get :show, params: { config_type: 'smtp' }, format: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
+      it_behaves_like 'a forbidden admin request'
+    end
+
+    context 'when authenticated as an administrator without the grant' do
+      subject { get :show, params: { config_type: 'smtp' }, format: :json }
+
+      include_context 'authenticated administrator without the grant'
+
+      it_behaves_like 'a forbidden admin request'
     end
 
     context 'when authenticated as admin' do
@@ -211,12 +247,19 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
 
     context 'when authenticated as non-admin' do
+      subject { post :create, params: { config_type: 'smtp', app_config: { SMTP_ADDRESS: 'new.smtp.com' } }, format: :json }
+
       include_context 'authenticated non-admin'
 
-      it 'returns unauthorized' do
-        post :create, params: { config_type: 'smtp', app_config: { SMTP_ADDRESS: 'new.smtp.com' } }, format: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
+      it_behaves_like 'a forbidden admin request'
+    end
+
+    context 'when authenticated as an administrator without the grant' do
+      subject { post :create, params: { config_type: 'smtp', app_config: { SMTP_ADDRESS: 'new.smtp.com' } }, format: :json }
+
+      include_context 'authenticated administrator without the grant'
+
+      it_behaves_like 'a forbidden admin request'
     end
 
     context 'when authenticated as admin' do
@@ -470,12 +513,19 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
 
     context 'when authenticated as non-admin' do
+      subject { post :test_connection, params: { config_type: 'smtp' }, format: :json }
+
       include_context 'authenticated non-admin'
 
-      it 'returns unauthorized' do
-        post :test_connection, params: { config_type: 'smtp' }, format: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
+      it_behaves_like 'a forbidden admin request'
+    end
+
+    context 'when authenticated as an administrator without the grant' do
+      subject { post :test_connection, params: { config_type: 'smtp' }, format: :json }
+
+      include_context 'authenticated administrator without the grant'
+
+      it_behaves_like 'a forbidden admin request'
     end
 
     context 'when authenticated as admin' do

--- a/spec/policies/installation_config_policy_spec.rb
+++ b/spec/policies/installation_config_policy_spec.rb
@@ -3,57 +3,64 @@ require 'rails_helper'
 RSpec.describe InstallationConfigPolicy, type: :policy do
   let(:record) { :installation_config }
 
+  def policy_for(user)
+    described_class.new({ user: user, account: nil }, record)
+  end
+
   describe '#manage?' do
-    context 'when user is an administrator (SuperAdmin)' do
-      let(:user) { instance_double('User', administrator?: true, has_permission?: false) }
-      let(:policy) { described_class.new({ user: user, account: nil }, record) }
-
-      it 'returns true' do
-        expect(policy.manage?).to be true
-      end
-    end
-
-    context 'when user has installation_configs.manage permission' do
+    context 'when user holds the installation_configs.manage grant' do
       let(:user) { instance_double('User', administrator?: false) }
-      let(:policy) { described_class.new({ user: user, account: nil }, record) }
 
       before do
         allow(user).to receive(:has_permission?).with('installation_configs.manage').and_return(true)
       end
 
       it 'returns true' do
-        expect(policy.manage?).to be true
+        expect(policy_for(user).manage?).to be true
       end
     end
 
-    context 'when user is not admin and lacks permission' do
-      let(:user) { instance_double('User', administrator?: false) }
-      let(:policy) { described_class.new({ user: user, account: nil }, record) }
+    context 'when user is an administrator without the grant' do
+      let(:user) { instance_double('User', administrator?: true) }
 
       before do
         allow(user).to receive(:has_permission?).with('installation_configs.manage').and_return(false)
       end
 
       it 'returns false' do
-        expect(policy.manage?).to be false
+        expect(policy_for(user).manage?).to be false
+      end
+    end
+
+    context 'when user is neither administrator nor granted' do
+      let(:user) { instance_double('User', administrator?: false) }
+
+      before do
+        allow(user).to receive(:has_permission?).with('installation_configs.manage').and_return(false)
+      end
+
+      it 'returns false' do
+        expect(policy_for(user).manage?).to be false
       end
     end
 
     context 'when user is nil' do
-      let(:policy) { described_class.new({ user: nil, account: nil }, record) }
-
-      it 'returns falsy' do
-        expect(policy.manage?).to be_falsey
+      it 'returns false' do
+        expect(policy_for(nil).manage?).to be false
       end
     end
   end
 
   describe 'CRUD methods delegate to manage?' do
-    let(:user) { instance_double('User', administrator?: true, has_permission?: false) }
-    let(:policy) { described_class.new({ user: user, account: nil }, record) }
+    let(:user) { instance_double('User', administrator?: false) }
+
+    before do
+      allow(user).to receive(:has_permission?).with('installation_configs.manage').and_return(true)
+    end
 
     %i[index? show? create? update? destroy?].each do |method|
       it "#{method} delegates to manage?" do
+        policy = policy_for(user)
         expect(policy.send(method)).to eq(policy.manage?)
       end
     end


### PR DESCRIPTION
## O que muda

`InstallationConfigPolicy#manage?` — o único gate de `/api/v1/admin/*` — deixa de aceitar `administrator?` e passa a exigir a concessão `installation_configs.manage`.

## Por quê

O gate era um OR: `@user&.administrator? || @user&.has_permission?('installation_configs.manage')`. O primeiro termo é true para `super_admin`, `account_owner`, `administrator` e `admin` (`app/models/concerns/user_attribute_helpers.rb:20-28`), então a permissão nunca chegava a ser consultada.

Só que o seed de RBAC do auth **subtrai** `installation_configs.manage` do `account_owner` de propósito, reservando-a ao `super_admin`, e o front gateia o painel de Configurações do Admin por essa mesma permissão (`PermissionRoute resource="installation_configs" action="manage"`). Para um `account_owner`, o menu sumia e a rota respondia.

E não é só leitura mascarada: o `create` grava. SMTP, storage, credenciais de OAuth e a chave do Evolution Hub eram alcançáveis por API sem a permissão que o produto diz ser necessária.

## Risco — leia antes de aprovar

Isto **corta acesso** de quem hoje entra pelo primeiro termo do OR: `account_owner`, `administrator` e `admin` sem a concessão explícita. Em instalações que dependem disso, é lockout do painel de admin. O `super_admin` mantém acesso porque o seed lhe dá a concessão.

Se a intenção do produto for outra — por exemplo, manter `administrator` com acesso —, o ajuste certo é conceder `installation_configs.manage` a esse papel no seed, não reabrir o bypass no policy.

## Como validar

```
POSTGRES_HOST=localhost POSTGRES_PORT=5433 POSTGRES_USERNAME=postgres \
POSTGRES_PASSWORD=postgres_dev_password POSTGRES_DATABASE=evolution_test RAILS_ENV=test \
bundle exec rspec spec/policies/installation_config_policy_spec.rb spec/controllers/api/v1/admin/app_configs_controller_spec.rb
```

66 exemplos. As 2 falhas em `app_configs_controller_spec` (`returns all keys ... including nil` e `rejects save when a required key is omitted`) **já existem na develop** — conferi rodando os mesmos specs no commit base, sem estas mudanças.

## Origem

Achado por leitura de código durante uma investigação do Evo Hub, não exercitado em runtime com um usuário `account_owner` real.

## Summary by Sourcery

Enforce the granular installation configuration permission across admin APIs and preserve correct 403 authorization responses.

Bug Fixes:
- Restrict admin installation configuration endpoints to users with the explicit `installation_configs.manage` permission, preventing unauthorized access to sensitive configuration data and mutation operations.
- Return HTTP 403 for denied admin authorization requests so permission failures are not misinterpreted as expired sessions.

Enhancements:
- Update policy and controller coverage to verify that administrator roles without the granular permission are denied while granted users retain access.

CI:
- Include the installation configuration policy and admin authorization tests in the spec staleness guard dependencies and execution lane.

Tests:
- Add coverage for forbidden responses across installation configuration read, write, and connection-test endpoints.