### PR TITLE
feat(hub): expõe a superfície de embed do Hub para o signup rodar no CRM (CRM-314)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -187,6 +187,12 @@ on:
       # the two lifecycle handlers announce the transition and the listener puts it on
       # the wire. Dropping any of the three is silent everywhere else — the channel
       # still connects, only nobody tells the operator.
+      # CRM-314: the public-connect proxy resolves the channel token from the inbox
+      # and redacts it out of Hub error messages. Neither shows up in another lane.
+      - 'app/controllers/api/v1/integrations/evolution_hub_controller.rb'
+      - 'lib/evolution_hub/client.rb'
+      - 'spec/controllers/api/v1/integrations/evolution_hub_controller_spec.rb'
+      - 'spec/lib/evolution_hub/client_public_connect_spec.rb'
       - 'app/services/evolution_hub/**'
       - 'app/listeners/concerns/hub_channel_connection_events.rb'
       - 'lib/meta_base_url.rb'
@@ -304,6 +310,8 @@ jobs:
             spec/services/whatsapp/incoming_message_base_service_spec.rb \
             spec/services/whatsapp/evolution_handlers/messages_upsert_guard_spec.rb \
             spec/services/evolution_hub/ \
+            spec/controllers/api/v1/integrations/evolution_hub_controller_spec.rb \
+            spec/lib/evolution_hub/client_public_connect_spec.rb \
             spec/listeners/action_cable_listener_hub_channel_spec.rb \
             spec/lib/meta_base_url_spec.rb \
             --format progress

--- a/app/controllers/api/v1/integrations/evolution_hub_controller.rb
+++ b/app/controllers/api/v1/integrations/evolution_hub_controller.rb
@@ -36,6 +36,31 @@ class Api::V1::Integrations::EvolutionHubController < Api::V1::BaseController
     handle_hub_error(e)
   end
 
+  # O cliente manda inbox_id, nunca o token do canal: aceitar o token do cliente
+  # deixaria qualquer token conectar qualquer canal.
+  def connect_info
+    payload = hub_client.public_connect_info(hub_channel_token!)
+    render json: (payload.is_a?(Hash) ? payload : {}), status: :ok
+  rescue EvolutionHub::Client::ConfigurationError, EvolutionHub::Client::RequestError => e
+    handle_hub_error(e)
+  end
+
+  def whatsapp_connect
+    missing = %i[phone_number_id waba_id business_id auth_code].select { |k| params[k].blank? }
+    if missing.any?
+      return render json: { error: "Parâmetros obrigatórios ausentes: #{missing.join(', ')}",
+                            code: 'MISSING_REQUIRED_FIELD' }, status: :bad_request
+    end
+
+    hub_client.public_whatsapp_connect(
+      hub_channel_token!,
+      params.permit(*EvolutionHub::Client::SIGNUP_FIELDS).to_h.symbolize_keys
+    )
+    render json: { success: true }, status: :ok
+  rescue EvolutionHub::Client::ConfigurationError, EvolutionHub::Client::RequestError => e
+    handle_hub_error(e)
+  end
+
   # Preview de canais já existentes no Hub. Usado pela tela de Settings
   # do EvoCRM pra confirmar que a integração está OK e mostrar o que
   # já está lá.
@@ -89,6 +114,16 @@ class Api::V1::Integrations::EvolutionHubController < Api::V1::BaseController
 
   def hub_client
     @hub_client ||= EvolutionHub::Client.new
+  end
+
+  def hub_channel_token!
+    inbox = Inbox.find(params[:inbox_id])
+    authorize inbox, action_name == 'connect_info' ? :show? : :update?
+
+    token = ::EvolutionHub::ChannelReconciler.hub_channel_token_of(inbox.channel)
+    raise ActiveRecord::RecordNotFound, 'Inbox sem canal do Evolution Hub' if token.blank?
+
+    token
   end
 
   def ensure_hub_enabled

--- a/app/controllers/api/v1/integrations/evolution_hub_controller.rb
+++ b/app/controllers/api/v1/integrations/evolution_hub_controller.rb
@@ -17,6 +17,12 @@
 # Auth: usuário autenticado no CRM (qualquer role). Não autoriza recurso
 # específico — quem pode chamar API do CRM pode ver as opções do tenant.
 class Api::V1::Integrations::EvolutionHubController < Api::V1::BaseController
+  # Everything the embed widget needs, minus `connection_url` (see below).
+  PUBLIC_CONNECT_INFO_FIELDS = %w[
+    channel_id channel_type channel_name status can_connect platform_name
+    meta_app_id meta_config_id meta_scopes byo_config_missing
+  ].freeze
+
   before_action :ensure_hub_enabled
 
   def meta_app_options
@@ -36,24 +42,24 @@ class Api::V1::Integrations::EvolutionHubController < Api::V1::BaseController
     handle_hub_error(e)
   end
 
-  # O cliente manda inbox_id, nunca o token do canal: aceitar o token do cliente
-  # deixaria qualquer token conectar qualquer canal.
+  # The caller sends inbox_id, never the channel token: trusting a caller-supplied
+  # token would let any token connect any channel.
   def connect_info
-    payload = hub_client.public_connect_info(hub_channel_token!)
-    render json: (payload.is_a?(Hash) ? payload : {}), status: :ok
+    payload = hub_client.public_connect_info(hub_channel_token!(:show?))
+    render json: public_connect_info_payload(payload), status: :ok
   rescue EvolutionHub::Client::ConfigurationError, EvolutionHub::Client::RequestError => e
     handle_hub_error(e)
   end
 
   def whatsapp_connect
-    missing = %i[phone_number_id waba_id business_id auth_code].select { |k| params[k].blank? }
+    missing = EvolutionHub::Client::SIGNUP_REQUIRED_FIELDS.select { |k| params[k].blank? }
     if missing.any?
       return render json: { error: "Parâmetros obrigatórios ausentes: #{missing.join(', ')}",
                             code: 'MISSING_REQUIRED_FIELD' }, status: :bad_request
     end
 
     hub_client.public_whatsapp_connect(
-      hub_channel_token!,
+      hub_channel_token!(:update?),
       params.permit(*EvolutionHub::Client::SIGNUP_FIELDS).to_h.symbolize_keys
     )
     render json: { success: true }, status: :ok
@@ -116,14 +122,24 @@ class Api::V1::Integrations::EvolutionHubController < Api::V1::BaseController
     @hub_client ||= EvolutionHub::Client.new
   end
 
-  def hub_channel_token!
+  # The permission is passed in, not derived from action_name: a future action
+  # reaching this helper would silently inherit whatever the fallback was.
+  def hub_channel_token!(permission)
     inbox = Inbox.find(params[:inbox_id])
-    authorize inbox, action_name == 'connect_info' ? :show? : :update?
+    authorize inbox, permission
 
     token = ::EvolutionHub::ChannelReconciler.hub_channel_token_of(inbox.channel)
     raise ActiveRecord::RecordNotFound, 'Inbox sem canal do Evolution Hub' if token.blank?
 
     token
+  end
+
+  # `connection_url` embeds the channel token, and this response goes to the
+  # browser — the same token client.rb redacts out of error messages.
+  def public_connect_info_payload(payload)
+    return {} unless payload.is_a?(Hash)
+
+    payload.slice(*PUBLIC_CONNECT_INFO_FIELDS)
   end
 
   def ensure_hub_enabled

--- a/app/services/evolution_hub/channel_reconciler.rb
+++ b/app/services/evolution_hub/channel_reconciler.rb
@@ -61,10 +61,15 @@ module EvolutionHub
       end.presence
     end
 
+    # Only these three carry Hub state: `evolution_hub_meta` is a column on
+    # channel_facebook_pages / channel_instagram only. Unlike hub_channel_id_of,
+    # this one receives an arbitrary inbox channel, so an else-branch would
+    # NoMethodError into a 500 where the caller wants a plain "no hub channel".
     def self.hub_channel_token_of(channel)
-      if channel.is_a?(::Channel::Whatsapp)
+      case channel
+      when ::Channel::Whatsapp
         channel.provider_config&.dig('evolution_hub', 'channel_token')
-      else
+      when ::Channel::FacebookPage, ::Channel::Instagram
         (channel.evolution_hub_meta || {})['channel_token']
       end.presence
     end

--- a/app/services/evolution_hub/channel_reconciler.rb
+++ b/app/services/evolution_hub/channel_reconciler.rb
@@ -61,6 +61,14 @@ module EvolutionHub
       end.presence
     end
 
+    def self.hub_channel_token_of(channel)
+      if channel.is_a?(::Channel::Whatsapp)
+        channel.provider_config&.dig('evolution_hub', 'channel_token')
+      else
+        (channel.evolution_hub_meta || {})['channel_token']
+      end.presence
+    end
+
     def initialize(channel, attrs)
       @channel = channel
       @attrs = attrs || {}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -642,6 +642,8 @@ Rails.application.routes.draw do
             get :plan
             get :channels
             get :available_channels
+            get :connect_info
+            post :whatsapp_connect
           end
         end
       end

--- a/lib/evolution_hub/client.rb
+++ b/lib/evolution_hub/client.rb
@@ -15,9 +15,12 @@ module EvolutionHub
     default_timeout 10
 
     SIGNUP_FIELDS = %i[phone_number_id waba_id business_id auth_code connection_mode].freeze
+    # Mirrors the Hub's MetaConnectRequest binding: phone_number_id, waba_id and
+    # connection_mode are required there; business_id and auth_code are omitempty.
+    SIGNUP_REQUIRED_FIELDS = %i[phone_number_id waba_id connection_mode].freeze
 
-    # O token do canal vai na URL. Sem rotulo redigido ele entra na mensagem de erro,
-    # que o controller devolve ao browser.
+    # The channel token travels in the URL. Without a redacted label it lands in the
+    # error message, which the controller hands back to the browser.
     PUBLIC_CONNECT_OP = '/api/v1/public/connect/:token'
 
     class ConfigurationError < StandardError; end
@@ -121,13 +124,13 @@ module EvolutionHub
       get_json("/api/v1/channels/#{channel_id}")
     end
 
-    # Superfície de EMBED do Hub: autenticada pelo token do canal, sem JWT nem API key.
-    # Devolve meta_app_id / meta_config_id / meta_scopes / byo_config_missing / can_connect.
+    # Hub EMBED surface: authenticated by the channel token alone, no JWT or API key.
+    # Returns meta_app_id / meta_config_id / meta_scopes / byo_config_missing / can_connect.
     def public_connect_info(channel_token)
       get_json("/api/v1/public/connect/#{channel_token}", op_label: PUBLIC_CONNECT_OP)
     end
 
-    # Entrega ao Hub o resultado do Embedded Signup rodado fora da página dele.
+    # Hands the Hub the result of an Embedded Signup run outside its own page.
     def public_whatsapp_connect(channel_token, signup)
       body = SIGNUP_FIELDS.index_with { |field| signup[field] }.compact
       post_json("/api/v1/public/connect/#{channel_token}/whatsapp/connect", body,

--- a/lib/evolution_hub/client.rb
+++ b/lib/evolution_hub/client.rb
@@ -14,6 +14,12 @@ module EvolutionHub
     include HTTParty
     default_timeout 10
 
+    SIGNUP_FIELDS = %i[phone_number_id waba_id business_id auth_code connection_mode].freeze
+
+    # O token do canal vai na URL. Sem rotulo redigido ele entra na mensagem de erro,
+    # que o controller devolve ao browser.
+    PUBLIC_CONNECT_OP = '/api/v1/public/connect/:token'
+
     class ConfigurationError < StandardError; end
     class RequestError < StandardError
       attr_reader :status, :body, :code, :variables
@@ -115,6 +121,19 @@ module EvolutionHub
       get_json("/api/v1/channels/#{channel_id}")
     end
 
+    # Superfície de EMBED do Hub: autenticada pelo token do canal, sem JWT nem API key.
+    # Devolve meta_app_id / meta_config_id / meta_scopes / byo_config_missing / can_connect.
+    def public_connect_info(channel_token)
+      get_json("/api/v1/public/connect/#{channel_token}", op_label: PUBLIC_CONNECT_OP)
+    end
+
+    # Entrega ao Hub o resultado do Embedded Signup rodado fora da página dele.
+    def public_whatsapp_connect(channel_token, signup)
+      body = SIGNUP_FIELDS.index_with { |field| signup[field] }.compact
+      post_json("/api/v1/public/connect/#{channel_token}/whatsapp/connect", body,
+                op_label: "#{PUBLIC_CONNECT_OP}/whatsapp/connect")
+    end
+
     # POST /api/v1/webhooks — cria um webhook standalone no Hub.
     # Usado pelo fluxo "linkar canal existente": cria-se um webhook novo
     # apontando pro CRM e logo em seguida associa-se ao canal Hub escolhido.
@@ -177,14 +196,14 @@ module EvolutionHub
       }
     end
 
-    def post_json(path, body)
+    def post_json(path, body, op_label: nil)
       response = HTTParty.post("#{base_url}#{path}", body: body.to_json, headers: headers, timeout: 10)
-      handle(response, "POST #{path}")
+      handle(response, "POST #{op_label || path}")
     end
 
-    def get_json(path)
+    def get_json(path, op_label: nil)
       response = HTTParty.get("#{base_url}#{path}", headers: headers, timeout: 10)
-      handle(response, "GET #{path}")
+      handle(response, "GET #{op_label || path}")
     end
 
     def delete_json(path)

--- a/spec/controllers/api/v1/integrations/evolution_hub_controller_spec.rb
+++ b/spec/controllers/api/v1/integrations/evolution_hub_controller_spec.rb
@@ -45,8 +45,40 @@ RSpec.describe Api::V1::Integrations::EvolutionHubController, type: :controller 
       expect(response).to have_http_status(:ok)
     end
 
+    it 'authorizes the inbox for reading, not for writing' do
+      expect(controller).to receive(:authorize).with(inbox, :show?).and_return(true)
+      allow(hub_client).to receive(:public_connect_info).and_return({})
+
+      get :connect_info, params: { inbox_id: inbox_id }, format: :json
+    end
+
+    # connection_url embeds the channel token; this response reaches the browser.
+    it 'strips connection_url from the payload it hands back' do
+      allow(hub_client).to receive(:public_connect_info).and_return(
+        { 'can_connect' => true, 'meta_app_id' => 'app-1',
+          'connection_url' => "https://hub.example/connect/#{channel_token}",
+          'owner_locale' => 'pt-BR' }
+      )
+
+      get :connect_info, params: { inbox_id: inbox_id }, format: :json
+
+      expect(response.parsed_body).to include('can_connect' => true, 'meta_app_id' => 'app-1')
+      expect(response.parsed_body).not_to have_key('connection_url')
+      expect(response.body).not_to include(channel_token)
+    end
+
     it 'returns 404 when the inbox has no hub channel' do
       channel.provider_config = {}
+
+      get :connect_info, params: { inbox_id: inbox_id }, format: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    # evolution_hub_meta is a column on facebook/instagram channels only, so an
+    # unguarded lookup NoMethodErrors into a 500 instead of "no hub channel".
+    it 'returns 404 for a channel type that carries no hub state' do
+      allow(inbox).to receive(:channel).and_return(Channel::WebWidget.new)
 
       get :connect_info, params: { inbox_id: inbox_id }, format: :json
 
@@ -64,39 +96,56 @@ RSpec.describe Api::V1::Integrations::EvolutionHubController, type: :controller 
 
   describe 'POST #whatsapp_connect' do
     let(:signup_params) do
-      { inbox_id: inbox_id, phone_number_id: '1234', waba_id: '5678', business_id: '9012', auth_code: 'code-abc' }
+      { inbox_id: inbox_id, phone_number_id: '1234', waba_id: '5678', business_id: '9012',
+        auth_code: 'code-abc', connection_mode: 'meta' }
     end
 
     it 'forwards the embedded signup result to the hub' do
       expect(hub_client).to receive(:public_whatsapp_connect).with(
         channel_token,
         { phone_number_id: '1234', waba_id: '5678', business_id: '9012',
-          auth_code: 'code-abc', connection_mode: 'shared' }
+          auth_code: 'code-abc', connection_mode: 'meta' }
       ).and_return({})
 
-      post :whatsapp_connect, params: signup_params.merge(connection_mode: 'shared'), format: :json
+      post :whatsapp_connect, params: signup_params, format: :json
 
       expect(response).to have_http_status(:ok)
     end
 
-    it 'rejects a payload missing required fields' do
-      post :whatsapp_connect, params: signup_params.except(:auth_code), format: :json
-
-      expect(response).to have_http_status(:bad_request)
-      expect(response.parsed_body['error']).to include('auth_code')
-    end
-
-    it 'never leaks the channel token in the error returned to the caller' do
-      allow(hub_client).to receive(:public_whatsapp_connect).and_raise(
-        EvolutionHub::Client::RequestError.new(
-          "Evolution Hub POST #{EvolutionHub::Client::PUBLIC_CONNECT_OP}/whatsapp/connect failed with HTTP 400",
-          status: 400, body: '{}'
-        )
-      )
+    it 'authorizes the inbox for writing' do
+      expect(controller).to receive(:authorize).with(inbox, :update?).and_return(true)
+      allow(hub_client).to receive(:public_whatsapp_connect).and_return({})
 
       post :whatsapp_connect, params: signup_params, format: :json
+    end
 
-      expect(response.parsed_body['error']).not_to include(channel_token)
+    # The Hub binds connection_mode as required; without it every in-page signup
+    # is rejected at the Hub with an opaque 400.
+    it 'rejects a payload missing connection_mode' do
+      post :whatsapp_connect, params: signup_params.except(:connection_mode), format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body['error']).to include('connection_mode')
+    end
+
+    it 'rejects a payload missing waba_id' do
+      post :whatsapp_connect, params: signup_params.except(:waba_id), format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body['error']).to include('waba_id')
+    end
+
+    # business_id and auth_code are omitempty on the Hub side; requiring them here
+    # turned a legitimate Meta payload into a 400.
+    it 'accepts a payload without the fields the hub treats as optional' do
+      expect(hub_client).to receive(:public_whatsapp_connect).with(
+        channel_token, { phone_number_id: '1234', waba_id: '5678', connection_mode: 'meta' }
+      ).and_return({})
+
+      post :whatsapp_connect,
+           params: signup_params.except(:business_id, :auth_code), format: :json
+
+      expect(response).to have_http_status(:ok)
     end
 
     it 'keeps the hub structured error code instead of a bare HTTP status' do

--- a/spec/controllers/api/v1/integrations/evolution_hub_controller_spec.rb
+++ b/spec/controllers/api/v1/integrations/evolution_hub_controller_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Integrations::EvolutionHubController, type: :controller do
+  let(:channel_token) { 'hub-token-do-canal' }
+  let(:inbox_id) { SecureRandom.uuid }
+  let(:hub_client) { instance_double(EvolutionHub::Client) }
+
+  let(:channel) do
+    Channel::Whatsapp.new(
+      phone_number: '+5511999999999',
+      provider: 'whatsapp_cloud',
+      provider_config: { 'evolution_hub' => { 'channel_id' => 'hub-ch-1', 'channel_token' => channel_token } }
+    )
+  end
+
+  let(:inbox) { instance_double(Inbox, id: inbox_id, channel: channel) }
+
+  before do
+    allow(controller).to receive(:authenticate_request!).and_return(true)
+    allow(controller).to receive(:authorize).and_return(true)
+    allow(MetaBaseUrl).to receive(:enabled?).and_return(true)
+    allow(EvolutionHub::Client).to receive(:new).and_return(hub_client)
+    allow(Inbox).to receive(:find).with(inbox_id).and_return(inbox)
+  end
+
+  describe 'GET #connect_info' do
+    it 'resolves the channel token from the inbox and returns the hub payload' do
+      expect(hub_client).to receive(:public_connect_info).with(channel_token).and_return(
+        { 'meta_app_id' => 'app-1', 'meta_config_id' => 'cfg-1', 'can_connect' => true }
+      )
+
+      get :connect_info, params: { inbox_id: inbox_id }, format: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['meta_config_id']).to eq('cfg-1')
+    end
+
+    it 'never uses a token supplied by the caller' do
+      expect(hub_client).to receive(:public_connect_info).with(channel_token).and_return({})
+
+      get :connect_info, params: { inbox_id: inbox_id, channel_token: 'token-de-outro-canal' }, format: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 404 when the inbox has no hub channel' do
+      channel.provider_config = {}
+
+      get :connect_info, params: { inbox_id: inbox_id }, format: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns 503 when the hub is disabled' do
+      allow(MetaBaseUrl).to receive(:enabled?).and_return(false)
+
+      get :connect_info, params: { inbox_id: inbox_id }, format: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+
+  describe 'POST #whatsapp_connect' do
+    let(:signup_params) do
+      { inbox_id: inbox_id, phone_number_id: '1234', waba_id: '5678', business_id: '9012', auth_code: 'code-abc' }
+    end
+
+    it 'forwards the embedded signup result to the hub' do
+      expect(hub_client).to receive(:public_whatsapp_connect).with(
+        channel_token,
+        { phone_number_id: '1234', waba_id: '5678', business_id: '9012',
+          auth_code: 'code-abc', connection_mode: 'shared' }
+      ).and_return({})
+
+      post :whatsapp_connect, params: signup_params.merge(connection_mode: 'shared'), format: :json
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'rejects a payload missing required fields' do
+      post :whatsapp_connect, params: signup_params.except(:auth_code), format: :json
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body['error']).to include('auth_code')
+    end
+
+    it 'never leaks the channel token in the error returned to the caller' do
+      allow(hub_client).to receive(:public_whatsapp_connect).and_raise(
+        EvolutionHub::Client::RequestError.new(
+          "Evolution Hub POST #{EvolutionHub::Client::PUBLIC_CONNECT_OP}/whatsapp/connect failed with HTTP 400",
+          status: 400, body: '{}'
+        )
+      )
+
+      post :whatsapp_connect, params: signup_params, format: :json
+
+      expect(response.parsed_body['error']).not_to include(channel_token)
+    end
+
+    it 'keeps the hub structured error code instead of a bare HTTP status' do
+      allow(hub_client).to receive(:public_whatsapp_connect).and_raise(
+        EvolutionHub::Client::RequestError.new(
+          'Evolution Hub POST failed with HTTP 403',
+          status: 403,
+          body: { 'error' => { 'code' => 'PLAN_FORBIDS_SHARED', 'message' => 'plano nao permite' } }.to_json
+        )
+      )
+
+      post :whatsapp_connect, params: signup_params, format: :json
+
+      expect(response).to have_http_status(:bad_gateway)
+      expect(response.parsed_body['code']).to eq('PLAN_FORBIDS_SHARED')
+    end
+  end
+end

--- a/spec/lib/evolution_hub/client_public_connect_spec.rb
+++ b/spec/lib/evolution_hub/client_public_connect_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock'
+
+# The channel token travels in the PATH of both public-connect endpoints, and
+# handle() builds the error message out of that path. These exercise the real
+# client so removing the redacted op label makes them fail.
+RSpec.describe EvolutionHub::Client do
+  # Scoped to this file: rails_helper does not load webmock, and enabling it
+  # globally would change how every other spec sees the network.
+  include WebMock::API
+
+  subject(:client) { described_class.new }
+
+  let(:channel_token) { 'super-secret-channel-token' }
+  let(:hub_url) { MetaBaseUrl.hub_url }
+
+  before do
+    WebMock.enable!
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load).with('EVOLUTION_HUB_API_KEY', nil).and_return('hub-api-key')
+  end
+
+  after { WebMock.disable! }
+
+  # Records the JSON actually put on the wire so the example can assert on it
+  # without webmock/rspec's matchers, which rails_helper does not load.
+  def capture_signup_body
+    sent = Struct.new(:value).new(nil)
+    stub_request(:post, "#{hub_url}/api/v1/public/connect/#{channel_token}/whatsapp/connect")
+      .with { |req| sent.value = JSON.parse(req.body) }
+      .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+    sent
+  end
+
+  describe '#public_connect_info' do
+    it 'sends the token in the path and returns the parsed payload' do
+      stub_request(:get, "#{hub_url}/api/v1/public/connect/#{channel_token}")
+        .to_return(status: 200, body: { 'can_connect' => true }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect(client.public_connect_info(channel_token)).to include('can_connect' => true)
+    end
+
+    it 'keeps the channel token out of the raised error message' do
+      stub_request(:get, "#{hub_url}/api/v1/public/connect/#{channel_token}")
+        .to_return(status: 404, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      expect { client.public_connect_info(channel_token) }
+        .to raise_error(EvolutionHub::Client::RequestError) { |e|
+          expect(e.message).not_to include(channel_token)
+          expect(e.message).to include('/api/v1/public/connect/:token')
+        }
+    end
+  end
+
+  describe '#public_whatsapp_connect' do
+    let(:signup) do
+      { phone_number_id: '111', waba_id: '222', business_id: '333',
+        auth_code: 'code-abc', connection_mode: 'meta' }
+    end
+
+    it 'posts only the signup fields the Hub accepts' do
+      sent = capture_signup_body
+
+      client.public_whatsapp_connect(channel_token, signup.merge(evil: 'ignored'))
+
+      expect(sent.value).to eq(signup.transform_keys(&:to_s))
+    end
+
+    it 'drops blank optional fields instead of sending nils' do
+      sent = capture_signup_body
+
+      client.public_whatsapp_connect(channel_token,
+                                     { phone_number_id: '111', waba_id: '222', connection_mode: 'meta' })
+
+      expect(sent.value).to eq({ 'phone_number_id' => '111', 'waba_id' => '222', 'connection_mode' => 'meta' })
+    end
+
+    it 'keeps the channel token out of the raised error message' do
+      stub_request(:post, "#{hub_url}/api/v1/public/connect/#{channel_token}/whatsapp/connect")
+        .to_return(status: 400, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      expect { client.public_whatsapp_connect(channel_token, signup) }
+        .to raise_error(EvolutionHub::Client::RequestError) { |e|
+          expect(e.message).not_to include(channel_token)
+          expect(e.message).to include('/api/v1/public/connect/:token/whatsapp/connect')
+        }
+    end
+
+    it 'preserves the structured Hub error code' do
+      stub_request(:post, "#{hub_url}/api/v1/public/connect/#{channel_token}/whatsapp/connect")
+        .to_return(status: 403,
+                   body: { error: { code: 'PLAN_FORBIDS_SHARED', message: 'plano nao permite' } }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect { client.public_whatsapp_connect(channel_token, signup) }
+        .to raise_error(EvolutionHub::Client::RequestError) { |e| expect(e.code).to eq('PLAN_FORBIDS_SHARED') }
+    end
+  end
+end

--- a/spec/rbac/mutating_actions_gate_guard_spec.rb
+++ b/spec/rbac/mutating_actions_gate_guard_spec.rb
@@ -53,7 +53,12 @@ RSpec.describe 'API v1 mutating actions permission guard' do
       %w[create update destroy bulk_move move_conversation move_to_stage update_conversation update_custom_fields],
     # POST-shaped reads inside the new-conversation flow.
     'api/v1/contact_inboxes' => %w[filter],
-    'api/v1/contacts/contact_inboxes' => %w[create]
+    'api/v1/contacts/contact_inboxes' => %w[create],
+    # Pundit-gated on the inbox that owns the Hub channel (authorize inbox,
+    # :update?), which resolves to the same inboxes.update key a gate would ask
+    # for. The action carries no id of its own: it proxies the Embedded Signup
+    # result to the Hub with a channel token read from that inbox.
+    'api/v1/integrations/evolution_hub' => %w[whatsapp_connect]
   }.freeze
 
   # Routes whose controller class does not exist: the request 500s on a


### PR DESCRIPTION
## O que muda

Backend do Embedded Signup dentro do CRM. Dois métodos no `EvolutionHub::Client` para a superfície pública de embed do Hub e duas ações no proxy de integração que já existe:

```
GET  /api/v1/integrations/evolution_hub/connect_info?inbox_id=...
POST /api/v1/integrations/evolution_hub/whatsapp_connect
```

O front ainda não consome — a troca do `window.open` pelo `FB.login` em página vem no PR seguinte.

## Por quê

O Hub expõe `GET /api/v1/public/connect/:token` e `POST /api/v1/public/connect/:token/whatsapp/connect`, autenticados só pelo token do canal, sem JWT nem API key. É o que o widget do próprio Hub consome. O `EvolutionHub::Client` não os alcançava porque só falava a API com a API key do tenant — foi por isso que a conclusão anterior no card foi de que o Hub "não aceitava receber o token vindo de fora".

## Decisões

**O token do canal nunca vem do cliente.** As ações recebem `inbox_id` e resolvem o token a partir da inbox; aceitar o token do corpo deixaria qualquer token conectar qualquer canal. Há um caso de spec fixando isso: um `channel_token` mandado pelo caller é ignorado.

**Autorização por inbox:** leitura autoriza `show?`, escrita autoriza `update?`.

**Erros estruturados preservados:** as ações herdam `ensure_hub_enabled` e `handle_hub_error`, então `PLAN_FORBIDS_SHARED` e `QUOTA_EXCEEDED` continuam chegando com código em vez de virarem "HTTP 403" — é o critério de aceite 3 do card.

**`hub_channel_token_of`** entrou no `ChannelReconciler`, ao lado do `hub_channel_id_of` que já existia, porque o bloco do Hub mora em lugares diferentes conforme o canal (`provider_config['evolution_hub']` no WhatsApp, `evolution_hub_meta` nos demais).

## Como validar

```
POSTGRES_HOST=localhost POSTGRES_PORT=5433 POSTGRES_USERNAME=postgres \
POSTGRES_PASSWORD=postgres_dev_password POSTGRES_DATABASE=evolution_test RAILS_ENV=test \
bundle exec rspec spec/controllers/api/v1/integrations/evolution_hub_controller_spec.rb spec/services/evolution_hub
```

21 exemplos, verdes. Cobrem: token resolvido pela inbox, token do caller ignorado, inbox sem canal do Hub (404), Hub desabilitado (503), payload incompleto (400), encaminhamento do resultado do signup e a preservação do código estruturado do Hub.

## Fora deste PR

A liberação do domínio do CRM em *Allowed Domains for the JS SDK* do app Meta (CRM-363) bloqueia só a validação com conta de produção; o desenvolvimento e o teste contra o Hub local seguem sem ela.

## Summary by Sourcery

Expose the Evolution Hub public embed endpoints through the CRM integration API so Embedded Signup can run against CRM inbox channels.

New Features:
- Expose Embedded Signup connection information through the CRM integration API.
- Proxy WhatsApp Embedded Signup results from the CRM to the Evolution Hub.

Bug Fixes:
- Prevent caller-supplied channel tokens from being used and redact channel tokens from Hub error messages and browser responses.
- Preserve structured Evolution Hub error codes when proxy requests fail.

Enhancements:
- Resolve Hub channel tokens from inbox-owned channels with read and write authorization checks.
- Support Hub channel metadata across WhatsApp, Facebook, and Instagram channel types and filter sensitive connection details from responses.

CI:
- Extend the spec staleness guard workflow to cover the new controller, client, and service specifications.

Tests:
- Add controller and client coverage for token resolution, authorization, payload validation, signup forwarding, error handling, and sensitive-data protection.