### PR TITLE
fix(admin): achados do code review do CRM-366 (#313)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -65,6 +65,15 @@ on:
       # keeps credentials out of the response. Neither shows up in another lane.
       - 'app/controllers/api/v1/admin/app_configs_controller.rb'
       - 'spec/controllers/api/v1/admin/app_configs_controller_spec.rb'
+      # CRM-366: this policy is the ONLY gate on /api/v1/admin/* (the controller
+      # declares no require_permissions), and re-admitting `administrator?` next to
+      # the grant hands SMTP, storage, OAuth and the Hub key to every account_owner
+      # while still answering 200. The base_controller is what keeps that denial a
+      # 403 instead of the 401 the SPA reads as a dead session. No other lane runs
+      # either file.
+      - 'app/policies/installation_config_policy.rb'
+      - 'app/controllers/api/v1/admin/base_controller.rb'
+      - 'spec/policies/installation_config_policy_spec.rb'
       # A macro only reports `failed` because ActionParamGuards validates the
       # param before delegating to the shared handler. Loosening that guard
       # brings back the silent success — and the junk label — invisibly to every
@@ -276,6 +285,7 @@ jobs:
             spec/initializers/active_storage_dynamic_service_spec.rb \
             spec/services/config_test/storage_test_service_spec.rb \
             spec/controllers/api/v1/admin/app_configs_controller_spec.rb \
+            spec/policies/installation_config_policy_spec.rb \
             spec/services/macros/execution_service_spec.rb \
             spec/requests/api/v1/macros_spec.rb \
             spec/presenters/conversations/event_data_presenter_spec.rb \

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -6,8 +6,15 @@ module Api
 
         private
 
+        # The Pundit error is rescued here, not left to the rescue_from in
+        # Api::BaseController: ApplicationController wraps every action in
+        # `around_action :handle_with_exception`, which catches it first and
+        # answers 401/UNAUTHORIZED — a code the SPA interceptor treats as a dead
+        # session and logs the user out. A permission denial must be 403.
         def authorize_admin!
           authorize :installation_config, :manage?
+        rescue Pundit::NotAuthorizedError => e
+          handle_not_authorized(e)
         end
 
         def handle_not_authorized(_exception)

--- a/app/policies/installation_config_policy.rb
+++ b/app/policies/installation_config_policy.rb
@@ -1,9 +1,9 @@
 class InstallationConfigPolicy < ApplicationPolicy
-  # Gate of /api/v1/admin/* — the controller declares no require_permissions.
-  # The grant alone: `administrator?` short-circuited it and is true for account_owner,
-  # whose role deliberately lacks installation_configs.manage in the auth seed.
+  # Sole gate of /api/v1/admin/* — that controller declares no require_permissions.
+  # The grant is the only term on purpose: `administrator?` short-circuited it and
+  # is true for account_owner, whose role deliberately lacks the grant in the auth seed.
   def manage?
-    @user&.has_permission?('installation_configs.manage') || false
+    !!@user&.has_permission?('installation_configs.manage')
   end
 
   def index?

--- a/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/app_configs_controller_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
+  # No `administrator?` stub on purpose: the grant is the whole gate, so the admin
+  # of this spec is defined by holding it. The catch-all `false` keeps any other
+  # permission key answering instead of raising on an unexpected argument.
   let(:admin_user) do
     user = User.create!(email: 'admin@example.com', name: 'Admin User')
-    allow(user).to receive(:administrator?).and_return(true)
+    allow(user).to receive(:has_permission?).and_return(false)
     allow(user).to receive(:has_permission?).with('installation_configs.manage').and_return(true)
     user
   end
@@ -11,6 +14,14 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
   let(:regular_user) do
     user = User.create!(email: 'agent@example.com', name: 'Agent User')
     allow(user).to receive(:administrator?).and_return(false)
+    allow(user).to receive(:has_permission?).and_return(false)
+    user
+  end
+
+  # The role that used to open this route through the old `administrator? ||` term.
+  let(:ungranted_admin_user) do
+    user = User.create!(email: 'owner@example.com', name: 'Account Owner')
+    allow(user).to receive(:administrator?).and_return(true)
     allow(user).to receive(:has_permission?).and_return(false)
     user
   end
@@ -43,6 +54,24 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
   end
 
+  shared_context 'authenticated administrator without the grant' do
+    before do
+      Current.user = ungranted_admin_user
+      allow(controller).to receive(:authenticate_request!).and_return(true)
+    end
+  end
+
+  # The denial must be 403/FORBIDDEN, never 401/UNAUTHORIZED: the SPA interceptor
+  # kills the session on the auth-invalidation codes, so a 401 here logs out an
+  # account_owner instead of telling them they lack the permission.
+  shared_examples 'a forbidden admin request' do
+    it 'answers 403 FORBIDDEN, not a session-invalidating 401' do
+      subject
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body.dig('error', 'code')).to eq(ApiErrorCodes::FORBIDDEN)
+    end
+  end
+
   describe 'GET #show' do
     context 'when not authenticated' do
       it 'returns 401' do
@@ -52,12 +81,19 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
 
     context 'when authenticated as non-admin' do
+      subject { get :show, params: { config_type: 'smtp' }, format: :json }
+
       include_context 'authenticated non-admin'
 
-      it 'returns unauthorized' do
-        get :show, params: { config_type: 'smtp' }, format: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
+      it_behaves_like 'a forbidden admin request'
+    end
+
+    context 'when authenticated as an administrator without the grant' do
+      subject { get :show, params: { config_type: 'smtp' }, format: :json }
+
+      include_context 'authenticated administrator without the grant'
+
+      it_behaves_like 'a forbidden admin request'
     end
 
     context 'when authenticated as admin' do
@@ -211,12 +247,19 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
 
     context 'when authenticated as non-admin' do
+      subject { post :create, params: { config_type: 'smtp', app_config: { SMTP_ADDRESS: 'new.smtp.com' } }, format: :json }
+
       include_context 'authenticated non-admin'
 
-      it 'returns unauthorized' do
-        post :create, params: { config_type: 'smtp', app_config: { SMTP_ADDRESS: 'new.smtp.com' } }, format: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
+      it_behaves_like 'a forbidden admin request'
+    end
+
+    context 'when authenticated as an administrator without the grant' do
+      subject { post :create, params: { config_type: 'smtp', app_config: { SMTP_ADDRESS: 'new.smtp.com' } }, format: :json }
+
+      include_context 'authenticated administrator without the grant'
+
+      it_behaves_like 'a forbidden admin request'
     end
 
     context 'when authenticated as admin' do
@@ -470,12 +513,19 @@ RSpec.describe Api::V1::Admin::AppConfigsController, type: :controller do
     end
 
     context 'when authenticated as non-admin' do
+      subject { post :test_connection, params: { config_type: 'smtp' }, format: :json }
+
       include_context 'authenticated non-admin'
 
-      it 'returns unauthorized' do
-        post :test_connection, params: { config_type: 'smtp' }, format: :json
-        expect(response).to have_http_status(:unauthorized)
-      end
+      it_behaves_like 'a forbidden admin request'
+    end
+
+    context 'when authenticated as an administrator without the grant' do
+      subject { post :test_connection, params: { config_type: 'smtp' }, format: :json }
+
+      include_context 'authenticated administrator without the grant'
+
+      it_behaves_like 'a forbidden admin request'
     end
 
     context 'when authenticated as admin' do


### PR DESCRIPTION
Achados do code review da #313. Nada aqui reabre o gate — o `manage?` continua exigindo `installation_configs.manage` e só.

## 🔴 O deny saía 401 e o front deslogava o usuário

Verificado em runtime, na `develop` e na #313:

```
STATUS=401 BODY={"success":false,"error":{"code":"UNAUTHORIZED", ...}}
```

O `handle_not_authorized` do `Api::V1::Admin::BaseController` — que já renderizava **403 FORBIDDEN** — era **código morto**: o `around_action :handle_with_exception` do `ApplicationController:9` captura o `Pundit::NotAuthorizedError` antes do `rescue_from` do `Api::BaseController`, e o `RequestExceptionHandler:17` responde 401/`UNAUTHORIZED`.

Do outro lado, `vendor/crm/src/services/core/api.ts:17-24` tem `UNAUTHORIZED` na lista `AUTH_INVALIDATION_ERROR_CODES` → `terminateSession()` → `clearUser()`. Um **403** o interceptor apenas repassa (linha 175).

Ou seja: com o gate da #313 no ar, um `account_owner` que tocasse a rota não veria "sem permissão" — seria **deslogado do CRM**. E é alcançável em um clique: o shell do ecosystem monta `/settings/admin/*` sem o gate `installation_configs:manage` (`CrmScreenHost.tsx:103` e `:370`, bypass intencional documentado) e `IntegrationByoCard.tsx:422` linka pra `/settings/admin/openai`.

Fix: o `rescue` no próprio `before_action` torna o handler de 403 alcançável, sem mexer no tratamento de `RecordNotFound`/`ParameterMissing` do around_action.

## 🟡 O spec do policy não rodava em lane nenhuma

`spec/policies/installation_config_policy_spec.rb` não era executado por **nenhum** workflow: o `spec-staleness-guard.yml` não tinha o policy como path de trigger nem o spec na invocação do rspec (só o spec do *controller*), e o `community-parity.yml` roda `spec/rbac` e `spec/requests/**_rbac_spec.rb`, não `spec/policies/`. A guarda de regressão que é o ponto da #313 nunca ia rodar, e o arquivo do único gate do `/api/v1/admin/*` podia mudar sem disparar spec. `app/policies/pipeline_policy.rb` já está registrado assim.

Entram no guard: o policy, o `base_controller` e o spec do policy.

## 🟡 O spec do controller era cego à mudança

O `admin_user` stubava **as duas coisas** (`administrator?` **e** a concessão), e o `regular_user` passava antes e depois — nada ali provava o gate novo. Agora:

- `admin_user` **não stuba mais `administrator?`**: a concessão é o gate inteiro, então é ela que define o admin do spec. Ganhou também o catch-all `false` antes do `with(...)`, pra outra chave devolver `false` em vez de levantar *unexpected arguments*.
- Novo `ungranted_admin_user` (`administrator?` true, sem a concessão) — exatamente o papel que entrava pelo termo antigo do OR.
- Os três deny (`show`, `create`, `test_connection`) passam por um `shared_examples` que exige **403 + code FORBIDDEN**, e não mais `:unauthorized`.

## 🟢 Detalhes

- `|| false` pendurado num método `?` → `!!`.
- Comentário do policy reescrito (a segunda linha era manchete colada em frase).

## Validação

```
bundle exec rspec spec/policies/installation_config_policy_spec.rb \
  spec/controllers/api/v1/admin/app_configs_controller_spec.rb
# 69 exemplos, 0 falhas
```

Lane de paridade (`spec/rbac` + `*_rbac_spec` + resolver/concern): **297 exemplos, 0 falhas, 1 pending** (o pending é o conformance do catálogo, que pede o auth clonado ao lado).
Vizinhos de config (`email_configuration`, `global_config_service`, `active_storage_dynamic_service`, `storage_test_service`): **64 exemplos, 0 falhas**.
RuboCop sem ofensa nova nos arquivos tocados.

> As 2 falhas que a #313 dá como pré-existentes **não reproduzem** em banco de teste limpo — eram linhas de `installation_configs` residuais.

## Fora do escopo (fica de follow-up)

O shell do ecosystem monta `/settings/admin/*` **sem** o gate `installation_configs:manage`, e o card BYO OpenAI linka pra lá sem checar permissão. Com o 403 no lugar do 401 ninguém mais é deslogado, mas um `account_owner` ainda cai numa tela que 403 em toda leitura e todo save. O próprio comentário do `CrmScreenHost.tsx` marca isso como *"decisão de produto pendente"* — é decisão, não conserto.

## Summary by Sourcery

Preserve CRM sessions on unauthorized admin configuration access while enforcing and continuously testing the required installation configuration permission.

Bug Fixes:
- Return HTTP 403/FORBIDDEN for denied admin configuration requests instead of 401/UNAUTHORIZED responses that invalidate CRM sessions.
- Ensure administrator users without the `installation_configs.manage` grant remain denied across admin configuration endpoints.

Enhancements:
- Make `installation_configs.manage` the explicit sole policy gate for admin configuration access.
- Improve controller coverage to verify permission-based denials and their response codes.

CI:
- Add the installation configuration policy, admin base controller, and policy spec to the spec staleness guard and its RSpec lane.

Tests:
- Add regression coverage for denied show, create, and connection-test requests, including administrators lacking the required grant.