### PR TITLE
fix(locale): use the inbox's configured locale for auto-sent template messages

### DIFF
--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -14,10 +14,29 @@ class MessageTemplates::HookExecutionService
   delegate :contact, to: :conversation
 
   def trigger_templates
-    ::MessageTemplates::Template::OutOfOffice.new(conversation: conversation).perform if should_send_out_of_office_message?
-    ::MessageTemplates::Template::Greeting.new(conversation: conversation).perform if should_send_greeting?
-    ::MessageTemplates::Template::EmailCollect.new(conversation: conversation).perform if inbox.enable_email_collect && should_send_email_collect?
-    ::MessageTemplates::Template::CsatSurvey.new(conversation: conversation).perform if should_send_csat_survey?
+    # This runs from an async event listener, outside any controller request,
+    # so there's no SwitchLocale-set I18n.locale to inherit — without this it
+    # silently falls back to I18n.default_locale (English) regardless of the
+    # inbox's configured locale (EVO-2201).
+    I18n.with_locale(template_locale) do
+      ::MessageTemplates::Template::OutOfOffice.new(conversation: conversation).perform if should_send_out_of_office_message?
+      ::MessageTemplates::Template::Greeting.new(conversation: conversation).perform if should_send_greeting?
+      ::MessageTemplates::Template::EmailCollect.new(conversation: conversation).perform if inbox.enable_email_collect && should_send_email_collect?
+      ::MessageTemplates::Template::CsatSurvey.new(conversation: conversation).perform if should_send_csat_survey?
+    end
+  end
+
+  def template_locale
+    locale = inbox.channel&.locale
+    return I18n.default_locale if locale.blank?
+
+    available_locales = I18n.available_locales.map(&:to_s)
+    return locale if available_locales.include?(locale)
+
+    locale_without_variant = locale.split('_')[0]
+    return locale_without_variant if available_locales.include?(locale_without_variant)
+
+    I18n.default_locale
   end
 
   def should_send_out_of_office_message?

--- a/app/services/message_templates/hook_execution_service.rb
+++ b/app/services/message_templates/hook_execution_service.rb
@@ -27,7 +27,11 @@ class MessageTemplates::HookExecutionService
   end
 
   def template_locale
-    locale = inbox.channel&.locale
+    channel = inbox.channel
+    # Safe navigation only guards a nil channel — most channel types (e.g.
+    # Channel::Api, Channel::Whatsapp) don't define #locale at all, so a bare
+    # `channel&.locale` would raise NoMethodError for them.
+    locale = channel.locale if channel.respond_to?(:locale)
     return I18n.default_locale if locale.blank?
 
     available_locales = I18n.available_locales.map(&:to_s)


### PR DESCRIPTION
## Summary
- `MessageTemplates::HookExecutionService` runs from an async event listener, outside any controller request — it never inherits the `I18n.locale` that `SwitchLocale` sets for HTTP requests. Every auto-sent template message (greeting, out-of-office, email-collect, CSAT survey) was rendered in `I18n.default_locale` (English), regardless of the inbox's configured locale (e.g. `pt_BR`), producing mixed-language conversations for non-English installs.
- Fix: resolve the inbox's `channel.locale` (falling back to the app default when unset/unsupported, mirroring `SwitchLocale#validate_and_get_locale`'s own fallback logic) and wrap all four template-generation calls in `I18n.with_locale(...)`.

## Testing notes
- Verified against a live pt_BR Web Widget inbox: before the fix, `email_collect`'s auto-sent messages ("Give the team a way to reach you." / "Get notified by email") rendered in English even though `pt.yml`/`pt_BR.yml` both already have correct translations for these exact keys — confirming the locale was simply never being set, not a missing translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Render asynchronous template messages using each inbox's configured, validated locale.

Bug Fixes:
- Ensure automatically generated greeting, out-of-office, email-collection, and CSAT messages use the inbox's configured locale instead of defaulting to English.
- Fall back safely to the application locale when the inbox locale is unset or unsupported.