### PR TITLE
fix(widget): localize pre-chat form validation errors to the widget's language

### DIFF
--- a/app/services/widget/pre_chat_form_validator.rb
+++ b/app/services/widget/pre_chat_form_validator.rb
@@ -46,7 +46,8 @@ class Widget::PreChatFormValidator
   # Validation error messages are built via I18n.t, which otherwise renders in
   # Rails' server-wide default locale regardless of the widget's own
   # configured language — showing English errors on a Portuguese widget.
-  # Mirrors MessageTemplates::HookExecutionService#template_locale.
+  # Normalizes an exact locale match, then the base language (stripping a
+  # region variant like "pt_BR" -> "pt"), then falls back to the app default.
   def widget_locale
     locale = @web_widget.locale
     return I18n.default_locale if locale.blank?

--- a/app/services/widget/pre_chat_form_validator.rb
+++ b/app/services/widget/pre_chat_form_validator.rb
@@ -22,12 +22,14 @@ class Widget::PreChatFormValidator
   def perform
     return { valid: true, sanitized_data: {} } unless @web_widget.pre_chat_form_enabled?
 
-    validate_required_fields
-    validate_email_format
-    validate_phone_format
-    sanitize_inputs
+    I18n.with_locale(widget_locale) do
+      validate_required_fields
+      validate_email_format
+      validate_phone_format
+      sanitize_inputs
 
-    raise ValidationError, @errors if @errors.any?
+      raise ValidationError, @errors if @errors.any?
+    end
 
     {
       valid: true,
@@ -40,6 +42,23 @@ class Widget::PreChatFormValidator
   end
 
   private
+
+  # Validation error messages are built via I18n.t, which otherwise renders in
+  # Rails' server-wide default locale regardless of the widget's own
+  # configured language — showing English errors on a Portuguese widget.
+  # Mirrors MessageTemplates::HookExecutionService#template_locale.
+  def widget_locale
+    locale = @web_widget.locale
+    return I18n.default_locale if locale.blank?
+
+    available_locales = I18n.available_locales.map(&:to_s)
+    return locale if available_locales.include?(locale)
+
+    locale_without_variant = locale.split('_').first
+    return locale_without_variant if available_locales.include?(locale_without_variant)
+
+    I18n.default_locale
+  end
 
   def pre_chat_fields
     @pre_chat_fields ||= begin


### PR DESCRIPTION
## Summary
- `Widget::PreChatFormValidator` built its validation error messages via `I18n.t(...)` without ever switching `I18n.locale`, so errors always rendered in Rails' server-wide default locale (English) regardless of the widget's own configured language — e.g. a `pt_BR` widget still showed "Invalid phone. Use international format..." in English.
- Wrap validation in `I18n.with_locale(widget_locale)`, where `widget_locale` mirrors `MessageTemplates::HookExecutionService#template_locale`'s normalization: exact locale match, falls back to the base language (stripping region), then to `I18n.default_locale`.

## Test plan
- [ ] Configure a Web Widget inbox's locale to `pt_BR`, submit an invalid phone number in the pre-chat form, confirm the returned error is in Portuguese instead of English
- [ ] Confirm inboxes with no configured locale still get the existing default-locale error text (no regression)

## Summary by Sourcery

Bug Fixes:
- Localize pre-chat form validation errors according to the web widget's configured locale, including regional-to-base locale fallback.