### PR TITLE
fix(whatsapp): rejeição do provider não fica mais invisível como enviada (CRM-358)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -208,6 +208,26 @@ on:
       - 'spec/services/evolution_hub/**'
       - 'spec/listeners/action_cable_listener_hub_channel_spec.rb'
       - 'spec/lib/meta_base_url_spec.rb'
+      # CRM-358: a rejected send is only visible because the caller marks every
+      # non-success provider return as failed, and because failed is terminal in
+      # the status funnel. Both are silent to every other lane — a message that
+      # goes back to reading `sent` still answers 201 and still shows a check.
+      - 'app/services/whatsapp/send_on_whatsapp_service.rb'
+      - 'app/services/whatsapp/providers/base_service.rb'
+      - 'app/services/whatsapp/providers/whatsapp_cloud_service.rb'
+      - 'app/services/whatsapp/providers/evolution_go_service.rb'
+      - 'app/services/whatsapp/providers/notificame_service.rb'
+      - 'app/services/whatsapp/providers/zapi_service.rb'
+      - 'app/services/whatsapp/providers/whatsapp_360_dialog_service.rb'
+      - 'app/services/messages/status_update_service.rb'
+      - 'app/jobs/send_reply_job.rb'
+      - 'spec/services/whatsapp/send_on_whatsapp_service_spec.rb'
+      - 'spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb'
+      - 'spec/services/whatsapp/providers/evolution_go_service_send_spec.rb'
+      - 'spec/services/whatsapp/providers/notificame_service_send_spec.rb'
+      - 'spec/services/whatsapp/providers/zapi_service_send_spec.rb'
+      - 'spec/services/messages/status_update_service_spec.rb'
+      - 'spec/jobs/send_reply_job_spec.rb'
 
 permissions:
   contents: read
@@ -324,4 +344,11 @@ jobs:
             spec/lib/evolution_hub/client_public_connect_spec.rb \
             spec/listeners/action_cable_listener_hub_channel_spec.rb \
             spec/lib/meta_base_url_spec.rb \
+            spec/services/whatsapp/send_on_whatsapp_service_spec.rb \
+            spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb \
+            spec/services/whatsapp/providers/evolution_go_service_send_spec.rb \
+            spec/services/whatsapp/providers/notificame_service_send_spec.rb \
+            spec/services/whatsapp/providers/zapi_service_send_spec.rb \
+            spec/services/messages/status_update_service_spec.rb \
+            spec/jobs/send_reply_job_spec.rb \
             --format progress

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -37,14 +37,8 @@ class SendReplyJob < ApplicationJob
 
   private
 
-  # CRM-358: route through the status funnel (instead of a raw update) so
-  # Wisper :message_status_changed reaches the EvoFlow listener — a provider
-  # that raises (e.g. Evolution Go on HTTP error) lands here, not in
-  # SendOnWhatsappService#handle_send_result. The marking itself must NEVER
-  # raise out of the job's rescue: a validation failure (e.g. message flooding
-  # runs on every save) would trigger a Sidekiq retry and RE-SEND a message
-  # that may already be delivered. Last resort: raw column write, funnel bypassed
-  # but no duplicate send.
+  # Goes through the funnel so Wisper :message_status_changed is published, and
+  # never raises out of the rescue — a retry would re-send a delivered message.
   def mark_failed_through_funnel(message, reason)
     Messages::StatusUpdateService.new(message, 'failed', reason).perform
   rescue StandardError => e

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -32,10 +32,28 @@ class SendReplyJob < ApplicationJob
     raise
   rescue StandardError => e
     Rails.logger.error "[SendReplyJob] Delivery failed for message #{message_id}: #{e.message}"
-    message&.update(status: :failed, external_error: e.message.to_s.truncate(1000))
+    mark_failed_through_funnel(message, e.message.to_s.truncate(1000)) if message
   end
 
   private
+
+  # CRM-358: route through the status funnel (instead of a raw update) so
+  # Wisper :message_status_changed reaches the EvoFlow listener — a provider
+  # that raises (e.g. Evolution Go on HTTP error) lands here, not in
+  # SendOnWhatsappService#handle_send_result. The marking itself must NEVER
+  # raise out of the job's rescue: a validation failure (e.g. message flooding
+  # runs on every save) would trigger a Sidekiq retry and RE-SEND a message
+  # that may already be delivered. Last resort: raw column write, funnel bypassed
+  # but no duplicate send.
+  def mark_failed_through_funnel(message, reason)
+    Messages::StatusUpdateService.new(message, 'failed', reason).perform
+  rescue StandardError => e
+    Rails.logger.error "[SendReplyJob] Could not mark message #{message.id} failed via funnel: #{e.message}"
+    message.update_columns( # rubocop:disable Rails/SkipsModelValidations
+      status: :failed,
+      content_attributes: (message.content_attributes || {}).merge('external_error' => reason)
+    )
+  end
 
   def send_on_facebook_page(message)
     if message.conversation.additional_attributes['type'] == 'instagram_direct_message'

--- a/app/services/whatsapp/providers/base_service.rb
+++ b/app/services/whatsapp/providers/base_service.rb
@@ -11,6 +11,10 @@
 class Whatsapp::Providers::BaseService
   pattr_initialize [:whatsapp_channel!]
 
+  # CRM-358: the reason of the last failed send, parsed from the provider
+  # response, for the caller (SendOnWhatsappService) to persist on the message.
+  attr_reader :last_delivery_error
+
   def send_message(_phone_number, _message)
     raise 'Overwrite this method in child class'
   end
@@ -27,8 +31,15 @@ class Whatsapp::Providers::BaseService
     raise 'Overwrite this method in child class'
   end
 
-  def error_message
-    raise 'Overwrite this method in child class'
+  # Meta Graph shape as a safe default; providers with a different error
+  # format override this. Non-JSON bodies (proxy/CDN 502 HTML) parse to a
+  # String, which has no #dig — fall back to the raw body.
+  def error_message(response)
+    parsed = response.parsed_response
+    return response.body.to_s.truncate(300).presence unless parsed.is_a?(Hash)
+
+    error = parsed['error']
+    error.is_a?(Hash) ? error['message'] : error.presence
   end
 
   def process_response(response)
@@ -43,17 +54,14 @@ class Whatsapp::Providers::BaseService
 
   def handle_error(response)
     Rails.logger.error response.body
-    return if @message.blank?
-
+    # CRM-358: failure marking is owned by the CALLER (SendOnWhatsappService),
+    # which treats any non-success return as failed. The old StatusUpdateService
+    # call here sat behind `return if @message.blank?` and @message was never
+    # set on the template path, so Cloud template rejections stayed invisible
+    # (the EVO-1460 fix landed inside that dead branch). The provider only
+    # records the reason for the caller to persist.
     # https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#sample-response
-    error_message = error_message(response)
-    return if error_message.blank?
-
-    # EVO-1460 follow-up: route through the funnel so Wisper :message_status_changed
-    # is published — handle_error used to bypass it via save! and the nil return tricked
-    # send_on_whatsapp_service's `== false` guard, leaving Cloud failures invisible to
-    # the EvoFlow listener (EVO-1240).
-    Messages::StatusUpdateService.new(@message, 'failed', error_message).perform
+    @last_delivery_error = error_message(response)
   end
 
   def create_buttons(items)

--- a/app/services/whatsapp/providers/base_service.rb
+++ b/app/services/whatsapp/providers/base_service.rb
@@ -11,8 +11,7 @@
 class Whatsapp::Providers::BaseService
   pattr_initialize [:whatsapp_channel!]
 
-  # CRM-358: the reason of the last failed send, parsed from the provider
-  # response, for the caller (SendOnWhatsappService) to persist on the message.
+  # Reason of the last failed send, for the caller to persist on the message.
   attr_reader :last_delivery_error
 
   def send_message(_phone_number, _message)
@@ -31,8 +30,7 @@ class Whatsapp::Providers::BaseService
     raise 'Overwrite this method in child class'
   end
 
-  # Meta Graph shape as a safe default; providers with a different error
-  # format override this. Non-JSON bodies (proxy/CDN 502 HTML) parse to a
+  # Meta Graph shape as the default; a non-JSON body (proxy 502) parses to a
   # String, which has no #dig — fall back to the raw body.
   def error_message(response)
     parsed = response.parsed_response
@@ -54,12 +52,7 @@ class Whatsapp::Providers::BaseService
 
   def handle_error(response)
     Rails.logger.error response.body
-    # CRM-358: failure marking is owned by the CALLER (SendOnWhatsappService),
-    # which treats any non-success return as failed. The old StatusUpdateService
-    # call here sat behind `return if @message.blank?` and @message was never
-    # set on the template path, so Cloud template rejections stayed invisible
-    # (the EVO-1460 fix landed inside that dead branch). The provider only
-    # records the reason for the caller to persist.
+    # Records only; SendOnWhatsappService owns the status marking.
     # https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#sample-response
     @last_delivery_error = error_message(response)
   end

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -446,8 +446,11 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
         Rails.logger.info "[Evolution Go] Message sent successfully with ID: #{message_id}"
         return message_id
       else
+        # CRM-358: this is a DELIVERED send (HTTP 200) — return true (success
+        # without id, same contract as EvolutionService) so the caller does not
+        # mark a delivered message as failed.
         Rails.logger.warn "[Evolution Go] Message sent but no ID returned: #{parsed_response}"
-        return nil
+        return true
       end
     end
 

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -446,9 +446,8 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
         Rails.logger.info "[Evolution Go] Message sent successfully with ID: #{message_id}"
         return message_id
       else
-        # CRM-358: this is a DELIVERED send (HTTP 200) — return true (success
-        # without id, same contract as EvolutionService) so the caller does not
-        # mark a delivered message as failed.
+        # HTTP 200 is a delivered send: `true` (same contract as EvolutionService)
+        # keeps the caller from marking it failed.
         Rails.logger.warn "[Evolution Go] Message sent but no ID returned: #{parsed_response}"
         return true
       end

--- a/app/services/whatsapp/providers/notificame_service.rb
+++ b/app/services/whatsapp/providers/notificame_service.rb
@@ -331,6 +331,9 @@ class Whatsapp::Providers::NotificameService < Whatsapp::Providers::BaseService
 
     if response.success? && parsed_response['error'].blank? && !has_error
       store_message_ids(parsed_response)
+      # CRM-358: `|| true` — a success shape whose id only store_message_ids
+      # understands (providerMessageId digs) must still read as success, or the
+      # caller marks a delivered message as failed.
       parsed_response['messageId'] || parsed_response['id'] ||
         parsed_response.dig('data', 'id') ||
         parsed_response.dig('data', 'messageId') ||
@@ -338,7 +341,7 @@ class Whatsapp::Providers::NotificameService < Whatsapp::Providers::BaseService
         parsed_response.dig('data', 0, 'messageId') ||
         parsed_response.dig('data', 0, 'id') ||
         parsed_response.dig(0, 'messageId') ||
-        parsed_response.dig(0, 'id')
+        parsed_response.dig(0, 'id') || true
     else
       handle_error(response)
       nil

--- a/app/services/whatsapp/providers/notificame_service.rb
+++ b/app/services/whatsapp/providers/notificame_service.rb
@@ -331,9 +331,8 @@ class Whatsapp::Providers::NotificameService < Whatsapp::Providers::BaseService
 
     if response.success? && parsed_response['error'].blank? && !has_error
       store_message_ids(parsed_response)
-      # CRM-358: `|| true` — a success shape whose id only store_message_ids
-      # understands (providerMessageId digs) must still read as success, or the
-      # caller marks a delivered message as failed.
+      # `|| true`: a success shape whose id only store_message_ids understands
+      # (providerMessageId) must still read as success at the caller.
       parsed_response['messageId'] || parsed_response['id'] ||
         parsed_response.dig('data', 'id') ||
         parsed_response.dig('data', 'messageId') ||

--- a/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_360_dialog_service.rb
@@ -105,7 +105,10 @@ class Whatsapp::Providers::Whatsapp360DialogService < Whatsapp::Providers::BaseS
 
   def error_message(response)
     # {"meta": {"success": false, "http_code": 400, "developer_message": "errro-message", "360dialog_trace_id": "someid"}}
-    response.parsed_response.dig('meta', 'developer_message')
+    parsed = response.parsed_response
+    return response.body.to_s.truncate(300).presence unless parsed.is_a?(Hash)
+
+    parsed.dig('meta', 'developer_message')
   end
 
   def template_body_parameters(template_info)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -409,7 +409,10 @@ module Whatsapp
           end
 
           media_id = upload_media_to_whatsapp(upload_path, upload_mime)
-          return if media_id.blank?
+          if media_id.blank?
+            record_audio_upload_failure(message, 'WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED - upload returned no media id')
+            return
+          end
 
           # Send message with media_id and voice: true
           response = HTTParty.post(
@@ -429,10 +432,10 @@ module Whatsapp
 
           process_response(response)
         rescue Whatsapp::AudioConverterService::ConversionError => e
-          mark_audio_upload_failed(message, "WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED - #{e.message}")
+          record_audio_upload_failure(message, "WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED - #{e.message}")
           nil
         rescue AudioUploadError => e
-          mark_audio_upload_failed(message, e.message)
+          record_audio_upload_failure(message, e.message)
           nil
         ensure
           # Clean up temporary files. close! also releases the Tempfile handle,
@@ -553,12 +556,11 @@ module Whatsapp
         codec.present? && codec != 'opus'
       end
 
-      def mark_audio_upload_failed(message, error_message)
-        Rails.logger.error("WhatsApp Cloud audio send failed for message #{message.id}: #{error_message}")
-        return if message.blank?
-
-        # EVO-1460 follow-up: same bypass as handle_error — see base_service.rb.
-        Messages::StatusUpdateService.new(message, 'failed', error_message).perform
+      # Only records the reason; SendOnWhatsappService marks the status, like
+      # every other failure path in this provider.
+      def record_audio_upload_failure(message, error_message)
+        Rails.logger.error("WhatsApp Cloud audio send failed for message #{message&.id}: #{error_message}")
+        @last_delivery_error = error_message
       end
 
       def find_template_by_id(template_id)

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -13,8 +13,6 @@ module Whatsapp
       WHATSAPP_MAX_MEDIA_BYTES = 16.megabytes
 
       def send_message(phone_number, message)
-        @message = message
-
         if message.attachments.present?
           send_attachment_message(phone_number, message)
         elsif message.content_type == 'input_select'
@@ -232,11 +230,6 @@ module Whatsapp
         else
           send_attachment_via_link(phone_number, message, attachment, type)
         end
-      end
-
-      def error_message(response)
-        # https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#sample-response
-        response.parsed_response&.dig('error', 'message')
       end
 
       def template_body_parameters(template_info)

--- a/app/services/whatsapp/providers/zapi_service.rb
+++ b/app/services/whatsapp/providers/zapi_service.rb
@@ -155,6 +155,9 @@ class Whatsapp::Providers::ZapiService < Whatsapp::Providers::BaseService
   # Z-API does not support template sending via API
   def send_template(_phone_number, _template_info, _message = nil)
     Rails.logger.warn 'Z-API: Templates are not supported via API'
+    # CRM-358: nil now marks the message failed at the caller — record the
+    # actual reason so the UI does not show the generic fallback.
+    @last_delivery_error = 'Z-API does not support template messages'
     nil
   end
 

--- a/app/services/whatsapp/providers/zapi_service.rb
+++ b/app/services/whatsapp/providers/zapi_service.rb
@@ -155,8 +155,8 @@ class Whatsapp::Providers::ZapiService < Whatsapp::Providers::BaseService
   # Z-API does not support template sending via API
   def send_template(_phone_number, _template_info, _message = nil)
     Rails.logger.warn 'Z-API: Templates are not supported via API'
-    # CRM-358: nil now marks the message failed at the caller — record the
-    # actual reason so the UI does not show the generic fallback.
+    # nil marks the message failed at the caller: record the real reason so the
+    # UI does not show the generic fallback.
     @last_delivery_error = 'Z-API does not support template messages'
     nil
   end
@@ -352,8 +352,9 @@ class Whatsapp::Providers::ZapiService < Whatsapp::Providers::BaseService
 
     if response.success? && parsed_response['error'].blank?
       store_message_ids(parsed_response)
-      # Z-API returns messageId or id
-      parsed_response['messageId'] || parsed_response['id'] || parsed_response['zaapId']
+      # `|| true`: a 200 with none of the id fields is still a delivered send, and
+      # the caller marks any non-success return as failed.
+      parsed_response['messageId'] || parsed_response['id'] || parsed_response['zaapId'] || true
     else
       handle_error(response)
       nil

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -24,8 +24,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
 
     Rails.logger.info "WhatsApp Template: Using number #{target_number} for contact #{message.conversation.contact.id}"
 
-    # CRM-358: hold ONE provider instance — the channel's `delegate` builds a
-    # fresh service per call, which would drop `last_delivery_error`.
+    # One instance: the channel's `delegate` builds a fresh service per call,
+    # which would drop `last_delivery_error`.
     provider = channel.provider_service
     message_id = provider.send_template(target_number, {
                                           name: name,
@@ -129,19 +129,12 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     handle_send_result(message_id, provider, 'Delivery failed: provider returned an error response')
   end
 
-  # CRM-358: single owner of failure marking. Anything that is not a known
-  # success shape becomes `failed` — the old `== false` guard let Cloud's nil
-  # (rejected by Meta) fall through and the message stayed `sent` forever.
-  # Known success shapes, per provider contract:
-  #   message id (String/numeric)  → persist as source_id (all providers)
-  #   true                         → sent, API returned no id (Evolution/Go/Notificame)
-  #   nil + is_unsupported flagged → EvolutionGo/Evolution bailed pre-send and
-  #                                  already marked the message; not a delivery failure
+  # Single owner of failure marking: any return that is not a known success shape
+  # (id, `true`, or a nil already flagged unsupported) is failed, never ignored.
   def handle_send_result(result, provider, fallback_reason)
     return if result == true
-    # A blank-String id can only come from a provider SUCCESS shape whose id
-    # field came empty (every error path returns nil/false) — success without
-    # a usable id, not a failure.
+    # Every error path returns nil/false, so a blank-String id is a success
+    # shape with an empty id field, not a failure.
     return if result.is_a?(String) && result.blank?
 
     if result.present?

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -24,23 +24,17 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
 
     Rails.logger.info "WhatsApp Template: Using number #{target_number} for contact #{message.conversation.contact.id}"
 
-    message_id = channel.send_template(target_number, {
-                                         name: name,
-                                         namespace: namespace,
-                                         lang_code: lang_code,
-                                         parameters: processed_parameters
-                                       })
+    # CRM-358: hold ONE provider instance — the channel's `delegate` builds a
+    # fresh service per call, which would drop `last_delivery_error`.
+    provider = channel.provider_service
+    message_id = provider.send_template(target_number, {
+                                          name: name,
+                                          namespace: namespace,
+                                          lang_code: lang_code,
+                                          parameters: processed_parameters
+                                        })
 
-    if message_id == false
-      Rails.logger.error "[WhatsApp] Template delivery failed for message #{message.id} — provider returned error"
-      Messages::StatusUpdateService.new(
-        message,
-        'failed',
-        'Template delivery failed: provider returned an error response'
-      ).perform
-    elsif message_id.is_a?(String) && message_id.present?
-      message.update!(source_id: message_id)
-    end
+    handle_send_result(message_id, provider, 'Template delivery failed: provider returned an error response')
   end
 
   def processable_channel_message_template
@@ -129,18 +123,36 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
 
     Rails.logger.info "WhatsApp Send: Using number #{target_number} for contact #{message.conversation.contact.id} (identifier: #{message.conversation.contact.identifier}, source_id: #{message.conversation.contact_inbox.source_id})"
 
-    message_id = channel.send_message(target_number, message)
+    provider = channel.provider_service
+    message_id = provider.send_message(target_number, message)
 
-    if message_id == false
-      Rails.logger.error "[WhatsApp] Delivery failed for message #{message.id} — provider returned error"
-      Messages::StatusUpdateService.new(
-        message,
-        'failed',
-        'Delivery failed: provider returned an error response'
-      ).perform
-    elsif message_id.is_a?(String) && message_id.present?
-      message.update!(source_id: message_id)
+    handle_send_result(message_id, provider, 'Delivery failed: provider returned an error response')
+  end
+
+  # CRM-358: single owner of failure marking. Anything that is not a known
+  # success shape becomes `failed` — the old `== false` guard let Cloud's nil
+  # (rejected by Meta) fall through and the message stayed `sent` forever.
+  # Known success shapes, per provider contract:
+  #   message id (String/numeric)  → persist as source_id (all providers)
+  #   true                         → sent, API returned no id (Evolution/Go/Notificame)
+  #   nil + is_unsupported flagged → EvolutionGo/Evolution bailed pre-send and
+  #                                  already marked the message; not a delivery failure
+  def handle_send_result(result, provider, fallback_reason)
+    return if result == true
+    # A blank-String id can only come from a provider SUCCESS shape whose id
+    # field came empty (every error path returns nil/false) — success without
+    # a usable id, not a failure.
+    return if result.is_a?(String) && result.blank?
+
+    if result.present?
+      message.update!(source_id: result.to_s)
+      return
     end
+    return if result.nil? && message.is_unsupported.present?
+
+    reason = provider.last_delivery_error.presence || fallback_reason
+    Rails.logger.error "[WhatsApp] Delivery failed for message #{message.id}: #{reason}"
+    Messages::StatusUpdateService.new(message, 'failed', reason).perform
   end
 
   def determine_target_number_for_sending

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SendReplyJob do
+  # CRM-358: a provider that raises (e.g. Evolution Go on HTTP error) must
+  # still land in the status funnel — the raw `update(status: :failed)` the
+  # rescue used before never published :message_status_changed.
+  let(:channel) { instance_double(Channel::Whatsapp) }
+  let(:inbox) { instance_double(Inbox, channel: channel) }
+  let(:conversation) { instance_double(Conversation, inbox: inbox) }
+  let(:message) { instance_double(Message, id: 42, conversation: conversation) }
+
+  before do
+    allow(channel).to receive(:class).and_return(Channel::Whatsapp)
+    allow(Message).to receive(:find).with(42).and_return(message)
+    allow(Whatsapp::SendOnWhatsappService).to receive(:new)
+      .and_raise('[Evolution Go] HTTP 500: boom')
+  end
+
+  it 'routes a raising provider through Messages::StatusUpdateService' do
+    status_service = instance_double(Messages::StatusUpdateService)
+    expect(Messages::StatusUpdateService).to receive(:new)
+      .with(message, 'failed', '[Evolution Go] HTTP 500: boom')
+      .and_return(status_service)
+    expect(status_service).to receive(:perform)
+
+    described_class.perform_now(42)
+  end
+
+  # The marking itself must never raise out of the job's rescue — a Sidekiq
+  # retry here would RE-SEND a message that may already be delivered.
+  it 'falls back to a raw column write when the funnel raises' do
+    status_service = instance_double(Messages::StatusUpdateService)
+    allow(Messages::StatusUpdateService).to receive(:new).and_return(status_service)
+    allow(status_service).to receive(:perform)
+      .and_raise(ActiveRecord::RecordInvalid.new(Message.new))
+    allow(message).to receive(:content_attributes).and_return({})
+
+    expect(message).to receive(:update_columns).with(
+      status: :failed,
+      content_attributes: { 'external_error' => '[Evolution Go] HTTP 500: boom' }
+    )
+
+    expect { described_class.perform_now(42) }.not_to raise_error
+  end
+end

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe SendReplyJob do
-  # CRM-358: a provider that raises (e.g. Evolution Go on HTTP error) must
-  # still land in the status funnel — the raw `update(status: :failed)` the
-  # rescue used before never published :message_status_changed.
+  # A provider that raises must still land in the status funnel: the raw
+  # `update(status: :failed)` the rescue used before published no Wisper event.
   let(:channel) { instance_double(Channel::Whatsapp) }
   let(:inbox) { instance_double(Inbox, channel: channel) }
   let(:conversation) { instance_double(Conversation, inbox: inbox) }
@@ -43,5 +42,46 @@ RSpec.describe SendReplyJob do
     )
 
     expect { described_class.perform_now(42) }.not_to raise_error
+  end
+
+  # The double above proves the call shape, not that the write lands. The enum
+  # symbol and the JSON store coder have to survive update_columns for real.
+  describe 'the last-resort write against a persisted message' do
+    let(:widget_channel) { Channel::WebWidget.create!(website_url: 'https://send-reply.example.com') }
+    let(:real_inbox) { Inbox.create!(name: 'SendReply Inbox', channel: widget_channel) }
+    let(:contact) { Contact.create!(name: 'SR', email: "sr-#{SecureRandom.hex(4)}@test.com") }
+    let(:contact_inbox) do
+      ContactInbox.create!(inbox: real_inbox, contact: contact, source_id: "sr-#{SecureRandom.hex(4)}")
+    end
+    let(:real_conversation) do
+      Conversation.create!(inbox: real_inbox, contact: contact, contact_inbox: contact_inbox)
+    end
+    let(:real_message) do
+      Message.create!(inbox: real_inbox, conversation: real_conversation, message_type: :outgoing, content: 'hi')
+    end
+
+    it 'persists failed and the reason without raising' do
+      expect(real_message.status).to eq('sent')
+
+      expect do
+        described_class.new.send(:mark_failed_through_funnel, real_message, 'boom')
+      end.not_to raise_error
+
+      real_message.reload
+      expect(real_message.status).to eq('failed')
+      expect(real_message.external_error).to eq('boom')
+    end
+
+    it 'still persists failed when the funnel raises' do
+      allow(Messages::StatusUpdateService).to receive(:new).and_raise(ActiveRecord::RecordInvalid.new(Message.new))
+
+      expect do
+        described_class.new.send(:mark_failed_through_funnel, real_message, 'boom')
+      end.not_to raise_error
+
+      real_message.reload
+      expect(real_message.status).to eq('failed')
+      expect(real_message.external_error).to eq('boom')
+    end
   end
 end

--- a/spec/services/whatsapp/providers/evolution_go_service_send_spec.rb
+++ b/spec/services/whatsapp/providers/evolution_go_service_send_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-358: the send-response contract consumed by SendOnWhatsappService —
+# a delivered send without an ID must NOT read as a failure.
+RSpec.describe Whatsapp::Providers::EvolutionGoService do
+  let(:whatsapp_channel) do
+    instance_double(Channel::Whatsapp, provider_config: { 'api_key' => 'token', 'instance_name' => 'inst' })
+  end
+  let(:service) { described_class.new(whatsapp_channel: whatsapp_channel) }
+
+  describe '#process_evolution_go_response' do
+    it 'returns the message id when the API provides one' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: true, code: 200,
+        parsed_response: { 'data' => { 'Info' => { 'ID' => 'GO123' } }, 'message' => 'success' },
+        body: '{}'
+      )
+
+      expect(service.send(:process_evolution_go_response, response)).to eq('GO123')
+    end
+
+    it 'returns true (success without id) when HTTP 200 carries no ID' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: true, code: 200,
+        parsed_response: { 'message' => 'success' },
+        body: '{}'
+      )
+
+      expect(service.send(:process_evolution_go_response, response)).to be(true)
+    end
+
+    it 'raises on HTTP error (handled by SendReplyJob rescue)' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: false, code: 500,
+        parsed_response: {},
+        body: 'boom'
+      )
+
+      expect { service.send(:process_evolution_go_response, response) }
+        .to raise_error(/HTTP 500/)
+    end
+  end
+end

--- a/spec/services/whatsapp/providers/evolution_go_service_send_spec.rb
+++ b/spec/services/whatsapp/providers/evolution_go_service_send_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-# CRM-358: the send-response contract consumed by SendOnWhatsappService —
-# a delivered send without an ID must NOT read as a failure.
+# The send-response contract consumed by SendOnWhatsappService: a delivered
+# send without an ID must not read as a failure.
 RSpec.describe Whatsapp::Providers::EvolutionGoService do
   let(:whatsapp_channel) do
     instance_double(Channel::Whatsapp, provider_config: { 'api_key' => 'token', 'instance_name' => 'inst' })

--- a/spec/services/whatsapp/providers/notificame_service_send_spec.rb
+++ b/spec/services/whatsapp/providers/notificame_service_send_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-358: the send-response contract consumed by SendOnWhatsappService.
+RSpec.describe Whatsapp::Providers::NotificameService do
+  let(:whatsapp_channel) do
+    instance_double(Channel::Whatsapp, provider_config: { 'api_key' => 'token' })
+  end
+  let(:service) { described_class.new(whatsapp_channel: whatsapp_channel) }
+
+  describe '#process_response' do
+    it 'returns the message id on success' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: true,
+        parsed_response: { 'messageId' => 'NM123' },
+        body: '{}'
+      )
+
+      expect(service.send(:process_response, response)).to eq('NM123')
+    end
+
+    # A success shape whose id only store_message_ids understands
+    # (providerMessageId) must still read as success at the caller.
+    it 'returns true when the success shape carries no extractable message id' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: true,
+        parsed_response: { 'messageStatus' => { 'code' => 'SENT', 'providerMessageId' => 'cHJvdg==' } },
+        body: '{}'
+      )
+
+      expect(service.send(:process_response, response)).to be(true)
+    end
+
+    it 'returns nil and records the reason on error' do
+      response = instance_double(
+        HTTParty::Response,
+        success?: false,
+        parsed_response: { 'messageStatus' => { 'code' => 'ERROR', 'error' => { 'message' => 'invalid token' } } },
+        body: '{"messageStatus":{"code":"ERROR"}}'
+      )
+
+      expect(service.send(:process_response, response)).to be_nil
+      expect(service.last_delivery_error).to eq('invalid token')
+    end
+  end
+end

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -140,13 +140,11 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect(result).to be_nil
     end
 
-    # EVO-1460 follow-up: handle_error and mark_audio_upload_failed used to write
-    # message.status = :failed + save! directly, bypassing Wisper. They now route
-    # through Messages::StatusUpdateService so :message_status_changed is published
-    # for the EvoFlow listener (EVO-1240).
-    it 'routes provider error to Messages::StatusUpdateService (handle_error funnel)' do
-      service.instance_variable_set(:@message, message)
-
+    # CRM-358: failure marking moved to the caller (SendOnWhatsappService) —
+    # the provider only records the parsed reason and returns nil. The old
+    # in-provider StatusUpdateService call sat behind `return if @message.blank?`
+    # and @message was never set on the template path.
+    it 'records the provider reason and returns nil (caller owns failure marking)' do
       failed_message_response = instance_double(
         HTTParty::Response,
         success?: false,
@@ -156,15 +154,12 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
 
       expect(service).to receive(:upload_media_to_whatsapp).with(converted_path, 'audio/ogg').and_return('media_123')
       allow(HTTParty).to receive(:post).and_return(failed_message_response)
-
-      status_service = instance_double(Messages::StatusUpdateService, perform: true)
-      expect(Messages::StatusUpdateService).to receive(:new)
-        .with(message, 'failed', 'Invalid audio payload')
-        .and_return(status_service)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
 
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
+      expect(service.last_delivery_error).to eq('Invalid audio payload')
     end
 
     it 'routes audio upload failure to Messages::StatusUpdateService (mark_audio_upload_failed funnel)' do
@@ -228,6 +223,59 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       end.to raise_error(described_class::AudioUploadError, /over the .* byte limit/)
     ensure
       upload_file.close!
+    end
+  end
+
+  describe '#send_template (CRM-358)' do
+    let(:template_info) { { name: 'order_update', lang_code: 'pt_BR', parameters: [] } }
+
+    it 'returns the message id on success' do
+      ok_response = instance_double(
+        HTTParty::Response,
+        success?: true,
+        parsed_response: { 'messages' => [{ 'id' => 'wamid.HBgL' }] }
+      )
+      allow(HTTParty).to receive(:post).and_return(ok_response)
+
+      expect(service.send_template('5511999999999', template_info)).to eq('wamid.HBgL')
+      expect(service.last_delivery_error).to be_nil
+    end
+
+    # Proxy/CDN failures parse to a String body (no JSON) — error_message must
+    # not blow up on String#dig and should surface the raw body instead.
+    it 'falls back to the raw body when the error response is not JSON' do
+      rejection = instance_double(
+        HTTParty::Response,
+        success?: false,
+        parsed_response: '<html>502 Bad Gateway</html>',
+        body: '<html>502 Bad Gateway</html>'
+      )
+      allow(HTTParty).to receive(:post).and_return(rejection)
+
+      expect(service.send_template('5511999999999', template_info)).to be_nil
+      expect(service.last_delivery_error).to eq('<html>502 Bad Gateway</html>')
+    end
+
+    # Real rejection shape from a template with a dynamic URL button missing
+    # its parameter — the exact case that used to stay `sent` forever.
+    it 'returns nil and records the Meta rejection reason' do
+      rejection = instance_double(
+        HTTParty::Response,
+        success?: false,
+        parsed_response: {
+          'error' => {
+            'message' => '(#131008) Required parameter is missing',
+            'code' => 131_008,
+            'error_data' => { 'details' => 'buttons: Button at index 0 of type Url requires a parameter' }
+          }
+        },
+        body: '{"error":{"message":"(#131008) Required parameter is missing","code":131008}}'
+      )
+      allow(HTTParty).to receive(:post).and_return(rejection)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
+
+      expect(service.send_template('5511999999999', template_info)).to be_nil
+      expect(service.last_delivery_error).to eq('(#131008) Required parameter is missing')
     end
   end
 end

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -124,26 +124,21 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect(message.status).to be_nil
     end
 
-    it 'marks the message failed (without uploading) when transcoding fails' do
+    it 'records the transcode reason (without uploading) when transcoding fails' do
       allow(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus).and_raise(
         Whatsapp::AudioConverterService::ConversionError, 'FFmpeg conversion failed: boom'
       )
       expect(service).not_to receive(:upload_media_to_whatsapp)
-
-      status_service = instance_double(Messages::StatusUpdateService, perform: true)
-      expect(Messages::StatusUpdateService).to receive(:new)
-        .with(message, 'failed', a_string_including('WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED'))
-        .and_return(status_service)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
 
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
+      expect(service.last_delivery_error).to include('WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED')
     end
 
-    # CRM-358: failure marking moved to the caller (SendOnWhatsappService) —
-    # the provider only records the parsed reason and returns nil. The old
-    # in-provider StatusUpdateService call sat behind `return if @message.blank?`
-    # and @message was never set on the template path.
+    # Failure marking lives in the caller now; the provider only records the
+    # parsed reason and returns nil.
     it 'records the provider reason and returns nil (caller owns failure marking)' do
       failed_message_response = instance_double(
         HTTParty::Response,
@@ -162,22 +157,29 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect(service.last_delivery_error).to eq('Invalid audio payload')
     end
 
-    it 'routes audio upload failure to Messages::StatusUpdateService (mark_audio_upload_failed funnel)' do
+    it 'records the audio upload reason and leaves the marking to the caller' do
       allow(service).to receive(:upload_media_to_whatsapp).and_raise(
         described_class::AudioUploadError,
         'WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED - WhatsApp API Error (131053) - Unsupported media type'
       )
       expect(HTTParty).not_to receive(:post)
-
-      status_service = instance_double(Messages::StatusUpdateService, perform: true)
-      expect(Messages::StatusUpdateService).to receive(:new)
-        .with(message, 'failed', a_string_including('WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED'))
-        .and_return(status_service)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
 
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
+      expect(service.last_delivery_error).to include('WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED')
       expect(temp_file).to have_received(:close!)
+    end
+
+    it 'records a reason when the upload returns no media id' do
+      allow(service).to receive(:upload_media_to_whatsapp).and_return(nil)
+      expect(HTTParty).not_to receive(:post)
+
+      result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
+
+      expect(result).to be_nil
+      expect(service.last_delivery_error).to include('upload returned no media id')
     end
   end
 

--- a/spec/services/whatsapp/providers/zapi_service_send_spec.rb
+++ b/spec/services/whatsapp/providers/zapi_service_send_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 # The send-response contract consumed by SendOnWhatsappService.
-RSpec.describe Whatsapp::Providers::NotificameService do
+RSpec.describe Whatsapp::Providers::ZapiService do
   let(:whatsapp_channel) do
-    instance_double(Channel::Whatsapp, provider_config: { 'api_key' => 'token' })
+    instance_double(Channel::Whatsapp,
+                    provider_config: { 'instance_id' => 'inst', 'token' => 'tok', 'client_token' => 'ct' })
   end
   let(:service) { described_class.new(whatsapp_channel: whatsapp_channel) }
 
@@ -14,20 +15,18 @@ RSpec.describe Whatsapp::Providers::NotificameService do
       response = instance_double(
         HTTParty::Response,
         success?: true,
-        parsed_response: { 'messageId' => 'NM123' },
+        parsed_response: { 'zaapId' => 'ZAAP1', 'messageId' => 'ZAPI123', 'id' => 'ZAPI123' },
         body: '{}'
       )
 
-      expect(service.send(:process_response, response)).to eq('NM123')
+      expect(service.send(:process_response, response)).to eq('ZAPI123')
     end
 
-    # A success shape whose id only store_message_ids understands
-    # (providerMessageId) must still read as success at the caller.
-    it 'returns true when the success shape carries no extractable message id' do
+    it 'returns true when a 200 carries none of the id fields' do
       response = instance_double(
         HTTParty::Response,
         success?: true,
-        parsed_response: { 'messageStatus' => { 'code' => 'SENT', 'providerMessageId' => 'cHJvdg==' } },
+        parsed_response: { 'value' => true },
         body: '{}'
       )
 
@@ -38,12 +37,12 @@ RSpec.describe Whatsapp::Providers::NotificameService do
       response = instance_double(
         HTTParty::Response,
         success?: false,
-        parsed_response: { 'messageStatus' => { 'code' => 'ERROR', 'error' => { 'message' => 'invalid token' } } },
-        body: '{"messageStatus":{"code":"ERROR"}}'
+        parsed_response: { 'error' => 'phone not found' },
+        body: '{"error":"phone not found"}'
       )
 
       expect(service.send(:process_response, response)).to be_nil
-      expect(service.last_delivery_error).to eq('invalid token')
+      expect(service.last_delivery_error).to eq('phone not found')
     end
   end
 end

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -297,8 +297,8 @@ RSpec.describe Whatsapp::SendOnWhatsappService do
     end
   end
 
-  # CRM-358: exhaustive return-contract matrix — no provider return may fall
-  # into a branchless void (the original bug).
+  # Exhaustive return-contract matrix: no provider return may fall into a
+  # branchless void.
   describe '#handle_send_result' do
     let(:provider) { 'whatsapp_cloud' }
     let(:contact_inbox_source_id) { '5511999999999' }

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -197,10 +197,18 @@ RSpec.describe Whatsapp::SendOnWhatsappService do
     let(:provider) { 'evolution_go' }
     let(:contact_inbox_source_id) { '5511999999999' }
     let(:additional_attributes) { { 'evolution_go_chat_id' => '5511999999999@s.whatsapp.net' } }
+    let(:provider_service) do
+      instance_double(Whatsapp::Providers::EvolutionGoService, last_delivery_error: nil)
+    end
+
+    before do
+      allow(channel).to receive(:provider_service).and_return(provider_service)
+      allow(message).to receive(:id).and_return(99)
+      allow(message).to receive(:is_unsupported).and_return(nil)
+    end
 
     it 'AC6: delegates failure to Messages::StatusUpdateService with external_error' do
-      allow(channel).to receive(:send_message).and_return(false)
-      allow(message).to receive(:id).and_return(99)
+      allow(provider_service).to receive(:send_message).and_return(false)
       status_service = instance_double(Messages::StatusUpdateService, perform: true)
 
       expect(Messages::StatusUpdateService).to receive(:new).with(
@@ -212,20 +220,50 @@ RSpec.describe Whatsapp::SendOnWhatsappService do
 
       service.send(:send_session_message)
     end
+
+    context 'when the provider is whatsapp_cloud and Meta rejects the send (CRM-358)' do
+      let(:provider) { 'whatsapp_cloud' }
+      let(:additional_attributes) { nil }
+      let(:provider_service) do
+        instance_double(Whatsapp::Providers::WhatsappCloudService,
+                        last_delivery_error: '(#131008) Required parameter is missing')
+      end
+
+      it 'marks the message failed with the Meta reason (nil used to fall through as sent)' do
+        allow(provider_service).to receive(:send_message).and_return(nil)
+        status_service = instance_double(Messages::StatusUpdateService, perform: true)
+
+        expect(Messages::StatusUpdateService).to receive(:new).with(
+          message,
+          'failed',
+          '(#131008) Required parameter is missing'
+        ).and_return(status_service)
+
+        service.send(:send_session_message)
+      end
+    end
   end
 
   describe '#send_template_message — failure routes through StatusUpdateService' do
     let(:provider) { 'evolution_go' }
     let(:contact_inbox_source_id) { '5511999999999' }
     let(:additional_attributes) { nil }
+    let(:provider_service) do
+      instance_double(Whatsapp::Providers::EvolutionGoService, last_delivery_error: nil)
+    end
 
-    it 'AC6: delegates template-send failure to Messages::StatusUpdateService' do
+    before do
       allow(service).to receive(:processable_channel_message_template).and_return(
         ['template_name', 'namespace', 'pt_BR', []]
       )
       allow(service).to receive(:determine_target_number_for_sending).and_return('5511999999999')
-      allow(channel).to receive(:send_template).and_return(false)
+      allow(channel).to receive(:provider_service).and_return(provider_service)
       allow(message).to receive(:id).and_return(99)
+      allow(message).to receive(:is_unsupported).and_return(nil)
+    end
+
+    it 'AC6: delegates template-send failure to Messages::StatusUpdateService' do
+      allow(provider_service).to receive(:send_template).and_return(false)
       status_service = instance_double(Messages::StatusUpdateService, perform: true)
 
       expect(Messages::StatusUpdateService).to receive(:new).with(
@@ -235,6 +273,108 @@ RSpec.describe Whatsapp::SendOnWhatsappService do
       ).and_return(status_service)
 
       service.send(:send_template_message)
+    end
+
+    context 'when the provider is whatsapp_cloud and Meta rejects the template (CRM-358)' do
+      let(:provider) { 'whatsapp_cloud' }
+      let(:provider_service) do
+        instance_double(Whatsapp::Providers::WhatsappCloudService,
+                        last_delivery_error: '(#131008) Required parameter is missing')
+      end
+
+      it 'marks the message failed with the Meta reason (the evidence case: sent + source_id NULL)' do
+        allow(provider_service).to receive(:send_template).and_return(nil)
+        status_service = instance_double(Messages::StatusUpdateService, perform: true)
+
+        expect(Messages::StatusUpdateService).to receive(:new).with(
+          message,
+          'failed',
+          '(#131008) Required parameter is missing'
+        ).and_return(status_service)
+
+        service.send(:send_template_message)
+      end
+    end
+  end
+
+  # CRM-358: exhaustive return-contract matrix — no provider return may fall
+  # into a branchless void (the original bug).
+  describe '#handle_send_result' do
+    let(:provider) { 'whatsapp_cloud' }
+    let(:contact_inbox_source_id) { '5511999999999' }
+    let(:additional_attributes) { nil }
+    let(:provider_service) do
+      instance_double(Whatsapp::Providers::WhatsappCloudService,
+                      last_delivery_error: '(#131008) Required parameter is missing')
+    end
+
+    before do
+      allow(message).to receive(:id).and_return(99)
+      allow(message).to receive(:is_unsupported).and_return(nil)
+    end
+
+    it 'persists a String id as source_id and marks nothing (happy path)' do
+      expect(message).to receive(:update!).with(source_id: 'wamid.HBgL')
+      expect(Messages::StatusUpdateService).not_to receive(:new)
+
+      service.send(:handle_send_result, 'wamid.HBgL', provider_service, 'fallback')
+    end
+
+    it 'persists a numeric id as source_id (Z-API/Notificame JSON ids)' do
+      expect(message).to receive(:update!).with(source_id: '12345')
+      expect(Messages::StatusUpdateService).not_to receive(:new)
+
+      service.send(:handle_send_result, 12_345, provider_service, 'fallback')
+    end
+
+    it 'treats a blank-String id as success without id (empty id field in a success shape)' do
+      expect(message).not_to receive(:update!)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
+
+      service.send(:handle_send_result, '', provider_service, 'fallback')
+    end
+
+    it 'treats true as success without id (Evolution/Go/Notificame contract)' do
+      expect(message).not_to receive(:update!)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
+
+      service.send(:handle_send_result, true, provider_service, 'fallback')
+    end
+
+    it 'skips a nil for a message the provider already flagged unsupported (EvolutionGo contract)' do
+      allow(message).to receive(:is_unsupported).and_return(true)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
+
+      service.send(:handle_send_result, nil, provider_service, 'fallback')
+    end
+
+    it 'still marks false failed even when the message carries the unsupported flag' do
+      allow(message).to receive(:is_unsupported).and_return(true)
+      status_service = instance_double(Messages::StatusUpdateService, perform: true)
+      expect(Messages::StatusUpdateService).to receive(:new)
+        .with(message, 'failed', '(#131008) Required parameter is missing')
+        .and_return(status_service)
+
+      service.send(:handle_send_result, false, provider_service, 'fallback')
+    end
+
+    it 'marks nil failed with the recorded provider reason' do
+      status_service = instance_double(Messages::StatusUpdateService, perform: true)
+      expect(Messages::StatusUpdateService).to receive(:new)
+        .with(message, 'failed', '(#131008) Required parameter is missing')
+        .and_return(status_service)
+
+      service.send(:handle_send_result, nil, provider_service, 'fallback')
+    end
+
+    it 'marks false failed with the fallback reason when no reason was recorded' do
+      no_reason = instance_double(Whatsapp::Providers::EvolutionService, last_delivery_error: nil)
+      status_service = instance_double(Messages::StatusUpdateService, perform: true)
+      expect(Messages::StatusUpdateService).to receive(:new)
+        .with(message, 'failed', 'fallback')
+        .and_return(status_service)
+
+      service.send(:handle_send_result, false, no_reason, 'fallback')
     end
   end
 end


### PR DESCRIPTION
## Summary
- Mensagem rejeitada pela Graph API (ex.: template com botão de URL sem parâmetro, `#131008`) ficava `status=sent` com `source_id NULL` — o job concluía com sucesso e o atendente nunca sabia que o cliente não recebeu. Causa dupla: `process_response` devolve `nil` no erro e o caller só tratava `== false`; no caminho de template o marcador de falha do provider era código morto (`@message` nunca é setado ali — o fix da EVO-1460 caiu dentro desse ramo).
- **`SendOnWhatsappService#handle_send_result` vira o dono único da marcação de falha:** id String/numérico → `source_id`; `true` → sucesso sem id; String vazia → sucesso sem id utilizável; `nil` com `is_unsupported` flagado → já tratado pelo provider; **qualquer outro retorno (`nil`/`false`) → `failed`** via `Messages::StatusUpdateService`, com a razão do provider persistida em `content_attributes.external_error` (a UI já renderiza).
- `BaseService#handle_error` deixa de marcar status e passa a expor a razão parseada (`last_delivery_error`); `error_message` ganha default no formato Graph, tolerante a body não-JSON (502 de proxy) e a `{"error": "string"}`.
- Contratos de sucesso alinhados para não virar falso-failed: EvolutionGo devolve `true` no 200 sem ID (antes `nil`), Notificame devolve `true` quando o id só existe como `providerMessageId`, Z-API registra a razão real ao recusar template.
- `SendReplyJob`: o rescue roteia pelo `StatusUpdateService` (publica Wisper `:message_status_changed` para o listener do EvoFlow), cobrindo provider que raisa no erro — com last-resort em `update_columns` para a marcação nunca escapar do rescue e causar reenvio duplicado via retry do Sidekiq.

## Security
- Sem endpoint novo, sem input de usuário novo. A razão persistida vem da resposta do provider e é renderizada como texto puro pela UI (sem HTML); body não-JSON é truncado em 300 chars.
- Nenhum segredo em log: `handle_error` loga o body da resposta de erro (comportamento pré-existente).

## Test plan
- `POSTGRES_PORT=5442 POSTGRES_USERNAME=evo_app POSTGRES_PASSWORD=evo_pass bundle exec rspec spec/services/whatsapp/ spec/jobs/send_reply_job_spec.rb spec/services/messages/status_update_service_spec.rb` → 231 exemplos, 1 falha **pré-existente** no develop (`evolution_handlers/attachment_processor_spec.rb:128`, não relacionada — falha igual no develop limpo)
- Red/green: revertendo só o caller, as specs novas de `nil` falham (o retorno que escapou do fix anterior)
- Validação headless em ambiente real: rejeição síncrona → `failed` + `external_error` persistido + broadcast `sent→failed`; webhook `statuses.failed` retroativo → `failed` com `"131026: Message undeliverable"`; canal não-WhatsApp segue intacto
- RuboCop: zero offenses novas (baseline dos arquivos modificados no develop: 154 → 151, specs novas limpas)

## Changed Files
- `app/services/whatsapp/send_on_whatsapp_service.rb` — `handle_send_result` (dono único da falha)
- `app/services/whatsapp/providers/base_service.rb` — `handle_error` expõe razão; `error_message` default robusto
- `app/services/whatsapp/providers/whatsapp_cloud_service.rb` — remove `@message` e override redundante
- `app/services/whatsapp/providers/evolution_go_service.rb` — 200 sem ID = `true`
- `app/services/whatsapp/providers/notificame_service.rb` — sucesso sem id extraível = `true`
- `app/services/whatsapp/providers/zapi_service.rb` — razão específica na recusa de template
- `app/services/whatsapp/providers/whatsapp_360_dialog_service.rb` — guard body não-JSON
- `app/jobs/send_reply_job.rb` — rescue via funil de status com last-resort
- specs: `send_on_whatsapp_service_spec.rb` (matriz de retornos), `whatsapp_cloud_service_spec.rb`, `evolution_go_service_send_spec.rb` (novo), `notificame_service_send_spec.rb` (novo), `send_reply_job_spec.rb` (novo)

## Linked Issue
- CRM-358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gLJMk7XnBVDmcypsR6VUg

## Summary by Sourcery

Ensure WhatsApp provider rejections are surfaced as terminal message failures with actionable error details instead of being reported as sent.

Bug Fixes:
- Mark rejected WhatsApp sends as failed instead of leaving them incorrectly in the sent state.
- Persist provider rejection reasons in message metadata so delivery failures are visible to agents.
- Route send-job exceptions through the status update funnel, with a fallback persistence path to prevent retries from resending messages.

Enhancements:
- Centralize WhatsApp send-result handling across templates and session messages, including success-without-ID and unsupported-message outcomes.
- Make provider error parsing resilient to non-JSON responses and string-based Graph API errors.
- Align provider success and failure contracts across Evolution Go, Notificame, Z-API, WhatsApp Cloud, and 360dialog.

CI:
- Extend the spec staleness guard to cover the WhatsApp delivery failure flow and its associated tests.

Tests:
- Add coverage for provider response contracts, rejection reason persistence, centralized status handling, and send-job rescue behavior.