### PR TITLE
fix(whatsapp): achados do code review do CRM-358 (#325)

### DIFF
--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -37,14 +37,8 @@ class SendReplyJob < ApplicationJob
 
   private
 
-  # CRM-358: route through the status funnel (instead of a raw update) so
-  # Wisper :message_status_changed reaches the EvoFlow listener — a provider
-  # that raises (e.g. Evolution Go on HTTP error) lands here, not in
-  # SendOnWhatsappService#handle_send_result. The marking itself must NEVER
-  # raise out of the job's rescue: a validation failure (e.g. message flooding
-  # runs on every save) would trigger a Sidekiq retry and RE-SEND a message
-  # that may already be delivered. Last resort: raw column write, funnel bypassed
-  # but no duplicate send.
+  # Goes through the funnel so Wisper :message_status_changed is published, and
+  # never raises out of the rescue — a retry would re-send a delivered message.
   def mark_failed_through_funnel(message, reason)
     Messages::StatusUpdateService.new(message, 'failed', reason).perform
   rescue StandardError => e

--- a/app/services/whatsapp/providers/base_service.rb
+++ b/app/services/whatsapp/providers/base_service.rb
@@ -11,8 +11,7 @@
 class Whatsapp::Providers::BaseService
   pattr_initialize [:whatsapp_channel!]
 
-  # CRM-358: the reason of the last failed send, parsed from the provider
-  # response, for the caller (SendOnWhatsappService) to persist on the message.
+  # Reason of the last failed send, for the caller to persist on the message.
   attr_reader :last_delivery_error
 
   def send_message(_phone_number, _message)
@@ -31,8 +30,7 @@ class Whatsapp::Providers::BaseService
     raise 'Overwrite this method in child class'
   end
 
-  # Meta Graph shape as a safe default; providers with a different error
-  # format override this. Non-JSON bodies (proxy/CDN 502 HTML) parse to a
+  # Meta Graph shape as the default; a non-JSON body (proxy 502) parses to a
   # String, which has no #dig — fall back to the raw body.
   def error_message(response)
     parsed = response.parsed_response
@@ -54,12 +52,7 @@ class Whatsapp::Providers::BaseService
 
   def handle_error(response)
     Rails.logger.error response.body
-    # CRM-358: failure marking is owned by the CALLER (SendOnWhatsappService),
-    # which treats any non-success return as failed. The old StatusUpdateService
-    # call here sat behind `return if @message.blank?` and @message was never
-    # set on the template path, so Cloud template rejections stayed invisible
-    # (the EVO-1460 fix landed inside that dead branch). The provider only
-    # records the reason for the caller to persist.
+    # Records only; SendOnWhatsappService owns the status marking.
     # https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#sample-response
     @last_delivery_error = error_message(response)
   end

--- a/app/services/whatsapp/providers/evolution_go_service.rb
+++ b/app/services/whatsapp/providers/evolution_go_service.rb
@@ -446,9 +446,8 @@ class Whatsapp::Providers::EvolutionGoService < Whatsapp::Providers::BaseService
         Rails.logger.info "[Evolution Go] Message sent successfully with ID: #{message_id}"
         return message_id
       else
-        # CRM-358: this is a DELIVERED send (HTTP 200) — return true (success
-        # without id, same contract as EvolutionService) so the caller does not
-        # mark a delivered message as failed.
+        # HTTP 200 is a delivered send: `true` (same contract as EvolutionService)
+        # keeps the caller from marking it failed.
         Rails.logger.warn "[Evolution Go] Message sent but no ID returned: #{parsed_response}"
         return true
       end

--- a/app/services/whatsapp/providers/notificame_service.rb
+++ b/app/services/whatsapp/providers/notificame_service.rb
@@ -331,9 +331,8 @@ class Whatsapp::Providers::NotificameService < Whatsapp::Providers::BaseService
 
     if response.success? && parsed_response['error'].blank? && !has_error
       store_message_ids(parsed_response)
-      # CRM-358: `|| true` — a success shape whose id only store_message_ids
-      # understands (providerMessageId digs) must still read as success, or the
-      # caller marks a delivered message as failed.
+      # `|| true`: a success shape whose id only store_message_ids understands
+      # (providerMessageId) must still read as success at the caller.
       parsed_response['messageId'] || parsed_response['id'] ||
         parsed_response.dig('data', 'id') ||
         parsed_response.dig('data', 'messageId') ||

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -409,7 +409,10 @@ module Whatsapp
           end
 
           media_id = upload_media_to_whatsapp(upload_path, upload_mime)
-          return if media_id.blank?
+          if media_id.blank?
+            record_audio_upload_failure(message, 'WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED - upload returned no media id')
+            return
+          end
 
           # Send message with media_id and voice: true
           response = HTTParty.post(
@@ -429,10 +432,10 @@ module Whatsapp
 
           process_response(response)
         rescue Whatsapp::AudioConverterService::ConversionError => e
-          mark_audio_upload_failed(message, "WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED - #{e.message}")
+          record_audio_upload_failure(message, "WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED - #{e.message}")
           nil
         rescue AudioUploadError => e
-          mark_audio_upload_failed(message, e.message)
+          record_audio_upload_failure(message, e.message)
           nil
         ensure
           # Clean up temporary files. close! also releases the Tempfile handle,
@@ -553,12 +556,11 @@ module Whatsapp
         codec.present? && codec != 'opus'
       end
 
-      def mark_audio_upload_failed(message, error_message)
-        Rails.logger.error("WhatsApp Cloud audio send failed for message #{message.id}: #{error_message}")
-        return if message.blank?
-
-        # EVO-1460 follow-up: same bypass as handle_error — see base_service.rb.
-        Messages::StatusUpdateService.new(message, 'failed', error_message).perform
+      # Only records the reason; SendOnWhatsappService marks the status, like
+      # every other failure path in this provider.
+      def record_audio_upload_failure(message, error_message)
+        Rails.logger.error("WhatsApp Cloud audio send failed for message #{message&.id}: #{error_message}")
+        @last_delivery_error = error_message
       end
 
       def find_template_by_id(template_id)

--- a/app/services/whatsapp/providers/zapi_service.rb
+++ b/app/services/whatsapp/providers/zapi_service.rb
@@ -155,8 +155,8 @@ class Whatsapp::Providers::ZapiService < Whatsapp::Providers::BaseService
   # Z-API does not support template sending via API
   def send_template(_phone_number, _template_info, _message = nil)
     Rails.logger.warn 'Z-API: Templates are not supported via API'
-    # CRM-358: nil now marks the message failed at the caller — record the
-    # actual reason so the UI does not show the generic fallback.
+    # nil marks the message failed at the caller: record the real reason so the
+    # UI does not show the generic fallback.
     @last_delivery_error = 'Z-API does not support template messages'
     nil
   end
@@ -352,8 +352,9 @@ class Whatsapp::Providers::ZapiService < Whatsapp::Providers::BaseService
 
     if response.success? && parsed_response['error'].blank?
       store_message_ids(parsed_response)
-      # Z-API returns messageId or id
-      parsed_response['messageId'] || parsed_response['id'] || parsed_response['zaapId']
+      # `|| true`: a 200 with none of the id fields is still a delivered send, and
+      # the caller marks any non-success return as failed.
+      parsed_response['messageId'] || parsed_response['id'] || parsed_response['zaapId'] || true
     else
       handle_error(response)
       nil

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -24,8 +24,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
 
     Rails.logger.info "WhatsApp Template: Using number #{target_number} for contact #{message.conversation.contact.id}"
 
-    # CRM-358: hold ONE provider instance — the channel's `delegate` builds a
-    # fresh service per call, which would drop `last_delivery_error`.
+    # One instance: the channel's `delegate` builds a fresh service per call,
+    # which would drop `last_delivery_error`.
     provider = channel.provider_service
     message_id = provider.send_template(target_number, {
                                           name: name,
@@ -129,19 +129,12 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     handle_send_result(message_id, provider, 'Delivery failed: provider returned an error response')
   end
 
-  # CRM-358: single owner of failure marking. Anything that is not a known
-  # success shape becomes `failed` — the old `== false` guard let Cloud's nil
-  # (rejected by Meta) fall through and the message stayed `sent` forever.
-  # Known success shapes, per provider contract:
-  #   message id (String/numeric)  → persist as source_id (all providers)
-  #   true                         → sent, API returned no id (Evolution/Go/Notificame)
-  #   nil + is_unsupported flagged → EvolutionGo/Evolution bailed pre-send and
-  #                                  already marked the message; not a delivery failure
+  # Single owner of failure marking: any return that is not a known success shape
+  # (id, `true`, or a nil already flagged unsupported) is failed, never ignored.
   def handle_send_result(result, provider, fallback_reason)
     return if result == true
-    # A blank-String id can only come from a provider SUCCESS shape whose id
-    # field came empty (every error path returns nil/false) — success without
-    # a usable id, not a failure.
+    # Every error path returns nil/false, so a blank-String id is a success
+    # shape with an empty id field, not a failure.
     return if result.is_a?(String) && result.blank?
 
     if result.present?

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe SendReplyJob do
-  # CRM-358: a provider that raises (e.g. Evolution Go on HTTP error) must
-  # still land in the status funnel — the raw `update(status: :failed)` the
-  # rescue used before never published :message_status_changed.
+  # A provider that raises must still land in the status funnel: the raw
+  # `update(status: :failed)` the rescue used before published no Wisper event.
   let(:channel) { instance_double(Channel::Whatsapp) }
   let(:inbox) { instance_double(Inbox, channel: channel) }
   let(:conversation) { instance_double(Conversation, inbox: inbox) }
@@ -43,5 +42,46 @@ RSpec.describe SendReplyJob do
     )
 
     expect { described_class.perform_now(42) }.not_to raise_error
+  end
+
+  # The double above proves the call shape, not that the write lands. The enum
+  # symbol and the JSON store coder have to survive update_columns for real.
+  describe 'the last-resort write against a persisted message' do
+    let(:widget_channel) { Channel::WebWidget.create!(website_url: 'https://send-reply.example.com') }
+    let(:real_inbox) { Inbox.create!(name: 'SendReply Inbox', channel: widget_channel) }
+    let(:contact) { Contact.create!(name: 'SR', email: "sr-#{SecureRandom.hex(4)}@test.com") }
+    let(:contact_inbox) do
+      ContactInbox.create!(inbox: real_inbox, contact: contact, source_id: "sr-#{SecureRandom.hex(4)}")
+    end
+    let(:real_conversation) do
+      Conversation.create!(inbox: real_inbox, contact: contact, contact_inbox: contact_inbox)
+    end
+    let(:real_message) do
+      Message.create!(inbox: real_inbox, conversation: real_conversation, message_type: :outgoing, content: 'hi')
+    end
+
+    it 'persists failed and the reason without raising' do
+      expect(real_message.status).to eq('sent')
+
+      expect do
+        described_class.new.send(:mark_failed_through_funnel, real_message, 'boom')
+      end.not_to raise_error
+
+      real_message.reload
+      expect(real_message.status).to eq('failed')
+      expect(real_message.external_error).to eq('boom')
+    end
+
+    it 'still persists failed when the funnel raises' do
+      allow(Messages::StatusUpdateService).to receive(:new).and_raise(ActiveRecord::RecordInvalid.new(Message.new))
+
+      expect do
+        described_class.new.send(:mark_failed_through_funnel, real_message, 'boom')
+      end.not_to raise_error
+
+      real_message.reload
+      expect(real_message.status).to eq('failed')
+      expect(real_message.external_error).to eq('boom')
+    end
   end
 end

--- a/spec/services/whatsapp/providers/evolution_go_service_send_spec.rb
+++ b/spec/services/whatsapp/providers/evolution_go_service_send_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-# CRM-358: the send-response contract consumed by SendOnWhatsappService —
-# a delivered send without an ID must NOT read as a failure.
+# The send-response contract consumed by SendOnWhatsappService: a delivered
+# send without an ID must not read as a failure.
 RSpec.describe Whatsapp::Providers::EvolutionGoService do
   let(:whatsapp_channel) do
     instance_double(Channel::Whatsapp, provider_config: { 'api_key' => 'token', 'instance_name' => 'inst' })

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -124,26 +124,21 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect(message.status).to be_nil
     end
 
-    it 'marks the message failed (without uploading) when transcoding fails' do
+    it 'records the transcode reason (without uploading) when transcoding fails' do
       allow(Whatsapp::AudioConverterService).to receive(:convert_to_ogg_opus).and_raise(
         Whatsapp::AudioConverterService::ConversionError, 'FFmpeg conversion failed: boom'
       )
       expect(service).not_to receive(:upload_media_to_whatsapp)
-
-      status_service = instance_double(Messages::StatusUpdateService, perform: true)
-      expect(Messages::StatusUpdateService).to receive(:new)
-        .with(message, 'failed', a_string_including('WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED'))
-        .and_return(status_service)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
 
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
+      expect(service.last_delivery_error).to include('WHATSAPP_CLOUD_AUDIO_TRANSCODE_FAILED')
     end
 
-    # CRM-358: failure marking moved to the caller (SendOnWhatsappService) —
-    # the provider only records the parsed reason and returns nil. The old
-    # in-provider StatusUpdateService call sat behind `return if @message.blank?`
-    # and @message was never set on the template path.
+    # Failure marking lives in the caller now; the provider only records the
+    # parsed reason and returns nil.
     it 'records the provider reason and returns nil (caller owns failure marking)' do
       failed_message_response = instance_double(
         HTTParty::Response,
@@ -162,22 +157,29 @@ RSpec.describe Whatsapp::Providers::WhatsappCloudService do
       expect(service.last_delivery_error).to eq('Invalid audio payload')
     end
 
-    it 'routes audio upload failure to Messages::StatusUpdateService (mark_audio_upload_failed funnel)' do
+    it 'records the audio upload reason and leaves the marking to the caller' do
       allow(service).to receive(:upload_media_to_whatsapp).and_raise(
         described_class::AudioUploadError,
         'WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED - WhatsApp API Error (131053) - Unsupported media type'
       )
       expect(HTTParty).not_to receive(:post)
-
-      status_service = instance_double(Messages::StatusUpdateService, perform: true)
-      expect(Messages::StatusUpdateService).to receive(:new)
-        .with(message, 'failed', a_string_including('WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED'))
-        .and_return(status_service)
+      expect(Messages::StatusUpdateService).not_to receive(:new)
 
       result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
 
       expect(result).to be_nil
+      expect(service.last_delivery_error).to include('WHATSAPP_CLOUD_AUDIO_UPLOAD_FAILED')
       expect(temp_file).to have_received(:close!)
+    end
+
+    it 'records a reason when the upload returns no media id' do
+      allow(service).to receive(:upload_media_to_whatsapp).and_return(nil)
+      expect(HTTParty).not_to receive(:post)
+
+      result = service.send(:send_audio_via_media_upload, '5511999999999', message, attachment)
+
+      expect(result).to be_nil
+      expect(service.last_delivery_error).to include('upload returned no media id')
     end
   end
 

--- a/spec/services/whatsapp/providers/zapi_service_send_spec.rb
+++ b/spec/services/whatsapp/providers/zapi_service_send_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 # The send-response contract consumed by SendOnWhatsappService.
-RSpec.describe Whatsapp::Providers::NotificameService do
+RSpec.describe Whatsapp::Providers::ZapiService do
   let(:whatsapp_channel) do
-    instance_double(Channel::Whatsapp, provider_config: { 'api_key' => 'token' })
+    instance_double(Channel::Whatsapp,
+                    provider_config: { 'instance_id' => 'inst', 'token' => 'tok', 'client_token' => 'ct' })
   end
   let(:service) { described_class.new(whatsapp_channel: whatsapp_channel) }
 
@@ -14,20 +15,18 @@ RSpec.describe Whatsapp::Providers::NotificameService do
       response = instance_double(
         HTTParty::Response,
         success?: true,
-        parsed_response: { 'messageId' => 'NM123' },
+        parsed_response: { 'zaapId' => 'ZAAP1', 'messageId' => 'ZAPI123', 'id' => 'ZAPI123' },
         body: '{}'
       )
 
-      expect(service.send(:process_response, response)).to eq('NM123')
+      expect(service.send(:process_response, response)).to eq('ZAPI123')
     end
 
-    # A success shape whose id only store_message_ids understands
-    # (providerMessageId) must still read as success at the caller.
-    it 'returns true when the success shape carries no extractable message id' do
+    it 'returns true when a 200 carries none of the id fields' do
       response = instance_double(
         HTTParty::Response,
         success?: true,
-        parsed_response: { 'messageStatus' => { 'code' => 'SENT', 'providerMessageId' => 'cHJvdg==' } },
+        parsed_response: { 'value' => true },
         body: '{}'
       )
 
@@ -38,12 +37,12 @@ RSpec.describe Whatsapp::Providers::NotificameService do
       response = instance_double(
         HTTParty::Response,
         success?: false,
-        parsed_response: { 'messageStatus' => { 'code' => 'ERROR', 'error' => { 'message' => 'invalid token' } } },
-        body: '{"messageStatus":{"code":"ERROR"}}'
+        parsed_response: { 'error' => 'phone not found' },
+        body: '{"error":"phone not found"}'
       )
 
       expect(service.send(:process_response, response)).to be_nil
-      expect(service.last_delivery_error).to eq('invalid token')
+      expect(service.last_delivery_error).to eq('phone not found')
     end
   end
 end

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -297,8 +297,8 @@ RSpec.describe Whatsapp::SendOnWhatsappService do
     end
   end
 
-  # CRM-358: exhaustive return-contract matrix — no provider return may fall
-  # into a branchless void (the original bug).
+  # Exhaustive return-contract matrix: no provider return may fall into a
+  # branchless void.
   describe '#handle_send_result' do
     let(:provider) { 'whatsapp_cloud' }
     let(:contact_inbox_source_id) { '5511999999999' }


### PR DESCRIPTION
Achados do code review da #325. Nada aqui reabre o contrato — o `handle_send_result` continua sendo o dono único da marcação, e é justamente isso que os dois primeiros itens passam a valer de fato.

## 🟡 Sobrava um segundo dono da marcação de falha

`WhatsappCloudService#mark_audio_upload_failed` continuava chamando `Messages::StatusUpdateService` dentro do provider — contra o AC2 do card ("a responsabilidade sai dele e fica no caller, **uma das duas, não as duas**") e contra o próprio comentário novo do caller.

Sequência real de um upload de áudio rejeitado: o provider marcava `failed` com a razão específica → `send_audio_via_media_upload` devolvia `nil` → `handle_send_result` logava `[WhatsApp] Delivery failed for message X: Delivery failed: provider returned an error response` e instanciava o `StatusUpdateService` de novo. O resultado só saía certo porque `valid_status_transition?` trata `failed` como terminal (`status_update_service.rb:47`) e a 2ª chamada virava no-op silencioso. Relaxar esse guard (ex.: para atualizar `external_error`) sobrescreveria a razão do áudio pela genérica.

`mark_audio_upload_failed` virou `record_audio_upload_failure`: só grava `@last_delivery_error`, como todo o resto do provider. Bônus: `upload_media_to_whatsapp` devolvendo `media_id` em branco também registra razão agora, em vez de cair no fallback genérico.

## 🟡 O Z-API ainda podia devolver `nil` num envio bem-sucedido

`ZapiService#process_response` retornava `parsed_response['messageId'] || parsed_response['id'] || parsed_response['zaapId']` no ramo de **sucesso** — um 200 sem nenhuma das três chaves cai em `nil`, e sob o contrato novo `nil` = `failed`. Era o único provider fora do ajuste: a #325 já tinha fechado a mesma forma no EvolutionGo (`return true`) e no Notificame (`|| true`).

Consequência: mensagem entregue pelo Z-API apareceria como "não entregue" — o espelho exato do bug que o card conserta. Fechado com `|| true` e specs de contrato (`zapi_service_send_spec.rb`).

## 🟢 O spec do last-resort não exercitava o write

`spec/jobs/send_reply_job_spec.rb` testava o fallback contra `instance_double(Message)` com `update_columns` stubado: provava a *forma da chamada*, não que `update_columns(status: :failed, content_attributes: hash)` funciona num registro real — justamente o ramo cujo contrato é **nunca raisar** (se raisar, escapa do rescue do job e o retry do Sidekiq reenvia mensagem já entregue).

Agora há um bloco contra uma `Message` persistida provando que o símbolo do enum e o store JSON sobrevivem ao `update_columns`. Prova negativa: trocando `content_attributes:` por `external_error:` no job, o spec novo fica vermelho.

## 🟢 Comentários

Os três blocos narrativos (8, 8 e 6 linhas em `send_reply_job.rb`, `send_on_whatsapp_service.rb` e `base_service.rb`) repetiam o corpo da PR — causa-raiz, histórico da EVO-1460, por que o ramo antigo era morto. Encurtados para o "porquê" que o código não expressa, e os IDs de card saíram dos comentários (seguem nos labels dos specs).

## Validação

```
bundle exec rspec spec/services/whatsapp/ spec/jobs/send_reply_job_spec.rb \
  spec/services/messages/status_update_service_spec.rb
# 237 exemplos, 1 falha
```

A falha é `evolution_handlers/attachment_processor_spec.rb:128` (`meta=` com kwargs vs options hash), **pré-existente** — reproduzida no `develop` limpo, em banco de teste zerado. As 5 falhas de `audio_converter_service_spec` que aparecem sem ffmpeg somem com o binário instalado; nada a ver com o diff.

RuboCop nos arquivos tocados: **152** ofensas, mesmo número da #325 e abaixo do baseline do develop (154). O spec novo do Z-API entra com 0.

## Fora do escopo (fica de follow-up)

Mensagem outgoing que o provider recusa antes de sair, marcando `is_unsupported`, continua terminando como `sent` (`send_on_whatsapp_service.rb:151`): o atendente acha que enviou e nada saiu — mesma classe de sintoma do CRM-358. A #325 já trata isso como ramo explícito, não como buraco, e o card não pede; ampliar aqui seria escopo novo.

## Summary by Sourcery

Centralize WhatsApp delivery failure marking and align provider success responses with the delivery contract.

Bug Fixes:
- Ensure WhatsApp Cloud audio upload failures are recorded by the provider and marked only once by the caller, preserving specific failure reasons.
- Treat successful Z-API responses without message IDs as delivered instead of incorrectly marking messages as failed.

Enhancements:
- Simplify comments describing failure handling and provider response contracts.

Tests:
- Add persisted-record coverage for the job's last-resort failure write and provider contract coverage for Z-API responses.