### PR TITLE
ci(whatsapp): roda os specs do envio no spec-staleness-guard (CRM-358)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -208,6 +208,26 @@ on:
       - 'spec/services/evolution_hub/**'
       - 'spec/listeners/action_cable_listener_hub_channel_spec.rb'
       - 'spec/lib/meta_base_url_spec.rb'
+      # CRM-358: a rejected send is only visible because the caller marks every
+      # non-success provider return as failed, and because failed is terminal in
+      # the status funnel. Both are silent to every other lane — a message that
+      # goes back to reading `sent` still answers 201 and still shows a check.
+      - 'app/services/whatsapp/send_on_whatsapp_service.rb'
+      - 'app/services/whatsapp/providers/base_service.rb'
+      - 'app/services/whatsapp/providers/whatsapp_cloud_service.rb'
+      - 'app/services/whatsapp/providers/evolution_go_service.rb'
+      - 'app/services/whatsapp/providers/notificame_service.rb'
+      - 'app/services/whatsapp/providers/zapi_service.rb'
+      - 'app/services/whatsapp/providers/whatsapp_360_dialog_service.rb'
+      - 'app/services/messages/status_update_service.rb'
+      - 'app/jobs/send_reply_job.rb'
+      - 'spec/services/whatsapp/send_on_whatsapp_service_spec.rb'
+      - 'spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb'
+      - 'spec/services/whatsapp/providers/evolution_go_service_send_spec.rb'
+      - 'spec/services/whatsapp/providers/notificame_service_send_spec.rb'
+      - 'spec/services/whatsapp/providers/zapi_service_send_spec.rb'
+      - 'spec/services/messages/status_update_service_spec.rb'
+      - 'spec/jobs/send_reply_job_spec.rb'
 
 permissions:
   contents: read
@@ -324,4 +344,11 @@ jobs:
             spec/lib/evolution_hub/client_public_connect_spec.rb \
             spec/listeners/action_cable_listener_hub_channel_spec.rb \
             spec/lib/meta_base_url_spec.rb \
+            spec/services/whatsapp/send_on_whatsapp_service_spec.rb \
+            spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb \
+            spec/services/whatsapp/providers/evolution_go_service_send_spec.rb \
+            spec/services/whatsapp/providers/notificame_service_send_spec.rb \
+            spec/services/whatsapp/providers/zapi_service_send_spec.rb \
+            spec/services/messages/status_update_service_spec.rb \
+            spec/jobs/send_reply_job_spec.rb \
             --format progress


### PR DESCRIPTION
Os specs que provam o CRM-358 não rodavam em lane nenhuma. O CI da #325 fechou verde sem executar **nenhum** deles.

## O buraco

O `spec-staleness-guard` é allowlist **dupla** — `paths:` decide se o job dispara, e a lista fixa no `run:` decide o que o rspec executa. De WhatsApp ele só tinha os specs de mensagem **entrante** (`incoming_message_base_service_spec.rb`, `evolution_handlers/messages_upsert_guard_spec.rb`). O caminho de **envio** não estava em lista nenhuma.

Nas outras lanes também não: o `community-parity` roda só RBAC (`spec/rbac` + `*_rbac_spec`), o `community-with-extension-consumer-stub` roda só `evo_extension_points`, e os outros seis workflows (`cascade-deletion-guard`, `action-mailbox-config-guard`, `docker-publish`, `role-sti-guard`, `migration-version-parity`, `storage-config-guard`) não invocam `rspec`.

Ou seja: a matriz de retornos do caller, a rejeição real da Meta em template e sessão, os contratos de EvolutionGo/Notificame/Z-API e o rescue do job podiam quebrar sem que PR nenhuma reprovasse.

## O que entra

Nas duas listas: `send_on_whatsapp_service.rb`, os cinco providers tocados, `send_reply_job.rb` e `messages/status_update_service.rb`, com os sete specs correspondentes.

O `status_update_service` entra junto de propósito: `failed` ser terminal no `valid_status_transition?` é o que impede a razão específica do provider de ser sobrescrita pela genérica quando dois caminhos marcam a mesma mensagem. Mexer nesse guard sem rodar estes specs é exatamente a regressão silenciosa que o card fecha.

## Validação

```
bundle exec rspec \
  spec/services/whatsapp/send_on_whatsapp_service_spec.rb \
  spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb \
  spec/services/whatsapp/providers/evolution_go_service_send_spec.rb \
  spec/services/whatsapp/providers/notificame_service_send_spec.rb \
  spec/services/whatsapp/providers/zapi_service_send_spec.rb \
  spec/services/messages/status_update_service_spec.rb \
  spec/jobs/send_reply_job_spec.rb --format progress
# 64 exemplos, 0 falhas
```

Exatamente a invocação nova da lane, em banco de teste zerado. YAML validado.

## Summary by Sourcery

Run the previously uncovered WhatsApp sending and status-transition specs in CI to prevent regressions from passing undetected.

Enhancements:
- Ensure WhatsApp sending and message status regression specs are executed by the CI staleness-guard lane when related application code changes.

CI:
- Expand the spec-staleness-guard path allowlist and RSpec invocation to cover WhatsApp send providers, reply jobs, and status update behavior.

Tests:
- Add seven WhatsApp sending, provider, reply-job, and status-update specs to the CI lane, covering 64 examples with no failures.