### PR TITLE
fix(mailers): literais de marca resolvem por BRAND_NAME em vez de "Evolution" cravado (CRM-422 F1)

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,8 @@
 class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::SanitizeHelper
 
+  DEFAULT_SENDER_EMAIL = 'accounts@evoai.app'.freeze
+
   default from: proc { ApplicationMailer.get_mailer_sender_email }
   around_action :switch_locale
   before_action :load_dynamic_mail_settings
@@ -152,10 +154,10 @@ class ApplicationMailer < ActionMailer::Base
     begin
       # Try GlobalConfig first, then fallback to ENV
       sender_email = GlobalConfigService.load('MAILER_SENDER_EMAIL', nil) if defined?(GlobalConfigService)
-      sender_email.presence || ENV.fetch('MAILER_SENDER_EMAIL', 'Evolution <accounts@evoai.app>')
+      sender_email.presence || ENV.fetch('MAILER_SENDER_EMAIL', DEFAULT_SENDER_EMAIL)
     rescue => e
       Rails.logger.warn "Failed to load MAILER_SENDER_EMAIL from GlobalConfig: #{e.message}" if defined?(Rails.logger)
-      ENV.fetch('MAILER_SENDER_EMAIL', 'Evolution <accounts@evoai.app>')
+      ENV.fetch('MAILER_SENDER_EMAIL', DEFAULT_SENDER_EMAIL)
     end
   end
 

--- a/app/mailers/pipeline_task_mailer.rb
+++ b/app/mailers/pipeline_task_mailer.rb
@@ -53,6 +53,6 @@ class PipelineTaskMailer < ApplicationMailer
   private
 
   def brand_name
-    GlobalConfig.get('BRAND_NAME')['BRAND_NAME'] || 'Evo CRM'
+    GlobalConfig.get('BRAND_NAME')['BRAND_NAME'].presence || 'CRM'
   end
 end

--- a/app/views/mailers/administrator_notifications/account_compliance_mailer/account_deleted.liquid
+++ b/app/views/mailers/administrator_notifications/account_compliance_mailer/account_deleted.liquid
@@ -1,9 +1,9 @@
 <p>Hello,</p>
 
-<p>This is a notification to inform you that data has been permanently deleted from your Evolution instance.</p>
+<p>This is a notification to inform you that data has been permanently deleted from your {{ global_config['BRAND_NAME'] }} instance.</p>
 
 <p>
-  <strong>Evolution Installation:</strong> {{ meta.instance_url }}<br>
+  <strong>{{ global_config['BRAND_NAME'] }} Installation:</strong> {{ meta.instance_url }}<br>
   <strong>Deleted At:</strong> {{ meta.deleted_at }}<br>
   <strong>Marked for Deletion at:</strong> {{ meta.marked_for_deletion_at }}<br>
   <strong>Deletion Reason:</strong> {{ meta.deletion_reason }}
@@ -25,4 +25,4 @@
 <p>This email serves as a record for compliance purposes.</p>
 
 <p>Thank you,<br>
-Evolution System</p>
+{{ global_config['BRAND_NAME'] }} System</p>

--- a/app/views/mailers/administrator_notifications/account_compliance_mailer/account_deleted.liquid
+++ b/app/views/mailers/administrator_notifications/account_compliance_mailer/account_deleted.liquid
@@ -1,9 +1,9 @@
 <p>Hello,</p>
 
-<p>This is a notification to inform you that data has been permanently deleted from your {{ global_config['BRAND_NAME'] }} instance.</p>
+<p>This is a notification to inform you that data has been permanently deleted from your {{ global_config['BRAND_NAME'] | default: 'CRM' }} instance.</p>
 
 <p>
-  <strong>{{ global_config['BRAND_NAME'] }} Installation:</strong> {{ meta.instance_url }}<br>
+  <strong>{{ global_config['BRAND_NAME'] | default: 'CRM' }} Installation:</strong> {{ meta.instance_url }}<br>
   <strong>Deleted At:</strong> {{ meta.deleted_at }}<br>
   <strong>Marked for Deletion at:</strong> {{ meta.marked_for_deletion_at }}<br>
   <strong>Deletion Reason:</strong> {{ meta.deletion_reason }}
@@ -25,4 +25,4 @@
 <p>This email serves as a record for compliance purposes.</p>
 
 <p>Thank you,<br>
-{{ global_config['BRAND_NAME'] }} System</p>
+{{ global_config['BRAND_NAME'] | default: 'CRM' }} System</p>

--- a/app/views/mailers/administrator_notifications/account_notification_mailer/account_deletion.liquid
+++ b/app/views/mailers/administrator_notifications/account_notification_mailer/account_deletion.liquid
@@ -13,4 +13,4 @@
 <p><a href="{{ action_url }}">Cancel Account Deletion</a></p>
 
 <p>Thank you,<br>
-{{ global_config['BRAND_NAME'] }} Team</p>
+{{ global_config['BRAND_NAME'] | default: 'CRM' }} Team</p>

--- a/app/views/mailers/administrator_notifications/account_notification_mailer/account_deletion.liquid
+++ b/app/views/mailers/administrator_notifications/account_notification_mailer/account_deletion.liquid
@@ -13,4 +13,4 @@
 <p><a href="{{ action_url }}">Cancel Account Deletion</a></p>
 
 <p>Thank you,<br>
-Team Evolution</p>
+{{ global_config['BRAND_NAME'] }} Team</p>

--- a/spec/mailers/administrator_notifications/brand_name_spec.rb
+++ b/spec/mailers/administrator_notifications/brand_name_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe 'administrator notification e-mails use BRAND_NAME', type: :maile
     expect(mail.body.encoded).not_to match(/Evolution/)
   end
 
+  it 'signs with a neutral CRM when BRAND_NAME is blank' do
+    allow(GlobalConfig).to receive(:get).with('BRAND_NAME', 'BRAND_URL')
+                                        .and_return('BRAND_NAME' => '', 'BRAND_URL' => '')
+    mail = AdministratorNotifications::AccountNotificationMailer.account_deletion(account).deliver_now
+
+    expect(mail.body.encoded).to include('CRM Team')
+    expect(mail.body.encoded).not_to match(/Evolution/)
+  end
+
   it 'falls back to a bare address when MAILER_SENDER_EMAIL is unset' do
     allow(GlobalConfigService).to receive(:load).with('MAILER_SENDER_EMAIL', nil).and_return(nil)
     allow(ENV).to receive(:fetch).and_call_original

--- a/spec/mailers/administrator_notifications/brand_name_spec.rb
+++ b/spec/mailers/administrator_notifications/brand_name_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'administrator notification e-mails use BRAND_NAME', type: :mailer do
+  let(:account) do
+    double('account', name: 'Acme Corp', custom_attributes: { 'marked_for_deletion_at' => Time.current.iso8601 })
+  end
+
+  before do
+    allow_any_instance_of(ApplicationMailer).to receive(:smtp_config_set_or_development?).and_return(true)
+    allow_any_instance_of(AdministratorNotifications::BaseMailer).to receive(:admin_emails).and_return(['admin@example.com'])
+    allow(GlobalConfig).to receive(:get).and_call_original
+    allow(GlobalConfig).to receive(:get).with('BRAND_NAME', 'BRAND_URL')
+                                        .and_return('BRAND_NAME' => 'Acme Agency', 'BRAND_URL' => 'https://acme.test')
+    allow(GlobalConfig).to receive(:get).with('EVOLUTION_INSTANCE_ADMIN_EMAIL')
+                                        .and_return('EVOLUTION_INSTANCE_ADMIN_EMAIL' => 'compliance@example.com')
+  end
+
+  it 'signs the account deletion notice with the configured brand' do
+    mail = AdministratorNotifications::AccountNotificationMailer.account_deletion(account).deliver_now
+
+    expect(mail.body.encoded).to include('Acme Agency Team')
+    expect(mail.body.encoded).not_to match(/Evolution/)
+  end
+
+  it 'refers to the configured brand in the compliance notice' do
+    mail = AdministratorNotifications::AccountComplianceMailer.with(soft_deleted_users: [])
+                                                              .account_deleted(account).deliver_now
+
+    expect(mail.body.encoded).to include('Acme Agency Installation')
+    expect(mail.body.encoded).to include('Acme Agency System')
+    expect(mail.body.encoded).not_to match(/Evolution/)
+  end
+
+  it 'falls back to a bare address when MAILER_SENDER_EMAIL is unset' do
+    allow(GlobalConfigService).to receive(:load).with('MAILER_SENDER_EMAIL', nil).and_return(nil)
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('MAILER_SENDER_EMAIL', ApplicationMailer::DEFAULT_SENDER_EMAIL)
+                                 .and_return(ApplicationMailer::DEFAULT_SENDER_EMAIL)
+
+    expect(ApplicationMailer.get_mailer_sender_email).to eq('accounts@evoai.app')
+  end
+end

--- a/spec/mailers/administrator_notifications/brand_name_spec.rb
+++ b/spec/mailers/administrator_notifications/brand_name_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'administrator notification e-mails use BRAND_NAME', type: :mailer do
+  # Account is a module in this codebase, so a verifying double is not available.
   let(:account) do
-    double('account', name: 'Acme Corp', custom_attributes: { 'marked_for_deletion_at' => Time.current.iso8601 })
+    double('account', name: 'Acme Corp', custom_attributes: { 'marked_for_deletion_at' => Time.current.iso8601 }) # rubocop:disable RSpec/VerifiedDoubles
   end
 
   before do
-    allow_any_instance_of(ApplicationMailer).to receive(:smtp_config_set_or_development?).and_return(true)
-    allow_any_instance_of(AdministratorNotifications::BaseMailer).to receive(:admin_emails).and_return(['admin@example.com'])
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load).with('MAILER_TYPE', nil).and_return('smtp')
+    allow(User).to receive(:joins).with(:roles).and_return(double(where: double(pluck: ['admin@example.com']))) # rubocop:disable RSpec/VerifiedDoubles
     allow(GlobalConfig).to receive(:get).and_call_original
     allow(GlobalConfig).to receive(:get).with('BRAND_NAME', 'BRAND_URL')
                                         .and_return('BRAND_NAME' => 'Acme Agency', 'BRAND_URL' => 'https://acme.test')


### PR DESCRIPTION
**Título:** `fix(mailers): literais de marca resolvem por BRAND_NAME em vez de "Evolution" cravado (CRM-422 F1)`

### Resumo
Parte community da CRM-422 F1: `application_mailer`, `pipeline_task_mailer` e os liquid de `account_deleted`/`account_deletion` deixam de cravar "Evolution"; `BRAND_NAME` com default neutro (`'CRM'`, revisão), spec de mailers sem `any_instance`. Nada enterprise aqui: a marca por agência vem da gem/Orion.

### Commits
```
18df36b test(mailers): cover BRAND_NAME in admin notices without any_instance stubs
950e404 fix(mailers): brand literals resolve through BRAND_NAME instead of hardcoded Evolution
```
(+ `cc7b8fa` do Dev-Email, `| default: 'CRM'`: ainda LOCAL em 30/08 tarde, conferir a publicação.)

### Migrations / envs / rollout
Nenhuma migration. `BRAND_NAME` já existe como env do community; sem valor cai no default. Lembrete do ECOSYSTEM: a imagem enterprise faz `FROM evoapicloud/evo-ai-crm-community:develop`; o fix só chega quando a imagem community for republicada e a enterprise rebuildada.

---

## Summary by Sourcery

Make community mailers resolve branding from BRAND_NAME instead of using hardcoded Evolution text.

Bug Fixes:
- Replace hardcoded Evolution branding in mailer messages with the configured BRAND_NAME, falling back to a neutral CRM label.
- Use a bare default sender address when MAILER_SENDER_EMAIL is not configured.

Enhancements:
- Centralize the default mail sender address in ApplicationMailer.
- Cover configured and fallback branding behavior in administrator notification mailer specs without any_instance stubs.

Tests:
- Add mailer coverage for BRAND_NAME usage, neutral fallback branding, and default sender behavior.