### PR TITLE
fix(mail): BmsProvider posts to the configured BMS_API_URL instance

### DIFF
--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -571,6 +571,11 @@
   value:
   locked: false
   description: 'BMS IP Pool'
+- name: BMS_API_URL
+  display_title: 'BMS API URL'
+  value:
+  locked: false
+  description: 'Base URL of the BMS API instance (e.g. https://bms-app.example.com); empty uses the legacy host'
 ## ------ End of Configs added for BMS ------ ##
 
 ## ------ Configs added for Linear ------ ##

--- a/lib/mail/bms_provider.rb
+++ b/lib/mail/bms_provider.rb
@@ -67,11 +67,24 @@ module Mail
 
     private
 
+    # Base host of the BMS API. BMS_API_URL points each installation at its own
+    # instance; the legacy host only remains as the fallback for an empty config.
+    # The API has no /api global prefix (that segment only exists through the
+    # front's nginx rewrite), so a configured base carrying it is normalized,
+    # otherwise POST /api/services/send-email answers 404.
+    LEGACY_API_BASE = 'https://bms-api.bri.us'.freeze
+
+    def bms_api_base
+      configured = GlobalConfigService.load('BMS_API_URL', nil).to_s.strip
+      base = configured.empty? ? LEGACY_API_BASE : configured
+      base.sub(%r{/+\z}, '').delete_suffix('/api')
+    end
+
     def send_via_bms_api(payload)
-      Rails.logger.info "🌐 BMS API: Calling https://bms-api.bri.us/services/send-email"
+      uri = URI("#{bms_api_base}/services/send-email")
+      Rails.logger.info "🌐 BMS API: Calling #{uri}"
       Rails.logger.info "🌐 BMS API: Payload size: #{payload.to_json.length} bytes"
 
-      uri = URI('https://bms-api.bri.us/services/send-email')
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.read_timeout = 30

--- a/spec/lib/mail/bms_provider_spec.rb
+++ b/spec/lib/mail/bms_provider_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Mail::BmsProvider do
+  let(:provider) { described_class.new({}) }
+  let(:mail) do
+    message = Mail.new
+    message.from = 'ACME <no-reply@acme.test>'
+    message.to = 'buyer@x.test'
+    message.subject = 'Welcome'
+    message.body = '<p>hi</p>'
+    message
+  end
+
+  before do
+    allow(GlobalConfigService).to receive(:load).with('BMS_API_SECRET', nil).and_return('mk_test')
+    allow(GlobalConfigService).to receive(:load).with('BMS_IPPOOL', 'default').and_return('default')
+  end
+
+  def stub_bms(base)
+    stub_request(:post, "#{base}/services/send-email")
+      .to_return(status: 200, body: '{"ok":true}', headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def configure_url(value)
+    allow(GlobalConfigService).to receive(:load).with('BMS_API_URL', nil).and_return(value)
+  end
+
+  it 'posts to the instance configured in BMS_API_URL with the api-key header' do
+    configure_url('https://bms-app.example.test')
+    stub = stub_bms('https://bms-app.example.test')
+
+    provider.deliver!(mail)
+
+    expect(stub.with(headers: { 'api-key' => 'mk_test' })).to have_been_requested
+  end
+
+  it 'normalizes a configured base carrying a trailing slash or the front /api prefix' do
+    configure_url('https://bms-app.example.test/api/')
+    stub = stub_bms('https://bms-app.example.test')
+
+    provider.deliver!(mail)
+
+    expect(stub).to have_been_requested
+  end
+
+  it 'falls back to the legacy host when the config is empty' do
+    configure_url(nil)
+    stub = stub_bms('https://bms-api.bri.us')
+
+    provider.deliver!(mail)
+
+    expect(stub).to have_been_requested
+  end
+
+  it 'raises DeliveryError when the configured instance rejects the key' do
+    configure_url('https://bms-app.example.test')
+    stub_request(:post, 'https://bms-app.example.test/services/send-email')
+      .to_return(status: 401, body: '{"message":"Invalid API key"}')
+
+    expect { provider.deliver!(mail) }.to raise_error(Mail::BmsProvider::DeliveryError, /401/)
+  end
+end

--- a/spec/lib/mail/bms_provider_spec.rb
+++ b/spec/lib/mail/bms_provider_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe Mail::BmsProvider do
     expect(stub).to have_been_requested
   end
 
+  it 'posts as-is when the configured base has no /api (the common prod shape)' do
+    configure_url('https://bms-app.example.test')
+    stub = stub_bms('https://bms-app.example.test')
+
+    provider.deliver!(mail)
+
+    expect(stub).to have_been_requested
+  end
+
+  it 'keeps an explicit port on the configured base' do
+    configure_url('https://bms-app.example.test:8443/api')
+    stub = stub_bms('https://bms-app.example.test:8443')
+
+    provider.deliver!(mail)
+
+    expect(stub).to have_been_requested
+  end
+
   it 'falls back to the legacy host when the config is empty' do
     configure_url(nil)
     stub = stub_bms('https://bms-api.bri.us')


### PR DESCRIPTION
**P0 (prod)**: every CRM enterprise e-mail dies with BMS 401 because the provider hardcodes the legacy `bms-api.bri.us` host while the installation's `mk_...` key belongs to its own BMS instance.

**Fix**: `send_via_bms_api` builds the URL from the `BMS_API_URL` config (now registered in `installation_config.yml`), stripping trailing slashes and a trailing `/api` — the BMS API has no `/api` global prefix (it only exists through the front's nginx rewrite; direct POST to `/api/services/send-email` answers 404, contract proven by Orion's `apps/api/src/lib/bms.ts`). An empty config falls back to the legacy host, so existing installs keep working.

**Proof**: `spec/lib/mail/bms_provider_spec.rb` 4/4 (configured URL + api-key header, normalization, legacy fallback, 401 raises DeliveryError). RuboCop: the file's pre-existing offenses stay (19 on develop, 18 here); the new code adds none.

## Summary by Sourcery

Configure BMS email delivery to target each installation’s BMS API instance while preserving compatibility with existing installations.

Bug Fixes:
- Route BMS email delivery through the installation-specific `BMS_API_URL`, preventing valid instance keys from being sent to the legacy host.

Enhancements:
- Normalize configured BMS base URLs and retain the legacy host as a fallback when no URL is configured.

Tests:
- Add coverage for configured URLs, URL normalization, explicit ports, legacy fallback, API-key headers, and rejected credentials.