### PR TITLE
feat(channels): re-sondagem periódica da credencial de canal token-based (CRM-469)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -245,6 +245,14 @@ on:
       - 'app/models/concerns/evolution_hub_channel_cleanup.rb'
       - 'spec/models/concerns/evolution_hub_channel_cleanup_spec.rb'
       - 'spec/requests/api/v1/inboxes_abort_hub_connection_spec.rb'
+      # CRM-469: the credential stamp only stays honest because a job keeps
+      # re-asking the provider, and the resolver expires it only where that job
+      # runs. Neither half shows up in another lane, and dropping either one
+      # brings back a channel that reads connected on a revoked credential.
+      - 'app/jobs/channels/whatsapp/credential_probe_scheduler_job.rb'
+      - 'app/jobs/channels/whatsapp/credential_probe_job.rb'
+      - 'spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb'
+      - 'spec/jobs/channels/whatsapp/credential_probe_job_spec.rb'
 
 permissions:
   contents: read
@@ -374,4 +382,6 @@ jobs:
             spec/serializers/inbox_serializer_connection_state_spec.rb \
             spec/models/concerns/evolution_hub_channel_cleanup_spec.rb \
             spec/requests/api/v1/inboxes_abort_hub_connection_spec.rb \
+            spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb \
+            spec/jobs/channels/whatsapp/credential_probe_job_spec.rb \
             --format progress

--- a/app/jobs/channels/whatsapp/credential_probe_job.rb
+++ b/app/jobs/channels/whatsapp/credential_probe_job.rb
@@ -1,0 +1,21 @@
+class Channels::Whatsapp::CredentialProbeJob < ApplicationJob
+  queue_as :low
+
+  def perform(whatsapp_channel)
+    whatsapp_channel.record_credential_probe!(probe(whatsapp_channel))
+  end
+
+  private
+
+  # A probe that raises told us nothing about the credential — a timeout or a
+  # provider 502 is not a revocation. It still counts as a failed probe: the
+  # reauthorization threshold is what separates one bad answer from a channel
+  # that is really down, so a blip costs a count and a revocation costs the
+  # channel.
+  def probe(channel)
+    channel.provider_service.validate_provider_config?
+  rescue StandardError => e
+    Rails.logger.warn("Credential probe failed for whatsapp channel #{channel.id}: #{e.message}")
+    false
+  end
+end

--- a/app/jobs/channels/whatsapp/credential_probe_scheduler_job.rb
+++ b/app/jobs/channels/whatsapp/credential_probe_scheduler_job.rb
@@ -1,0 +1,60 @@
+# Re-asks the provider whether a token-based channel's credential still works.
+#
+# The probe that runs on save proves the credential worked the day it was
+# written. A credential revoked at the provider afterwards — outside the Hub
+# flow, which has its own disconnect event — leaves no trace in the CRM, so the
+# channel reads connected forever. This job is what asks again.
+class Channels::Whatsapp::CredentialProbeSchedulerJob < ApplicationJob
+  queue_as :low
+
+  # Target interval between two probes of the same channel. With the batch
+  # ceiling below and an hourly cron, an installation of up to
+  # BULK_EXTERNAL_HTTP_CALLS_LIMIT * 6 token channels is fully covered inside
+  # the window; past that the backlog drains later, still well inside
+  # Channels::ConnectionStateResolver::CREDENTIALS_TTL.
+  PROBE_INTERVAL = 6.hours
+
+  # The stamp format written by Channel::Whatsapp#stamp_credentials_verified.
+  # Anything else is not a timestamp we can compare, so it counts as no
+  # evidence and the channel goes back in the queue — the same rule the
+  # resolver applies when it reads the stamp.
+  STAMP_FORMAT = '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'.freeze
+
+  def perform
+    due_channels.each { |channel| Channels::Whatsapp::CredentialProbeJob.perform_later(channel) }
+  end
+
+  private
+
+  def due_channels
+    Channel::Whatsapp
+      .where(provider: Channel::Whatsapp::CREDENTIAL_PROBE_PROVIDERS)
+      .where(not_hub_managed_sql)
+      .where(stale_stamp_sql, cutoff: PROBE_INTERVAL.ago.utc.iso8601)
+      .order(Arel.sql(oldest_first_sql))
+      .limit(Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT)
+  end
+
+  # Mirrors Channel::Whatsapp#hub_managed?, which asks whether the block is a
+  # Hash. COALESCE, not `<>` alone: a channel with no block at all compares
+  # NULL, and NULL would drop the row instead of keeping it.
+  def not_hub_managed_sql
+    "COALESCE(jsonb_typeof(provider_config -> 'evolution_hub'), '') <> 'object'"
+  end
+
+  # Compared as text, not cast to a timestamp: a channel carrying a malformed
+  # stamp would blow up the whole batch on the cast, and it is exactly the
+  # channel most in need of a fresh probe. Same-format UTC strings order
+  # identically as text and as timestamps.
+  def stale_stamp_sql
+    "COALESCE(provider_connection ->> 'credentials_verified_at', '') !~ '#{STAMP_FORMAT}' " \
+      "OR provider_connection ->> 'credentials_verified_at' < :cutoff"
+  end
+
+  # Collapses "never probed" and "unreadable stamp" to the same empty string so
+  # both sort ahead of every real timestamp.
+  def oldest_first_sql
+    "CASE WHEN COALESCE(provider_connection ->> 'credentials_verified_at', '') ~ '#{STAMP_FORMAT}' " \
+      "THEN provider_connection ->> 'credentials_verified_at' ELSE '' END ASC"
+  end
+end

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -32,6 +32,12 @@ class Channel::Whatsapp < ApplicationRecord
   # half of Channels::ConnectionStateResolver::CONNECTION_MAP.
   DISCONNECTED_CONNECTIONS = %w[close closed disconnected].freeze
 
+  # Token providers whose credential probe is a read-only request, so it can be
+  # repeated on a schedule. 360dialog is deliberately absent: its probe is a
+  # POST that re-registers the webhook, and re-registering it every hour is a
+  # write against the provider, not a health check.
+  CREDENTIAL_PROBE_PROVIDERS = %w[whatsapp_cloud notificame].freeze
+
   before_validation :ensure_webhook_verify_token
   before_validation :merge_evolution_go_global_config, if: -> { provider == 'evolution_go' }
 
@@ -125,6 +131,24 @@ class Channel::Whatsapp < ApplicationRecord
   def mark_connected!
     reauthorized! if reauthorization_required?
     update_provider_connection!({ 'connection' => 'open', 'error' => nil })
+  end
+
+  # Records the outcome of an out-of-band credential probe.
+  #
+  # Writes without validation on purpose: the caller already asked the
+  # provider, and re-running the validation chain would ask again. A failure
+  # feeds the reauthorization counter instead of erasing the stamp — erasing it
+  # would answer `unknown`, which says we never looked, when what happened is
+  # that we looked and the provider said no.
+  def record_credential_probe!(verified)
+    return authorization_error! unless verified
+
+    # Unconditional: a single stray failure leaves a count of 1 behind that
+    # never expires on its own, so a healthy channel would eventually trip the
+    # threshold on unrelated blips.
+    reauthorized!
+    stamp_credentials_verified
+    save!(validate: false)
   end
 
   def provider_connection_data

--- a/app/services/channels/connection_state_resolver.rb
+++ b/app/services/channels/connection_state_resolver.rb
@@ -6,6 +6,7 @@
 #   Whatsapp (hub-managed)             -> provider_config.evolution_hub.status
 #   Whatsapp (QR providers)            -> provider_connection['connection']
 #   Whatsapp (token providers)         -> recorded credential probe, else unknown
+#                                         (probe expires where a job renews it)
 #   Email                              -> configured == assumed connected
 #   Sendgrid                           -> webhook_registration_status
 #   FacebookPage / Instagram (hub)     -> evolution_hub_meta['status']
@@ -86,10 +87,27 @@ module Channels
       end
     end
 
+    # How long a credential probe keeps counting as evidence. Sized well above
+    # the re-probe cadence (see Channels::Whatsapp::CredentialProbeSchedulerJob)
+    # so a healthy channel waiting its turn in the batch is never degraded —
+    # only a channel nothing has re-probed for a week falls out.
+    CREDENTIALS_TTL = 7.days
+
     # Token-based providers have no session event stream: the credential probe
-    # recorded on save is their only evidence of a working connection.
+    # is their only evidence of a working connection.
     def token_based_state(channel)
-      credentials_verified_at(channel).present? ? %w[connected stored_flag] : %w[unknown stored_flag]
+      verified_at = credentials_verified_at(channel)
+      return %w[unknown stored_flag] if verified_at.nil?
+      # The expiry only applies where something renews the evidence. On a
+      # provider nobody re-probes it would degrade every healthy channel to
+      # unknown at the end of the window, trading one wrong answer for another.
+      return %w[unknown stored_flag] if expirable?(channel) && verified_at < CREDENTIALS_TTL.ago
+
+      %w[connected stored_flag]
+    end
+
+    def expirable?(channel)
+      Channel::Whatsapp::CREDENTIAL_PROBE_PROVIDERS.include?(channel.provider)
     end
 
     # A stamp that does not parse, or that sits in the future, is not evidence.

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -126,13 +126,16 @@ module Whatsapp
               else
                 "#{business_account_path}/message_templates?access_token=#{whatsapp_channel.provider_config['api_key']}"
               end
-        Rails.logger.info "WhatsApp Cloud validation URL: #{url}"
-        Rails.logger.info "WhatsApp Cloud provider_config: #{whatsapp_channel.provider_config.inspect}"
+        # Neither the URL nor the config can be logged: the query string carries
+        # the access_token and the config is nothing but credentials. This probe
+        # now also runs on a schedule, so either line would write the token to
+        # disk every hour, for every channel.
+        Rails.logger.info "WhatsApp Cloud validation for channel #{whatsapp_channel.id}"
 
         response = HTTParty.get(url, headers: api_headers)
 
         Rails.logger.info "WhatsApp Cloud validation response status: #{response.code}"
-        Rails.logger.info "WhatsApp Cloud validation response body: #{response.body}"
+        Rails.logger.info "WhatsApp Cloud validation response body: #{response.body}" unless response.success?
 
         response.success?
       end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -88,3 +88,11 @@ automation_rule_runs_cleanup_job:
   cron: '45 3 * * *'
   class: 'AutomationRuleRunsCleanupJob'
   queue: low
+
+# executed hourly to re-ask the provider whether a token-based whatsapp
+# credential still works; the probe on save only proves it worked that day
+whatsapp_credential_probe_scheduler_job:
+  cron: '0 * * * *'
+  class: 'Channels::Whatsapp::CredentialProbeSchedulerJob'
+  queue: low
+  description: 'Re-probe token-based whatsapp credentials and refresh the verified stamp'

--- a/spec/jobs/channels/whatsapp/credential_probe_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/credential_probe_job_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Channels::Whatsapp::CredentialProbeJob, type: :job do
+  def graph_returns(status, body)
+    stub_request(:get, /graph\.facebook\.com/).to_return(status: status, body: body)
+  end
+
+  def resolved_state(channel)
+    Channels::ConnectionStateResolver.call(channel.reload)[:state]
+  end
+
+  let(:channel) do
+    Channel::Whatsapp.create!(provider: 'whatsapp_cloud', phone_number: '+5511911110001',
+                              provider_config: { 'api_key' => 'valid', 'waba_id' => '1' })
+  end
+
+  before do
+    stub_request(:any, /graph\.facebook\.com/).to_return(status: 200, body: '{"data":[]}')
+    channel.reauthorized!
+  end
+
+  # The reauthorization flag and its counter live in Redis, which no
+  # transaction rolls back.
+  after { channel.reauthorized! }
+
+  describe '#perform' do
+    it 'refreshes the stamp when the credential still works' do
+      travel_to(3.days.from_now) do
+        graph_returns(200, '{"data":[]}')
+
+        described_class.perform_now(channel)
+
+        expect(Time.zone.parse(channel.reload.provider_connection['credentials_verified_at']))
+          .to be_within(1.minute).of(Time.current)
+      end
+    end
+
+    # The credential is revoked at Meta between two runs of the job: nothing in
+    # the CRM changed, so only a fresh probe can notice.
+    it 'reports a credential revoked between two runs as an error, not as silence' do
+      described_class.perform_now(channel)
+      expect(resolved_state(channel)).to eq('connected')
+
+      graph_returns(401, '{"error":{"code":190}}')
+      Channel::Whatsapp::AUTHORIZATION_ERROR_THRESHOLD.times { described_class.perform_now(channel) }
+
+      expect(resolved_state(channel)).to eq('error')
+      expect(channel.reauthorization_required?).to be(true)
+    end
+
+    # 'unknown' says nobody looked. We looked, and the provider said no.
+    it 'does not erase the stamp on a failed probe' do
+      graph_returns(401, '{"error":{}}')
+
+      Channel::Whatsapp::AUTHORIZATION_ERROR_THRESHOLD.times { described_class.perform_now(channel) }
+
+      expect(channel.reload.provider_connection).to have_key('credentials_verified_at')
+    end
+
+    it 'tolerates a single failure without condemning the channel' do
+      graph_returns(500, '{}')
+
+      described_class.perform_now(channel)
+
+      expect(resolved_state(channel)).to eq('connected')
+      expect(channel.authorization_error_count).to eq(1)
+    end
+
+    # Without this, one stray failure a month accumulates until an untouched,
+    # perfectly healthy channel trips the threshold.
+    it 'clears a stray failure count once the credential answers again' do
+      graph_returns(500, '{}')
+      described_class.perform_now(channel)
+
+      graph_returns(200, '{"data":[]}')
+      described_class.perform_now(channel)
+
+      expect(channel.authorization_error_count).to eq(0)
+    end
+
+    it 'counts a probe that raises as a failed probe rather than dying' do
+      stub_request(:get, /graph\.facebook\.com/).to_timeout
+
+      expect { described_class.perform_now(channel) }.not_to raise_error
+      expect(channel.authorization_error_count).to eq(1)
+    end
+  end
+end

--- a/spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Channels::Whatsapp::CredentialProbeSchedulerJob, type: :job do
+  let(:probed) { [] }
+
+  before do
+    stub_request(:any, /graph\.facebook\.com/).to_return(status: 200, body: '{"data":[]}')
+    stub_request(:any, /360dialog\.io/).to_return(status: 200, body: '{}')
+    stub_request(:any, /notificame/).to_return(status: 200, body: '{}')
+    allow(Channels::Whatsapp::CredentialProbeJob).to receive(:perform_later) { |channel| probed << channel.id }
+  end
+
+  # Saved without validation so the save-time probe does not write a fresh
+  # stamp over the one the example is testing.
+  def channel(provider:, phone_number:, stamp: nil, provider_config: { 'api_key' => 'valid', 'waba_id' => '1' })
+    record = Channel::Whatsapp.new(
+      provider: provider,
+      phone_number: phone_number,
+      provider_config: provider_config,
+      provider_connection: stamp.nil? ? {} : { 'credentials_verified_at' => stamp }
+    )
+    record.save!(validate: false)
+    record
+  end
+
+  describe '#perform' do
+    it 'enqueues a probe for a channel whose stamp is older than the interval' do
+      stale = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000001', stamp: 7.hours.ago.utc.iso8601)
+
+      described_class.perform_now
+
+      expect(probed).to eq([stale.id])
+    end
+
+    it 'leaves a channel probed inside the interval alone' do
+      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000002', stamp: 1.hour.ago.utc.iso8601)
+
+      described_class.perform_now
+
+      expect(probed).to be_empty
+    end
+
+    it 'enqueues a channel that was never probed' do
+      unproven = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000003')
+
+      described_class.perform_now
+
+      expect(probed).to eq([unproven.id])
+    end
+
+    # A stamp the resolver cannot read already answers `unknown`. If the batch
+    # query skipped it, or blew up casting it, nothing would ever repair it.
+    it 'enqueues a channel carrying an unreadable stamp instead of choking on it' do
+      garbled = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000004', stamp: 'sim, confia')
+
+      expect { described_class.perform_now }.not_to raise_error
+      expect(probed).to eq([garbled.id])
+    end
+
+    it 'covers notificame too, not just whatsapp_cloud' do
+      notificame = channel(provider: 'notificame', phone_number: '+5511900000005',
+                           provider_config: { 'api_token' => 'valid' })
+
+      described_class.perform_now
+
+      expect(probed).to eq([notificame.id])
+    end
+
+    it 'skips a hub-managed channel, which has no local credential to probe' do
+      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000006',
+              provider_config: { 'evolution_hub' => { 'status' => 'active' } })
+
+      described_class.perform_now
+
+      expect(probed).to be_empty
+    end
+
+    it 'skips QR providers, whose state comes from connection events' do
+      channel(provider: 'evolution', phone_number: '+5511900000007',
+              provider_config: { 'api_url' => 'https://evo.test', 'instance_name' => 'i' })
+
+      described_class.perform_now
+
+      expect(probed).to be_empty
+    end
+
+    # 360dialog's probe is a POST that re-registers the webhook. Repeating it on
+    # a schedule would be a write against the provider every hour.
+    it 'skips 360dialog, whose probe is not a read-only request' do
+      channel(provider: 'default', phone_number: '+5511900000008')
+
+      described_class.perform_now
+
+      expect(probed).to be_empty
+    end
+
+    it 'takes the oldest stamps first and stops at the batch ceiling' do
+      stub_const('Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT', 2)
+      never = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000010')
+      oldest = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000011', stamp: 30.hours.ago.utc.iso8601)
+      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000012', stamp: 8.hours.ago.utc.iso8601)
+
+      described_class.perform_now
+
+      expect(probed).to eq([never.id, oldest.id])
+    end
+
+    # The window has to stay well inside the TTL: a channel that fell out of the
+    # resolver's evidence window before the job got back to it would read
+    # `unknown` while nothing is actually wrong with it.
+    it 'schedules re-probes far more often than the evidence expires' do
+      expect(described_class::PROBE_INTERVAL).to be < Channels::ConnectionStateResolver::CREDENTIALS_TTL
+    end
+  end
+end

--- a/spec/services/channels/connection_state_resolver_spec.rb
+++ b/spec/services/channels/connection_state_resolver_spec.rb
@@ -126,6 +126,45 @@ RSpec.describe Channels::ConnectionStateResolver do
       expect(resolve(channel)[:state]).to eq('unknown')
     end
 
+    # The evidence expires only where the re-probe job renews it. On 360dialog,
+    # which nobody re-probes, an expiry would degrade every healthy channel at
+    # the end of the window — the reason the first TTL was pulled.
+    it 'stops trusting a probe older than the TTL on a re-probed provider' do
+      channel = Channel::Whatsapp.new(
+        provider: 'whatsapp_cloud',
+        provider_connection: {
+          'credentials_verified_at' => (Channels::ConnectionStateResolver::CREDENTIALS_TTL.ago - 1.hour).utc.iso8601
+        }
+      )
+      stub_reauth(channel)
+
+      expect(resolve(channel)[:state]).to eq('unknown')
+    end
+
+    it 'keeps trusting a probe still inside the TTL' do
+      channel = Channel::Whatsapp.new(
+        provider: 'whatsapp_cloud',
+        provider_connection: {
+          'credentials_verified_at' => (Channels::ConnectionStateResolver::CREDENTIALS_TTL.ago + 1.hour).utc.iso8601
+        }
+      )
+      stub_reauth(channel)
+
+      expect(resolve(channel)[:state]).to eq('connected')
+    end
+
+    it 'never expires the stamp on a provider no job re-probes' do
+      channel = Channel::Whatsapp.new(
+        provider: 'default',
+        provider_connection: {
+          'credentials_verified_at' => (Channels::ConnectionStateResolver::CREDENTIALS_TTL.ago - 1.year).utc.iso8601
+        }
+      )
+      stub_reauth(channel)
+
+      expect(resolve(channel)[:state]).to eq('connected')
+    end
+
     it 'overrides any state with error when reauthorization is required' do
       channel = Channel::Whatsapp.new(provider: 'evolution', provider_connection: { 'connection' => 'open' })
       stub_reauth(channel, value: true)


### PR DESCRIPTION
## Problema

A sondagem de credencial que roda no save prova que a credencial funcionava no dia em que foi gravada. Uma credencial revogada na Meta depois disso — fora do fluxo do Hub, que tem evento próprio de desconexão — não deixa rastro nenhum no CRM, e o canal continua lendo `connected` indefinidamente. A evidência existe, mas envelhece sem ninguém olhar.

## Solução

Um job horário (`Channels::Whatsapp::CredentialProbeSchedulerJob`) seleciona os canais token-based não gerenciados pelo Hub cujo carimbo está ausente, ilegível ou mais velho que 6h, e enfileira uma re-sondagem para cada um. Ordena do carimbo mais antigo para o mais novo e para no teto de 25 por execução, o mesmo `Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT` que o sync de templates já usa contra os mesmos provedores.

O `CredentialProbeJob` chama `validate_provider_config?` direto, fora da cadeia de validação — passar por `save` faria a mesma pergunta duas vezes e, em alguns provedores, escreveria.

## Sondagem que falha não deixa o canal conectado

A falha alimenta `authorization_error!` em vez de apagar o carimbo. Apagar responderia `unknown`, que diz que ninguém olhou; o que houve foi que olhamos e o provedor disse não. Ao cruzar o threshold de reautorização o canal vai para `error` e o e-mail de desconexão sai, exatamente como em qualquer outra falha de credencial do produto. Uma falha isolada custa só uma contagem: um 502 da Meta não é revogação. Com o job de hora em hora, uma credencial revogada aparece em até duas horas.

Sucesso limpa o contador incondicionalmente. Sem isso, uma falha esporádica por mês acumula até um canal saudável e intocado tropeçar no threshold sozinho.

## O TTL volta, com uma condição

A evidência volta a expirar em 7 dias, mas só nos provedores que o job re-sonda. Numa família que ninguém re-sonda, o prazo degradaria todo canal saudável para `unknown` no fim da janela — trocar uma afirmação errada por outra foi o motivo de ele cair da primeira vez. A janela de 6h fica muito abaixo dos 7 dias de propósito, para que um canal esperando a vez na fila nunca caia por atraso de lote; um spec trava essa invariante.

## 360dialog fora

O `validate_provider_config?` do 360dialog é um `POST /configs/webhook`: ele re-registra o webhook. Repetir isso de hora em hora é escrita no provedor, não health check. Ele continua com o carimbo do save e sem prazo de validade, e a lacuna fica marcada no código para quem quiser escrever um probe read-only depois.

## Log de credencial

`Whatsapp::Providers::WhatsappCloudService#validate_provider_config?` logava, em nível info, a URL da sondagem — que carrega o `access_token` na query string — e o `provider_config` inteiro. Essa chamada passa de uma-por-save para uma-por-hora-por-canal com este PR, então as duas linhas escreveriam a credencial em disco a cada ciclo. Sobrou uma linha com o id do canal, e o dump do body virou só-em-falha.

## Testes

Suíte completa do `spec-staleness-guard`: 843 exemplos, 0 falhas. `zeitwerk:check` limpo e rubocop sem ofensa nova (o `whatsapp_cloud_service.rb` já tinha 11, o mesmo número antes e depois).

Os dois specs novos entraram no guard, nos paths e na lista de execução. Confirmei que não passam vacuamente com três mutações no código de produção: admitir `default` na lista de provedores sondáveis derruba o skip do 360dialog e o "nunca expira onde ninguém re-sonda"; remover o filtro de janela e a exclusão de Hub derruba dois; e trocar `COALESCE(jsonb_typeof(...), '')` por `jsonb_typeof(...)` derruba cinco — `jsonb_typeof(NULL) <> 'object'` é NULL, e descartaria silenciosamente todo canal que não tem bloco de Hub, ou seja, justamente os que o job existe para sondar.

## Summary by Sourcery

Keep token-based WhatsApp channel connectivity state current by periodically revalidating eligible credentials and expiring stale evidence safely.

New Features:
- Add hourly re-probing of read-only token-based WhatsApp credentials for eligible non-Hub channels, prioritizing stale evidence and limiting each batch.
- Track probe results so successful checks refresh credential evidence while repeated failures trigger the existing reauthorization and disconnection flow.

Bug Fixes:
- Prevent revoked or invalid token-based credentials from remaining indefinitely in the connected state.
- Avoid exposing WhatsApp access tokens and provider credentials in validation logs.

Enhancements:
- Expire credential evidence after seven days only for providers covered by scheduled re-probing, while preserving existing behavior for unsupported providers such as 360dialog.
- Exclude Hub-managed, QR-based, and non-read-only provider integrations from scheduled probing.

CI:
- Include the new credential probe jobs and specifications in the staleness guard workflow and execution list.

Deployment:
- Schedule the credential probe scheduler to run hourly on the low-priority queue.

Tests:
- Add coverage for probe success and failure handling, retry thresholds, malformed or missing timestamps, provider exclusions, batching, ordering, and evidence expiration.