### PR TITLE
fix(channels): fecha os achados do review da re-sondagem de credencial (CRM-469)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -251,9 +251,11 @@ on:
       - 'app/controllers/api/v1/automation_rules_controller.rb'
       - 'spec/requests/api/v1/automation_rules_spec.rb'
       # CRM-469: the credential stamp only stays honest because a job keeps
-      # re-asking the provider, and the resolver expires it only where that job
-      # runs. Neither half shows up in another lane, and dropping either one
-      # brings back a channel that reads connected on a revoked credential.
+      # re-asking the provider, the probe tells "the provider said no" apart
+      # from "we could not ask", and the resolver expires the evidence only
+      # where that job runs. Dropping any of the three brings back a channel
+      # that reads connected on a revoked credential — or condemns every
+      # healthy one during a provider outage.
       - 'app/jobs/channels/whatsapp/credential_probe_scheduler_job.rb'
       - 'app/jobs/channels/whatsapp/credential_probe_job.rb'
       - 'spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb'

--- a/app/jobs/channels/whatsapp/credential_probe_job.rb
+++ b/app/jobs/channels/whatsapp/credential_probe_job.rb
@@ -7,15 +7,13 @@ class Channels::Whatsapp::CredentialProbeJob < ApplicationJob
 
   private
 
-  # A probe that raises told us nothing about the credential — a timeout or a
-  # provider 502 is not a revocation. It still counts as a failed probe: the
-  # reauthorization threshold is what separates one bad answer from a channel
-  # that is really down, so a blip costs a count and a revocation costs the
-  # channel.
+  # A probe that raises told us nothing about the credential: a timeout or a
+  # provider outage is not a revocation, so it records the attempt and leaves
+  # the state alone.
   def probe(channel)
-    channel.provider_service.validate_provider_config?
+    channel.provider_service.probe_credential
   rescue StandardError => e
     Rails.logger.warn("Credential probe failed for whatsapp channel #{channel.id}: #{e.message}")
-    false
+    :inconclusive
   end
 end

--- a/app/jobs/channels/whatsapp/credential_probe_scheduler_job.rb
+++ b/app/jobs/channels/whatsapp/credential_probe_scheduler_job.rb
@@ -1,23 +1,16 @@
 # Re-asks the provider whether a token-based channel's credential still works.
-#
-# The probe that runs on save proves the credential worked the day it was
-# written. A credential revoked at the provider afterwards — outside the Hub
-# flow, which has its own disconnect event — leaves no trace in the CRM, so the
-# channel reads connected forever. This job is what asks again.
+# The probe that runs on save only proves the credential worked that day; a
+# credential revoked afterwards leaves no trace, so the channel reads connected
+# forever. This job is what asks again.
 class Channels::Whatsapp::CredentialProbeSchedulerJob < ApplicationJob
   queue_as :low
 
-  # Target interval between two probes of the same channel. With the batch
-  # ceiling below and an hourly cron, an installation of up to
-  # BULK_EXTERNAL_HTTP_CALLS_LIMIT * 6 token channels is fully covered inside
-  # the window; past that the backlog drains later, still well inside
-  # Channels::ConnectionStateResolver::CREDENTIALS_TTL.
+  # Target interval between two probes of the same channel, kept far below
+  # Channels::ConnectionStateResolver::CREDENTIALS_TTL so queue backlog never
+  # degrades a healthy channel.
   PROBE_INTERVAL = 6.hours
 
-  # The stamp format written by Channel::Whatsapp#stamp_credentials_verified.
-  # Anything else is not a timestamp we can compare, so it counts as no
-  # evidence and the channel goes back in the queue — the same rule the
-  # resolver applies when it reads the stamp.
+  # The stamp format written by Channel::Whatsapp#record_credential_probe!.
   STAMP_FORMAT = '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'.freeze
 
   def perform
@@ -26,35 +19,37 @@ class Channels::Whatsapp::CredentialProbeSchedulerJob < ApplicationJob
 
   private
 
+  # Ordered by attempt, not by evidence: a channel the provider keeps rejecting
+  # never refreshes credentials_verified_at, so ordering by that would park it
+  # at the head of every batch and starve the healthy channels behind it.
   def due_channels
     Channel::Whatsapp
+      .joins(:inbox)
       .where(provider: Channel::Whatsapp::CREDENTIAL_PROBE_PROVIDERS)
       .where(not_hub_managed_sql)
-      .where(stale_stamp_sql, cutoff: PROBE_INTERVAL.ago.utc.iso8601)
+      .where(due_sql, cutoff: PROBE_INTERVAL.ago.utc.iso8601, now: Time.current.utc.iso8601)
       .order(Arel.sql(oldest_first_sql))
       .limit(Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT)
   end
 
-  # Mirrors Channel::Whatsapp#hub_managed?, which asks whether the block is a
-  # Hash. COALESCE, not `<>` alone: a channel with no block at all compares
-  # NULL, and NULL would drop the row instead of keeping it.
+  # Mirrors Channel::Whatsapp#hub_managed?. COALESCE, not `<>` alone: a channel
+  # with no block at all compares NULL, and NULL would drop the row.
   def not_hub_managed_sql
     "COALESCE(jsonb_typeof(provider_config -> 'evolution_hub'), '') <> 'object'"
   end
 
-  # Compared as text, not cast to a timestamp: a channel carrying a malformed
-  # stamp would blow up the whole batch on the cast, and it is exactly the
-  # channel most in need of a fresh probe. Same-format UTC strings order
-  # identically as text and as timestamps.
-  def stale_stamp_sql
-    "COALESCE(provider_connection ->> 'credentials_verified_at', '') !~ '#{STAMP_FORMAT}' " \
-      "OR provider_connection ->> 'credentials_verified_at' < :cutoff"
+  # Compared as text, not cast: a malformed stamp would blow up the batch on
+  # the cast, and it is exactly the channel most in need of a probe. A stamp in
+  # the future is not evidence either — the resolver already refuses it.
+  def due_sql
+    "#{probed_at} !~ '#{STAMP_FORMAT}' OR #{probed_at} < :cutoff OR #{probed_at} > :now"
   end
 
-  # Collapses "never probed" and "unreadable stamp" to the same empty string so
-  # both sort ahead of every real timestamp.
   def oldest_first_sql
-    "CASE WHEN COALESCE(provider_connection ->> 'credentials_verified_at', '') ~ '#{STAMP_FORMAT}' " \
-      "THEN provider_connection ->> 'credentials_verified_at' ELSE '' END ASC"
+    "CASE WHEN #{probed_at} ~ '#{STAMP_FORMAT}' THEN #{probed_at} ELSE '' END ASC"
+  end
+
+  def probed_at
+    "COALESCE(provider_connection ->> 'credentials_probed_at', '')"
   end
 end

--- a/app/models/channel/whatsapp.rb
+++ b/app/models/channel/whatsapp.rb
@@ -33,10 +33,13 @@ class Channel::Whatsapp < ApplicationRecord
   DISCONNECTED_CONNECTIONS = %w[close closed disconnected].freeze
 
   # Token providers whose credential probe is a read-only request, so it can be
-  # repeated on a schedule. 360dialog is deliberately absent: its probe is a
-  # POST that re-registers the webhook, and re-registering it every hour is a
-  # write against the provider, not a health check.
+  # repeated on a schedule. 360dialog is absent because its probe is a POST
+  # that re-registers the webhook.
   CREDENTIAL_PROBE_PROVIDERS = %w[whatsapp_cloud notificame].freeze
+
+  # provider_connection keys the credential probe owns, kept across an
+  # unrelated snapshot so a QR/Hub event does not erase its evidence.
+  CREDENTIAL_PROBE_KEYS = %w[credentials_verified_at credentials_probed_at].freeze
 
   before_validation :ensure_webhook_verify_token
   before_validation :merge_evolution_go_global_config, if: -> { provider == 'evolution_go' }
@@ -117,7 +120,7 @@ class Channel::Whatsapp < ApplicationRecord
     # an unrelated event does not degrade a verified token-based channel. A
     # snapshot declaring the connection closed is not unrelated.
     keep_stamp = !incoming['connection'].to_s.in?(DISCONNECTED_CONNECTIONS)
-    kept = keep_stamp ? self.provider_connection.to_h.slice('credentials_verified_at') : {}
+    kept = keep_stamp ? self.provider_connection.to_h.slice(*CREDENTIAL_PROBE_KEYS) : {}
     assign_attributes(provider_connection: kept.merge(incoming))
     # NOTE: Skip `validate_provider_config?` check
     save!(validate: false)
@@ -133,21 +136,29 @@ class Channel::Whatsapp < ApplicationRecord
     update_provider_connection!({ 'connection' => 'open', 'error' => nil })
   end
 
-  # Records the outcome of an out-of-band credential probe.
+  # Records the outcome of an out-of-band credential probe: :ok, :rejected (the
+  # provider answered that the credential is bad) or :inconclusive (we could
+  # not ask). Writes without validation because the caller already asked.
   #
-  # Writes without validation on purpose: the caller already asked the
-  # provider, and re-running the validation chain would ask again. A failure
-  # feeds the reauthorization counter instead of erasing the stamp — erasing it
-  # would answer `unknown`, which says we never looked, when what happened is
-  # that we looked and the provider said no.
-  def record_credential_probe!(verified)
-    return authorization_error! unless verified
+  # Every outcome stamps the attempt, so a channel the provider keeps rejecting
+  # leaves the head of the scheduler's queue instead of holding a batch slot
+  # forever while healthy channels go unprobed.
+  def record_credential_probe!(outcome)
+    now = Time.current.utc.iso8601
+    snapshot = provider_connection.to_h.merge('credentials_probed_at' => now)
 
-    # Unconditional: a single stray failure leaves a count of 1 behind that
-    # never expires on its own, so a healthy channel would eventually trip the
-    # threshold on unrelated blips.
-    reauthorized!
-    stamp_credentials_verified
+    case outcome
+    when :ok
+      # Only clears what a probe raised: the counter is shared with
+      # PARTNER_REMOVED and media 401s, which this probe cannot observe.
+      reauthorized! if snapshot['credentials_rejected_at'].present?
+      snapshot = snapshot.merge('credentials_verified_at' => now).except('credentials_rejected_at')
+    when :rejected
+      snapshot = snapshot.merge('credentials_rejected_at' => now)
+      authorization_error!
+    end
+
+    assign_attributes(provider_connection: snapshot)
     save!(validate: false)
   end
 
@@ -280,9 +291,13 @@ class Channel::Whatsapp < ApplicationRecord
   end
 
   # The probe is the only evidence a token-based channel ever produces.
-  # Assigning here persists it: validations run inside the same save.
+  # Assigning here persists it: validations run inside the same save. Clearing
+  # the rejection is what lets a re-save with fresh credentials bring the
+  # channel back without waiting for the next scheduled probe.
   def stamp_credentials_verified
-    self.provider_connection = (provider_connection || {}).merge('credentials_verified_at' => Time.current.utc.iso8601)
+    self.provider_connection = provider_connection.to_h
+                                                  .merge('credentials_verified_at' => Time.current.utc.iso8601)
+                                                  .except('credentials_rejected_at')
   end
 
   def hub_managed?

--- a/app/services/channels/connection_state_resolver.rb
+++ b/app/services/channels/connection_state_resolver.rb
@@ -6,7 +6,8 @@
 #   Whatsapp (hub-managed)             -> provider_config.evolution_hub.status
 #   Whatsapp (QR providers)            -> provider_connection['connection']
 #   Whatsapp (token providers)         -> recorded credential probe, else unknown
-#                                         (probe expires where a job renews it)
+#                                         (a rejected probe is error; evidence
+#                                          expires where a job renews it)
 #   Email                              -> configured == assumed connected
 #   Sendgrid                           -> webhook_registration_status
 #   FacebookPage / Instagram (hub)     -> evolution_hub_meta['status']
@@ -89,14 +90,18 @@ module Channels
 
     # How long a credential probe keeps counting as evidence. Sized well above
     # the re-probe cadence (see Channels::Whatsapp::CredentialProbeSchedulerJob)
-    # so a healthy channel waiting its turn in the batch is never degraded —
-    # only a channel nothing has re-probed for a week falls out.
+    # so a healthy channel waiting its turn in the batch is never degraded.
     CREDENTIALS_TTL = 7.days
 
     # Token-based providers have no session event stream: the credential probe
     # is their only evidence of a working connection.
     def token_based_state(channel)
-      verified_at = credentials_verified_at(channel)
+      # A probe the provider answered `no` to is evidence too, and it outranks
+      # the stamp it invalidates: holding `connected` until a counter fills
+      # would be the inertia this evidence exists to remove.
+      return %w[error stored_flag] if credentials_rejected?(channel)
+
+      verified_at = stamp_at(channel, 'credentials_verified_at')
       return %w[unknown stored_flag] if verified_at.nil?
       # The expiry only applies where something renews the evidence. On a
       # provider nobody re-probes it would degrade every healthy channel to
@@ -110,9 +115,16 @@ module Channels
       Channel::Whatsapp::CREDENTIAL_PROBE_PROVIDERS.include?(channel.provider)
     end
 
+    # Presence is the whole signal: every path that records a working
+    # credential removes the key, so a rejection can only be newer than the
+    # last success.
+    def credentials_rejected?(channel)
+      stamp_at(channel, 'credentials_rejected_at').present?
+    end
+
     # A stamp that does not parse, or that sits in the future, is not evidence.
-    def credentials_verified_at(channel)
-      raw = channel.provider_connection['credentials_verified_at'] if channel.provider_connection.is_a?(Hash)
+    def stamp_at(channel, key)
+      raw = channel.provider_connection[key] if channel.provider_connection.is_a?(Hash)
       return nil if raw.blank?
 
       parsed = Time.zone.parse(raw.to_s)

--- a/app/services/whatsapp/providers/notificame_service.rb
+++ b/app/services/whatsapp/providers/notificame_service.rb
@@ -257,12 +257,20 @@ class Whatsapp::Providers::NotificameService < Whatsapp::Providers::BaseService
     nil
   end
 
-  def validate_provider_config?
+  # Outcome of the credential check: :ok, :rejected (the provider says the
+  # credential is bad) or :inconclusive (we could not ask).
+  def probe_credential
     response = HTTParty.get(
       "#{BASE_URL}/resale/",
       headers: api_headers
     )
-    response.success?
+    return :ok if response.success?
+
+    [401, 403].include?(response.code) ? :rejected : :inconclusive
+  end
+
+  def validate_provider_config?
+    probe_credential == :ok
   rescue StandardError
     false
   end

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -12,6 +12,13 @@ module Whatsapp
       # Meta rejects media uploads over 16 MB.
       WHATSAPP_MAX_MEDIA_BYTES = 16.megabytes
 
+      # Meta answers a revoked or invalid token with OAuthException 190 over
+      # HTTP 400, so the status alone cannot tell a dead credential from a
+      # provider that is merely unavailable. Rate limits (4, 17, 32, 613) and
+      # transient errors (1, 2) are deliberately absent.
+      REJECTED_ERROR_CODES = [10, 102, 190].freeze
+      REJECTED_ERROR_CODE_RANGE = (200..299)
+
       def send_message(phone_number, message)
         if message.attachments.present?
           send_attachment_message(phone_number, message)
@@ -120,24 +127,24 @@ module Whatsapp
         response['paging'] ? response['paging']['next'] : ''
       end
 
-      def validate_provider_config?
-        url = if MetaBaseUrl.enabled?
-                "#{business_account_path}/message_templates"
-              else
-                "#{business_account_path}/message_templates?access_token=#{whatsapp_channel.provider_config['api_key']}"
-              end
-        # Neither the URL nor the config can be logged: the query string carries
-        # the access_token and the config is nothing but credentials. This probe
-        # now also runs on a schedule, so either line would write the token to
-        # disk every hour, for every channel.
+      # Outcome of the credential check: :ok, :rejected (the provider says the
+      # credential is bad) or :inconclusive (we could not ask). Raises on a
+      # network failure, which the caller classifies.
+      def probe_credential
+        # Neither the URL nor the config can be logged: the query string
+        # carries the access_token and the config is nothing but credentials.
         Rails.logger.info "WhatsApp Cloud validation for channel #{whatsapp_channel.id}"
 
-        response = HTTParty.get(url, headers: api_headers)
+        response = HTTParty.get(validation_url, headers: api_headers)
+        return :ok if response.success?
 
-        Rails.logger.info "WhatsApp Cloud validation response status: #{response.code}"
-        Rails.logger.info "WhatsApp Cloud validation response body: #{response.body}" unless response.success?
+        Rails.logger.info "WhatsApp Cloud validation failed for channel #{whatsapp_channel.id}: " \
+                          "status=#{response.code} body=#{response.body}"
+        credential_rejected?(response) ? :rejected : :inconclusive
+      end
 
-        response.success?
+      def validate_provider_config?
+        probe_credential == :ok
       end
 
       def api_headers
@@ -370,6 +377,33 @@ module Whatsapp
       end
 
       private
+
+      def credential_rejected?(response)
+        return true if [401, 403].include?(response.code)
+
+        code = meta_error_code(response)
+        return false if code.nil?
+
+        REJECTED_ERROR_CODES.include?(code) || REJECTED_ERROR_CODE_RANGE.cover?(code)
+      end
+
+      # Parses the body itself when HTTParty did not: an error response without
+      # a JSON content-type still carries the code that says whether the
+      # credential is dead.
+      def meta_error_code(response)
+        body = response.parsed_response
+        body = JSON.parse(response.body.to_s) unless body.is_a?(Hash)
+        code = body.dig('error', 'code')
+        code.to_s.match?(/\A\d+\z/) ? code.to_i : nil
+      rescue StandardError
+        nil
+      end
+
+      def validation_url
+        return "#{business_account_path}/message_templates" if MetaBaseUrl.enabled?
+
+        "#{business_account_path}/message_templates?access_token=#{whatsapp_channel.provider_config['api_key']}"
+      end
 
       def build_recipient_field(phone_or_bsuid)
         if phone_or_bsuid.present? && phone_or_bsuid.match?(RegexHelper::BSUID_REGEX)

--- a/spec/jobs/channels/whatsapp/credential_probe_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/credential_probe_job_spec.rb
@@ -5,7 +5,12 @@ require 'webmock/rspec'
 
 RSpec.describe Channels::Whatsapp::CredentialProbeJob, type: :job do
   def graph_returns(status, body)
-    stub_request(:get, /graph\.facebook\.com/).to_return(status: status, body: body)
+    stub_request(:get, /graph\.facebook\.com/)
+      .to_return(status: status, body: body, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def revoked_token
+    graph_returns(400, '{"error":{"code":190,"message":"Invalid OAuth access token"}}')
   end
 
   def resolved_state(channel)
@@ -44,48 +49,99 @@ RSpec.describe Channels::Whatsapp::CredentialProbeJob, type: :job do
       described_class.perform_now(channel)
       expect(resolved_state(channel)).to eq('connected')
 
-      graph_returns(401, '{"error":{"code":190}}')
-      Channel::Whatsapp::AUTHORIZATION_ERROR_THRESHOLD.times { described_class.perform_now(channel) }
+      revoked_token
+      described_class.perform_now(channel)
 
       expect(resolved_state(channel)).to eq('error')
-      expect(channel.reauthorization_required?).to be(true)
     end
 
     # 'unknown' says nobody looked. We looked, and the provider said no.
-    it 'does not erase the stamp on a failed probe' do
-      graph_returns(401, '{"error":{}}')
+    it 'does not erase the stamp on a rejected probe' do
+      revoked_token
 
-      Channel::Whatsapp::AUTHORIZATION_ERROR_THRESHOLD.times { described_class.perform_now(channel) }
+      described_class.perform_now(channel)
 
       expect(channel.reload.provider_connection).to have_key('credentials_verified_at')
     end
 
-    it 'tolerates a single failure without condemning the channel' do
+    it 'prompts reauthorization once rejections cross the threshold' do
+      revoked_token
+
+      Channel::Whatsapp::AUTHORIZATION_ERROR_THRESHOLD.times { described_class.perform_now(channel) }
+
+      expect(channel.reauthorization_required?).to be(true)
+    end
+
+    # A 500 is the provider being unavailable, not the provider revoking a
+    # credential. Counting it would turn any outage lasting two cycles into a
+    # mass disconnect e-mail for every token channel in the install.
+    it 'does not condemn the channel when the provider is merely unavailable' do
       graph_returns(500, '{}')
+
+      2.times { described_class.perform_now(channel) }
+
+      expect(resolved_state(channel)).to eq('connected')
+      expect(channel.authorization_error_count).to eq(0)
+      expect(channel.reauthorization_required?).to be(false)
+    end
+
+    it 'treats a rate limit as inconclusive, not as a revocation' do
+      graph_returns(429, '{"error":{"code":4,"message":"Application request limit reached"}}')
 
       described_class.perform_now(channel)
 
       expect(resolved_state(channel)).to eq('connected')
-      expect(channel.authorization_error_count).to eq(1)
+      expect(channel.authorization_error_count).to eq(0)
     end
 
-    # Without this, one stray failure a month accumulates until an untouched,
-    # perfectly healthy channel trips the threshold.
-    it 'clears a stray failure count once the credential answers again' do
+    # Without this the channel never leaves the head of the scheduler's queue:
+    # it stays due forever and starves every healthy channel behind it.
+    it 'records the attempt even when the probe tells us nothing' do
       graph_returns(500, '{}')
+
       described_class.perform_now(channel)
+
+      expect(channel.reload.provider_connection['credentials_probed_at']).to be_present
+    end
+
+    it 'records the attempt when the provider rejects the credential' do
+      revoked_token
+
+      described_class.perform_now(channel)
+
+      expect(channel.reload.provider_connection['credentials_probed_at']).to be_present
+    end
+
+    it 'clears the rejection once the credential answers again' do
+      revoked_token
+      described_class.perform_now(channel)
+      expect(resolved_state(channel)).to eq('error')
 
       graph_returns(200, '{"data":[]}')
       described_class.perform_now(channel)
 
+      expect(resolved_state(channel)).to eq('connected')
       expect(channel.authorization_error_count).to eq(0)
     end
 
-    it 'counts a probe that raises as a failed probe rather than dying' do
+    # The counter is shared with PARTNER_REMOVED and media 401s, which this
+    # probe cannot observe. Clearing it on every success would mean no signal
+    # outside the probe ever reaches the threshold.
+    it 'leaves a failure count raised elsewhere alone' do
+      channel.authorization_error!
+      graph_returns(200, '{"data":[]}')
+
+      described_class.perform_now(channel)
+
+      expect(channel.authorization_error_count).to eq(1)
+    end
+
+    it 'counts a probe that raises as inconclusive rather than dying' do
       stub_request(:get, /graph\.facebook\.com/).to_timeout
 
       expect { described_class.perform_now(channel) }.not_to raise_error
-      expect(channel.authorization_error_count).to eq(1)
+      expect(channel.authorization_error_count).to eq(0)
+      expect(channel.reload.provider_connection['credentials_probed_at']).to be_present
     end
   end
 end

--- a/spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb
+++ b/spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb
@@ -15,20 +15,27 @@ RSpec.describe Channels::Whatsapp::CredentialProbeSchedulerJob, type: :job do
 
   # Saved without validation so the save-time probe does not write a fresh
   # stamp over the one the example is testing.
-  def channel(provider:, phone_number:, stamp: nil, provider_config: { 'api_key' => 'valid', 'waba_id' => '1' })
+  def channel(provider:, phone_number:, connection: {}, provider_config: { 'api_key' => 'valid', 'waba_id' => '1' },
+              inbox: true)
     record = Channel::Whatsapp.new(
       provider: provider,
       phone_number: phone_number,
       provider_config: provider_config,
-      provider_connection: stamp.nil? ? {} : { 'credentials_verified_at' => stamp }
+      provider_connection: connection
     )
     record.save!(validate: false)
+    Inbox.create!(name: "Inbox #{phone_number}", channel: record) if inbox
     record
   end
 
+  def probed_at(stamp)
+    { 'credentials_probed_at' => stamp }
+  end
+
   describe '#perform' do
-    it 'enqueues a probe for a channel whose stamp is older than the interval' do
-      stale = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000001', stamp: 7.hours.ago.utc.iso8601)
+    it 'enqueues a probe for a channel whose last attempt is older than the interval' do
+      stale = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000001',
+                      connection: probed_at(7.hours.ago.utc.iso8601))
 
       described_class.perform_now
 
@@ -36,7 +43,8 @@ RSpec.describe Channels::Whatsapp::CredentialProbeSchedulerJob, type: :job do
     end
 
     it 'leaves a channel probed inside the interval alone' do
-      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000002', stamp: 1.hour.ago.utc.iso8601)
+      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000002',
+              connection: probed_at(1.hour.ago.utc.iso8601))
 
       described_class.perform_now
 
@@ -54,10 +62,22 @@ RSpec.describe Channels::Whatsapp::CredentialProbeSchedulerJob, type: :job do
     # A stamp the resolver cannot read already answers `unknown`. If the batch
     # query skipped it, or blew up casting it, nothing would ever repair it.
     it 'enqueues a channel carrying an unreadable stamp instead of choking on it' do
-      garbled = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000004', stamp: 'sim, confia')
+      garbled = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000004',
+                        connection: probed_at('sim, confia'))
 
       expect { described_class.perform_now }.not_to raise_error
       expect(probed).to eq([garbled.id])
+    end
+
+    # The resolver refuses a stamp in the future, so the channel reads unknown.
+    # Skipping it here would leave that state with nothing to repair it.
+    it 'enqueues a channel whose stamp sits in the future' do
+      ahead = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000013',
+                      connection: probed_at(2.days.from_now.utc.iso8601))
+
+      described_class.perform_now
+
+      expect(probed).to eq([ahead.id])
     end
 
     it 'covers notificame too, not just whatsapp_cloud' do
@@ -97,15 +117,46 @@ RSpec.describe Channels::Whatsapp::CredentialProbeSchedulerJob, type: :job do
       expect(probed).to be_empty
     end
 
-    it 'takes the oldest stamps first and stops at the batch ceiling' do
+    # A channel with no inbox has nobody to notify: the reauthorization mailer
+    # builds its URL from the inbox and would raise on nil.
+    it 'skips a channel with no inbox' do
+      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000009', inbox: false)
+
+      described_class.perform_now
+
+      expect(probed).to be_empty
+    end
+
+    it 'takes the oldest attempts first and stops at the batch ceiling' do
       stub_const('Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT', 2)
       never = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000010')
-      oldest = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000011', stamp: 30.hours.ago.utc.iso8601)
-      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000012', stamp: 8.hours.ago.utc.iso8601)
+      oldest = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000011',
+                       connection: probed_at(30.hours.ago.utc.iso8601))
+      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000012',
+              connection: probed_at(8.hours.ago.utc.iso8601))
 
       described_class.perform_now
 
       expect(probed).to eq([never.id, oldest.id])
+    end
+
+    # The batch is picked by attempt, not by evidence. A channel the provider
+    # keeps rejecting never refreshes credentials_verified_at, so ordering by
+    # that stamp would park it at the head of every batch forever and starve
+    # every healthy channel behind it.
+    it 'does not let a channel the provider keeps rejecting hold a batch slot' do
+      stub_const('Limits::BULK_EXTERNAL_HTTP_CALLS_LIMIT', 1)
+      channel(provider: 'whatsapp_cloud', phone_number: '+5511900000014',
+              connection: { 'credentials_verified_at' => 2.years.ago.utc.iso8601,
+                            'credentials_rejected_at' => 5.minutes.ago.utc.iso8601,
+                            'credentials_probed_at' => 5.minutes.ago.utc.iso8601 })
+      healthy = channel(provider: 'whatsapp_cloud', phone_number: '+5511900000015',
+                        connection: { 'credentials_verified_at' => 8.hours.ago.utc.iso8601,
+                                      'credentials_probed_at' => 8.hours.ago.utc.iso8601 })
+
+      described_class.perform_now
+
+      expect(probed).to eq([healthy.id])
     end
 
     # The window has to stay well inside the TTL: a channel that fell out of the

--- a/spec/models/channel/whatsapp_spec.rb
+++ b/spec/models/channel/whatsapp_spec.rb
@@ -117,6 +117,20 @@ RSpec.describe Channel::Whatsapp, type: :model do
       expect(channel.provider_connection).not_to have_key('credentials_verified_at')
     end
 
+    # Re-saving with fresh credentials has to bring the channel back right
+    # away; waiting for the next scheduled probe would leave it reading error
+    # for up to six hours after the admin fixed it.
+    it 'clears a rejection recorded by the probe when the credentials are re-saved' do
+      stub_request(:get, %r{https://graph\.facebook\.com/}).to_return(status: 200, body: '{"data":[]}')
+
+      channel = described_class.new(provider: 'whatsapp_cloud', phone_number: '+5511999990009',
+                                    provider_config: { 'api_key' => 'valid', 'waba_id' => '1' },
+                                    provider_connection: { 'credentials_rejected_at' => 1.hour.ago.utc.iso8601 })
+
+      expect(channel).to be_valid
+      expect(channel.provider_connection).not_to have_key('credentials_rejected_at')
+    end
+
     it 'does not stamp a hub-managed channel, whose state comes from the Hub' do
       channel = described_class.new(provider: 'whatsapp_cloud', phone_number: '+5511999990003',
                                     provider_config: { 'evolution_hub' => { 'status' => 'pending' } })

--- a/spec/services/channels/connection_state_resolver_spec.rb
+++ b/spec/services/channels/connection_state_resolver_spec.rb
@@ -165,6 +165,32 @@ RSpec.describe Channels::ConnectionStateResolver do
       expect(resolve(channel)[:state]).to eq('connected')
     end
 
+    # A probe the provider answered `no` to is evidence: holding `connected`
+    # until the reauthorization counter fills would leave the channel claiming
+    # a credential we already know is dead.
+    it 'reports error as soon as a probe is rejected, before the threshold' do
+      channel = Channel::Whatsapp.new(
+        provider: 'whatsapp_cloud',
+        provider_connection: {
+          'credentials_verified_at' => 2.hours.ago.utc.iso8601,
+          'credentials_rejected_at' => 1.hour.ago.utc.iso8601
+        }
+      )
+      stub_reauth(channel)
+
+      expect(resolve(channel)[:state]).to eq('error')
+    end
+
+    it 'trusts the stamp again once no rejection is recorded' do
+      channel = Channel::Whatsapp.new(
+        provider: 'whatsapp_cloud',
+        provider_connection: { 'credentials_verified_at' => 1.hour.ago.utc.iso8601 }
+      )
+      stub_reauth(channel)
+
+      expect(resolve(channel)[:state]).to eq('connected')
+    end
+
     it 'overrides any state with error when reauthorization is required' do
       channel = Channel::Whatsapp.new(provider: 'evolution', provider_connection: { 'connection' => 'open' })
       stub_reauth(channel, value: true)


### PR DESCRIPTION
Follow-up do #332, que mergeou com os achados do review em aberto. Mesmo diff que foi levantado lá, rebaseado na develop de agora.

## Canal rejeitado monopolizava o lote

O caminho de falha não regravava carimbo nenhum, então o canal que o provedor rejeita ficava permanentemente `< cutoff` **e** ordenava primeiro (carimbo mais antigo). Ele consumia uma das 25 vagas toda hora, para sempre — nada o tirava da fila.

Com 25 canais token mortos, o lote inteiro era gasto neles e nenhum canal saudável era re-sondado. E como o #332 reintroduziu o TTL de 7 dias justamente para esses provedores, ao fim da janela todo canal saudável cairia para `unknown` — a troca de "uma afirmação errada por outra" que derrubou o TTL na primeira rodada. Abaixo de 25 já custava quota: uma chamada por hora, para sempre, com um token conhecidamente morto.

`record_credential_probe!` passa a carimbar `credentials_probed_at` em **todo** resultado, e o agendador filtra e ordena pela tentativa, não pela evidência.

## Indisponibilidade do provedor não é revogação

`validate_provider_config?` devolvia booleano: 401, 429 e 500 viravam todos `false`. Com threshold 2 e cadência horária, dois ciclos consecutivos dentro de uma queda da Meta marcavam `reauthorization_required` em todos os canais `whatsapp_cloud`/`notificame`, jogavam o estado para `error` e disparavam `whatsapp_disconnect` para todos os admins.

`probe_credential` devolve `:ok` / `:rejected` / `:inconclusive`. **Token revogado da Meta volta 400 com OAuthException 190**, não 401, então a classificação lê o código de erro (190/102/10 e a faixa 200-299 são rejeição; 4/17/32/613 de rate limit e 1/2 transitórios, não). Timeout e 5xx registram a tentativa e não encostam no estado nem no contador.

## Sondagem que falha não deixa o canal conectado

O aceite pede isso; com threshold 2, a primeira rejeição deixava `connected` por mais uma hora. A rejeição vira carimbo próprio (`credentials_rejected_at`) e o resolver responde `error` na primeira. O e-mail continua saindo só no threshold, então uma rejeição espúria isolada não vira notificação.

Todo caminho de sucesso apaga o carimbo — inclusive o do save — então re-salvar com credencial nova devolve o canal na hora, em vez de esperar as 6h do próximo ciclo.

## O contador é compartilhado

`reauthorized!` incondicional apagava contagem levantada por `PARTNER_REMOVED` (`whatsapp_events_job.rb:180`) e por 401 de mídia (`incoming_message_whatsapp_cloud_service.rb:14`) — sinais que a sondagem não observa, já que ela só pergunta `GET {waba}/message_templates`. Com reset horário, nenhum deles voltaria a alcançar o threshold. Agora só limpa se a rejeição foi da própria sondagem.

## Menores

- Canal órfão fora do lote (`.joins(:inbox)`): o mailer de reautorização monta a URL pelo inbox e levantaria `NoMethodError` em nil.
- Carimbo no futuro volta a ser re-sondado: o resolver o recusa e responde `unknown`, e o agendador não o selecionava — o estado travado que o job existe para quebrar.
- Comentários enxugados (cabeçalho 6→3 linhas, constantes 5→3 e 4→1, ensaios dos helpers de SQL cortados). O contexto longo vive na PR.

## Testes

Suíte completa do `spec-staleness-guard`: **863 exemplos, 0 falhas**. `zeitwerk:check` limpo, rubocop em paridade exata com a baseline (59 = 59).

Nenhum spec passa vacuamente — 6 mutações no código de produção, todas pegas: ordenar por evidência (2 falhas), tirar a guarda de futuro (1), tirar o join de inbox (1), rejeição não afetar estado (3), limpeza incondicional do contador (1), qualquer falha virar revogação (2).

## Nota de deploy

`credentials_probed_at` não existe nos canais atuais, então a primeira execução considera todos vencidos e drena a 25/hora. Com o TTL de 7 dias, a capacidade é ~4.200 canais por janela.

## Summary by Sourcery

Harden scheduled WhatsApp credential re-probing so revoked tokens are surfaced promptly without disrupting healthy channels during provider failures.

Bug Fixes:
- Prevent rejected channels from monopolizing credential-probe batches by recording every probe attempt and scheduling based on the latest attempt.
- Distinguish invalid or revoked credentials from provider outages, rate limits, and transient failures to avoid incorrect reauthorization and disconnect notifications.
- Mark channels as errored immediately after a rejected credential probe while preserving threshold-based notifications.
- Preserve shared authorization error signals and clear probe-specific rejection state when credentials are successfully revalidated or saved.
- Ensure orphaned channels are excluded from probing and future or malformed timestamps remain eligible for recovery.

Enhancements:
- Expand credential probe outcomes and state resolution to represent inconclusive provider checks without changing channel health state.
- Retain credential probe metadata across unrelated provider connection updates and improve scheduling coverage for token-based providers.

CI:
- Update the staleness-guard workflow dependencies to cover probe outcome classification alongside scheduling and state resolution.

Tests:
- Add coverage for rejected credentials, provider outages, rate limits, timeouts, shared authorization counters, timestamp recovery, inbox filtering, and batch fairness.