### PR TITLE
fix(evo-flow): journeys/segments proxy forwards the caller's tenant and identity

### DIFF
--- a/app/controllers/api/v1/evo_flow/journeys_controller.rb
+++ b/app/controllers/api/v1/evo_flow/journeys_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
+  include EvoFlowTenantPassthrough
+
   # ParamsWrapper MERGES its wrapper into request.request_parameters — the hash
   # this proxy forwards.
   wrap_parameters false
@@ -48,7 +50,7 @@ class Api::V1::EvoFlow::JourneysController < Api::V1::BaseController
   private
 
   def client
-    @client ||= EvoFlow::Client.new
+    @client ||= EvoFlow::Client.new(extra_headers: evo_flow_passthrough_headers)
   end
 
   # evo-flow's own status, not a guessed one: 201 on create AND duplicate, 204 on delete.

--- a/app/controllers/api/v1/evo_flow/segments_controller.rb
+++ b/app/controllers/api/v1/evo_flow/segments_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::EvoFlow::SegmentsController < Api::V1::BaseController
+  include EvoFlowTenantPassthrough
+
   # EVO-1938: gate every proxied action by permission. Without this, the segments
   # endpoints were reachable by any authenticated user (incl. the default agent)
   # even though the Settings UI hides Segments — so revoking segments.* from the
@@ -96,7 +98,7 @@ class Api::V1::EvoFlow::SegmentsController < Api::V1::BaseController
   private
 
   def client
-    @client ||= EvoFlow::Client.new
+    @client ||= EvoFlow::Client.new(extra_headers: evo_flow_passthrough_headers)
   end
 
   def list_params

--- a/app/controllers/concerns/evo_flow_tenant_passthrough.rb
+++ b/app/controllers/concerns/evo_flow_tenant_passthrough.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Multi-tenant evo-flow requires the CALLER's tenant and identity on every
+# proxied request: X-Evo-Tenant-Id scopes, and the runtime-context enricher
+# reads the user from the JWT `sub` of the Authorization header (authentication
+# itself stays on the integration key, which the bearer guard honors first).
+# Without them evo-flow answers 401 TENANT_REQUIRED even to the proxy.
+# Single-tenant deployments send neither header and nothing changes.
+module EvoFlowTenantPassthrough
+  extend ActiveSupport::Concern
+
+  private
+
+  def evo_flow_passthrough_headers
+    {
+      'X-Evo-Tenant-Id' => request.headers['X-Evo-Tenant-Id'],
+      'Authorization' => request.headers['Authorization']
+    }.compact
+  end
+end

--- a/app/services/evo_flow/client.rb
+++ b/app/services/evo_flow/client.rb
@@ -37,12 +37,16 @@ module EvoFlow
     # request, so it never reaches HTTParty unchecked.
     SUPPORTED_VERBS = %i[get post put patch delete].freeze
 
+    # `extra_headers`: per-request passthrough (the proxies forward the caller's
+    # X-Evo-Tenant-Id + Authorization so multi-tenant evo-flow can resolve the
+    # tenant scope; auth itself stays on the integration key). nil values dropped.
     def initialize(api_url: ENV.fetch('EVO_FLOW_API_URL', DEFAULT_API_URL),
                    api_key: ENV.fetch('AUTH_APIKEY_INTEGRATION_LOCAL', nil),
-                   timeout: 10)
+                   timeout: 10, extra_headers: {})
       @api_url = api_url
       @api_key = api_key
       @timeout = timeout
+      @extra_headers = (extra_headers || {}).compact
       validate_config!
     end
 
@@ -155,7 +159,7 @@ module EvoFlow
     end
 
     def request_headers
-      { 'Content-Type' => 'application/json', 'X-Integration-API-Key' => @api_key }
+      { 'Content-Type' => 'application/json', 'X-Integration-API-Key' => @api_key }.merge(@extra_headers)
     end
 
     def handle_response(response)

--- a/spec/controllers/api/v1/evo_flow/journeys_controller_spec.rb
+++ b/spec/controllers/api/v1/evo_flow/journeys_controller_spec.rb
@@ -22,6 +22,27 @@ RSpec.describe Api::V1::EvoFlow::JourneysController, type: :controller do
   describe 'proxying to evo-flow (authorized via service token)' do
     before { Current.service_authenticated = true } # bypasses the permission gate
 
+    it 'forwards the caller tenant and identity to evo-flow (multi-tenant scope)' do
+      request.headers['X-Evo-Tenant-Id'] = '2c013165-3992-4e6f-ba0d-4b6cb768a5d6'
+      request.headers['Authorization'] = 'Bearer user-jwt'
+      allow(fake_client).to receive(:request).and_return([200, {}])
+
+      get :proxy
+
+      expect(EvoFlow::Client).to have_received(:new).with(
+        extra_headers: { 'X-Evo-Tenant-Id' => '2c013165-3992-4e6f-ba0d-4b6cb768a5d6',
+                         'Authorization' => 'Bearer user-jwt' }
+      )
+    end
+
+    it 'sends no passthrough header when the caller sent none (single-tenant)' do
+      allow(fake_client).to receive(:request).and_return([200, {}])
+
+      get :proxy
+
+      expect(EvoFlow::Client).to have_received(:new).with(extra_headers: {})
+    end
+
     it 'GET /journeys forwards to the client and returns the response' do
       allow(fake_client).to receive(:request).with(:get, '/journeys', query: anything)
                                              .and_return([200, { 'items' => [] }])

--- a/spec/services/evo_flow/client_spec.rb
+++ b/spec/services/evo_flow/client_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe EvoFlow::Client do
     end
   end
 
+  describe 'extra_headers (multi-tenant passthrough)' do
+    it 'merges the passthrough onto the base headers, dropping nils' do
+      stub = stub_request(:get, "#{api_url}/journeys")
+             .with(headers: { 'X-Integration-API-Key' => api_key,
+                              'X-Evo-Tenant-Id' => '2c013165-3992-4e6f-ba0d-4b6cb768a5d6',
+                              'Authorization' => 'Bearer user-jwt' })
+             .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+      described_class.new(api_url: api_url, api_key: api_key,
+                          extra_headers: { 'X-Evo-Tenant-Id' => '2c013165-3992-4e6f-ba0d-4b6cb768a5d6',
+                                           'Authorization' => 'Bearer user-jwt',
+                                           'X-Dropped' => nil })
+                     .request(:get, '/journeys')
+
+      expect(stub).to have_been_requested
+    end
+  end
+
   describe '#patch' do
     it 'PATCHes to the full /api/v1 URL with auth + json headers (EVO-2188)' do
       stub = stub_request(:patch, "#{api_url}/journeys/j1")


### PR DESCRIPTION
**P1 (prod)**: `GET /api/v1/journeys` (and segments) proxied to multi-tenant evo-flow answered **401 TENANT_REQUIRED**: the proxy sent only `X-Integration-API-Key`, and evo-flow's enterprise runtime-context needs `X-Evo-Tenant-Id` **and** a caller identity (it reads the JWT `sub` from `Authorization` at middleware time — no verification there; auth stays on the integration key, which its bearer guard honors first, and membership is checked fail-closed).

Proven in prod: with the integration key alone → 401 TENANT_REQUIRED; adding only the tenant header → still 401 (no-user branch).

**Fix**: `EvoFlow::Client` gains `extra_headers` (nil-compacted, merged over the base headers) and both proxy controllers (`EvoFlowTenantPassthrough`) forward the inbound `X-Evo-Tenant-Id` + `Authorization` verbatim when present. Single-tenant callers send neither → behavior unchanged.

**Proof**: client + journeys/segments controller + journeys RBAC suites = 92 examples, 1 failure **pre-existing on develop** (`client_spec` F9 expects the old `:3000` default; fails identically on a pristine checkout). RuboCop: zero new offenses (6 pre-existing in the touched files).

## Summary by Sourcery

Forward tenant scope and caller identity from evo-flow proxy requests to restore multi-tenant journeys and segments access.

Bug Fixes:
- Forward the caller’s tenant and identity headers through journeys and segments proxies so multi-tenant evo-flow requests receive the required runtime context.

Enhancements:
- Extend the evo-flow client to support optional per-request headers while preserving existing single-tenant behavior.

Tests:
- Add coverage for client header merging and tenant/identity forwarding for journeys proxy requests.