### PR TITLE
fix(evo-flow): events carry the tenant captured at enqueue time

### DIFF
--- a/app/listeners/evo_flow/contact_events_listener.rb
+++ b/app/listeners/evo_flow/contact_events_listener.rb
@@ -189,7 +189,7 @@ module EvoFlow
       )
       # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
       # round-tripping through JSON normalises both at the listener boundary.
-      EvoFlow::PublishEventWorker.perform_async(IDENTIFY_PATH, JSON.parse(payload.to_json))
+      EvoFlow::PublishEventWorker.perform_async(IDENTIFY_PATH, JSON.parse(payload.to_json), current_tenant_id)
     end
 
     # Ported from legacy evo_campaign/contact_events_integration_service.rb:553-571.
@@ -236,6 +236,14 @@ module EvoFlow
     def enqueue_loss?(error)
       (defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)) ||
         (error.is_a?(ArgumentError) && error.message.include?('occurred_at is required'))
+    end
+
+    # Multi-tenant deployments fill the runtime-context extension point with the
+    # tenant bound to the CURRENT process (request or job); the id is serialized
+    # into the job args so the publish carries X-Evo-Tenant-Id. Community
+    # single-tenant: the default impl answers nil and nothing is sent.
+    def current_tenant_id
+      EvoExtensionPoints::RuntimeContext.current_scope_id
     end
   end
 end

--- a/app/listeners/evo_flow/conversation_events_listener.rb
+++ b/app/listeners/evo_flow/conversation_events_listener.rb
@@ -61,7 +61,7 @@ module EvoFlow
         occurred_at: conversation.created_at,
         message_id: message_id
       )
-      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json), current_tenant_id)
     end
 
     def enqueue_resolved(conversation, event_data)
@@ -78,7 +78,7 @@ module EvoFlow
         occurred_at: occurred_at,
         message_id: message_id
       )
-      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json), current_tenant_id)
     end
 
     def build_created_properties(conversation)
@@ -131,6 +131,14 @@ module EvoFlow
       return true if defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)
 
       error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
+    end
+
+    # Multi-tenant deployments fill the runtime-context extension point with the
+    # tenant bound to the CURRENT process (request or job); the id is serialized
+    # into the job args so the publish carries X-Evo-Tenant-Id. Community
+    # single-tenant: the default impl answers nil and nothing is sent.
+    def current_tenant_id
+      EvoExtensionPoints::RuntimeContext.current_scope_id
     end
   end
 end

--- a/app/listeners/evo_flow/message_events_listener.rb
+++ b/app/listeners/evo_flow/message_events_listener.rb
@@ -117,7 +117,7 @@ module EvoFlow
         occurred_at: message.created_at,
         message_id: message_id
       )
-      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json), current_tenant_id)
     end
 
     def enqueue_status_change(message, inbox, event_name, event_data)
@@ -134,7 +134,7 @@ module EvoFlow
         occurred_at: occurred_at,
         message_id: message_id
       )
-      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json), current_tenant_id)
     end
 
     # PII/volume guard: `content` is truncated (default 2000 chars) and can be
@@ -207,6 +207,14 @@ module EvoFlow
       return true if defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)
 
       error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
+    end
+
+    # Multi-tenant deployments fill the runtime-context extension point with the
+    # tenant bound to the CURRENT process (request or job); the id is serialized
+    # into the job args so the publish carries X-Evo-Tenant-Id. Community
+    # single-tenant: the default impl answers nil and nothing is sent.
+    def current_tenant_id
+      EvoExtensionPoints::RuntimeContext.current_scope_id
     end
   end
 end

--- a/app/listeners/evo_flow/pipeline_events_listener.rb
+++ b/app/listeners/evo_flow/pipeline_events_listener.rb
@@ -70,7 +70,7 @@ module EvoFlow
       )
       # Sidekiq strict_args!(:raise) rejects symbol keys and non-JSON values;
       # PayloadBuilder is out of scope for this story — normalise at boundary.
-      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json), current_tenant_id)
     end
 
     def resolve_contact_id(pipeline_item)
@@ -112,7 +112,7 @@ module EvoFlow
         occurred_at: occurred_at,
         message_id: message_id
       )
-      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json))
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json), current_tenant_id)
     end
 
     def build_stage_changed_properties(pipeline_item, contact_id, old_stage_id, new_stage_id)
@@ -182,6 +182,14 @@ module EvoFlow
       return true if defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)
 
       error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
+    end
+
+    # Multi-tenant deployments fill the runtime-context extension point with the
+    # tenant bound to the CURRENT process (request or job); the id is serialized
+    # into the job args so the publish carries X-Evo-Tenant-Id. Community
+    # single-tenant: the default impl answers nil and nothing is sent.
+    def current_tenant_id
+      EvoExtensionPoints::RuntimeContext.current_scope_id
     end
   end
 end

--- a/app/workers/evo_flow/publish_event_worker.rb
+++ b/app/workers/evo_flow/publish_event_worker.rb
@@ -83,8 +83,12 @@ module EvoFlow
       FailureBroadcaster.new.broadcast_failed(path: path, payload: safe_payload, error: safe_error)
     end
 
-    def perform(path, payload)
-      EvoFlow::Client.new.post(path, payload)
+    # `tenant_id` (3rd arg, nil-able for jobs enqueued before it existed):
+    # multi-tenant evo-flow scopes every /events/* call by X-Evo-Tenant-Id, so
+    # the listener captures the tenant at enqueue time and the publish carries
+    # it. nil (community single-tenant) sends no extra header.
+    def perform(path, payload, tenant_id = nil)
+      client_for(tenant_id).post(path, payload)
       Rails.logger.info("[EvoFlow] published path=#{path} messageId=#{message_id(payload)}")
     rescue EvoFlow::InvalidEventName => e
       # Defense-in-depth: PayloadBuilder.validate_event_name! already runs at
@@ -138,6 +142,10 @@ module EvoFlow
     end
 
     private
+
+    def client_for(tenant_id)
+      EvoFlow::Client.new(extra_headers: { 'X-Evo-Tenant-Id' => tenant_id.presence }.compact)
+    end
 
     # Sidekiq JSON-serialises args → string keys for enqueued jobs; tolerate
     # symbol keys too (in-process / console invocation with builder output).

--- a/spec/workers/evo_flow/publish_event_worker_spec.rb
+++ b/spec/workers/evo_flow/publish_event_worker_spec.rb
@@ -11,6 +11,23 @@ RSpec.describe EvoFlow::PublishEventWorker, type: :job do
   before { allow(EvoFlow::Client).to receive(:new).and_return(client) }
 
   describe '#perform' do
+    it 'sends X-Evo-Tenant-Id when the job carries a tenant (multi-tenant)' do
+      allow(client).to receive(:post)
+
+      described_class.new.perform(path, payload, '2c013165-3992-4e6f-ba0d-4b6cb768a5d6')
+
+      expect(EvoFlow::Client).to have_received(:new)
+        .with(extra_headers: { 'X-Evo-Tenant-Id' => '2c013165-3992-4e6f-ba0d-4b6cb768a5d6' })
+    end
+
+    it 'sends no extra header without a tenant (single-tenant / legacy 2-arg job)' do
+      allow(client).to receive(:post)
+
+      described_class.new.perform(path, payload)
+
+      expect(EvoFlow::Client).to have_received(:new).with(extra_headers: {})
+    end
+
     it 'forwards path + payload to EvoFlow::Client#post (happy path)' do
       allow(client).to receive(:post).and_return('messageId' => 'm-1', 'status' => 'queued')
 


### PR DESCRIPTION
**Stacked on #335** (needs `EvoFlow::Client#extra_headers`; retarget to develop after it merges).

Under the multi-tenant gate every CRM→evo-flow event (contact/conversation/message/pipeline) died with 401 TENANT_REQUIRED → 5 retries → Dead Set (prod: ~9999 dead jobs), so segments/journeys never triggered. The four listeners stamp the current tenant via `EvoExtensionPoints::RuntimeContext.current_scope_id` (the enterprise docker overlay already fills it with `TenantContext`; community default = nil) into the job args; `PublishEventWorker#perform(path, payload, tenant_id = nil)` sends `X-Evo-Tenant-Id` when present. Legacy 2-arg jobs keep running.

**Proof**: workers+listeners suites = 113 examples, 5 failures all **pre-existing on the base** (identical run on pristine ecfabb1); the new worker cases (header with tenant / none without) pass. RuboCop clean on the touched files. Requires the enricher's trusted-service path (evo-enterprise-licensing-nestjs) for the header to be honored on service calls.

## Summary by Sourcery

Ensure CRM-to-evo-flow events are published within the tenant context captured when they are enqueued.

Bug Fixes:
- Preserve the tenant associated with CRM events when publishing them to evo-flow, preventing multi-tenant events from being rejected and sent to the Dead Set.
- Continue supporting existing two-argument publish jobs and omit tenant headers for single-tenant events.

Tests:
- Add coverage for publishing tenant headers and for header-free legacy or single-tenant jobs.