### PR TITLE
feat(webhooks): superfície de config do webhook de compra — providers e URL assinada (CRM-493)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -276,6 +276,13 @@ on:
       - 'config/initializers/purchase_adapters.rb'
       - 'spec/requests/api/v1/webhooks/purchases_spec.rb'
       - 'spec/requests/api/v1/webhooks/purchase_platforms_spec.rb'
+      # CRM-493: the minter is the other half of that contract — it signs the
+      # destination query the ingress verifies. A drift on either side (secret
+      # rule, MAC values, provider casing) mints URLs the ingress 401s, and the
+      # operator only finds out at the payment platform.
+      - 'app/controllers/api/v1/purchase_webhooks_controller.rb'
+      - 'app/lib/webhooks/purchase_webhook_url.rb'
+      - 'spec/requests/api/v1/purchase_webhooks_spec.rb'
 
 permissions:
   contents: read
@@ -341,6 +348,7 @@ jobs:
             spec/requests/api/v1/automation_rules_spec.rb \
             spec/requests/api/v1/webhooks/purchases_spec.rb \
             spec/requests/api/v1/webhooks/purchase_platforms_spec.rb \
+            spec/requests/api/v1/purchase_webhooks_spec.rb \
             spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb \
             spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb \
             spec/listeners/pipeline_stage_automation_listener_spec.rb \

--- a/app/controllers/api/v1/purchase_webhooks_controller.rb
+++ b/app/controllers/api/v1/purchase_webhooks_controller.rb
@@ -19,8 +19,16 @@ class Api::V1::PurchaseWebhooksController < Api::V1::BaseController
                          'No credential configured for this platform', :unprocessable_entity],
     destination_secret_required: [ApiErrorCodes::VALIDATION_ERROR,
                                   "This platform's credential is public — configure the URL destination secret first",
-                                  :unprocessable_entity]
+                                  :unprocessable_entity],
+    host_not_configured: [ApiErrorCodes::VALIDATION_ERROR,
+                          'No public host resolved for this account — FRONTEND_URL is not configured',
+                          :unprocessable_entity]
   }.freeze
+
+  # EVO-2204: `pipelines.update` alone is not the gate — the funnel must also be
+  # one the caller may manage. Minting picks where purchases land, so a private
+  # or team funnel the caller cannot see must never become a destination.
+  before_action :authorize_pipeline!, only: :url
 
   def providers
     success_response(
@@ -37,13 +45,31 @@ class Api::V1::PurchaseWebhooksController < Api::V1::BaseController
     )
 
     if result.error
-      code, message, status = ERROR_RESPONSES.fetch(result.error)
-      error_response(code, message, details: { reason: result.error.to_s.upcase }, status: status)
+      refuse(result.error)
     else
       success_response(
         data: { url: result.url, host_kind: result.host_kind },
         message: 'Purchase webhook URL minted successfully'
       )
     end
+  end
+
+  private
+
+  # A service token already bypasses require_permissions and resolves no
+  # Current.user, so every PipelinePolicy predicate would refuse it — same
+  # bypass PipelinePolicy::Scope#resolve makes for the listing.
+  def authorize_pipeline!
+    return if Current.service_authenticated == true
+
+    pipeline = ::Pipeline.find_by(id: params[:pipeline_id])
+    return refuse(:pipeline_not_found) if pipeline.nil?
+
+    authorize pipeline, :update?
+  end
+
+  def refuse(reason)
+    code, message, status = ERROR_RESPONSES.fetch(reason)
+    error_response(code, message, details: { reason: reason.to_s.upcase }, status: status)
   end
 end

--- a/app/controllers/api/v1/purchase_webhooks_controller.rb
+++ b/app/controllers/api/v1/purchase_webhooks_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Authenticated config surface of the purchase-webhook ingress: which platforms
+# exist/are configured, and the signed URL the operator registers at one. Gated
+# by pipelines.update — choosing where purchases land IS pipeline management.
+# (The unauthenticated delivery ingress lives in Webhooks::PurchasesController.)
+class Api::V1::PurchaseWebhooksController < Api::V1::BaseController
+  require_permissions({
+    providers: 'pipelines.update',
+    url: 'pipelines.update'
+  })
+
+  ERROR_RESPONSES = {
+    unknown_provider: [ApiErrorCodes::UNKNOWN_PROVIDER, 'Provider not registered', :not_found],
+    pipeline_not_found: [ApiErrorCodes::VALIDATION_ERROR, 'Pipeline not found', :unprocessable_entity],
+    pipeline_without_stages: [ApiErrorCodes::VALIDATION_ERROR,
+                              'Pipeline has no stages — the lead would have no entry stage', :unprocessable_entity],
+    credential_missing: [ApiErrorCodes::VALIDATION_ERROR,
+                         'No credential configured for this platform', :unprocessable_entity],
+    destination_secret_required: [ApiErrorCodes::VALIDATION_ERROR,
+                                  "This platform's credential is public — configure the URL destination secret first",
+                                  :unprocessable_entity]
+  }.freeze
+
+  def providers
+    success_response(
+      data: Webhooks::PurchaseWebhookUrl.new.providers_payload,
+      message: 'Purchase webhook providers retrieved successfully'
+    )
+  end
+
+  def url
+    result = Webhooks::PurchaseWebhookUrl.new.mint(
+      provider: params[:provider],
+      pipeline_id: params[:pipeline_id],
+      product: params[:product].presence
+    )
+
+    if result.error
+      code, message, status = ERROR_RESPONSES.fetch(result.error)
+      error_response(code, message, details: { reason: result.error.to_s.upcase }, status: status)
+    else
+      success_response(
+        data: { url: result.url, host_kind: result.host_kind },
+        message: 'Purchase webhook URL minted successfully'
+      )
+    end
+  end
+end

--- a/app/lib/webhooks/purchase_adapters.rb
+++ b/app/lib/webhooks/purchase_adapters.rb
@@ -45,6 +45,10 @@ module Webhooks
         @adapters.key?(key.to_sym)
       end
 
+      def keys
+        @adapters.keys
+      end
+
       def clear!
         @adapters = {}
       end

--- a/app/lib/webhooks/purchase_webhook_url.rb
+++ b/app/lib/webhooks/purchase_webhook_url.rb
@@ -36,8 +36,13 @@ module Webhooks
       query[PurchaseDestinationMac::QUERY_PARAM] = PurchaseDestinationMac.mint(mac_secret, provider, values)
 
       tenant_for_host = values['evo_tenant']
+      # No host resolved means a relative URL nobody can register; the operator
+      # would only find out at the platform, on the first failed delivery.
+      base = base_url(tenant_for_host)
+      return Result.new(error: :host_not_configured) if base.blank?
+
       Result.new(
-        url: "#{base_url(tenant_for_host)}/api/v1/webhooks/purchases/#{provider}?#{query.to_query}",
+        url: "#{base}/api/v1/webhooks/purchases/#{provider}?#{query.to_query}",
         host_kind: host_kind(tenant_for_host)
       )
     end

--- a/app/lib/webhooks/purchase_webhook_url.rb
+++ b/app/lib/webhooks/purchase_webhook_url.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
 # Mints the URL an operator registers at a purchase platform: the destination
-# query (evo_tenant/pipeline_id/product) signed with the account's secret —
-# same rules as the ingress (PurchaseWebhookSignatureConcern), so a URL this
-# service refuses is one the ingress would refuse too. Consumed by the
-# pipeline screen's "purchase webhook" modal and by `rake
-# evo_purchase_webhook:url`.
-#
-# `base_url`/`host_kind` are instance methods on purpose: an embedding
-# distribution may prepend a module to resolve the host per deployment (e.g. a
-# whitelabel domain) — the community default is the global FRONTEND_URL.
+# query (evo_tenant/pipeline_id/product) signed under the same secret rules as
+# the ingress (PurchaseWebhookSignatureConcern), so a URL this service refuses
+# is one the ingress would refuse too. Used by the pipeline screen and the rake.
 module Webhooks
   class PurchaseWebhookUrl
     Result = Struct.new(:url, :host_kind, :error, keyword_init: true)

--- a/app/lib/webhooks/purchase_webhook_url.rb
+++ b/app/lib/webhooks/purchase_webhook_url.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Mints the URL an operator registers at a purchase platform: the destination
+# query (evo_tenant/pipeline_id/product) signed with the account's secret —
+# same rules as the ingress (PurchaseWebhookSignatureConcern), so a URL this
+# service refuses is one the ingress would refuse too. Consumed by the
+# pipeline screen's "purchase webhook" modal and by `rake
+# evo_purchase_webhook:url`.
+#
+# `base_url`/`host_kind` are instance methods on purpose: an embedding
+# distribution may prepend a module to resolve the host per deployment (e.g. a
+# whitelabel domain) — the community default is the global FRONTEND_URL.
+module Webhooks
+  class PurchaseWebhookUrl
+    Result = Struct.new(:url, :host_kind, :error, keyword_init: true)
+
+    # evo_tenant: explicit override for operator tooling (the rake mints for
+    # any account); the screen path leaves it nil and uses the bound tenant.
+    def mint(provider:, pipeline_id:, product: nil, evo_tenant: nil)
+      provider = provider.to_s.downcase
+      return Result.new(error: :unknown_provider) unless PurchaseAdapters.registered?(provider)
+
+      pipeline = ::Pipeline.find_by(id: pipeline_id)
+      return Result.new(error: :pipeline_not_found) if pipeline.nil?
+      # A URL to a stage-less pipeline mints fine and then fails on every
+      # delivery (the lead needs the entry stage) — refuse here, where the
+      # operator can still fix it.
+      return Result.new(error: :pipeline_without_stages) unless pipeline.pipeline_stages.exists?
+
+      platform_secret = GlobalConfigService.load("PURCHASE_WEBHOOK_SECRET_#{provider.upcase}", nil).to_s
+      return Result.new(error: :credential_missing) if platform_secret.blank?
+
+      mac_secret = resolve_mac_secret(provider, platform_secret)
+      return Result.new(error: :destination_secret_required) if mac_secret.nil?
+
+      values = {
+        'evo_tenant' => (evo_tenant.presence || bound_tenant_id).to_s,
+        'pipeline_id' => pipeline.id.to_s,
+        'product' => product.to_s
+      }
+      query = values.reject { |_k, v| v.blank? }
+      query[PurchaseDestinationMac::QUERY_PARAM] = PurchaseDestinationMac.mint(mac_secret, provider, values)
+
+      tenant_for_host = values['evo_tenant']
+      Result.new(
+        url: "#{base_url(tenant_for_host)}/api/v1/webhooks/purchases/#{provider}?#{query.to_query}",
+        host_kind: host_kind(tenant_for_host)
+      )
+    end
+
+    # What the platform picker needs: which providers exist, which have a
+    # credential, and whether the URL destination secret (required for
+    # public-credential schemes) is configured.
+    def providers_payload
+      {
+        providers: PurchaseAdapters.keys.map do |key|
+          provider = key.to_s
+          verifier = PurchaseAdapters.verifier_for(provider)
+          {
+            provider: provider,
+            configured: GlobalConfigService.load("PURCHASE_WEBHOOK_SECRET_#{provider.upcase}", nil).present?,
+            requires_destination_secret: verifier&.public_credential? || false
+          }
+        end,
+        destination_secret_configured: GlobalConfigService.load(PurchaseDestinationMac::SECRET_KEY, nil).present?
+      }
+    end
+
+    private
+
+    # Same rule as the ingress: the account's destination secret when set;
+    # fallback to the platform credential ONLY while it is private — for an
+    # asymmetric scheme (public key) there is no fallback.
+    def resolve_mac_secret(provider, platform_secret)
+      destination = GlobalConfigService.load(PurchaseDestinationMac::SECRET_KEY, nil).to_s
+      return destination if destination.present?
+
+      verifier = PurchaseAdapters.verifier_for(provider)
+      return nil if verifier.nil? || verifier.public_credential?
+
+      platform_secret
+    end
+
+    # tenant_id is unused here; an embedding overlay resolves the host per
+    # account (whitelabel) and needs to know WHICH account the URL is for.
+    def base_url(_tenant_id)
+      ENV.fetch('FRONTEND_URL', '').chomp('/')
+    end
+
+    def host_kind(_tenant_id)
+      'global'
+    end
+
+    # Multi-tenant embeddings bind the account per request; standalone has no
+    # tenant and mints an unbound URL (the single-account box).
+    def bound_tenant_id
+      return nil unless defined?(Evo::Enterprise::Licensing) &&
+                        Evo::Enterprise::Licensing.respond_to?(:current_tenant_id)
+
+      Evo::Enterprise::Licensing.current_tenant_id
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,6 +303,13 @@ Rails.application.routes.draw do
         post 'purchases/:provider', to: 'purchases#receive', as: :purchase_webhook
       end
 
+      # Authenticated CONFIG surface of the purchase-webhook ingress (CRM-493):
+      # the pipeline screen lists the platforms and mints the signed URL the
+      # operator registers at one. Deliberately outside `namespace :webhooks`
+      # (that one is the unauthenticated delivery ingress).
+      get 'purchase_webhooks/providers', to: 'purchase_webhooks#providers'
+      get 'purchase_webhooks/url', to: 'purchase_webhooks#url'
+
       # Attach/detach products to AI agents (agent lives in evo_core; we only
       # track the join here and propagate to agent.config via
       # Ai::AgentProductSyncService).

--- a/lib/tasks/purchase_webhook.rake
+++ b/lib/tasks/purchase_webhook.rake
@@ -3,35 +3,32 @@
 # Mints the URL to register at the payment platform. Hand-building it is a
 # footgun: the `d` MAC pins evo_tenant/pipeline_id/product, which the platform's
 # body signature cannot cover, and a wrong one fails closed with a 401.
+# Delegates to Webhooks::PurchaseWebhookUrl — the same minter behind the
+# pipeline screen — so host resolution and secret rules never drift.
 namespace :evo_purchase_webhook do
+  ABORTS = {
+    unknown_provider: 'provider has no registered adapter',
+    pipeline_not_found: 'pipeline_id does not match a pipeline',
+    pipeline_without_stages: 'pipeline has no stages — the lead would have no entry stage',
+    credential_missing: 'PURCHASE_WEBHOOK_SECRET_<PROVIDER> is not configured — the endpoint refuses every request until it is',
+    destination_secret_required: 'PURCHASE_WEBHOOK_SECRET_DESTINATION is not configured — required for a ' \
+                                 'public-credential platform: its key cannot sign the URL'
+  }.freeze
+
   desc 'Print the URL to register: evo_purchase_webhook:url[provider,evo_tenant,pipeline_id,product]'
   task :url, %i[provider evo_tenant pipeline_id product] => :environment do |_task, args|
     provider = args[:provider].to_s.downcase
     abort('usage: rake "evo_purchase_webhook:url[provider,evo_tenant,pipeline_id,product]"') if provider.blank?
-    abort("provider '#{provider}' has no registered adapter") unless Webhooks::PurchaseAdapters.registered?(provider)
 
-    config_key = "PURCHASE_WEBHOOK_SECRET_#{provider.upcase}"
-    secret = GlobalConfigService.load(config_key, nil).to_s
-    abort("#{config_key} is not configured — the endpoint refuses every request until it is") if secret.blank?
+    result = Webhooks::PurchaseWebhookUrl.new.mint(
+      provider: provider,
+      pipeline_id: args[:pipeline_id],
+      product: args[:product].to_s.presence,
+      evo_tenant: args[:evo_tenant].to_s.presence
+    )
 
-    # The MAC key mirrors purchase_destination_mac_secret: the account's own
-    # destination secret when set, else the platform credential — except for a
-    # public-credential scheme (Kiwify), where the fallback would be forgeable.
-    destination_secret = GlobalConfigService.load(Webhooks::PurchaseDestinationMac::SECRET_KEY, nil).to_s
-    mac_secret = destination_secret.presence
-    if mac_secret.nil?
-      verifier = Webhooks::PurchaseAdapters.verifier_for(provider)
-      if verifier.public_credential?
-        abort("#{Webhooks::PurchaseDestinationMac::SECRET_KEY} is not configured — required for " \
-              "#{provider}: its platform credential is a public key and cannot sign the URL")
-      end
-      mac_secret = secret
-    end
+    abort("#{provider}: #{ABORTS.fetch(result.error, result.error.to_s)}") if result.error
 
-    values = Webhooks::PurchaseDestinationMac::PARAMS.index_with { |key| args[key.to_sym].to_s }
-    query = values.reject { |_key, value| value.blank? }
-    query[Webhooks::PurchaseDestinationMac::QUERY_PARAM] = Webhooks::PurchaseDestinationMac.mint(mac_secret, provider, values)
-
-    puts "#{ENV.fetch('FRONTEND_URL', '')}/api/v1/webhooks/purchases/#{provider}?#{query.to_query}"
+    puts result.url
   end
 end

--- a/lib/tasks/purchase_webhook.rake
+++ b/lib/tasks/purchase_webhook.rake
@@ -12,7 +12,8 @@ namespace :evo_purchase_webhook do
     pipeline_without_stages: 'pipeline has no stages — the lead would have no entry stage',
     credential_missing: 'PURCHASE_WEBHOOK_SECRET_<PROVIDER> is not configured — the endpoint refuses every request until it is',
     destination_secret_required: 'PURCHASE_WEBHOOK_SECRET_DESTINATION is not configured — required for a ' \
-                                 'public-credential platform: its key cannot sign the URL'
+                                 'public-credential platform: its key cannot sign the URL',
+    host_not_configured: 'FRONTEND_URL is not configured — the URL would be relative and unregistrable'
   }.freeze
 
   desc 'Print the URL to register: evo_purchase_webhook:url[provider,evo_tenant,pipeline_id,product]'

--- a/spec/requests/api/v1/purchase_webhooks_spec.rb
+++ b/spec/requests/api/v1/purchase_webhooks_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-493: the authenticated config surface of the purchase-webhook ingress —
+# the pipeline screen's platform picker (providers) and the signed URL minting.
+# The minted URL must agree with the ingress: same MAC, same secret rules.
+RSpec.describe 'Api::V1::PurchaseWebhooks', type: :request do
+  let(:service_token) { 'spec-service-token' }
+  let(:headers) { { 'X-Service-Token' => service_token } }
+
+  let!(:user) { User.create!(name: 'Config User', email: "cfg-#{SecureRandom.hex(4)}@example.com") }
+  let!(:pipeline) { Pipeline.create!(name: "Compras #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user) }
+  let!(:entry_stage) { pipeline.pipeline_stages.create!(name: 'Entrada', position: 1) }
+
+  before do
+    ENV['EVOAI_CRM_API_TOKEN'] = service_token
+    ENV['FRONTEND_URL'] = 'https://app.evo.test'
+    allow(GlobalConfigService).to receive(:load).and_call_original
+    allow(GlobalConfigService).to receive(:load)
+      .with('PURCHASE_WEBHOOK_SECRET_CAKTO', nil).and_return('cakto-token')
+  end
+
+  after do
+    ENV.delete('EVOAI_CRM_API_TOKEN')
+    ENV.delete('FRONTEND_URL')
+    Current.reset
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  describe 'GET /api/v1/purchase_webhooks/providers' do
+    it 'lists every registered provider with its configured flag and the destination-secret flag' do
+      get '/api/v1/purchase_webhooks/providers', headers: headers
+
+      expect(response).to have_http_status(:ok)
+      providers = json_response.dig('data', 'providers')
+      by_name = providers.index_by { |p| p['provider'] }
+
+      expect(by_name.keys).to include('virtu', 'hotmart', 'kiwify', 'cakto')
+      expect(by_name['cakto']['configured']).to be(true)
+      expect(by_name['hotmart']['configured']).to be(false)
+      expect(by_name['kiwify']['requires_destination_secret']).to be(true)
+      expect(by_name['cakto']['requires_destination_secret']).to be(false)
+      expect(json_response.dig('data', 'destination_secret_configured')).to be(false)
+    end
+  end
+
+  describe 'GET /api/v1/purchase_webhooks/url' do
+    it 'mints a URL the ingress accepts (same MAC over the same values)' do
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: pipeline.id }, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      url = json_response.dig('data', 'url')
+      expect(url).to start_with("https://app.evo.test/api/v1/webhooks/purchases/cakto?")
+
+      expected_mac = Webhooks::PurchaseDestinationMac.mint(
+        'cakto-token', 'cakto',
+        { 'evo_tenant' => '', 'pipeline_id' => pipeline.id.to_s, 'product' => '' }
+      )
+      expect(url).to include("d=#{expected_mac}")
+      expect(json_response.dig('data', 'host_kind')).to eq('global')
+    end
+
+    it 'signs with the destination secret when configured' do
+      allow(GlobalConfigService).to receive(:load)
+        .with(Webhooks::PurchaseDestinationMac::SECRET_KEY, nil).and_return('dest-secret')
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: pipeline.id }, headers: headers
+
+      expected_mac = Webhooks::PurchaseDestinationMac.mint(
+        'dest-secret', 'cakto',
+        { 'evo_tenant' => '', 'pipeline_id' => pipeline.id.to_s, 'product' => '' }
+      )
+      expect(json_response.dig('data', 'url')).to include("d=#{expected_mac}")
+    end
+
+    it 'refuses the config errors with distinct reasons' do
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'nope', pipeline_id: pipeline.id }, headers: headers
+      expect(response).to have_http_status(:not_found)
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: SecureRandom.uuid }, headers: headers
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include('PIPELINE_NOT_FOUND')
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'hotmart', pipeline_id: pipeline.id }, headers: headers
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include('CREDENTIAL_MISSING')
+
+      allow(GlobalConfigService).to receive(:load)
+        .with('PURCHASE_WEBHOOK_SECRET_KIWIFY', nil).and_return('pub-key')
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'kiwify', pipeline_id: pipeline.id }, headers: headers
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include('DESTINATION_SECRET_REQUIRED')
+    end
+
+    it 'refuses a stage-less pipeline (the URL would fail on every delivery)' do
+      empty = Pipeline.create!(name: "Vazio #{SecureRandom.hex(4)}", pipeline_type: 'sales', created_by: user)
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: empty.id }, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include('PIPELINE_WITHOUT_STAGES')
+    end
+
+    it 'carries the product filter inside the signed query' do
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: pipeline.id, product: 'curso-x' },
+          headers: headers
+
+      url = json_response.dig('data', 'url')
+      expect(url).to include('product=curso-x')
+      expected_mac = Webhooks::PurchaseDestinationMac.mint(
+        'cakto-token', 'cakto',
+        { 'evo_tenant' => '', 'pipeline_id' => pipeline.id.to_s, 'product' => 'curso-x' }
+      )
+      expect(url).to include("d=#{expected_mac}")
+    end
+  end
+end

--- a/spec/requests/api/v1/purchase_webhooks_spec.rb
+++ b/spec/requests/api/v1/purchase_webhooks_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'webmock/rspec'
 
 # CRM-493: the authenticated config surface of the purchase-webhook ingress —
 # the pipeline screen's platform picker (providers) and the signed URL minting.
@@ -112,6 +113,16 @@ RSpec.describe 'Api::V1::PurchaseWebhooks', type: :request do
       expect(response.body).to include('PIPELINE_WITHOUT_STAGES')
     end
 
+    it 'refuses when no host resolves (the URL would be relative)' do
+      ENV['FRONTEND_URL'] = ''
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: pipeline.id }, headers: headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include('HOST_NOT_CONFIGURED')
+    end
+
     it 'carries the product override inside the signed query (stamps the card, never filters)' do
       get '/api/v1/purchase_webhooks/url',
           params: { provider: 'cakto', pipeline_id: pipeline.id, product: 'curso-x' },
@@ -124,6 +135,79 @@ RSpec.describe 'Api::V1::PurchaseWebhooks', type: :request do
         { 'evo_tenant' => '', 'pipeline_id' => pipeline.id.to_s, 'product' => 'curso-x' }
       )
       expect(url).to include("d=#{expected_mac}")
+    end
+  end
+
+  # The examples above authenticate with a service token, which EvoPermissionConcern
+  # short-circuits — so neither the permission nor the pipeline policy is exercised
+  # there. These resolve a real Current.user through evo-auth.
+  describe 'GET /api/v1/purchase_webhooks/url as a real user' do
+    let(:auth_url) { 'http://auth.test' }
+    let(:bearer) { { 'Authorization' => 'Bearer test-bearer-token' } }
+    let!(:outsider) { User.create!(name: 'Outsider', email: "out-#{SecureRandom.hex(4)}@example.com") }
+    let(:private_pipeline) do
+      Pipeline.create!(name: "Privado #{SecureRandom.hex(4)}", pipeline_type: 'sales',
+                       visibility: :private, created_by: user).tap do |p|
+        p.pipeline_stages.create!(name: 'Entrada', position: 1)
+      end
+    end
+
+    around do |example|
+      original = ENV.fetch('EVO_AUTH_SERVICE_URL', nil)
+      ENV['EVO_AUTH_SERVICE_URL'] = auth_url
+      Rails.cache.clear
+      Current.reset
+      example.run
+      Rails.cache.clear
+      Current.reset
+      ENV['EVO_AUTH_SERVICE_URL'] = original
+    end
+
+    def stub_auth(as_user, granted:)
+      stub_request(:post, "#{auth_url}/api/v1/auth/validate")
+        .to_return(status: 200,
+                   body: { success: true,
+                           data: { user: { id: as_user.id, email: as_user.email,
+                                           role: { id: 1, key: 'r', name: 'r' } } } }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+      stub_request(:post, "#{auth_url}/api/v1/users/#{as_user.id}/check_permission")
+        .to_return do |req|
+          key = JSON.parse(req.body)['permission_key']
+          { status: 200, body: { success: true, data: { has_permission: granted.include?(key) } }.to_json,
+            headers: { 'Content-Type' => 'application/json' } }
+        end
+    end
+
+    it 'refuses a caller without pipelines.update (403)' do
+      stub_auth(user, granted: [])
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: pipeline.id }, headers: bearer
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    # EVO-2204: the permission is global, the funnel is not. Without the policy a
+    # manager could point purchases at a private funnel they cannot even see.
+    # 401, not 403: RequestExceptionHandler's around_action catches the Pundit
+    # refusal before the rescue_from that would answer 403.
+    it 'refuses a private pipeline the caller cannot see, even with pipelines.update' do
+      stub_auth(outsider, granted: %w[pipelines.update])
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: private_pipeline.id }, headers: bearer
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'mints for the owner of that same private pipeline' do
+      stub_auth(user, granted: %w[pipelines.update])
+
+      get '/api/v1/purchase_webhooks/url',
+          params: { provider: 'cakto', pipeline_id: private_pipeline.id }, headers: bearer
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response.dig('data', 'url')).to start_with('https://app.evo.test/')
     end
   end
 end

--- a/spec/requests/api/v1/purchase_webhooks_spec.rb
+++ b/spec/requests/api/v1/purchase_webhooks_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Api::V1::PurchaseWebhooks', type: :request do
       expect(response.body).to include('PIPELINE_WITHOUT_STAGES')
     end
 
-    it 'carries the product filter inside the signed query' do
+    it 'carries the product override inside the signed query (stamps the card, never filters)' do
       get '/api/v1/purchase_webhooks/url',
           params: { provider: 'cakto', pipeline_id: pipeline.id, product: 'curso-x' },
           headers: headers


### PR DESCRIPTION
## Summary
- A URL que o operador registra na plataforma de pagamento só nascia via rake. Entra o minter `Webhooks::PurchaseWebhookUrl` — mesmas regras de segredo do ingress (segredo de destino como chave do MAC; fallback à credencial da plataforma só quando privada; recusa pipeline sem estágio) — e a superfície autenticada `GET /api/v1/purchase_webhooks/{providers,url}`, gate `pipelines.update` (escolher onde compras entram é gestão do pipeline).
- `providers` lista as plataformas registradas com flag de credencial e a exigência do segredo de destino — alimenta o picker do modal da tela de pipeline (PR irmã no frontend community).
- `base_url`/`host_kind` são um seam de instância de propósito: uma distribuição embutida pode prependar a resolução de host por deploy; o default é o `FRONTEND_URL` global.
- O rake delega ao minter — host e regras nunca divergem (e ele passa a validar pipeline: mintar URL para pipeline inexistente/sem estágio era gerar uma URL que 422a em toda entrega).

## Security
- Endpoints autenticados + RBAC (`pipelines.update`); `providers` não expõe segredo algum (só flags). A URL mintada é o artefato que o operador cola em terceiros por definição; adulterá-la continua 401 no ingress (MAC).

## Test plan
- `bundle exec rspec spec/requests/api/v1/purchase_webhooks_spec.rb` — 6 exemplos: MAC idêntico ao do ingress (recalculado no spec), destino preferido como chave, erros distintos (404/422 por razão), pipeline sem estágio recusado, produto dentro da assinatura.
- `bundle exec rspec spec/requests/api/v1/webhooks/` — ingress 75/75 sem regressão.
- Manual: URL gerada pela tela → entrega assinada aceita (`created`), redelivery `duplicate`, query adulterada 401.

## Changed Files
- `app/lib/webhooks/purchase_webhook_url.rb` (novo) · `app/lib/webhooks/purchase_adapters.rb` (`keys`)
- `app/controllers/api/v1/purchase_webhooks_controller.rb` (novo) · `config/routes.rb`
- `lib/tasks/purchase_webhook.rake` · `spec/requests/api/v1/purchase_webhooks_spec.rb` (novo)

## Related PRs
- frontend community: modal "Webhook de compra" no ⋮ do pipeline (consome estes endpoints)

## Linked Issue
- CRM-493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gLJMk7XnBVDmcypsR6VUg

## Summary by Sourcery

Provide a secure, authenticated configuration surface for registering signed purchase-webhook URLs while keeping URL generation consistent with webhook delivery validation.

New Features:
- Add authenticated endpoints to list configured purchase-webhook providers and mint signed webhook URLs for pipeline integrations.

Bug Fixes:
- Prevent generation of unusable webhook URLs by rejecting missing credentials, unsupported public-credential signing fallbacks, pipelines without stages, and unavailable public hosts.
- Keep webhook URL signing rules consistent between the configuration surface and the delivery ingress by routing the rake task through the shared URL minter.

Enhancements:
- Expose provider credential and destination-secret status without revealing secrets.
- Enforce pipeline management authorization and pipeline visibility when minting purchase-webhook URLs.

CI:
- Extend the spec staleness guard to cover the purchase-webhook configuration controller, URL minter, and request specifications.

Tests:
- Add request coverage for provider discovery, signed URL generation, validation failures, destination-secret precedence, product signing, host resolution, and authorization scenarios.