### PR TITLE
fix(mail): BMS_API_URL is used as configured; stop stripping the /api prefix

### DIFF
--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -575,7 +575,7 @@
   display_title: 'BMS API URL'
   value:
   locked: false
-  description: 'Base URL of the BMS API instance (e.g. https://bms-app.example.com); empty uses the legacy host'
+  description: 'Base URL of the BMS API instance, used as configured (include the /api prefix if your instance serves the API behind it); empty uses the legacy host'
 ## ------ End of Configs added for BMS ------ ##
 
 ## ------ Configs added for Linear ------ ##

--- a/lib/mail/bms_provider.rb
+++ b/lib/mail/bms_provider.rb
@@ -67,17 +67,18 @@ module Mail
 
     private
 
-    # Base host of the BMS API. BMS_API_URL points each installation at its own
-    # instance; the legacy host only remains as the fallback for an empty config.
-    # The API has no /api global prefix (that segment only exists through the
-    # front's nginx rewrite), so a configured base carrying it is normalized,
-    # otherwise POST /api/services/send-email answers 404.
+    # Base of the BMS API. BMS_API_URL points each installation at its own
+    # instance and is used AS CONFIGURED (only trailing slashes stripped): BMS
+    # deployments differ on the /api prefix — behind evofoundation's nginx the
+    # prefix is required (without it: 405), while other instances serve the
+    # routes at the root — so the provider must not second-guess the value.
+    # The legacy host only remains as the fallback for an empty config.
     LEGACY_API_BASE = 'https://bms-api.bri.us'.freeze
 
     def bms_api_base
       configured = GlobalConfigService.load('BMS_API_URL', nil).to_s.strip
       base = configured.empty? ? LEGACY_API_BASE : configured
-      base.sub(%r{/+\z}, '').delete_suffix('/api')
+      base.sub(%r{/+\z}, '')
     end
 
     def send_via_bms_api(payload)

--- a/spec/lib/mail/bms_provider_spec.rb
+++ b/spec/lib/mail/bms_provider_spec.rb
@@ -35,9 +35,11 @@ RSpec.describe Mail::BmsProvider do
     expect(stub.with(headers: { 'api-key' => 'mk_test' })).to have_been_requested
   end
 
-  it 'normalizes a configured base carrying a trailing slash or the front /api prefix' do
+  it 'keeps a configured /api prefix as-is, stripping only the trailing slash' do
+    # The evofoundation instance REQUIRES the /api prefix (405 without it);
+    # stripping it regressed prod, so the config value decides.
     configure_url('https://bms-app.example.test/api/')
-    stub = stub_bms('https://bms-app.example.test')
+    stub = stub_bms('https://bms-app.example.test/api')
 
     provider.deliver!(mail)
 
@@ -54,7 +56,7 @@ RSpec.describe Mail::BmsProvider do
   end
 
   it 'keeps an explicit port on the configured base' do
-    configure_url('https://bms-app.example.test:8443/api')
+    configure_url('https://bms-app.example.test:8443')
     stub = stub_bms('https://bms-app.example.test:8443')
 
     provider.deliver!(mail)


### PR DESCRIPTION
**Regression from #330 (P0, blocks the 228 builder access e-mails)**: on the evofoundation instance the nginx serves the BMS API **behind** `/api` — proven from the pod: `POST /services/send-email` → **405**, `POST /api/services/send-email` → 401 (route exists; no key sent). The `/api`-strip assumed the Orion instance's shape; deployments differ, so the provider must not second-guess the config.

**Fix**: `bms_api_base` uses `BMS_API_URL` as configured, normalizing only trailing slashes. `installation_config.yml` description now says to include `/api` when the instance requires it. The stuck Sidekiq retries deliver on their own once this ships.

**Proof**: `spec/lib/mail/bms_provider_spec.rb` 6/6 (configured `/api` kept, trailing slash stripped, port kept, legacy fallback, api-key header, 401→DeliveryError). RuboCop: 18 offenses all pre-existing in the provider file, zero new.

## Summary by Sourcery

Use each deployment’s configured BMS API URL without stripping its `/api` prefix.

Bug Fixes:
- Preserve the configured BMS API URL path, including an optional `/api` prefix, while continuing to remove only trailing slashes so mail delivery works across differing deployments.

Documentation:
- Clarify that BMS API URLs should include the `/api` prefix when required by the deployment.

Tests:
- Update BMS provider coverage to verify configured path preservation and trailing-slash normalization.