### PR TITLE
test(automation): corrige spec de contato obsoleto e o inclui no CI (CRM-487)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, develop]
     paths:
+      # The run: list below is a second allowlist: a spec only executes if it is
+      # named there. Editing that list has to trigger this lane, so it watches itself.
+      - '.github/workflows/spec-staleness-guard.yml'
       - 'app/models/inbox.rb'
       - 'app/models/pipeline.rb'
       - 'app/models/pipeline_item.rb'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -343,6 +343,7 @@ jobs:
           bundle exec rspec \
             spec/services/automation_rules/action_service_spec.rb \
             spec/services/automation_rules/conditions_filter_service_spec.rb \
+            spec/services/automation_rules/conditions_filter_service_contact_spec.rb \
             spec/services/pipelines/stage_automation_service_spec.rb \
             spec/listeners/automation_rule_listener_attribute_changed_spec.rb \
             spec/requests/api/v1/automation_rules_spec.rb \

--- a/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
@@ -8,13 +8,14 @@ require 'rails_helper'
 # replaced was deleted in phase 2. This spec is its regression net: it asserts
 # the correct boolean for every contact operator in the whitelist
 # (AutomationRuleListener#rule_has_only_contact_conditions?) using the operator
-# sets in lib/filters/filter_keys.yml (the only combos the frontend produces).
+# sets in lib/filters/filter_keys.yml, which is what ConditionValidationService
+# enforces at evaluation time regardless of what the frontend lets the user pick.
 RSpec.describe AutomationRules::ConditionsFilterService do
   let!(:vip) { Label.create!(title: "vip-#{SecureRandom.hex(3)}", color: '#abcdef') }
   let!(:gold) { Label.create!(title: "gold-#{SecureRandom.hex(3)}", color: '#ffd700') }
   let(:contact) do
     c = Contact.create!(name: 'Jane', email: "jane-#{SecureRandom.hex(4)}@test.com", phone_number: "+55#{rand(10**10)}")
-    c.update!(additional_attributes: { 'city' => 'SP', 'company' => 'Acme', 'country_code' => 'BR' }, label_list: [vip.title])
+    c.update!(additional_attributes: { 'city' => 'SP', 'country_code' => 'BR' }, label_list: [vip.title])
     Current.reset
     c.reload
   end
@@ -51,10 +52,16 @@ RSpec.describe AutomationRules::ConditionsFilterService do
     it('phone_number starts_with')     { expect_match([cond('phone_number', 'starts_with', ['+55'])], expected: true) }
   end
 
-  describe 'additional_attributes (city/company/country_code)' do
-    it('city equal_to matches')        { expect_match([cond('city', 'equal_to', ['SP'])], expected: true) }
-    it('company contains matches')     { expect_match([cond('company', 'contains', ['Acm'])], expected: true) }
-    it('country_code not_equal_to')    { expect_match([cond('country_code', 'not_equal_to', ['US'])], expected: true) }
+  # `company` is no longer an additional attribute: EVO-1887 turned it into the
+  # contact_companies association (equal_to/not_equal_to/is_present/is_not_present),
+  # so it does not belong in this describe. contains/does_not_contain go through
+  # ILIKE, hence the lowercase needle against the 'SP' fixture value.
+  describe 'additional_attributes (city/country_code)' do
+    it('city equal_to matches')                     { expect_match([cond('city', 'equal_to', ['SP'])], expected: true) }
+    it('city contains matches case-insensitively')  { expect_match([cond('city', 'contains', ['sp'])], expected: true) }
+    it('city does_not_contain excludes a match')    { expect_match([cond('city', 'does_not_contain', ['sp'])], expected: false) }
+    it('city does_not_contain matches a non-match') { expect_match([cond('city', 'does_not_contain', ['rj'])], expected: true) }
+    it('country_code not_equal_to')                 { expect_match([cond('country_code', 'not_equal_to', ['US'])], expected: true) }
   end
 
   describe 'blocked (boolean)' do

--- a/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
+++ b/spec/services/automation_rules/conditions_filter_service_contact_spec.rb
@@ -10,12 +10,19 @@ require 'rails_helper'
 # (AutomationRuleListener#rule_has_only_contact_conditions?) using the operator
 # sets in lib/filters/filter_keys.yml, which is what ConditionValidationService
 # enforces at evaluation time regardless of what the frontend lets the user pick.
+# The one whitelisted key with no example is `company`: every operator on it is
+# inert today (see the describe below and CRM-509), so there is no true boolean
+# to assert until that is fixed.
 RSpec.describe AutomationRules::ConditionsFilterService do
   let!(:vip) { Label.create!(title: "vip-#{SecureRandom.hex(3)}", color: '#abcdef') }
   let!(:gold) { Label.create!(title: "gold-#{SecureRandom.hex(3)}", color: '#ffd700') }
   let(:contact) do
-    c = Contact.create!(name: 'Jane', email: "jane-#{SecureRandom.hex(4)}@test.com", phone_number: "+55#{rand(10**10)}")
-    c.update!(additional_attributes: { 'city' => 'SP', 'country_code' => 'BR' }, label_list: [vip.title])
+    c = Contact.create!(name: 'Jane', email: "jane-#{SecureRandom.hex(4)}@test.com", phone_number: "+55#{rand(10**10)}",
+                        identifier: "ext-#{SecureRandom.hex(4)}")
+    # contacts.country_code cannot be written directly: Contacts::SyncAttributes runs
+    # before_save and re-derives it from additional_attributes['country'] (note the
+    # key is `country`, not `country_code`), blanking the column when it is absent.
+    c.update!(additional_attributes: { 'city' => 'SP', 'country' => 'BR' }, label_list: [vip.title])
     Current.reset
     c.reload
   end
@@ -43,25 +50,32 @@ RSpec.describe AutomationRules::ConditionsFilterService do
     expect(sql).to eq(expected), "sql evaluator: expected #{expected}, got #{sql.inspect}"
   end
 
-  describe 'text attributes (name/email/phone)' do
+  # country_code joined this describe in EVO-1849: it stopped being an additional
+  # attribute and became the top-level contacts.country_code column, in the same
+  # commit that removed the `company` key. `identifier` had no example at all.
+  describe 'standard columns (name/email/phone/identifier/country_code)' do
     it('name equal_to matches')        { expect_match([cond('name', 'equal_to', ['Jane'])], expected: true) }
     it('name equal_to mismatches')     { expect_match([cond('name', 'equal_to', ['Bob'])], expected: false) }
     it('name not_equal_to matches')    { expect_match([cond('name', 'not_equal_to', ['Bob'])], expected: true) }
     it('email contains matches')       { expect_match([cond('email', 'contains', ['@test.com'])], expected: true) }
     it('name does_not_contain')        { expect_match([cond('name', 'does_not_contain', ['Bob'])], expected: true) }
     it('phone_number starts_with')     { expect_match([cond('phone_number', 'starts_with', ['+55'])], expected: true) }
+    it('identifier equal_to matches')  { expect_match([cond('identifier', 'equal_to', [contact.identifier])], expected: true) }
+    it('country_code equal_to')        { expect_match([cond('country_code', 'equal_to', ['BR'])], expected: true) }
+    it('country_code not_equal_to')    { expect_match([cond('country_code', 'not_equal_to', ['US'])], expected: true) }
   end
 
-  # `company` is no longer an additional attribute: EVO-1887 turned it into the
-  # contact_companies association (equal_to/not_equal_to/is_present/is_not_present),
-  # so it does not belong in this describe. contains/does_not_contain go through
-  # ILIKE, hence the lowercase needle against the 'SP' fixture value.
-  describe 'additional_attributes (city/country_code)' do
+  # `city` is the only key left here: EVO-1849 moved country_code to a column and
+  # dropped `company`, which EVO-1887 brought back as the contact_companies
+  # association — every company operator is inert today (CRM-509). The needles are
+  # lowercase because contains/does_not_contain go through ILIKE.
+  describe 'additional_attributes (city)' do
     it('city equal_to matches')                     { expect_match([cond('city', 'equal_to', ['SP'])], expected: true) }
     it('city contains matches case-insensitively')  { expect_match([cond('city', 'contains', ['sp'])], expected: true) }
     it('city does_not_contain excludes a match')    { expect_match([cond('city', 'does_not_contain', ['sp'])], expected: false) }
     it('city does_not_contain matches a non-match') { expect_match([cond('city', 'does_not_contain', ['rj'])], expected: true) }
-    it('country_code not_equal_to')                 { expect_match([cond('country_code', 'not_equal_to', ['US'])], expected: true) }
+    # does_not_contain is NOT ILIKE ALL: one matching needle is enough to exclude.
+    it('city does_not_contain excludes on any needle') { expect_match([cond('city', 'does_not_contain', %w[rj sp])], expected: false) }
   end
 
   describe 'blocked (boolean)' do


### PR DESCRIPTION
## Summary
- O spec `conditions_filter_service_contact_spec.rb` estava vermelho no develop desde a EVO-1849: o exemplo `company contains` trata `company` como atributo adicional de texto, mas a chave foi removida (#164) e recriada na EVO-1887 (#177) como associação `contact_companies`, só com `equal_to`/`not_equal_to`/`is_present`/`is_not_present`. A condição reprova na `ConditionValidationService` antes de gerar SQL.
- Não há descasamento de caixa a corrigir no serviço: `contains`/`does_not_contain` já usam `ILIKE ANY` / `NOT ILIKE ALL` em qualquer ramo, inclusive `additional_attributes`. O `LOWER()` proposto no card não se aplica.
- O exemplo obsoleto vira `city contains 'sp'` contra o fixture `SP` (prova o case-insensitive ao vivo), com os dois lados de `does_not_contain` em atributo adicional cobertos.
- O spec entra na lista fixa do `spec-staleness-guard.yml`: estava coberto pelo `paths:` mas nunca executava.

Desvio consciente do AC 1 ("sem alterar a expectativa"): a expectativa foi mantida, o atributo mudou de `company` para `city` porque `company` não é mais atributo adicional filtrável.

## Security
- Só spec e lista de execução do CI. Sem código de produção, sem migração, sem mudança de contrato.

## Test plan
- `bundle exec rspec spec/services/automation_rules/conditions_filter_service_contact_spec.rb spec/services/automation_rules/conditions_filter_service_spec.rb` → 45 exemplos, 0 falhas (no develop: 1 falha).
- `rubocop` no spec: mesmas 17 ofensas autocorrigíveis já presentes no develop, nenhuma nas linhas alteradas.
- Lane `spec-staleness-guard` dispara neste PR via `spec/services/automation_rules/**`.

## Changed Files
- `spec/services/automation_rules/conditions_filter_service_contact_spec.rb`
- `.github/workflows/spec-staleness-guard.yml`

## Linked Issue
- CRM-487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRPsgsN7utWQAvTt2UWsMD

## Summary by Sourcery

Atualize a cobertura de filtros de contatos e inclua o spec corrigido na verificação contínua do CI.

Bug Fixes:
- Atualiza os testes de filtros de contatos para remover o cenário obsoleto de `company` e validar filtros atuais, incluindo correspondência sem distinção de maiúsculas e minúsculas em atributos adicionais.

Enhancements:
- Amplia a cobertura dos testes para `identifier`, `country_code` e operadores `does_not_contain` em múltiplos valores.

CI:
- Inclui o spec de filtros de contatos na execução fixa do guardião de obsolescência e faz o workflow monitorar as próprias alterações.

Tests:
- Corrige e reforça a cobertura do spec de `ConditionsFilterService` para condições de contatos válidas.