### PR TITLE
fix(evolution-go): aceita chaves qrcode/code minúsculas no retorno do QR

### DIFF
--- a/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
+++ b/app/controllers/api/v1/evolution_go/qrcodes_controller.rb
@@ -147,26 +147,23 @@ class Api::V1::EvolutionGo::QrcodesController < Api::V1::BaseController
     # Evolution Go API retorna:
     # {
     #   "data": {
-    #     "Qrcode": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
-    #     "Code": "2@C7BUZArTUkKYRlxxRvQxa3+qoKLOywu5QcewxlFtU1bbG2..."
+    #     "qrcode": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
+    #     "code": "2@C7BUZArTUkKYRlxxRvQxa3+qoKLOywu5QcewxlFtU1bbG2..."
     #   },
     #   "message": "success"
     # }
+    #
+    # Builds atuais respondem com chaves minúsculas; versões antigas mandavam
+    # "Qrcode"/"Code". Ler só a forma capitalizada devolve nil silenciosamente
+    # (a request é 200 e o corpo chega inteiro — só o mapeamento perde o QR),
+    # então aceitamos as duas grafias.
+    data = parsed_response['data'].is_a?(Hash) ? parsed_response['data'] : parsed_response
 
-    if parsed_response['data']
-      {
-        base64: parsed_response['data']['Qrcode'],
-        code: parsed_response['data']['Code'],
-        connected: false
-      }
-    else
-      # Fallback se estrutura for diferente
-      {
-        base64: parsed_response['Qrcode'],
-        code: parsed_response['Code'],
-        connected: false
-      }
-    end
+    {
+      base64: data['qrcode'] || data['Qrcode'],
+      code: data['code'] || data['Code'],
+      connected: false
+    }
 
   rescue JSON::ParserError => e
     Rails.logger.error "Evolution Go API: QR code JSON parse error: #{e.message}, Body: #{response&.body}"

--- a/spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'webmock/rspec'
 
 # Pins that QrcodesController#set_instance_params resolves credentials through
 # EvolutionGoConcern#evolution_go_credentials_for, so a refactor that drops the
@@ -90,6 +91,53 @@ RSpec.describe Api::V1::EvolutionGo::QrcodesController, type: :controller do
       )
 
       controller_instance.create
+    end
+  end
+
+  # Builds atuais do Evolution Go respondem com "qrcode"/"code" minúsculos.
+  # Lendo só "Qrcode"/"Code", o mapeamento devolvia nil com a request em 200 e
+  # o corpo completo — o frontend recebia {"base64":null,"code":null} e exibia
+  # "Erro ao gerar código QR" apontando para o lugar errado. Estes testes pinam
+  # as duas grafias para que nenhuma das duas volte a regredir em silêncio.
+  describe '#get_qrcode_go' do
+    let(:controller_instance) { described_class.new }
+    let(:api_url) { 'http://evolution-go.test:4000' }
+    let(:instance_token) { 'inst-tok' }
+
+    def qr_returns(body)
+      stub_request(:get, "#{api_url}/instance/qr")
+        .to_return(status: 200, body: body.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'reads the lowercase keys current Evolution Go builds return' do
+      qr_returns(data: { 'qrcode' => 'data:image/png;base64,AAA', 'code' => '2@lowercase' }, message: 'success')
+
+      result = controller_instance.send(:get_qrcode_go, api_url, instance_token)
+
+      expect(result).to eq(base64: 'data:image/png;base64,AAA', code: '2@lowercase', connected: false)
+    end
+
+    it 'still reads the legacy capitalized keys' do
+      qr_returns(data: { 'Qrcode' => 'data:image/png;base64,BBB', 'Code' => '2@legacy' }, message: 'success')
+
+      result = controller_instance.send(:get_qrcode_go, api_url, instance_token)
+
+      expect(result).to eq(base64: 'data:image/png;base64,BBB', code: '2@legacy', connected: false)
+    end
+
+    it 'falls back to the root object when the payload has no data wrapper' do
+      qr_returns('qrcode' => 'data:image/png;base64,CCC', 'code' => '2@root')
+
+      result = controller_instance.send(:get_qrcode_go, api_url, instance_token)
+
+      expect(result).to eq(base64: 'data:image/png;base64,CCC', code: '2@root', connected: false)
+    end
+
+    it 'raises when Evolution Go answers with a non-success status' do
+      stub_request(:get, "#{api_url}/instance/qr").to_return(status: 401, body: 'unauthorized')
+
+      expect { controller_instance.send(:get_qrcode_go, api_url, instance_token) }
+        .to raise_error(RuntimeError, /Failed to get QR code/)
     end
   end
 end


### PR DESCRIPTION
## Problema

`GET /instance/qr` do Evolution Go responde com as chaves em minúsculo:

```json
{ "data": { "qrcode": "data:image/png;base64,...", "code": "2@..." }, "message": "success" }
```

`Api::V1::EvolutionGo::QrcodesController#get_qrcode_go` lia apenas `data['Qrcode']` e `data['Code']`. Em Ruby são chaves diferentes, então o mapeamento devolvia `nil` **em silêncio**: a request é `200 OK`, o corpo chega inteiro e aparece completo no log do container, e só o último passo perde o QR.

O frontend recebe `{"base64":null,"code":null,"connected":false}` e mostra "Erro ao gerar código QR" — apontando para o lugar errado, já que o QR sempre foi gerado corretamente.

Reproduzido com Evolution Go rodando via `evoapicloud/evolution-go:latest`.

## Solução

Aceita as duas grafias (`qrcode`/`Qrcode` e `code`/`Code`), preservando compatibilidade com versões antigas do Evolution Go. O comentário do método, que documentava só a forma capitalizada, foi atualizado.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `app/controllers/api/v1/evolution_go/qrcodes_controller.rb` | `get_qrcode_go` aceita chaves minúsculas e capitalizadas; comentário atualizado |
| `spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb` | 4 exemplos cobrindo minúsculas, legado capitalizado, payload sem `data` e status não-2xx |

## Testes

```
bundle exec rspec spec/controllers/api/v1/evolution_go/qrcodes_controller_spec.rb
7 examples, 0 failures
```

Os testes falham sem o fix, confirmando que fixam a regressão:

```
# com o controller de develop
7 examples, 2 failures
  - reads the lowercase keys current Evolution Go builds return
  - falls back to the root object when the payload has no data wrapper
```

RuboCop nos dois arquivos: 14 ofensas antes e 14 depois — todas preexistentes, nenhuma introduzida.

Verificado também de ponta a ponta contra uma instância real: o QR passou a renderizar e o pareamento do dispositivo concluiu.

## Summary by Sourcery

Fix Evolution Go QR code mapping to correctly return QR data across current and legacy response formats.

Bug Fixes:
- Support lowercase and legacy capitalized QR code keys returned by Evolution Go, preventing valid QR responses from being mapped to null values.

Enhancements:
- Preserve fallback handling for QR payloads without a data wrapper and document the supported response formats.

Tests:
- Add controller coverage for lowercase keys, legacy capitalized keys, root-level payloads, and non-success responses.