### PR TITLE
feat(crm): webhook de compra emite purchase.approved para o evo-flow (CRM-316)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -286,9 +286,8 @@ on:
       - 'app/controllers/api/v1/purchase_webhooks_controller.rb'
       - 'app/lib/webhooks/purchase_webhook_url.rb'
       - 'spec/requests/api/v1/purchase_webhooks_spec.rb'
-      # CRM-316: the capture is also an evo-flow event (purchase.approved). The
-      # listener and the event-name/schema mirrors have no other lane; a drift
-      # here means the CRM ships an event evo-flow rejects, or none at all.
+      # CRM-316: the listener and the event-name/schema mirrors have no other
+      # lane; a drift ships an event evo-flow rejects, or none at all.
       - 'app/listeners/evo_flow/purchase_events_listener.rb'
       - 'app/services/evo_flow/event_schema.rb'
       - 'lib/events/evo_flow_event_names.rb'

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -286,6 +286,14 @@ on:
       - 'app/controllers/api/v1/purchase_webhooks_controller.rb'
       - 'app/lib/webhooks/purchase_webhook_url.rb'
       - 'spec/requests/api/v1/purchase_webhooks_spec.rb'
+      # CRM-316: the capture is also an evo-flow event (purchase.approved). The
+      # listener and the event-name/schema mirrors have no other lane; a drift
+      # here means the CRM ships an event evo-flow rejects, or none at all.
+      - 'app/listeners/evo_flow/purchase_events_listener.rb'
+      - 'app/services/evo_flow/event_schema.rb'
+      - 'lib/events/evo_flow_event_names.rb'
+      - 'spec/listeners/evo_flow/purchase_events_listener_spec.rb'
+      - 'spec/lib/events/evo_flow_event_names_spec.rb'
 
 permissions:
   contents: read
@@ -353,6 +361,8 @@ jobs:
             spec/requests/api/v1/webhooks/purchases_spec.rb \
             spec/requests/api/v1/webhooks/purchase_platforms_spec.rb \
             spec/requests/api/v1/purchase_webhooks_spec.rb \
+            spec/listeners/evo_flow/purchase_events_listener_spec.rb \
+            spec/lib/events/evo_flow_event_names_spec.rb \
             spec/listeners/automation_rule_listener_pipeline_stage_updated_contact_card_spec.rb \
             spec/listeners/automation_rule_listener_pipeline_stage_updated_e2e_spec.rb \
             spec/listeners/pipeline_stage_automation_listener_spec.rb \

--- a/app/lib/webhooks/purchase_adapters/base.rb
+++ b/app/lib/webhooks/purchase_adapters/base.rb
@@ -15,7 +15,8 @@ module Webhooks
       #     email: String or nil,
       #     phone_number: String or nil (raw; the service normalizes to E.164),
       #     product: String or nil,
-      #     amount: Numeric or nil,
+      #     amount: Numeric or nil (currency MAJOR unit, e.g. 197.5 reais — never
+      #       cents; an adapter converts when the platform sends minor units),
       #     currency: String or nil
       #   }
       #   email OR phone_number must be present — a lead with neither is

--- a/app/lib/webhooks/purchase_adapters/kiwify_adapter.rb
+++ b/app/lib/webhooks/purchase_adapters/kiwify_adapter.rb
@@ -31,12 +31,24 @@ module Webhooks
           email: email,
           phone_number: normalize_br_phone(phone),
           product: first_value(first_hash(payload, %w[Product product]) || {}, %w[product_name name]),
-          amount: first_value(commissions, %w[charge_amount]) || first_value(payload, %w[amount total]),
+          amount: amount_in_major_unit(commissions, payload),
           currency: first_value(commissions, %w[currency]) || 'BRL'
         }
       end
 
       private
+
+      # Kiwify's Commissions.charge_amount is in CENTS (integer); the canonical
+      # lead carries the currency's major unit like every other platform, so a
+      # segment "spent more than 500" means the same thing whatever the source.
+      def amount_in_major_unit(commissions, payload)
+        cents = first_value(commissions, %w[charge_amount])
+        return Float(cents) / 100.0 if cents.present?
+
+        first_value(payload, %w[amount total])
+      rescue ArgumentError, TypeError
+        nil
+      end
 
       def event_name(payload)
         (payload['webhook_event_type'] || payload['order_status'] || '').to_s

--- a/app/lib/webhooks/purchase_adapters/kiwify_adapter.rb
+++ b/app/lib/webhooks/purchase_adapters/kiwify_adapter.rb
@@ -38,9 +38,8 @@ module Webhooks
 
       private
 
-      # Kiwify's Commissions.charge_amount is in CENTS (integer); the canonical
-      # lead carries the currency's major unit like every other platform, so a
-      # segment "spent more than 500" means the same thing whatever the source.
+      # Kiwify's Commissions.charge_amount is in CENTS; the canonical lead carries
+      # the major unit, so "spent more than 500" means the same for every source.
       def amount_in_major_unit(commissions, payload)
         cents = first_value(commissions, %w[charge_amount])
         return Float(cents) / 100.0 if cents.present?

--- a/app/listeners/evo_flow/purchase_events_listener.rb
+++ b/app/listeners/evo_flow/purchase_events_listener.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module EvoFlow
+  # Subscribes to Wisper :purchase_approved (Webhooks::Purchases::LeadCaptureService)
+  # and forwards it to evo-flow as `purchase.approved` (CRM-316).
+  #
+  # Before this the purchase only reached evo-flow buried inside the
+  # campaign.triggered / pipeline.stage_changed the card creation emits — no
+  # name to trigger a journey on, no typed amount/product for a segment to
+  # filter, and nothing at all for a second sale appended to an open card.
+  #
+  # `evo_flow_enabled?` is duplicated across the EvoFlow listeners by design
+  # (tech-spec §Technical Decisions #2: no shared base class).
+  class PurchaseEventsListener
+    TRACK_PATH = '/events/track'
+    EVENT_NAME = 'purchase.approved'
+    SOURCE = 'purchase_webhook'
+
+    def purchase_approved(data)
+      return if data.respond_to?(:data)
+
+      event_data = data[:data] || data
+      contact = event_data[:contact]
+      pipeline_item = event_data[:pipeline_item]
+      unless contact && pipeline_item
+        Rails.logger.error('EvoFlow::PurchaseEventsListener#purchase_approved: contact or pipeline_item is nil')
+        return
+      end
+      return unless evo_flow_enabled?
+
+      enqueue_track(contact, pipeline_item, event_data)
+    rescue StandardError => e
+      log_failure(__method__, e)
+    end
+
+    private
+
+    def enqueue_track(contact, pipeline_item, event_data)
+      purchase = (event_data[:purchase] || {}).with_indifferent_access
+      # One purchase = one event, however many times the platform redelivers
+      # or the listener retries: the id is the purchase identity, not the clock.
+      source_event_uuid = "#{event_data[:provider]}.#{purchase[:purchase_id]}"
+      message_id = EvoFlow::PayloadBuilder.message_id_for(EVENT_NAME, contact.id, source_event_uuid)
+      payload = EvoFlow::PayloadBuilder.build_track(
+        event_name: EVENT_NAME,
+        contact_id: contact.id,
+        properties: build_properties(contact, pipeline_item, event_data, purchase),
+        occurred_at: Time.current,
+        message_id: message_id
+      )
+      EvoFlow::PublishEventWorker.perform_async(TRACK_PATH, JSON.parse(payload.to_json), current_tenant_id)
+    end
+
+    # Optional fields that resolve to nil are OMITTED, never sent as null —
+    # the evo-flow schema pipe rejects explicit null for typed fields.
+    def build_properties(contact, pipeline_item, event_data, purchase)
+      pipeline = pipeline_item.pipeline
+      stage = pipeline_item.pipeline_stage
+      {
+        provider: event_data[:provider].to_s,
+        purchase_id: purchase[:purchase_id].to_s,
+        pipeline_id: pipeline_item.pipeline_id,
+        pipeline_item_id: pipeline_item.id,
+        source: SOURCE,
+        product: purchase[:product],
+        amount: numeric_amount(purchase[:amount]),
+        currency: purchase[:currency],
+        platform_event: purchase[:event],
+        outcome: event_data[:outcome].to_s,
+        new_contact: event_data[:new_contact] == true,
+        contact_id: contact.id,
+        pipeline_name: pipeline&.name,
+        pipeline_stage_id: pipeline_item.pipeline_stage_id,
+        pipeline_stage_name: stage&.name
+      }.compact
+    end
+
+    # Adapters may hand the amount over as the platform sent it (string or
+    # number); the contract says number.
+    def numeric_amount(value)
+      return nil if value.blank?
+
+      Float(value)
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def evo_flow_enabled?
+      EvoFlow.enabled?
+    end
+
+    def log_failure(handler, error)
+      tag = enqueue_loss?(error) ? '[EvoFlow][enqueue-loss]' : '[EvoFlow]'
+      Rails.logger.error(
+        "#{tag} EvoFlow::PurchaseEventsListener##{handler} failed: #{error.class}: #{error.message}"
+      )
+      Sentry.capture_exception(error) if defined?(Sentry)
+      nil
+    end
+
+    def enqueue_loss?(error)
+      return true if defined?(Redis::BaseConnectionError) && error.is_a?(Redis::BaseConnectionError)
+
+      error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
+    end
+
+    # The purchase webhook runs with the tenant bound by the enterprise
+    # around_action; the runtime-context seam hands it over so the publish
+    # carries X-Evo-Tenant-Id. Community single-tenant: nil, no header.
+    def current_tenant_id
+      EvoExtensionPoints::RuntimeContext.current_scope_id
+    end
+  end
+end

--- a/app/listeners/evo_flow/purchase_events_listener.rb
+++ b/app/listeners/evo_flow/purchase_events_listener.rb
@@ -4,17 +4,13 @@ module EvoFlow
   # Subscribes to Wisper :purchase_approved (Webhooks::Purchases::LeadCaptureService)
   # and forwards it to evo-flow as `purchase.approved` (CRM-316).
   #
-  # Before this the purchase only reached evo-flow buried inside the
-  # campaign.triggered / pipeline.stage_changed the card creation emits — no
-  # name to trigger a journey on, no typed amount/product for a segment to
-  # filter, and nothing at all for a second sale appended to an open card.
-  #
   # `evo_flow_enabled?` is duplicated across the EvoFlow listeners by design
   # (tech-spec §Technical Decisions #2: no shared base class).
   class PurchaseEventsListener
     TRACK_PATH = '/events/track'
     EVENT_NAME = 'purchase.approved'
-    SOURCE = 'purchase_webhook'
+    # Same value the capture stamps on the card, so event and card agree.
+    SOURCE = Webhooks::Purchases::LeadCaptureService::LEAD_SOURCE
 
     def purchase_approved(data)
       return if data.respond_to?(:data)
@@ -75,12 +71,13 @@ module EvoFlow
       }.compact
     end
 
-    # Adapters may hand the amount over as the platform sent it (string or
-    # number); the contract says number.
+    # Adapters hand the amount over as the platform sent it (string or number);
+    # the contract says a finite number — NaN/Infinity would blow up to_json.
     def numeric_amount(value)
       return nil if value.blank?
 
-      Float(value)
+      amount = Float(value)
+      amount.finite? ? amount : nil
     rescue ArgumentError, TypeError
       nil
     end
@@ -104,9 +101,8 @@ module EvoFlow
       error.is_a?(ArgumentError) && error.message.include?('occurred_at is required')
     end
 
-    # The purchase webhook runs with the tenant bound by the enterprise
-    # around_action; the runtime-context seam hands it over so the publish
-    # carries X-Evo-Tenant-Id. Community single-tenant: nil, no header.
+    # Bound by the enterprise around_action on the webhook; the seam hands it
+    # over so the publish carries X-Evo-Tenant-Id. Community: nil, no header.
     def current_tenant_id
       EvoExtensionPoints::RuntimeContext.current_scope_id
     end

--- a/app/services/evo_flow/event_schema.rb
+++ b/app/services/evo_flow/event_schema.rb
@@ -186,9 +186,8 @@ module EvoFlow
         contact_id: :uuid
       }
     },
-    # CRM-316: an approved purchase captured by the purchase webhook, emitted
-    # with the contact the CRM resolved — a journey can start on it and a
-    # segment can filter its properties (product, amount).
+    # CRM-316: purchase webhook capture, with the contact the CRM resolved — a
+    # journey starts on it, a segment filters its product/amount.
     'purchase.approved' => {
       category: :purchase,
       required: {

--- a/app/services/evo_flow/event_schema.rb
+++ b/app/services/evo_flow/event_schema.rb
@@ -11,7 +11,7 @@ module EvoFlow
   #
   # Wrapped in a class (rather than a top-level EVENT_SCHEMA constant) so
   # Zeitwerk's expected_definition check passes for this file's path.
-  class EventSchema
+  class EventSchema # rubocop:disable Metrics/ClassLength -- a data table, one entry per event
     def self.fetch(event_name)
       DEFINITIONS[event_name]
     end
@@ -184,6 +184,20 @@ module EvoFlow
         pipeline_item_id: :uuid,
         conversation_id: :uuid,
         contact_id: :uuid
+      }
+    },
+    # CRM-316: an approved purchase captured by the purchase webhook, emitted
+    # with the contact the CRM resolved — a journey can start on it and a
+    # segment can filter its properties (product, amount).
+    'purchase.approved' => {
+      category: :purchase,
+      required: {
+        provider: :string, purchase_id: :string, pipeline_id: :uuid, pipeline_item_id: :uuid, source: :string
+      },
+      optional: {
+        product: :string, amount: :number, currency: :string, platform_event: :string,
+        outcome: :string, new_contact: :boolean, contact_id: :uuid,
+        pipeline_name: :string, pipeline_stage_id: :uuid, pipeline_stage_name: :string
       }
     },
     'custom' => {

--- a/app/services/webhooks/purchases/lead_capture_service.rb
+++ b/app/services/webhooks/purchases/lead_capture_service.rb
@@ -38,15 +38,11 @@ module Webhooks
 
       private
 
-      # CRM-316: an approved purchase that landed on a card (new or the open one)
-      # is a first-class event for evo-flow (purchase.approved). Duplicate and
-      # ignored deliveries are not: nothing was sold that the CRM did not know.
-      # Fires after the writes committed; a listener failure never fails the
-      # webhook (EvoFlow listeners rescue internally).
-      PURCHASE_EVENT_STATUSES = %i[created already_in_pipeline].freeze
-
+      # CRM-316: a sale the CRM did not already know becomes purchase.approved on
+      # evo-flow. Fires after the writes committed; a listener failure never
+      # fails the webhook (EvoFlow listeners rescue internally).
       def announce(result)
-        return result unless PURCHASE_EVENT_STATUSES.include?(result.status)
+        return result unless emit_purchase_event?(result)
 
         broadcast(
           :purchase_approved,
@@ -55,6 +51,17 @@ module Webhooks
           outcome: result.status, new_contact: @contact_created == true
         )
         result
+      end
+
+      # The open card's `purchases` history is the idempotency record of a second
+      # sale, so a delivery that appended nothing emits nothing — evo-flow has no
+      # consumer-side dedup to fall back on.
+      def emit_purchase_event?(result)
+        case result.status
+        when :created then true
+        when :already_in_pipeline then @extra_purchase_recorded
+        else false
+        end
       end
 
       # No wrapping transaction on purpose: a committed contact with a failed
@@ -174,7 +181,7 @@ module Webhooks
         active = @pipeline.pipeline_items.active.find_by(contact_id: @contact.id)
         return nil unless active
 
-        record_extra_purchase(active)
+        @extra_purchase_recorded = record_extra_purchase(active)
         Result.new(status: :already_in_pipeline, contact: @contact, pipeline_item: active)
       end
 
@@ -184,14 +191,16 @@ module Webhooks
       def record_extra_purchase(item)
         fields = item.custom_fields || {}
         purchase = card_custom_fields['purchase']
-        return if same_purchase?(fields['purchase'], purchase)
+        return false if same_purchase?(fields['purchase'], purchase)
 
         history = Array(fields['purchases'])
-        return if history.any? { |entry| same_purchase?(entry, purchase) }
+        return false if history.any? { |entry| same_purchase?(entry, purchase) }
 
         item.update!(custom_fields: fields.merge('purchases' => history + [purchase]))
+        true
       rescue ActiveRecord::ActiveRecordError => e
         Rails.logger.warn("Purchase webhook: could not append purchase #{@lead[:purchase_id]} to card #{item.id}: #{e.message}")
+        false
       end
 
       def same_purchase?(entry, purchase)

--- a/app/services/webhooks/purchases/lead_capture_service.rb
+++ b/app/services/webhooks/purchases/lead_capture_service.rb
@@ -7,6 +7,8 @@
 module Webhooks
   module Purchases
     class LeadCaptureService
+      include Wisper::Publisher
+
       Result = Struct.new(:status, :contact, :pipeline_item, :details, keyword_init: true)
 
       LEAD_SOURCE = 'purchase_webhook'
@@ -31,10 +33,29 @@ module Webhooks
           return Result.new(status: :duplicate, contact: existing.contact, pipeline_item: existing)
         end
 
-        capture!
+        announce(capture!)
       end
 
       private
+
+      # CRM-316: an approved purchase that landed on a card (new or the open one)
+      # is a first-class event for evo-flow (purchase.approved). Duplicate and
+      # ignored deliveries are not: nothing was sold that the CRM did not know.
+      # Fires after the writes committed; a listener failure never fails the
+      # webhook (EvoFlow listeners rescue internally).
+      PURCHASE_EVENT_STATUSES = %i[created already_in_pipeline].freeze
+
+      def announce(result)
+        return result unless PURCHASE_EVENT_STATUSES.include?(result.status)
+
+        broadcast(
+          :purchase_approved,
+          contact: result.contact, pipeline_item: result.pipeline_item,
+          provider: @provider, purchase: card_custom_fields['purchase'],
+          outcome: result.status, new_contact: @contact_created == true
+        )
+        result
+      end
 
       # No wrapping transaction on purpose: a committed contact with a failed
       # card is the GOOD failure shape — the redelivery finds the contact and
@@ -92,6 +113,7 @@ module Webhooks
         )
         contact.skip_default_pipeline_assignment = true
         contact.save!
+        @contact_created = true
         contact
       rescue ActiveRecord::RecordNotUnique
         # Concurrent delivery won the insert (the uniqueness validation cannot

--- a/config/initializers/evo_flow_listeners.rb
+++ b/config/initializers/evo_flow_listeners.rb
@@ -11,6 +11,7 @@ Rails.application.config.after_initialize do
   Wisper.subscribe(EvoFlow::ConversationEventsListener.new)
   Wisper.subscribe(EvoFlow::MessageEventsListener.new)
   Wisper.subscribe(EvoFlow::PipelineEventsListener.new)
+  Wisper.subscribe(EvoFlow::PurchaseEventsListener.new)
 
   # Eager-reference EventSchema so its boot-time sanity check (verifies every
   # EVENT_NAME has a DEFINITIONS entry) runs at startup, not lazily on the
@@ -19,5 +20,5 @@ Rails.application.config.after_initialize do
   # that broke the EVENT_NAMES <-> DEFINITIONS sync.
   EvoFlow::EventSchema
 
-  Rails.logger.info 'EvoFlow listeners registered (contact, conversation, message, pipeline)'
+  Rails.logger.info 'EvoFlow listeners registered (contact, conversation, message, pipeline, purchase)'
 end

--- a/lib/events/evo_flow_event_names.rb
+++ b/lib/events/evo_flow_event_names.rb
@@ -10,6 +10,7 @@ module EvoFlow
     message.created message.delivered message.read message.failed
     campaign.triggered campaign.message.sent campaign.message.opened campaign.message.clicked
     pipeline.stage_changed
+    purchase.approved
     custom
   ].freeze
 

--- a/spec/lib/events/evo_flow_event_names_spec.rb
+++ b/spec/lib/events/evo_flow_event_names_spec.rb
@@ -6,7 +6,9 @@ require 'rails_helper'
 # future refactor breaks that wiring (or production eager_load), it fails here
 # instead of only at deploy time.
 RSpec.describe 'EvoFlow::EVENT_NAMES' do
-  it 'is a frozen Array<String> of exactly the 22 events (AC6 + EVO-1245 backfill extension + custom sentinel)' do
+  # 22 (AC6 + EVO-1245 backfill + custom sentinel) + pipeline.stage_changed
+  # + purchase.approved (CRM-316). Mirrors evo-flow's event-names.enum.ts.
+  it 'is a frozen Array<String> of exactly the 24 canonical events' do
     expect(EvoFlow::EVENT_NAMES).to be_frozen
     expect(EvoFlow::EVENT_NAMES).to all(be_a(String))
     expect(EvoFlow::EVENT_NAMES).to contain_exactly(
@@ -18,6 +20,7 @@ RSpec.describe 'EvoFlow::EVENT_NAMES' do
       'message.created', 'message.delivered', 'message.read', 'message.failed',
       'campaign.triggered', 'campaign.message.sent',
       'campaign.message.opened', 'campaign.message.clicked',
+      'pipeline.stage_changed', 'purchase.approved',
       'custom'
     )
   end

--- a/spec/listeners/evo_flow/purchase_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/purchase_events_listener_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe EvoFlow::PurchaseEventsListener do
+  let(:listener) { described_class.new }
+  let(:pipeline) { instance_double(Pipeline, name: 'Compras') }
+  let(:stage) { instance_double(PipelineStage, name: 'Compra recebida') }
+  let(:contact) { instance_double(Contact, id: 42) }
+  let(:pipeline_item) do
+    instance_double(PipelineItem, id: 9, pipeline: pipeline, pipeline_id: 1, pipeline_stage: stage, pipeline_stage_id: 2)
+  end
+  let(:purchase) do
+    { 'provider' => 'virtu', 'purchase_id' => 'ORD-1001', 'event' => 'approved',
+      'product' => 'Curso X', 'amount' => 297.0, 'currency' => 'BRL' }
+  end
+  let(:event) do
+    { contact: contact, pipeline_item: pipeline_item, provider: 'virtu', purchase: purchase,
+      outcome: :created, new_contact: true }
+  end
+
+  before do
+    Sidekiq::Testing.fake!
+    EvoFlow::PublishEventWorker.clear
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return('test-key')
+  end
+
+  after { EvoFlow::PublishEventWorker.clear }
+
+  def sent_payload
+    EvoFlow::PublishEventWorker.jobs.last['args'][1]
+  end
+
+  it 'emits purchase.approved with the purchase as typed properties and the CRM contact' do
+    listener.purchase_approved(data: event)
+
+    job = EvoFlow::PublishEventWorker.jobs.last
+    expect(job['args'][0]).to eq('/events/track')
+    expect(sent_payload['event']).to eq('purchase.approved')
+    expect(sent_payload['contactId']).to eq('42')
+    expect(sent_payload['properties']).to include(
+      'provider' => 'virtu', 'purchase_id' => 'ORD-1001', 'pipeline_id' => 1, 'pipeline_item_id' => 9,
+      'source' => 'purchase_webhook', 'product' => 'Curso X', 'amount' => 297.0, 'currency' => 'BRL',
+      'platform_event' => 'approved', 'outcome' => 'created', 'new_contact' => true,
+      'pipeline_name' => 'Compras', 'pipeline_stage_name' => 'Compra recebida'
+    )
+  end
+
+  # The evo-flow pipe rejects explicit null for typed fields.
+  it 'omits optional fields the platform did not send instead of sending null' do
+    listener.purchase_approved(data: event.merge(purchase: purchase.except('product', 'currency', 'amount')))
+
+    expect(sent_payload['properties']).not_to have_key('product')
+    expect(sent_payload['properties']).not_to have_key('amount')
+    expect(sent_payload['properties']).to include('purchase_id' => 'ORD-1001')
+  end
+
+  it 'coerces a string amount into a number (the contract says number)' do
+    listener.purchase_approved(data: event.merge(purchase: purchase.merge('amount' => '297.90')))
+
+    expect(sent_payload['properties']['amount']).to eq(297.9)
+  end
+
+  it 'derives the same message_id for the same purchase, whatever the clock says' do
+    listener.purchase_approved(data: event)
+    first = sent_payload['messageId']
+    EvoFlow::PublishEventWorker.clear
+    travel_to(1.hour.from_now) { listener.purchase_approved(data: event) }
+
+    expect(sent_payload['messageId']).to eq(first)
+  end
+
+  it 'reports a second sale on the open card as already_in_pipeline' do
+    listener.purchase_approved(data: event.merge(outcome: :already_in_pipeline, new_contact: false))
+
+    expect(sent_payload['properties']).to include('outcome' => 'already_in_pipeline', 'new_contact' => false)
+  end
+
+  it 'logs an error and does not enqueue without contact or pipeline_item' do
+    expect(Rails.logger).to receive(:error).with(/contact or pipeline_item is nil/)
+    listener.purchase_approved(data: event.merge(contact: nil))
+    expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+  end
+
+  it 'does not enqueue when EvoFlow is disabled' do
+    allow(ENV).to receive(:[]).with('AUTH_APIKEY_INTEGRATION_LOCAL').and_return(nil)
+    allow(ENV).to receive(:[]).with('EVO_FLOW_ENABLED').and_return(nil)
+
+    listener.purchase_approved(data: event)
+    expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+  end
+
+  it 'returns early on an EventDispatcher payload' do
+    listener.purchase_approved(Struct.new(:data).new(event))
+    expect(EvoFlow::PublishEventWorker.jobs).to be_empty
+  end
+
+  it 'never raises: a builder failure is logged, not propagated to the webhook' do
+    allow(EvoFlow::PayloadBuilder).to receive(:build_track).and_raise(EvoFlow::InvalidEventPayload, 'boom')
+    expect(Rails.logger).to receive(:error).with(/PurchaseEventsListener#purchase_approved failed/)
+
+    expect { listener.purchase_approved(data: event) }.not_to raise_error
+  end
+end

--- a/spec/listeners/evo_flow/purchase_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/purchase_events_listener_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe EvoFlow::PurchaseEventsListener do
     )
   end
 
+  # Buyer PII (name/e-mail/phone) stays in the CRM contact: the event carries
+  # only what the schema declares, whatever else rides in the purchase hash.
+  it 'forwards only schema-declared keys, never buyer PII' do
+    leaked = purchase.merge('customer' => { 'email' => 'a@b.c' }, 'email' => 'a@b.c', 'phone' => '+5511999999999')
+    listener.purchase_approved(data: event.merge(purchase: leaked))
+
+    schema = EvoFlow::EventSchema.fetch('purchase.approved')
+    declared = (schema[:required].keys + schema[:optional].keys).map(&:to_s)
+    expect(sent_payload['properties'].keys - declared).to be_empty
+    expect(sent_payload.to_json).not_to include('a@b.c', '+5511999999999')
+  end
+
   # The evo-flow pipe rejects explicit null for typed fields.
   it 'omits optional fields the platform did not send instead of sending null' do
     listener.purchase_approved(data: event.merge(purchase: purchase.except('product', 'currency', 'amount')))

--- a/spec/listeners/evo_flow/purchase_events_listener_spec.rb
+++ b/spec/listeners/evo_flow/purchase_events_listener_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe EvoFlow::PurchaseEventsListener do
     expect(sent_payload['properties']['amount']).to eq(297.9)
   end
 
+  # JSON.generate refuses NaN/Infinity, so an unguarded one would be lost inside
+  # the listener's own rescue — the whole event, not just the amount.
+  it 'drops a non-finite amount instead of losing the whole event' do
+    listener.purchase_approved(data: event.merge(purchase: purchase.merge('amount' => Float::NAN)))
+
+    expect(sent_payload['properties']).not_to have_key('amount')
+    expect(sent_payload['properties']).to include('purchase_id' => 'ORD-1001')
+  end
+
   it 'derives the same message_id for the same purchase, whatever the clock says' do
     listener.purchase_approved(data: event)
     first = sent_payload['messageId']

--- a/spec/requests/api/v1/webhooks/purchase_platforms_spec.rb
+++ b/spec/requests/api/v1/webhooks/purchase_platforms_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController per-platform verification
         order_id: 'KW-001', order_status: 'paid', webhook_event_type: 'order_approved',
         Customer: { full_name: 'Ana Compradora', email: 'ana@cliente.com', mobile: '+5511977776666' },
         Product: { product_name: 'Curso Z' },
-        Commissions: { charge_amount: 197.0, currency: 'BRL' }
+        Commissions: { charge_amount: 19_700, currency: 'BRL' }
       }
     end
     let(:raw_body) { payload.to_json }
@@ -159,6 +159,9 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController per-platform verification
       end.to change(Contact, :count).by(1).and change(PipelineItem, :count).by(1)
 
       expect(response).to have_http_status(:created)
+      # charge_amount arrives in cents; the card (and purchase.approved) carry reais.
+      item = PipelineItem.order(created_at: :desc).first
+      expect(item.custom_fields.dig('purchase', 'amount')).to eq(197.0)
     end
 
     it 'refuses a signature from another key with 401' do

--- a/spec/requests/api/v1/webhooks/purchases_spec.rb
+++ b/spec/requests/api/v1/webhooks/purchases_spec.rb
@@ -148,6 +148,10 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
         'pipeline_id' => pipeline.id, 'pipeline_item_id' => response.parsed_body['data']['pipeline_item_id'],
         'outcome' => 'created', 'new_contact' => true, 'source' => 'purchase_webhook'
       )
+      schema = EvoFlow::EventSchema.fetch('purchase.approved')
+      declared = (schema[:required].keys + schema[:optional].keys).map(&:to_s)
+      expect(sent['properties'].keys - declared).to be_empty
+      expect(sent.to_json.downcase).not_to include(payload_hash.dig(:data, :customer, :email).to_s.downcase)
     end
 
     it 'does not emit on redelivery (duplicate) nor on a non-approved event (ignored)' do

--- a/spec/requests/api/v1/webhooks/purchases_spec.rb
+++ b/spec/requests/api/v1/webhooks/purchases_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'sidekiq/testing'
 
 RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request do
   RSpec::Matchers.define_negated_matcher :not_change, :change
@@ -117,6 +118,63 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
       post tampered, params: raw_body, headers: auth_headers
 
       expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  # CRM-316: the capture is a first-class event for evo-flow, on the two outcomes
+  # that mean a sale the CRM did not know — never on a redelivery or a refund.
+  context 'when EvoFlow is enabled' do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('EVO_FLOW_ENABLED').and_return('true')
+      Sidekiq::Testing.fake!
+      EvoFlow::PublishEventWorker.clear
+    end
+
+    after { EvoFlow::PublishEventWorker.clear }
+
+    def purchase_events
+      EvoFlow::PublishEventWorker.jobs.select { |j| j['args'][1]['event'] == 'purchase.approved' }
+    end
+
+    it 'emits purchase.approved once for a new purchase, with the contact and the card' do
+      post url, params: raw_body, headers: auth_headers
+
+      expect(purchase_events.size).to eq(1)
+      sent = purchase_events.first['args'][1]
+      expect(sent['contactId']).to eq(response.parsed_body['data']['contact_id'].to_s)
+      expect(sent['properties']).to include(
+        'provider' => 'virtu', 'purchase_id' => 'ORD-1001', 'product' => 'Curso X', 'amount' => 297.0,
+        'pipeline_id' => pipeline.id, 'pipeline_item_id' => response.parsed_body['data']['pipeline_item_id'],
+        'outcome' => 'created', 'new_contact' => true, 'source' => 'purchase_webhook'
+      )
+    end
+
+    it 'does not emit on redelivery (duplicate) nor on a non-approved event (ignored)' do
+      post url, params: raw_body, headers: auth_headers
+      EvoFlow::PublishEventWorker.clear
+
+      post url, params: raw_body, headers: auth_headers
+      expect(response.parsed_body['data']['status']).to eq('duplicate')
+
+      refund = payload_hash.deep_merge(event: 'refunded', data: { order_id: 'ORD-2002' }).to_json
+      post url, params: refund, headers: auth_headers(refund)
+      expect(response.parsed_body['data']['status']).to eq('ignored')
+
+      expect(purchase_events).to be_empty
+    end
+
+    it 'emits a second sale appended to the open card as already_in_pipeline' do
+      post url, params: raw_body, headers: auth_headers
+      EvoFlow::PublishEventWorker.clear
+
+      second = payload_hash.deep_merge(data: { order_id: 'ORD-1002' }).to_json
+      post url, params: second, headers: auth_headers(second)
+
+      expect(response.parsed_body['data']['status']).to eq('already_in_pipeline')
+      expect(purchase_events.size).to eq(1)
+      expect(purchase_events.first['args'][1]['properties'])
+        .to include('purchase_id' => 'ORD-1002', 'outcome' => 'already_in_pipeline', 'new_contact' => false)
     end
   end
 

--- a/spec/requests/api/v1/webhooks/purchases_spec.rb
+++ b/spec/requests/api/v1/webhooks/purchases_spec.rb
@@ -180,6 +180,37 @@ RSpec.describe 'Api::V1::Webhooks::PurchasesController#receive', type: :request 
       expect(purchase_events.first['args'][1]['properties'])
         .to include('purchase_id' => 'ORD-1002', 'outcome' => 'already_in_pipeline', 'new_contact' => false)
     end
+
+    # The second sale lives in the card's `purchases` history, not in the
+    # `purchase` field the duplicate index covers, so the replay answers
+    # already_in_pipeline instead of duplicate — the history is what says no.
+    it 'does not emit again when the second sale is redelivered' do
+      post url, params: raw_body, headers: auth_headers
+      second = payload_hash.deep_merge(data: { order_id: 'ORD-1002' }).to_json
+      post url, params: second, headers: auth_headers(second)
+      EvoFlow::PublishEventWorker.clear
+
+      post url, params: second, headers: auth_headers(second)
+
+      expect(response.parsed_body['data']['status']).to eq('already_in_pipeline')
+      expect(purchase_events).to be_empty
+      expect(PipelineItem.order(created_at: :desc).first.custom_fields['purchases'].size).to eq(1)
+    end
+
+    it 'does not emit when the second sale could not be appended to the open card' do
+      post url, params: raw_body, headers: auth_headers
+      # A card whose stored custom_fields no longer validate: the append raises,
+      # is rescued, and the purchase never lands on the card.
+      PipelineItem.order(created_at: :desc).first
+                  .update_column(:custom_fields, { 'services' => [{}] }) # rubocop:disable Rails/SkipsModelValidations -- storing what validation would refuse is the point
+      EvoFlow::PublishEventWorker.clear
+
+      second = payload_hash.deep_merge(data: { order_id: 'ORD-1002' }).to_json
+      post url, params: second, headers: auth_headers(second)
+
+      expect(response.parsed_body['data']['status']).to eq('already_in_pipeline')
+      expect(purchase_events).to be_empty
+    end
   end
 
   context 'when an approved purchase arrives (AC1)' do


### PR DESCRIPTION
## Summary
- O webhook de compras (`POST /api/v1/webhooks/purchases/:provider`) passa a emitir `purchase.approved` para o evo-flow quando a compra vira card (`created`) ou é anexada ao card aberto do contato (`already_in_pipeline`). Redelivery (`duplicate`) e eventos não aprovados (`ignored`) não emitem. Uma **segunda** venda redelivered responde `already_in_pipeline` (ela vive no `purchases` do card, fora do índice de duplicidade), então o gate é o append: só emite quando a compra de fato entrou no card.
- Novo `EvoFlow::PurchaseEventsListener` (Wisper), no mesmo padrão dos listeners existentes: rescue interno (nunca derruba o webhook), `message_id` determinístico por `provider.purchase_id` + contato, tenant capturado no enqueue.
- **Escopo do `message_id` determinístico:** ele identifica a compra, não deduplica. O evo-flow não tem dedup por `messageId` (`contact_events` é `MergeTree` puro), então um retry do `PublishEventWorker` depois de uma falha HTTP ambígua ainda grava uma segunda linha. Quem está protegido é a jornada (dedup por `messageId` em Redis, TTL 24h) e a contagem de segmento (`uniq(message_id)`); o que duplica é a linha de analytics. Dedup no consumidor é card próprio.
- Espelhos do contrato: `purchase.approved` em `EvoFlow::EVENT_NAMES` e em `EvoFlow::EventSchema` (categoria `purchase`).
- Kiwify: `Commissions.charge_amount` vem em centavos; o adapter converte para a unidade maior da moeda e o contrato do lead canônico escreve a unidade. Sem isso "gastou mais que 500" pegava R$ 5,00 da Kiwify e ignorava R$ 499 da Virtu.
- Lane `spec-staleness-guard` passa a rodar o listener e os specs dos espelhos.

## Security
- Sem nova rota nem mudança de autenticação: o webhook continua exigindo a assinatura da plataforma e o MAC de destino.
- As properties do evento levam só ids da compra e do CRM. Nome, e-mail e telefone do comprador ficam no contato. Spec prova que as chaves enviadas são subconjunto do `EventSchema` e que o e-mail não aparece no payload.
- O publish carrega o escopo corrente no `perform_async`, como os demais listeners.

## Test plan
- `bundle exec rspec spec/listeners/evo_flow/purchase_events_listener_spec.rb spec/requests/api/v1/webhooks/purchases_spec.rb spec/requests/api/v1/webhooks/purchase_platforms_spec.rb spec/lib/events/evo_flow_event_names_spec.rb spec/requests/api/v1/purchase_webhooks_spec.rb` (83 exemplos, 0 falhas)
- `bundle exec rubocop` nos arquivos tocados (sem ofensas)
- E2E local: compra Virtu assinada → `201 created` e `200 already_in_pipeline` → linha `purchase.approved` no ClickHouse do evo-flow com produto, `amount` numérico, funil e etapa.

## Ordem de deploy
evo-flow (catálogo) **antes** deste CRM. Emitindo antes, o evo-flow responde 400 e o `PublishEventWorker` retenta 5x até o Dead Set.

## Changed Files
- `app/listeners/evo_flow/purchase_events_listener.rb` (novo)
- `app/services/webhooks/purchases/lead_capture_service.rb`
- `app/services/evo_flow/event_schema.rb`
- `lib/events/evo_flow_event_names.rb`
- `config/initializers/evo_flow_listeners.rb`
- `app/lib/webhooks/purchase_adapters/kiwify_adapter.rb`
- `app/lib/webhooks/purchase_adapters/base.rb`
- `spec/listeners/evo_flow/purchase_events_listener_spec.rb` (novo)
- `spec/requests/api/v1/webhooks/purchases_spec.rb`
- `spec/requests/api/v1/webhooks/purchase_platforms_spec.rb`
- `spec/lib/events/evo_flow_event_names_spec.rb`
- `.github/workflows/spec-staleness-guard.yml`

## Related PRs
- evo-flow (deploy primeiro): https://github.com/evolution-foundation/evo-flow-community/pull/124
- CRM: https://github.com/evolution-foundation/evo-ai-crm-community/pull/345
- frontend (vendor/crm): https://github.com/evolution-foundation/evo-ai-frontend-community/pull/369

## Linked Issue
- CRM-316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxYjUwr2vV69kYddiXJHRo

## Summary by Sourcery

Publish approved purchase activity from the CRM to evo-flow while keeping webhook processing idempotent and provider amounts consistent.

New Features:
- Emit `purchase.approved` events to evo-flow when approved purchases create a CRM card or append a new purchase to an open card.

Bug Fixes:
- Normalize Kiwify commission amounts from cents to major currency units so purchase values are consistent across providers.

Enhancements:
- Add resilient, idempotent purchase event publishing with tenant context and schema-safe CRM purchase properties.
- Register `purchase.approved` in evo-flow event catalogs and schemas, and extend the staleness guard to cover the listener and contract mirrors.

CI:
- Run purchase webhook, listener, and evo-flow event contract specs in the spec-staleness guard lane.

Tests:
- Add listener and request coverage for event payloads, deduplication, ignored purchases, repeated sales, malformed amounts, missing data, and failure isolation.
