### PR TITLE
fix(channels): sessão QR estabelecendo deixa de ser rotulada como pending (CRM-490)

### DIFF
--- a/app/services/channels/connection_state_resolver.rb
+++ b/app/services/channels/connection_state_resolver.rb
@@ -27,7 +27,7 @@ module Channels
     CONNECTION_MAP = {
       'open' => 'connected',
       'connected' => 'connected',
-      'connecting' => 'pending',
+      'connecting' => 'connecting',
       'close' => 'disconnected',
       'closed' => 'disconnected',
       'disconnected' => 'disconnected'

--- a/app/services/channels/connection_state_resolver.rb
+++ b/app/services/channels/connection_state_resolver.rb
@@ -5,6 +5,8 @@
 #
 #   Whatsapp (hub-managed)             -> provider_config.evolution_hub.status
 #   Whatsapp (QR providers)            -> provider_connection['connection']
+#                                         (a session still establishing is
+#                                          'connecting', never 'pending')
 #   Whatsapp (token providers)         -> recorded credential probe, else unknown
 #                                         (a rejected probe is error; evidence
 #                                          expires where a job renews it)

--- a/spec/services/channels/connection_state_resolver_spec.rb
+++ b/spec/services/channels/connection_state_resolver_spec.rb
@@ -27,14 +27,23 @@ RSpec.describe Channels::ConnectionStateResolver do
       expect(result[:source]).to eq('provider_event')
     end
 
-    it 'maps connecting to pending and close to disconnected' do
-      connecting = Channel::Whatsapp.new(provider: 'evolution', provider_connection: { 'connection' => 'connecting' })
+    it 'maps close to disconnected' do
       closed = Channel::Whatsapp.new(provider: 'evolution_go', provider_connection: { 'connection' => 'close' })
-      stub_reauth(connecting)
       stub_reauth(closed)
 
-      expect(resolve(connecting)[:state]).to eq('pending')
       expect(resolve(closed)[:state]).to eq('disconnected')
+    end
+
+    # The QR session establishing is not waiting on anyone's confirmation — it
+    # gets its own state, distinct from the three producers that genuinely wait
+    # (CRM-490).
+    it 'maps a QR-provider connecting event to its own connecting state, not pending' do
+      connecting = Channel::Whatsapp.new(provider: 'evolution', provider_connection: { 'connection' => 'connecting' })
+      stub_reauth(connecting)
+
+      result = resolve(connecting)
+      expect(result[:state]).to eq('connecting')
+      expect(result[:source]).to eq('provider_event')
     end
 
     it 'falls back to unknown when a QR provider has no connection event yet' do


### PR DESCRIPTION
## Resumo

O `connecting` de uma sessão QR (Baileys/Evolution) caía no mesmo estado `pending` dos outros três produtores de `Channels::ConnectionStateResolver`, que de fato esperam confirmação externa — hub do WhatsApp aguardando o signup da Meta, `webhook_registration_status` do Sendgrid, e o `hub_state` de FacebookPage/Instagram. `CONNECTION_MAP['connecting']` agora devolve `'connecting'`, e os outros três produtores continuam em `pending`.

## Test plan

- `bundle exec rspec spec/services/channels spec/serializers/inbox_serializer_connection_state_spec.rb spec/requests/api/v1/inboxes_abort_hub_connection_spec.rb` — 35 exemplos, 0 falhas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d7g7Qr1S1jwvpmwZoz6FZ

## Summary by Sourcery

Report QR-provider sessions establishing a connection with their own `connecting` state rather than labeling them as `pending`.

Bug Fixes:
- Distinguish QR-provider sessions that are still establishing from connections that are genuinely awaiting external confirmation by reporting them as `connecting` instead of `pending`.

Tests:
- Update connection state resolver coverage to verify the dedicated `connecting` state and preserve disconnected and unknown state behavior.