### PR TITLE
fix(evolution): preserve existing instances and stop on lookup failures

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main, develop]
     paths:
+      - 'app/controllers/api/v1/evolution/authorizations_controller.rb'
+      - 'spec/controllers/api/v1/evolution/authorizations_controller_spec.rb'
       # The run: list below is a second allowlist: a spec only executes if it is
       # named there. Editing that list has to trigger this lane, so it watches itself.
       - '.github/workflows/spec-staleness-guard.yml'
@@ -351,6 +353,7 @@ jobs:
       - name: Run staleness-guard specs
         run: |
           bundle exec rspec \
+            spec/controllers/api/v1/evolution/authorizations_controller_spec.rb \
             spec/services/automation_rules/action_service_spec.rb \
             spec/services/automation_rules/conditions_filter_service_spec.rb \
             spec/services/automation_rules/conditions_filter_service_contact_spec.rb \

--- a/app/controllers/api/v1/evolution/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution/authorizations_controller.rb
@@ -33,8 +33,8 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
       # First, check if Evolution API is running by hitting the root endpoint
       evolution_status = check_server_status(api_url)
 
-      # Check if instance already exists, delete if it does
-      check_and_delete_existing_instance(api_url, admin_token, instance_name)
+      # Creating a channel must never replace an existing WhatsApp connection.
+      ensure_instance_available(api_url, admin_token, instance_name)
 
       # Create new instance
       instance_data = create_instance(api_url, admin_token, instance_name, phone_number, auth_params)
@@ -175,33 +175,12 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     raise "Failed to create instance: #{e.message}"
   end
 
-  def check_and_delete_existing_instance(api_url, admin_token, instance_name)
-    # Try to fetch existing instances
+  def ensure_instance_available(api_url, admin_token, instance_name)
+    instances = fetch_instances(api_url, admin_token, instance_name)
+    raise 'Invalid response from Evolution API fetchInstances endpoint' unless instances.is_a?(Array)
+    return if instances.empty?
 
-    fetch_instances(api_url, admin_token, instance_name)
-    # If we get here, instance exists, so delete it
-    Rails.logger.info "Evolution API: Instance #{instance_name} exists, deleting it"
-    delete_instance(api_url, admin_token, instance_name)
-    Rails.logger.info "Evolution API: Instance #{instance_name} deleted successfully"
-
-    # Wait a bit for Evolution API to process the deletion
-    Rails.logger.info 'Evolution API: Waiting 2 seconds for deletion to be processed...'
-    sleep(2)
-
-    # Verify the instance was actually deleted
-    begin
-      fetch_instances(api_url, admin_token, instance_name)
-      # If we get here, instance still exists after deletion
-      Rails.logger.error "Evolution API: Instance #{instance_name} still exists after deletion attempt"
-      raise 'Instance deletion failed - instance still exists'
-    rescue StandardError => e
-      # If 404 or error, instance is gone - good!
-      Rails.logger.info "Evolution API: Verified instance #{instance_name} was deleted (#{e.message})"
-    end
-
-  rescue StandardError => e
-    # If 404 or any error, instance doesn't exist, which is fine
-    Rails.logger.info "Evolution API: Instance #{instance_name} doesn't exist (#{e.message}), proceeding with creation"
+    raise 'Instance already exists. Choose a different instance name.'
   end
 
   def fetch_instances(api_url, admin_token, instance_name)
@@ -224,7 +203,7 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     Rails.logger.info "Evolution API: Fetch instances response body: #{response.body}"
 
     # If 404, instance doesn't exist
-    raise 'Instance not found' if response.code == '404'
+    return [] if response.code == '404'
 
     raise "Failed to fetch instances. Status: #{response.code}, Body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
 
@@ -235,37 +214,6 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
   rescue StandardError => e
     Rails.logger.error "Evolution API: Fetch instances connection error: #{e.class} - #{e.message}"
     raise e.message
-  end
-
-  def delete_instance(api_url, admin_token, instance_name)
-    delete_url = "#{api_url.chomp('/')}/instance/delete/#{instance_name}"
-    Rails.logger.info "Evolution API: Deleting instance at #{delete_url}"
-
-    uri = URI.parse(delete_url)
-
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = (uri.scheme == 'https')
-    http.open_timeout = 15
-    http.read_timeout = 15
-
-    request = Net::HTTP::Delete.new(uri)
-    request['apikey'] = admin_token
-    request['Content-Type'] = 'application/json'
-
-    response = http.request(request)
-
-    Rails.logger.info "Evolution API: Delete instance response code: #{response.code}"
-    Rails.logger.info "Evolution API: Delete instance response body: #{response.body}"
-
-    raise "Failed to delete instance. Status: #{response.code}, Body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
-
-    JSON.parse(response.body)
-  rescue JSON::ParserError => e
-    Rails.logger.error "Evolution API: Delete instance JSON parse error: #{e.message}, Body: #{response&.body}"
-    raise 'Invalid response from Evolution API delete endpoint'
-  rescue StandardError => e
-    Rails.logger.error "Evolution API: Delete instance connection error: #{e.class} - #{e.message}"
-    raise "Failed to delete instance: #{e.message}"
   end
 
   def get_qrcode(api_url, api_hash, instance_name)

--- a/app/controllers/api/v1/evolution/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution/authorizations_controller.rb
@@ -36,6 +36,11 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
       # Creating a channel must never replace an existing WhatsApp connection.
       ensure_instance_available(api_url, admin_token, instance_name)
 
+      # Testing credentials must not create an instance that blocks the save step.
+      if auth_params[:mode] == 'test'
+        return success_response(data: {}, message: 'Connection verified successfully')
+      end
+
       # Create new instance
       instance_data = create_instance(api_url, admin_token, instance_name, phone_number, auth_params)
 

--- a/spec/controllers/api/v1/evolution/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution/authorizations_controller_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+# These calls invoke a controller action, not ActiveRecord#create.
+# rubocop:disable Rails/SaveBang
+RSpec.describe Api::V1::Evolution::AuthorizationsController, type: :controller do
+  let(:api_url) { 'https://evolution.example.com' }
+  let(:instance_name) { 'support' }
+  let(:fetch_url) { "#{api_url}/instance/fetchInstances?instanceName=#{instance_name}" }
+  let(:created_instance) { { 'instance' => { 'instanceName' => instance_name } } }
+
+  before do
+    controller.params = ActionController::Parameters.new(
+      authorization: {
+        api_url: api_url, admin_token: 'test-admin-key', instance_name: instance_name,
+        phone_number: '15555550123'
+      }
+    )
+    allow(controller).to receive(:check_server_status).and_return('version' => '2.3.7')
+    allow(controller).to receive(:success_response)
+    allow(controller).to receive(:error_response)
+  end
+
+  it 'creates an instance when the filtered lookup returns an empty list' do
+    stub_request(:get, fetch_url).with(headers: { 'apikey' => 'test-admin-key' }).to_return(body: '[]')
+    expect(controller).to receive(:create_instance).and_return(created_instance)
+    expect(controller).to receive(:success_response).with(hash_including(data: hash_including(instance: created_instance)))
+
+    controller.create
+  end
+
+  it 'creates an instance when the server explicitly reports it missing' do
+    stub_request(:get, fetch_url).to_return(status: 404)
+    expect(controller).to receive(:create_instance).and_return(created_instance)
+
+    controller.create
+  end
+
+  it 'rejects a name collision without deleting or replacing the existing instance' do
+    stub_request(:get, fetch_url).to_return(body: [{ 'name' => instance_name }].to_json)
+    deletion = stub_request(:delete, "#{api_url}/instance/delete/#{instance_name}")
+    expect(controller).not_to receive(:create_instance)
+    expect(controller).to receive(:error_response).with(
+      ApiErrorCodes::EXTERNAL_SERVICE_ERROR, /Instance already exists/, status: :unprocessable_entity
+    )
+
+    controller.create
+
+    expect(deletion).not_to have_been_requested
+  end
+
+  [401, 403, 500, 503].each do |status|
+    it "does not create an instance when lookup returns HTTP #{status}" do
+      stub_request(:get, fetch_url).to_return(status: status, body: '{}')
+      expect(controller).not_to receive(:create_instance)
+      expect(controller).to receive(:error_response).with(
+        ApiErrorCodes::EXTERNAL_SERVICE_ERROR, /Failed to fetch instances/, status: :unprocessable_entity
+      )
+
+      controller.create
+    end
+  end
+
+  ['not json', '{}', 'null'].each do |body|
+    it "does not create an instance on an invalid lookup response: #{body}" do
+      stub_request(:get, fetch_url).to_return(body: body)
+      expect(controller).not_to receive(:create_instance)
+      expect(controller).to receive(:error_response).with(
+        ApiErrorCodes::EXTERNAL_SERVICE_ERROR, /Invalid response/, status: :unprocessable_entity
+      )
+
+      controller.create
+    end
+  end
+
+  it 'does not create an instance when lookup times out' do
+    stub_request(:get, fetch_url).to_timeout
+    expect(controller).not_to receive(:create_instance)
+    expect(controller).to receive(:error_response).with(
+      ApiErrorCodes::EXTERNAL_SERVICE_ERROR, anything, status: :unprocessable_entity
+    )
+
+    controller.create
+  end
+end
+
+# rubocop:enable Rails/SaveBang

--- a/spec/controllers/api/v1/evolution/authorizations_controller_spec.rb
+++ b/spec/controllers/api/v1/evolution/authorizations_controller_spec.rb
@@ -38,6 +38,39 @@ RSpec.describe Api::V1::Evolution::AuthorizationsController, type: :controller d
     controller.create
   end
 
+  it 'tests the connection without creating or configuring an instance' do
+    controller.params[:authorization][:mode] = 'test'
+    stub_request(:get, fetch_url).to_return(body: '[]')
+    expect(controller).not_to receive(:create_instance)
+    expect(controller).not_to receive(:apply_proxy_settings)
+    expect(controller).not_to receive(:apply_instance_settings)
+    expect(controller).to receive(:success_response).with(data: {}, message: 'Connection verified successfully')
+
+    controller.create
+  end
+
+  it 'allows repeated tests followed by one creation' do
+    stub_request(:get, fetch_url).to_return(status: 404)
+    expect(controller).to receive(:create_instance).once.and_return(created_instance)
+
+    controller.params[:authorization][:mode] = 'test'
+    2.times { controller.create }
+    controller.params[:authorization][:mode] = 'create'
+    controller.create
+  end
+
+  it 'refuses a connection test when credentials are rejected, without creating an instance' do
+    controller.params[:authorization][:mode] = 'test'
+    stub_request(:get, fetch_url).to_return(status: 401)
+    expect(controller).not_to receive(:create_instance)
+    expect(controller).not_to receive(:success_response)
+    expect(controller).to receive(:error_response).with(
+      ApiErrorCodes::EXTERNAL_SERVICE_ERROR, /Failed to fetch instances/, status: :unprocessable_entity
+    )
+
+    controller.create
+  end
+
   it 'rejects a name collision without deleting or replacing the existing instance' do
     stub_request(:get, fetch_url).to_return(body: [{ 'name' => instance_name }].to_json)
     deletion = stub_request(:delete, "#{api_url}/instance/delete/#{instance_name}")


### PR DESCRIPTION
Creating a WhatsApp channel with an existing Evolution instance name currently deletes that instance before creating its replacement. Lookup failures are also swallowed as “not found,” and the deletion verification catches its own failure exception.

Reject existing names without deleting the connection. Treat only an explicit 404 or an empty instance list as available, and stop creation on authorization errors, server failures, timeouts, malformed JSON, or an unexpected response shape. Add the regression spec to the existing CI guard.

Validation: 11 controller examples pass against stubbed HTTP responses; the same examples expose failures against the original implementation. The new spec passes RuboCop. The existing controller retains pre-existing complexity/style offenses; this change removes the destructive deletion helpers without expanding that refactor.

## Summary by Sourcery

Prevent Evolution connection replacement by validating instance availability safely before creation.

Bug Fixes:
- Preserve existing Evolution instances by rejecting name collisions instead of deleting and replacing connections.
- Stop instance creation when Evolution lookups fail due to authorization errors, server failures, timeouts, malformed responses, or unexpected response shapes.
- Allow connection tests to verify availability without creating an Evolution instance.

Enhancements:
- Treat only an explicit not-found response or an empty instance list as evidence that an instance name is available.
- Remove the destructive instance-deletion and verification flow.

CI:
- Add the Evolution authorization controller regression spec to the spec staleness guard workflow.

Tests:
- Add controller coverage for successful lookups, missing instances, connection tests, name collisions, lookup failures, invalid responses, and timeouts.

Connection testing is now read-only when authorization.mode is test. The wizard previously provisioned during its required connection test and tried to create again on save. Credential/status and availability checks still run, but tests do not create or configure an instance. Default mode retains creation behavior for existing clients. The frontend companion sends test/create explicitly. Regression coverage includes repeated tests followed by one creation and rejected credentials; all 14 controller examples pass.
