### PR TITLE
fix(evolution): keep credentials and provider bodies out of logs

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -293,6 +293,8 @@ on:
       - 'lib/events/evo_flow_event_names.rb'
       - 'spec/listeners/evo_flow/purchase_events_listener_spec.rb'
       - 'spec/lib/events/evo_flow_event_names_spec.rb'
+      - 'app/controllers/api/v1/evolution/authorizations_controller.rb'
+      - 'spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb'
 
 permissions:
   contents: read
@@ -431,4 +433,5 @@ jobs:
             spec/requests/api/v1/inboxes_abort_hub_connection_spec.rb \
             spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb \
             spec/jobs/channels/whatsapp/credential_probe_job_spec.rb \
+            spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb \
             --format progress

--- a/app/controllers/api/v1/evolution/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution/authorizations_controller.rb
@@ -1,4 +1,7 @@
 class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
+  # Only locally constructed messages from this error may be shown to callers.
+  ProviderError = Class.new(StandardError)
+
   require_permissions({
     create: 'inboxes.create'
   })
@@ -41,13 +44,13 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
       # Apply proxy settings if provided
       if auth_params[:proxy_settings].present?
-        Rails.logger.info "Evolution API: Applying proxy settings for instance #{instance_name}"
+        Rails.logger.info 'Evolution API: Applying proxy settings'
         apply_proxy_settings(api_url, admin_token, instance_name, auth_params[:proxy_settings])
       end
 
       # Apply instance settings if provided
       if auth_params[:instance_settings].present?
-        Rails.logger.info "Evolution API: Applying instance settings for instance #{instance_name}"
+        Rails.logger.info 'Evolution API: Applying instance settings'
         apply_instance_settings(api_url, admin_token, instance_name, auth_params[:instance_settings])
       end
 
@@ -67,8 +70,9 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
         message: 'Instance created successfully'
       )
     rescue StandardError => e
-      Rails.logger.error "Evolution API connection error: #{e.message}"
-      error_response(ApiErrorCodes::EXTERNAL_SERVICE_ERROR, e.message, status: :unprocessable_entity)
+      message = e.is_a?(ProviderError) ? e.message : "Evolution API request failed (#{e.class})"
+      Rails.logger.error "Evolution API connection error: #{message}"
+      error_response(ApiErrorCodes::EXTERNAL_SERVICE_ERROR, message, status: :unprocessable_entity)
     end
   end
 
@@ -76,7 +80,7 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
   def check_server_status(api_url)
     instance_url = "#{api_url.chomp('/')}/"
-    Rails.logger.info "Evolution API: Checking server at #{instance_url}"
+    Rails.logger.info 'Evolution API: Checking server'
 
     uri = URI.parse(instance_url)
 
@@ -91,20 +95,22 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     response = http.request(request)
     Rails.logger.info "Evolution API: Server response code: #{response.code}"
 
-    raise "Server verification failed. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+    raise ProviderError, "Server verification failed. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
   rescue JSON::ParserError
     Rails.logger.error 'Evolution API: Invalid JSON response'
-    raise 'Invalid response from Evolution API server endpoint'
+    raise ProviderError, 'Invalid response from Evolution API server endpoint'
+  rescue ProviderError
+    raise
   rescue StandardError => e
-    Rails.logger.error "Evolution API: Server connection error: #{e.class} - #{e.message}"
-    raise "Failed to verify instance: #{e.message}"
+    Rails.logger.error "Evolution API: Server connection error: #{e.class}"
+    raise ProviderError, "Failed to verify instance (#{e.class})", cause: nil
   end
 
   def create_instance(api_url, admin_token, instance_name, phone_number, auth_params)
     create_url = "#{api_url.chomp('/')}/instance/create"
-    Rails.logger.info "Evolution API: Creating instance at #{create_url}"
+    Rails.logger.info 'Evolution API: Creating instance'
 
     # Clean phone number (remove +, spaces, -)
     clean_number = phone_number.gsub(/[\+\s\-]/, '')
@@ -157,15 +163,17 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     response = http.request(request)
     Rails.logger.info "Evolution API: Create instance response code: #{response.code}"
 
-    raise "Failed to create instance. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+    raise ProviderError, "Failed to create instance. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
   rescue JSON::ParserError
     Rails.logger.error 'Evolution API: Invalid JSON response'
-    raise 'Invalid response from Evolution API create instance endpoint'
+    raise ProviderError, 'Invalid response from Evolution API create instance endpoint'
+  rescue ProviderError
+    raise
   rescue StandardError => e
-    Rails.logger.error "Evolution API: Create instance connection error: #{e.class} - #{e.message}"
-    raise "Failed to create instance: #{e.message}"
+    Rails.logger.error "Evolution API: Create instance connection error: #{e.class}"
+    raise ProviderError, "Failed to create instance (#{e.class})", cause: nil
   end
 
   def check_and_delete_existing_instance(api_url, admin_token, instance_name)
@@ -173,9 +181,9 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
     fetch_instances(api_url, admin_token, instance_name)
     # If we get here, instance exists, so delete it
-    Rails.logger.info "Evolution API: Instance #{instance_name} exists, deleting it"
+    Rails.logger.info 'Evolution API: Instance exists, deleting it'
     delete_instance(api_url, admin_token, instance_name)
-    Rails.logger.info "Evolution API: Instance #{instance_name} deleted successfully"
+    Rails.logger.info 'Evolution API: Instance deleted successfully'
 
     # Wait a bit for Evolution API to process the deletion
     Rails.logger.info 'Evolution API: Waiting 2 seconds for deletion to be processed...'
@@ -185,21 +193,21 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     begin
       fetch_instances(api_url, admin_token, instance_name)
       # If we get here, instance still exists after deletion
-      Rails.logger.error "Evolution API: Instance #{instance_name} still exists after deletion attempt"
-      raise 'Instance deletion failed - instance still exists'
+      Rails.logger.error 'Evolution API: Instance still exists after deletion attempt'
+      raise ProviderError, 'Instance deletion failed - instance still exists'
     rescue StandardError => e
       # If 404 or error, instance is gone - good!
-      Rails.logger.info "Evolution API: Verified instance #{instance_name} was deleted (#{e.message})"
+      Rails.logger.info "Evolution API: Verified instance was deleted (#{e.class})"
     end
 
   rescue StandardError => e
     # If 404 or any error, instance doesn't exist, which is fine
-    Rails.logger.info "Evolution API: Instance #{instance_name} doesn't exist (#{e.message}), proceeding with creation"
+    Rails.logger.info "Evolution API: Instance does not exist (#{e.class}), proceeding with creation"
   end
 
   def fetch_instances(api_url, admin_token, instance_name)
     fetch_url = "#{api_url.chomp('/')}/instance/fetchInstances?instanceName=#{instance_name}"
-    Rails.logger.info "Evolution API: Fetching instances at #{fetch_url}"
+    Rails.logger.info 'Evolution API: Fetching instances'
 
     uri = URI.parse(fetch_url)
 
@@ -216,22 +224,24 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     Rails.logger.info "Evolution API: Fetch instances response code: #{response.code}"
 
     # If 404, instance doesn't exist
-    raise 'Instance not found' if response.code == '404'
+    raise ProviderError, 'Instance not found' if response.code == '404'
 
-    raise "Failed to fetch instances. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+    raise ProviderError, "Failed to fetch instances. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
   rescue JSON::ParserError
     Rails.logger.error 'Evolution API: Invalid JSON response'
-    raise 'Invalid response from Evolution API fetchInstances endpoint'
+    raise ProviderError, 'Invalid response from Evolution API fetchInstances endpoint'
+  rescue ProviderError
+    raise
   rescue StandardError => e
-    Rails.logger.error "Evolution API: Fetch instances connection error: #{e.class} - #{e.message}"
-    raise e.message
+    Rails.logger.error "Evolution API: Fetch instances connection error: #{e.class}"
+    raise ProviderError, "Failed to fetch instances (#{e.class})", cause: nil
   end
 
   def delete_instance(api_url, admin_token, instance_name)
     delete_url = "#{api_url.chomp('/')}/instance/delete/#{instance_name}"
-    Rails.logger.info "Evolution API: Deleting instance at #{delete_url}"
+    Rails.logger.info 'Evolution API: Deleting instance'
 
     uri = URI.parse(delete_url)
 
@@ -248,20 +258,22 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
     Rails.logger.info "Evolution API: Delete instance response code: #{response.code}"
 
-    raise "Failed to delete instance. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+    raise ProviderError, "Failed to delete instance. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
   rescue JSON::ParserError
     Rails.logger.error 'Evolution API: Invalid JSON response'
-    raise 'Invalid response from Evolution API delete endpoint'
+    raise ProviderError, 'Invalid response from Evolution API delete endpoint'
+  rescue ProviderError
+    raise
   rescue StandardError => e
-    Rails.logger.error "Evolution API: Delete instance connection error: #{e.class} - #{e.message}"
-    raise "Failed to delete instance: #{e.message}"
+    Rails.logger.error "Evolution API: Delete instance connection error: #{e.class}"
+    raise ProviderError, "Failed to delete instance (#{e.class})", cause: nil
   end
 
   def get_qrcode(api_url, api_hash, instance_name)
     qrcode_url = "#{api_url.chomp('/')}/instance/connect/#{instance_name}"
-    Rails.logger.info "Evolution API: Getting QR code at #{qrcode_url}"
+    Rails.logger.info 'Evolution API: Getting QR code'
 
     uri = URI.parse(qrcode_url)
 
@@ -277,20 +289,22 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     response = http.request(request)
     Rails.logger.info "Evolution API: QR code response code: #{response.code}"
 
-    raise "Failed to get QR code. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+    raise ProviderError, "Failed to get QR code. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
   rescue JSON::ParserError
     Rails.logger.error 'Evolution API: Invalid JSON response'
-    raise 'Invalid response from Evolution API QR code endpoint'
+    raise ProviderError, 'Invalid response from Evolution API QR code endpoint'
+  rescue ProviderError
+    raise
   rescue StandardError => e
-    Rails.logger.error "Evolution API: QR code connection error: #{e.class} - #{e.message}"
-    raise "Failed to get QR code: #{e.message}"
+    Rails.logger.error "Evolution API: QR code connection error: #{e.class}"
+    raise ProviderError, "Failed to get QR code (#{e.class})", cause: nil
   end
 
   def webhook_url
     api_url = ENV['BACKEND_URL'].to_s.strip
-    raise 'BACKEND_URL is not configured (required to register Evolution webhook callback)' if api_url.empty?
+    raise ProviderError, 'BACKEND_URL is not configured (required to register Evolution webhook callback)' if api_url.empty?
 
     "#{api_url.chomp('/')}/webhooks/whatsapp/evolution"
   end
@@ -310,7 +324,7 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
       }
     }
 
-    Rails.logger.info "[EVOLUTION] Setting proxy configuration for #{instance_name}"
+    Rails.logger.info '[EVOLUTION] Setting proxy configuration'
 
     response = HTTParty.post(
       proxy_url,
@@ -339,7 +353,7 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
       readStatus: instance_settings['readStatus']
     }
 
-    Rails.logger.info "[EVOLUTION] Setting instance configuration for #{instance_name}"
+    Rails.logger.info '[EVOLUTION] Setting instance configuration'
 
     response = HTTParty.post(
       settings_url,

--- a/app/controllers/api/v1/evolution/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution/authorizations_controller.rb
@@ -88,7 +88,6 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     request = Net::HTTP::Get.new(uri)
     request['Content-Type'] = 'application/json'
 
-
     response = http.request(request)
     Rails.logger.info "Evolution API: Server response code: #{response.code}"
 
@@ -154,7 +153,6 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     request['apikey'] = admin_token
     request['Content-Type'] = 'application/json'
     request.body = request_body.to_json
-
 
     response = http.request(request)
     Rails.logger.info "Evolution API: Create instance response code: #{response.code}"
@@ -276,7 +274,6 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     request['apikey'] = api_hash
     request['Content-Type'] = 'application/json'
 
-
     response = http.request(request)
     Rails.logger.info "Evolution API: QR code response code: #{response.code}"
 
@@ -327,6 +324,7 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
     return if response.success?
 
+    Rails.logger.warn "[EVOLUTION] Proxy configuration failed. Status: #{response.code}"
   end
 
   def apply_instance_settings(api_url, admin_token, instance_name, instance_settings)
@@ -355,5 +353,6 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
     return if response.success?
 
+    Rails.logger.warn "[EVOLUTION] Instance settings configuration failed. Status: #{response.code}"
   end
 end

--- a/app/controllers/api/v1/evolution/authorizations_controller.rb
+++ b/app/controllers/api/v1/evolution/authorizations_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
   })
 
   def create
-    Rails.logger.info "Evolution API connection verification called with params: #{params.inspect}"
+    Rails.logger.info 'Evolution API connection verification requested'
 
     # Parâmetros vêm dentro de authorization
     auth_params = params[:authorization] || params
@@ -21,7 +21,7 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     missing_params << 'phone_number' if phone_number.blank?
 
     if missing_params.any?
-      Rails.logger.warn "Evolution API: Missing parameters: #{missing_params.join(', ')}. Params: #{params.inspect}"
+      Rails.logger.warn "Evolution API: Missing parameters: #{missing_params.join(', ')}"
       return error_response(
         ApiErrorCodes::MISSING_REQUIRED_FIELD,
         "Missing required parameters: #{missing_params.join(', ')}",
@@ -88,17 +88,15 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     request = Net::HTTP::Get.new(uri)
     request['Content-Type'] = 'application/json'
 
-    Rails.logger.info "Evolution API: Request headers: #{request.to_hash}"
 
     response = http.request(request)
     Rails.logger.info "Evolution API: Server response code: #{response.code}"
-    Rails.logger.info "Evolution API: Server response body: #{response.body}"
 
-    raise "Server verification failed. Status: #{response.code}, Body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+    raise "Server verification failed. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
-  rescue JSON::ParserError => e
-    Rails.logger.error "Evolution API: Server JSON parse error: #{e.message}, Body: #{response&.body}"
+  rescue JSON::ParserError
+    Rails.logger.error 'Evolution API: Invalid JSON response'
     raise 'Invalid response from Evolution API server endpoint'
   rescue StandardError => e
     Rails.logger.error "Evolution API: Server connection error: #{e.class} - #{e.message}"
@@ -157,18 +155,15 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     request['Content-Type'] = 'application/json'
     request.body = request_body.to_json
 
-    Rails.logger.info "Evolution API: Create instance request headers: #{request.to_hash}"
-    Rails.logger.info "Evolution API: Create instance request body: #{request.body}"
 
     response = http.request(request)
     Rails.logger.info "Evolution API: Create instance response code: #{response.code}"
-    Rails.logger.info "Evolution API: Create instance response body: #{response.body}"
 
-    raise "Failed to create instance. Status: #{response.code}, Body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+    raise "Failed to create instance. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
-  rescue JSON::ParserError => e
-    Rails.logger.error "Evolution API: Create instance JSON parse error: #{e.message}, Body: #{response&.body}"
+  rescue JSON::ParserError
+    Rails.logger.error 'Evolution API: Invalid JSON response'
     raise 'Invalid response from Evolution API create instance endpoint'
   rescue StandardError => e
     Rails.logger.error "Evolution API: Create instance connection error: #{e.class} - #{e.message}"
@@ -221,16 +216,15 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
     response = http.request(request)
     Rails.logger.info "Evolution API: Fetch instances response code: #{response.code}"
-    Rails.logger.info "Evolution API: Fetch instances response body: #{response.body}"
 
     # If 404, instance doesn't exist
     raise 'Instance not found' if response.code == '404'
 
-    raise "Failed to fetch instances. Status: #{response.code}, Body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+    raise "Failed to fetch instances. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
-  rescue JSON::ParserError => e
-    Rails.logger.error "Evolution API: Fetch instances JSON parse error: #{e.message}, Body: #{response&.body}"
+  rescue JSON::ParserError
+    Rails.logger.error 'Evolution API: Invalid JSON response'
     raise 'Invalid response from Evolution API fetchInstances endpoint'
   rescue StandardError => e
     Rails.logger.error "Evolution API: Fetch instances connection error: #{e.class} - #{e.message}"
@@ -255,13 +249,12 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     response = http.request(request)
 
     Rails.logger.info "Evolution API: Delete instance response code: #{response.code}"
-    Rails.logger.info "Evolution API: Delete instance response body: #{response.body}"
 
-    raise "Failed to delete instance. Status: #{response.code}, Body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+    raise "Failed to delete instance. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
-  rescue JSON::ParserError => e
-    Rails.logger.error "Evolution API: Delete instance JSON parse error: #{e.message}, Body: #{response&.body}"
+  rescue JSON::ParserError
+    Rails.logger.error 'Evolution API: Invalid JSON response'
     raise 'Invalid response from Evolution API delete endpoint'
   rescue StandardError => e
     Rails.logger.error "Evolution API: Delete instance connection error: #{e.class} - #{e.message}"
@@ -283,17 +276,15 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
     request['apikey'] = api_hash
     request['Content-Type'] = 'application/json'
 
-    Rails.logger.info "Evolution API: QR code request headers: #{request.to_hash}"
 
     response = http.request(request)
     Rails.logger.info "Evolution API: QR code response code: #{response.code}"
-    Rails.logger.info "Evolution API: QR code response body: #{response.body}"
 
-    raise "Failed to get QR code. Status: #{response.code}, Body: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+    raise "Failed to get QR code. Status: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
 
     JSON.parse(response.body)
-  rescue JSON::ParserError => e
-    Rails.logger.error "Evolution API: QR code JSON parse error: #{e.message}, Body: #{response&.body}"
+  rescue JSON::ParserError
+    Rails.logger.error 'Evolution API: Invalid JSON response'
     raise 'Invalid response from Evolution API QR code endpoint'
   rescue StandardError => e
     Rails.logger.error "Evolution API: QR code connection error: #{e.class} - #{e.message}"
@@ -336,7 +327,6 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
     return if response.success?
 
-    Rails.logger.warn "[EVOLUTION] Proxy configuration failed: #{response.body}"
   end
 
   def apply_instance_settings(api_url, admin_token, instance_name, instance_settings)
@@ -365,6 +355,5 @@ class Api::V1::Evolution::AuthorizationsController < Api::V1::BaseController
 
     return if response.success?
 
-    Rails.logger.warn "[EVOLUTION] Instance settings configuration failed: #{response.body}"
   end
 end

--- a/spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb
+++ b/spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe Api::V1::Evolution::AuthorizationsController, type: :controller do
+  let(:api_url) { 'https://evolution.example.com' }
+  let(:admin_token) { 'test-admin-credential-do-not-log' }
+  let(:instance_token) { 'test-instance-credential-do-not-log' }
+  let(:output) { StringIO.new }
+
+  before do
+    allow(Rails).to receive(:logger).and_return(Logger.new(output))
+    allow(controller).to receive(:webhook_url).and_return('https://crm.example.com/webhooks/evolution')
+  end
+
+  it 'keeps credentials in the outgoing request and returned result, without logging either' do
+    stub_request(:post, "#{api_url}/instance/create")
+      .with(headers: { 'apikey' => admin_token })
+      .to_return(body: { hash: instance_token }.to_json)
+
+    result = controller.send(:create_instance, api_url, admin_token, 'support', '15555550123', {})
+
+    expect(result['hash']).to eq(instance_token)
+    expect(output.string).not_to include(admin_token, instance_token)
+    expect(output.string).to include('response code: 200')
+  end
+
+  it 'does not log credentials returned by an instance lookup' do
+    stub_request(:get, "#{api_url}/instance/fetchInstances?instanceName=support")
+      .to_return(body: [{ token: instance_token }].to_json)
+
+    controller.send(:fetch_instances, api_url, admin_token, 'support')
+
+    expect(output.string).not_to include(instance_token)
+  end
+
+  it 'does not include a provider error body in logs or exception messages' do
+    stub_request(:post, "#{api_url}/instance/create")
+      .to_return(status: 500, body: { error: "request used #{admin_token}" }.to_json)
+
+    expect do
+      controller.send(:create_instance, api_url, admin_token, 'support', '15555550123', {})
+    end.to raise_error(/Status: 500/) { |error| expect(error.message).not_to include(admin_token) }
+    expect(output.string).not_to include(admin_token)
+  end
+
+  it 'does not log malformed response bodies or parser excerpts containing credentials' do
+    stub_request(:post, "#{api_url}/instance/create").to_return(body: "not-json: #{instance_token}")
+
+    expect do
+      controller.send(:create_instance, api_url, admin_token, 'support', '15555550123', {})
+    end.to raise_error('Invalid response from Evolution API create instance endpoint')
+    expect(output.string).not_to include(instance_token)
+  end
+
+  it 'does not log submitted credentials when required parameters are missing' do
+    controller.params = ActionController::Parameters.new(authorization: { api_url: api_url, admin_token: admin_token })
+    allow(controller).to receive(:error_response)
+
+    controller.create # rubocop:disable Rails/SaveBang -- controller action, not ActiveRecord
+
+    expect(output.string).not_to include(admin_token)
+    expect(output.string).to include('Missing parameters: instance_name, phone_number')
+  end
+end

--- a/spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb
+++ b/spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb
@@ -54,6 +54,18 @@ RSpec.describe Api::V1::Evolution::AuthorizationsController, type: :controller d
     expect(output.string).not_to include(instance_token)
   end
 
+  { apply_proxy_settings: 'proxy', apply_instance_settings: 'settings' }.each do |method, endpoint|
+    it "keeps failure status diagnostics without logging the #{endpoint} response body" do
+      stub_request(:post, "#{api_url}/#{endpoint}/set/support")
+        .to_return(status: 500, body: "request used #{admin_token}")
+
+      controller.send(method, api_url, admin_token, 'support', { 'enabled' => true })
+
+      expect(output.string).to include('Status: 500')
+      expect(output.string).not_to include(admin_token)
+    end
+  end
+
   it 'does not log submitted credentials when required parameters are missing' do
     controller.params = ActionController::Parameters.new(authorization: { api_url: api_url, admin_token: admin_token })
     allow(controller).to receive(:error_response)

--- a/spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb
+++ b/spec/controllers/api/v1/evolution/authorizations_controller_logging_spec.rb
@@ -66,6 +66,77 @@ RSpec.describe Api::V1::Evolution::AuthorizationsController, type: :controller d
     end
   end
 
+  credential_urls = [
+    'https://operator:url-password-secret@evolution.example.com',
+    'https://evolution.example.com?api_key=url-query-secret'
+  ]
+
+  {
+    check_server_status: [],
+    create_instance: ['admin-token', 'support', '15555550123', {}],
+    fetch_instances: %w[admin-token support],
+    delete_instance: %w[admin-token support],
+    get_qrcode: %w[instance-token support]
+  }.each do |operation, arguments|
+    credential_urls.each do |credential_url|
+      it "omits URL credentials from #{operation} diagnostics for #{credential_url}" do
+        stub_request(:any, /evolution\.example\.com/).to_return(body: '{}')
+
+        controller.send(operation, credential_url, *arguments)
+
+        expect(output.string).not_to include(credential_url, 'url-password-secret', 'url-query-secret')
+        expect(output.string).to include('response code: 200')
+      end
+    end
+
+    it "omits malformed URLs from #{operation} logs and exception messages" do
+      invalid_url = 'https://evolution.example.com/bad path?token=invalid-url-secret'
+
+      failure = nil
+      expect do
+        controller.send(operation, invalid_url, *arguments)
+      end.to raise_error(StandardError) { |error| failure = error }
+      expect(failure.message).not_to include(invalid_url, 'invalid-url-secret')
+      expect(failure.cause).to be_nil
+      expect(output.string).not_to include(invalid_url, 'invalid-url-secret')
+      expect(output.string).to include('URI::InvalidURIError')
+    end
+  end
+
+  it 'omits transport exception text even when it contains the endpoint URL and credentials' do
+    stub_request(:post, "#{api_url}/instance/create")
+      .to_raise(SocketError.new("could not connect to #{api_url}?token=#{admin_token}"))
+
+    failure = nil
+    expect do
+      controller.send(:create_instance, api_url, admin_token, 'support', '15555550123', {})
+    end.to raise_error(StandardError, /SocketError/) { |error| failure = error }
+    expect(failure.message).not_to include(api_url, admin_token)
+    expect(failure.cause).to be_nil
+    expect(output.string).not_to include(api_url, admin_token)
+  end
+
+  %i[apply_proxy_settings apply_instance_settings].each do |operation|
+    it "omits unexpected #{operation} errors from action logs and error responses" do
+      authorization = {
+        api_url: api_url, admin_token: admin_token, instance_name: 'support', phone_number: '15555550123',
+        proxy_settings: { enabled: true }, instance_settings: { alwaysOnline: true }
+      }
+      controller.params = ActionController::Parameters.new(authorization: authorization)
+      allow(controller).to receive_messages(check_server_status: {}, check_and_delete_existing_instance: nil, create_instance: {})
+      allow(controller).to receive(:apply_proxy_settings)
+      allow(controller).to receive(operation).and_raise(URI::InvalidURIError, "bad URL #{api_url}?token=#{admin_token}")
+      allow(controller).to receive(:error_response)
+
+      controller.create # rubocop:disable Rails/SaveBang -- controller action, not ActiveRecord
+
+      expect(controller).to have_received(:error_response).with(
+        ApiErrorCodes::EXTERNAL_SERVICE_ERROR, 'Evolution API request failed (URI::InvalidURIError)', status: :unprocessable_entity
+      )
+      expect(output.string).not_to include(api_url, admin_token)
+    end
+  end
+
   it 'does not log submitted credentials when required parameters are missing' do
     controller.params = ActionController::Parameters.new(authorization: { api_url: api_url, admin_token: admin_token })
     allow(controller).to receive(:error_response)


### PR DESCRIPTION
Evolution authorization writes raw parameters, API headers, and provider response bodies to application logs. Those values can include admin tokens, instance tokens, and proxy credentials. This change removes those dumps and excludes provider bodies and JSON parser excerpts from diagnostic errors, while retaining operation names and HTTP status codes. Credentials still reach the provider and successful response values remain available to callers.

Adds regression coverage for successful creation, instance lookup, provider errors, malformed JSON, proxy/settings failures, missing parameters, URL userinfo/query credentials, malformed URLs, and transport exceptions, and includes it in the CI staleness guard. Endpoint diagnostics use operation names without URLs; only locally constructed provider errors retain their messages, while unexpected errors expose their exception type without arbitrary exception text.

Validation:
- 25 focused RSpec examples pass with synthetic credentials and stubbed HTTP requests.
- The original five regression examples fail against the original controller and pass with this fix.
- The new spec passes RuboCop. Existing controller style/complexity offenses are outside this change.

Submitted publicly following the maintainers' request relayed to the contributor. This is independent of #348, which changes instance provisioning behavior in the same controller; overlapping edits may require reconciliation when merging both.

## Summary by Sourcery

Sanitize Evolution authorization diagnostics to prevent sensitive credentials and provider data from being exposed while retaining useful safe error context.

Bug Fixes:
- Prevent Evolution authorization credentials, provider response bodies, URLs, and arbitrary exception text from appearing in logs or diagnostic errors.

Enhancements:
- Retain safe operation and HTTP status diagnostics while preserving provider responses for callers and provider-generated error messages where appropriate.

CI:
- Add Evolution authorization logging regression coverage to the spec staleness guard and CI spec list.

Tests:
- Add regression coverage for credential leakage across successful requests, provider failures, malformed responses, URL credentials, malformed URLs, transport exceptions, settings failures, and missing parameters.