### PR TITLE
fix(evolution-go): preserva o servidor @lid no identificador do contato

### DIFF
--- a/app/services/whatsapp/evolution_go_handlers/helpers.rb
+++ b/app/services/whatsapp/evolution_go_handlers/helpers.rb
@@ -51,16 +51,55 @@ module Whatsapp::EvolutionGoHandlers::Helpers
     @evolution_go_info&.dig(:ID)
   end
 
+  # Splits a JID into [user, server], dropping the ":N" device suffix. The server
+  # is nil for a bare number (the channel's own phone_number has no "@" part).
+  def jid_parts(jid)
+    user, server = jid.to_s.split('@', 2)
+    [user.to_s.gsub(/:\d+$/, ''), server.presence]
+  end
+
+  # The sender address with its server preserved, e.g. "192234817380569@lid".
+  # Keeping the server is what makes the address routable: a 15-digit LID is
+  # indistinguishable from an E.164 number once "@lid" is dropped.
+  def sender_jid
+    jid = sender_id
+    return nil if jid.blank?
+
+    user, server = jid_parts(jid)
+    server ? "#{user}@#{server}" : user
+  end
+
+  # Extract phone number from JID (e.g., "557499879409@s.whatsapp.net" -> "557499879409").
+  # Returns nil for any addressed JID that is not a phone address (@lid, @g.us,
+  # @newsletter): those users are opaque WhatsApp identifiers, never dialable numbers.
+  # Callers that need a destination must use sender_jid instead.
   def phone_number_from_jid
     jid = sender_id
-    return nil unless jid
+    return nil if jid.blank?
 
-    # Extract phone number from JID (e.g., "557499879409@s.whatsapp.net" -> "557499879409")
-    jid.split('@').first.gsub(/:\d+$/, '')
+    user, server = jid_parts(jid)
+    return nil if server.present? && server != 's.whatsapp.net'
+
+    user
+  end
+
+  # The sender's LID address when the chat is LID-addressed, otherwise nil.
+  # WhatsApp uses a LID when the contact is not in the account's address book, so
+  # no phone number is available and the LID is the only routable destination.
+  def lid_from_jid
+    jid = sender_id
+    return nil if jid.blank?
+
+    _user, server = jid_parts(jid)
+    return nil unless server == 'lid'
+
+    sender_jid
   end
 
   def contact_name
-    @evolution_go_info&.dig(:PushName).presence || phone_number_from_jid
+    @evolution_go_info&.dig(:PushName).presence ||
+      phone_number_from_jid ||
+      jid_parts(sender_id).first.presence
   end
 
   def sender_alt

--- a/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
+++ b/app/services/whatsapp/evolution_go_handlers/messages_upsert.rb
@@ -100,14 +100,17 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
   def set_contact_for_incoming
     push_name = contact_name
     phone_number = phone_number_from_jid
-    sender_alt_value = sender_alt
+    lid_jid = lid_from_jid
     is_whatsapp_number = is_whatsapp_phone_number?
+    # SenderAlt is the resolved phone JID when WhatsApp knows the mapping; for a
+    # contact outside the address book it is absent and the LID is the identity.
+    identifier = sender_alt.presence || lid_jid
 
-    source_id = determine_source_id(sender_alt_value, phone_number)
+    source_id = determine_source_id(sender_alt.presence, phone_number, lid_jid)
 
     Rails.logger.info "Evolution Go API: Incoming contact - source_id: #{source_id}, phone_number: #{phone_number}, push_name: #{push_name}"
 
-    contact_attributes = build_contact_attributes(push_name, phone_number, sender_alt_value, is_whatsapp_number)
+    contact_attributes = build_contact_attributes(push_name, phone_number, identifier, is_whatsapp_number)
 
     contact_inbox = ::ContactInboxWithContactBuilder.new(
       source_id: source_id,
@@ -118,8 +121,9 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
     @contact_inbox = contact_inbox
     @contact = contact_inbox.contact
 
-    update_contact_information(push_name, phone_number, sender_alt_value, is_whatsapp_number)
-    update_contact_profile_picture(@contact, phone_number)
+    update_contact_information(push_name, phone_number, identifier, is_whatsapp_number)
+    # A LID chat has no phone number; the LID is what the avatar endpoint can resolve.
+    update_contact_profile_picture(@contact, phone_number || lid_jid)
 
     Rails.logger.info "Evolution Go API: Contact set - ID: #{@contact.id}, Name: #{@contact.name}, Identifier: #{@contact.identifier}, Source ID: #{@contact_inbox.source_id}"
   end
@@ -162,23 +166,30 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
     @contact = nil
   end
 
-  def determine_source_id(sender_alt_value, phone_number)
+  # The source_id has to stay routable: SendOnWhatsappService hands it to Evolution
+  # Go as the destination. A LID must therefore keep its "@lid" server — Evolution
+  # Go's CreateJID treats any bare digit string as a phone number and rewrites it to
+  # "<digits>@s.whatsapp.net", which the server then refuses with "no LID found".
+  def determine_source_id(sender_alt_value, phone_number, lid_jid)
     if sender_alt_value.present?
       Rails.logger.info "Evolution Go API: Using SenderAlt '#{sender_alt_value}' as source_id"
       sender_alt_value
+    elsif lid_jid.present?
+      Rails.logger.info "Evolution Go API: Using LID '#{lid_jid}' as source_id (no SenderAlt available)"
+      lid_jid
     else
       Rails.logger.info "Evolution Go API: Using phone_number '#{phone_number}' as source_id (no SenderAlt available)"
       phone_number
     end
   end
 
-  def build_contact_attributes(push_name, phone_number, sender_alt_value, is_whatsapp_number)
+  def build_contact_attributes(push_name, phone_number, identifier, is_whatsapp_number)
     attributes = {
       name: push_name
     }
 
-    # Use SenderAlt as identifier if available
-    attributes[:identifier] = sender_alt_value if sender_alt_value.present?
+    # Use SenderAlt (or the LID, when no SenderAlt exists) as identifier
+    attributes[:identifier] = identifier if identifier.present?
 
     # Only set phone_number if it's a WhatsApp phone number (@s.whatsapp.net)
     attributes[:phone_number] = "+#{phone_number}" if is_whatsapp_number
@@ -186,16 +197,16 @@ module Whatsapp::EvolutionGoHandlers::MessagesUpsert
     attributes
   end
 
-  def update_contact_information(push_name, phone_number, sender_alt_value, is_whatsapp_number)
+  def update_contact_information(push_name, phone_number, identifier, is_whatsapp_number)
     updates = {}
 
     # Update contact name if it was just the phone number
     updates[:name] = push_name if @contact.name == phone_number && push_name.present?
 
-    # Update identifier with SenderAlt if contact doesn't have one and SenderAlt is present
-    if @contact.identifier.blank? && sender_alt_value.present?
-      updates[:identifier] = sender_alt_value
-      Rails.logger.info "Evolution Go API: Adding identifier #{sender_alt_value} to existing contact #{@contact.id}"
+    # Update identifier with SenderAlt/LID if contact doesn't have one
+    if @contact.identifier.blank? && identifier.present?
+      updates[:identifier] = identifier
+      Rails.logger.info "Evolution Go API: Adding identifier #{identifier} to existing contact #{@contact.id}"
     end
 
     # Update phone_number if contact only has number without identifier and this is a WhatsApp number

--- a/app/services/whatsapp/incoming_message_evolution_go_service.rb
+++ b/app/services/whatsapp/incoming_message_evolution_go_service.rb
@@ -97,17 +97,10 @@ class Whatsapp::IncomingMessageEvolutionGoService < Whatsapp::IncomingMessageBas
     @evolution_go_info&.dig(:ID)
   end
 
-  def phone_number_from_jid
-    jid = sender_id
-    return nil unless jid
-
-    # Extract phone number from JID (e.g., "557499879409@s.whatsapp.net" -> "557499879409")
-    jid.split('@').first.gsub(/:\d+$/, '')
-  end
-
-  def contact_name
-    @evolution_go_info&.dig(:PushName).presence || phone_number_from_jid
-  end
+  # phone_number_from_jid and contact_name intentionally live only in
+  # EvolutionGoHandlers::Helpers. A copy here would override the module (a method
+  # defined in the class wins over an included one) and silently reintroduce the
+  # LID-as-phone bug this service's handlers depend on Helpers to avoid.
 
   def whatsapp_channel
     @whatsapp_channel ||= @inbox.channel

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -208,9 +208,13 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
         Rails.logger.info "WhatsApp Send: Using phone_number #{target} (from #{contact.phone_number}) - clean number without @lid"
         target
       else
-        # Last resort, use contact_inbox.source_id (might be a phone number)
-        Rails.logger.info "WhatsApp Send: Using source_id fallback #{contact_inbox.source_id}"
-        contact_inbox.source_id
+        # Last resort. A LID chat whose contact_inbox predates the LID-preserving
+        # ingest stores a bare digit string, which Evolution Go would rewrite to
+        # "@s.whatsapp.net" and fail to route. The conversation still carries the
+        # original "@lid" JID, so prefer it as the destination.
+        target = lid_jid_from_conversation.presence || contact_inbox.source_id
+        Rails.logger.info "WhatsApp Send: Using source_id fallback #{target}"
+        target
       end
     else
       # Default behavior for whatsapp_cloud and other providers
@@ -247,10 +251,22 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
     channel.provider.in?(%w[evolution evolution_go]) && group_jid_from_conversation.present?
   end
 
-  def group_jid_from_conversation
+  # The chat JID recorded when the conversation was created. It keeps the original
+  # WhatsApp server ("@g.us", "@lid", "@s.whatsapp.net") even when the contact_inbox
+  # stores a bare number, so it is the fallback source of a routable destination.
+  def chat_jid_from_conversation
     attrs = message.conversation.additional_attributes || {}
     key = channel.provider == 'evolution_go' ? 'evolution_go_chat_id' : 'evolution_chat_id'
-    candidate = attrs[key]
+    attrs[key]
+  end
+
+  def group_jid_from_conversation
+    candidate = chat_jid_from_conversation
     candidate if candidate.is_a?(String) && candidate.end_with?('@g.us')
+  end
+
+  def lid_jid_from_conversation
+    candidate = chat_jid_from_conversation
+    candidate if candidate.is_a?(String) && candidate.end_with?('@lid')
   end
 end

--- a/db/migrate/20260907120000_restore_lid_suffix_on_evolution_go_contact_inboxes.rb
+++ b/db/migrate/20260907120000_restore_lid_suffix_on_evolution_go_contact_inboxes.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Evolution Go addresses a contact that is absent from the account's address book
+# by LID ("192234817380569@lid") instead of by phone. The ingest used to store the
+# source_id as the bare user part, and a 15-digit LID is indistinguishable from an
+# E.164 number once "@lid" is gone: on reply, Evolution Go's CreateJID rebuilt it as
+# "<digits>@s.whatsapp.net" and WhatsApp refused it ("no LID found ... from server").
+#
+# The conversation kept the original JID in additional_attributes.evolution_go_chat_id,
+# so it is the authority for deciding which rows were really LID-addressed. Rows whose
+# source_id is a genuine phone number have no matching "<source_id>@lid" chat id and
+# are left untouched.
+class RestoreLidSuffixOnEvolutionGoContactInboxes < ActiveRecord::Migration[7.1]
+  def up
+    restore_source_ids
+    backfill_identifiers
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          'Dropping the "@lid" server again would make the destination unroutable.'
+  end
+
+  private
+
+  # The NOT EXISTS guard protects index_contact_inboxes_on_inbox_id_and_source_id
+  # (unique): skip a row whose corrected source_id is already claimed in that inbox.
+  # Keep SQL comments out of these heredocs — squish collapses them to one line and
+  # a "--" would comment out every condition that follows it.
+  def restore_source_ids
+    restored = execute(<<~SQL.squish).cmd_tuples
+      UPDATE contact_inboxes ci
+      SET source_id = ci.source_id || '@lid'
+      FROM conversations c
+      WHERE c.contact_inbox_id = ci.id
+        AND ci.source_id ~ '^[0-9]+$'
+        AND c.additional_attributes->>'evolution_go_chat_id' = ci.source_id || '@lid'
+        AND NOT EXISTS (
+          SELECT 1 FROM contact_inboxes other
+          WHERE other.inbox_id = ci.inbox_id
+            AND other.source_id = ci.source_id || '@lid'
+        )
+    SQL
+
+    say "contact_inboxes: #{restored} LID source_id(s) restored", true
+  end
+
+  # The outgoing echo (IsFromMe) looks the contact up by identifier against the
+  # chat LID, so a LID contact without one silently drops its own sent messages.
+  # The NOT EXISTS guard protects uniq_identifier_per_account_contact (unique).
+  def backfill_identifiers
+    identified = execute(<<~SQL.squish).cmd_tuples
+      UPDATE contacts ct
+      SET identifier = ci.source_id
+      FROM contact_inboxes ci
+      WHERE ci.contact_id = ct.id
+        AND ct.identifier IS NULL
+        AND ci.source_id LIKE '%@lid'
+        AND NOT EXISTS (
+          SELECT 1 FROM contacts other WHERE other.identifier = ci.source_id
+        )
+    SQL
+
+    say "contacts: #{identified} LID identifier(s) backfilled", true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_26_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_07_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"

--- a/spec/services/whatsapp/evolution_go_handlers/helpers_lid_addressing_spec.rb
+++ b/spec/services/whatsapp/evolution_go_handlers/helpers_lid_addressing_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# WhatsApp addresses a contact that is not in the account's address book by LID
+# ("192234817380569@lid") and sends no SenderAlt, so no phone number exists. The
+# ingest must keep the "@lid" server: a 15-digit LID is indistinguishable from an
+# E.164 number once the server is dropped, and Evolution Go's CreateJID turns any
+# bare digit string into "<digits>@s.whatsapp.net", which WhatsApp refuses with
+# "no LID found ... from server".
+RSpec.describe Whatsapp::EvolutionGoHandlers::Helpers do
+  subject(:handler) { harness.new(info) }
+
+  let(:harness) do
+    Class.new do
+      include Whatsapp::EvolutionGoHandlers::Helpers
+
+      def initialize(info)
+        @evolution_go_info = info
+      end
+
+      # Helpers' methods are private; expose the ones under test.
+      public :phone_number_from_jid, :lid_from_jid, :sender_jid, :contact_name,
+             :is_whatsapp_phone_number?
+    end
+  end
+
+  context 'when the chat is LID-addressed (contact not in the address book)' do
+    let(:info) { { IsFromMe: false, IsGroup: false, Chat: '192234817380569@lid', PushName: 'Pruebas Dimarka' } }
+
+    it 'does not expose the LID as a phone number' do
+      expect(handler.phone_number_from_jid).to be_nil
+    end
+
+    it 'exposes the LID with its server preserved' do
+      expect(handler.lid_from_jid).to eq('192234817380569@lid')
+      expect(handler.sender_jid).to eq('192234817380569@lid')
+    end
+
+    it 'is not treated as a WhatsApp phone number' do
+      expect(handler).not_to be_is_whatsapp_phone_number
+    end
+  end
+
+  context 'when the chat is phone-addressed' do
+    let(:info) { { IsFromMe: false, IsGroup: false, Chat: '557499879409:13@s.whatsapp.net', PushName: 'Ana' } }
+
+    it 'extracts the number and drops the device suffix' do
+      expect(handler.phone_number_from_jid).to eq('557499879409')
+    end
+
+    it 'reports no LID' do
+      expect(handler.lid_from_jid).to be_nil
+    end
+
+    it 'is treated as a WhatsApp phone number' do
+      expect(handler).to be_is_whatsapp_phone_number
+    end
+  end
+
+  context 'when there is no PushName' do
+    let(:info) { { IsFromMe: false, IsGroup: false, Chat: '192234817380569@lid' } }
+
+    it 'falls back to the JID user part for the display name' do
+      expect(handler.contact_name).to eq('192234817380569')
+    end
+  end
+end

--- a/spec/services/whatsapp/evolution_go_handlers/messages_upsert_source_id_spec.rb
+++ b/spec/services/whatsapp/evolution_go_handlers/messages_upsert_source_id_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The source_id is what SendOnWhatsappService hands to Evolution Go as the
+# destination, so it has to stay routable. See lid_addressing_spec.rb for why a
+# LID must keep its "@lid" server.
+RSpec.describe Whatsapp::EvolutionGoHandlers::MessagesUpsert do
+  subject(:handler) { harness.new }
+
+  let(:harness) do
+    Class.new do
+      include Whatsapp::EvolutionGoHandlers::MessagesUpsert
+
+      public :determine_source_id
+    end
+  end
+
+  it 'prefers SenderAlt, the resolved phone JID, when WhatsApp provides it' do
+    expect(handler.determine_source_id('5511999999999@s.whatsapp.net', '5511999999999', nil))
+      .to eq('5511999999999@s.whatsapp.net')
+  end
+
+  it 'keeps the "@lid" server when there is no SenderAlt' do
+    expect(handler.determine_source_id(nil, nil, '192234817380569@lid')).to eq('192234817380569@lid')
+  end
+
+  it 'still uses the plain number for a phone-addressed chat' do
+    expect(handler.determine_source_id(nil, '5511999999999', nil)).to eq('5511999999999')
+  end
+end

--- a/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
+++ b/spec/services/whatsapp/send_on_whatsapp_service_spec.rb
@@ -72,6 +72,42 @@ RSpec.describe Whatsapp::SendOnWhatsappService do
     end
   end
 
+  # A contact outside the address book is LID-addressed and has no phone number.
+  # contact_inboxes created before the ingest preserved the "@lid" server hold a bare
+  # digit string, which Evolution Go rewrites to "@s.whatsapp.net" and cannot route
+  # ("no LID found ... from server"). The conversation still carries the real JID.
+  describe '#determine_target_number_for_sending — evolution_go LID fallback' do
+    let(:provider) { 'evolution_go' }
+    let(:contact) { instance_double(Contact, id: 1, identifier: nil, phone_number: nil) }
+
+    context 'when source_id lost its "@lid" server and the conversation kept it' do
+      let(:contact_inbox_source_id) { '192234817380569' }
+      let(:additional_attributes) { { 'evolution_go_chat_id' => '192234817380569@lid' } }
+
+      it 'sends to the LID JID from the conversation, not the bare number' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('192234817380569@lid')
+      end
+    end
+
+    context 'when the conversation chat id is a phone JID' do
+      let(:contact_inbox_source_id) { '5511999999999' }
+      let(:additional_attributes) { { 'evolution_go_chat_id' => '5511999999999@s.whatsapp.net' } }
+
+      it 'keeps the existing source_id fallback untouched' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5511999999999')
+      end
+    end
+
+    context 'when the conversation has no chat id' do
+      let(:contact_inbox_source_id) { '5511999999999' }
+      let(:additional_attributes) { nil }
+
+      it 'keeps the existing source_id fallback untouched' do
+        expect(service.send(:determine_target_number_for_sending)).to eq('5511999999999')
+      end
+    end
+  end
+
   # EVO-1682: identifier is only a valid Evolution Go destination when it looks like
   # a number/JID; non-numeric identifiers (imported lead labels) must fall back to
   # phone_number / source_id instead of being sent as the recipient.


### PR DESCRIPTION
## Problema

Um contato que **não está salvo na agenda do WhatsApp** manda uma mensagem. Ela entra no CRM e a conversa aparece normalmente. Ao responder, a mensagem não chega e o envio falha.

O log do Evolution Go mostra cinco passos bem-sucedidos e uma única falha, no fim:

```
MESSAGE RECEIVED ... From: 192234817380569@lid          ← chega com @lid
Message sent to webhook successfully
webhook sent successfully - status: 200
Client successfully validated - Connected: true
SendMessage called for number: +192234817380569@s.whatsapp.net   ← já não é @lid
Recipient validated: +192234817380569@s.whatsapp.net
Error sending message: no LID found for 192234817380569@s.whatsapp.net from server
```

O identificador entrou como `@lid` e saiu como `@s.whatsapp.net`.

O WhatsApp endereça por **LID** os contatos que não estão na agenda da conta. Nesse caso não existe número de telefone, e o webhook também não traz `SenderAlt`, porque o WhatsApp não conhece o mapeamento LID → telefone. O LID é o único endereço com que dá para responder.

O CRM gravava esse identificador **sem o sufixo**. Em `evolution_go_handlers/helpers.rb`, `phone_number_from_jid` recortava o JID sem olhar o servidor:

```ruby
jid.split('@').first.gsub(/:\d+$/, '')   # "192234817380569@lid" -> "192234817380569"
```

E `determine_source_id` usava esse valor como `contact_inboxes.source_id` sempre que o webhook não trazia `SenderAlt` — exatamente o caso de um contato fora da agenda.

**Um LID de 15 dígitos é indistinguível de um número E.164**, que também aceita até 15 dígitos. Sem o sufixo não há como saber a qual espaço de endereçamento ele pertence. Na resposta, o `CreateJID` do Evolution Go (`pkg/utils/utils.go`) assume que todo dígito solto é telefone:

```go
if !strings.HasPrefix(number, "+") { number = "+" + number }
return number + "@s.whatsapp.net", nil
```

O `+` dentro do JID que aparece no log é a assinatura dessa função.

**O Evolution Go não tem culpa.** Ele preserva `@lid` de ponta a ponta quando recebe o JID completo: `send_service.go` pula a checagem de existência para `@lid` e o `CreateJID` respeita o sufixo. O dado se perdia no CRM, num `split`.

Reproduzido com `evoapicloud/evolution-go:latest` (0.7.2).

## Solução

O `source_id` precisa continuar roteável, porque é ele que o `SendOnWhatsappService` entrega ao Evolution Go como destino. `SenderAlt` continua tendo prioridade quando existe; na ausência dele, o LID é gravado com o servidor preservado.

Um chat de telefone continua gravando só os dígitos. Não é inconsistência: `RegexHelper::WHATSAPP_CHANNEL_REGEX` aceita `@lid` mas **recusa** `@s.whatsapp.net`, e gravar sempre o JID completo quebraria a validação de `ContactInbox`.

**A cópia que quase anulava a correção.** `IncomingMessageEvolutionGoService` tinha cópias literais de `phone_number_from_jid` e `contact_name`. Em Ruby, um método definido na classe **vence o do módulo incluído**, então a correção em `Helpers` ficaria morta sem gerar erro nenhum. As cópias foram removidas e um comentário no lugar explica por que não devem voltar.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `app/services/whatsapp/evolution_go_handlers/helpers.rb` | `phone_number_from_jid` devolve `nil` para JID que não seja de telefone; novos `jid_parts`, `sender_jid` e `lid_from_jid`; `contact_name` com fallback |
| `app/services/whatsapp/evolution_go_handlers/messages_upsert.rb` | `determine_source_id` preserva `@lid`; `identifier` recebe `SenderAlt` ou o LID; avatar usa o LID quando não há telefone |
| `app/services/whatsapp/incoming_message_evolution_go_service.rb` | removidas as cópias de `phone_number_from_jid` e `contact_name` que sobrescreviam o módulo |
| `app/services/whatsapp/send_on_whatsapp_service.rb` | `lid_jid_from_conversation` recupera o `@lid` que a conversa guarda em `evolution_go_chat_id`, para os contatos já gravados sem o sufixo |
| `db/migrate/20260907120000_restore_lid_suffix_on_evolution_go_contact_inboxes.rb` | restaura o sufixo nas linhas existentes |
| `spec/.../helpers_lid_addressing_spec.rb` | 8 exemplos: LID, chat de telefone com sufixo de device, fallback de nome |
| `spec/.../messages_upsert_source_id_spec.rb` | 3 exemplos cobrindo a precedência SenderAlt → LID → telefone |
| `spec/.../send_on_whatsapp_service_spec.rb` | 3 exemplos para o fallback pelo `@lid` da conversa |

A migração cruza `contact_inboxes.source_id` com o `evolution_go_chat_id` da conversa, que é a autoridade sobre quais linhas eram de fato LID — um `source_id` que é telefone de verdade não tem `"<source_id>@lid"` correspondente e fica intocado. Tem guarda `NOT EXISTS` para os índices únicos `index_contact_inboxes_on_inbox_id_and_source_id` e `uniq_identifier_per_account_contact`, e é irreversível por definição: voltar a tirar o servidor tornaria o destino não-roteável.

## Testes

```
bundle exec rspec spec/services/whatsapp/evolution_go_handlers/helpers_lid_addressing_spec.rb \
                  spec/services/whatsapp/evolution_go_handlers/messages_upsert_source_id_spec.rb \
                  spec/services/whatsapp/send_on_whatsapp_service_spec.rb
48 examples, 1 failure
```

A única falha é **preexistente na `develop`** e não tem relação com esta mudança — `InstanceDouble(Message)` não responde a `updated_at`, disparado pelo `EvoFlow::MessageEventsListener`. Na `develop` limpa, o mesmo arquivo dá `35 examples, 1 failure`, a mesma.

RuboCop nos quatro arquivos alterados: **53 ofensas antes e 53 depois** — todas preexistentes, nenhuma introduzida. Migração e specs novos: sem ofensas.

## Verificado em produção

Deploy feito em uma instância real. Duas mensagens para dois contatos LID distintos, ambas com **recibo de entrega** do WhatsApp:

```
SendMessage called for number: 46329980031107@lid
Recipient validated: 46329980031107@lid (Server: lid)     ← o sufixo sobrevive
Sending message to 46329980031107@lid with ID 3EB0F4F7B95C6EB483FBDE
Message sent successfully!
Message delivered to 46329980031107@lid                   ← recibo de entrega
```

Fica demonstrado que o **whatsmeow entrega direto a um JID `@lid`**, sem precisar resolver nenhum número. A correção não exige nada do lado do Evolution Go.

A migração rodou em produção: 3 `source_id` restaurados e 3 `identifier` preenchidos, sem duplicatas. Contatos normais `@s.whatsapp.net` seguiram funcionando sem alteração.

## Observação

Foi observado `SenderAlt` chegando como `@lid` em vez de `@s.whatsapp.net`, o que contraria a suposição do swap LID/JID do Evolution Go (`pkg/whatsmeow/service/whatsmeow.go`). Sem impacto conhecido nesta mudança, mas vale registrar.

## Summary by Sourcery

Keep WhatsApp LID addresses intact throughout Evolution Go contact ingestion and message delivery.

Bug Fixes:
- Preserve the @lid server in Evolution Go contact addresses so replies to contacts without phone-number mappings remain routable.
- Restore missing LID suffixes and identifiers for existing Evolution Go contact inboxes using conversation chat identifiers.

Enhancements:
- Use SenderAlt when available, otherwise retain LID addressing while continuing to store regular phone contacts as phone numbers.
- Fall back to the conversation's original @lid JID when sending messages for legacy contacts whose source identifiers lost the suffix.
- Centralize JID parsing and contact-name handling to prevent service-level overrides from bypassing LID addressing logic.

Tests:
- Add coverage for LID and phone JID parsing, source identifier precedence, and legacy LID send fallbacks.