### PR TITLE
fix(realtime): audiência dos eventos de conversa inclui os administradores, não só os membros do inbox (CRM-546)

### DIFF
--- a/.github/workflows/community-parity.yml
+++ b/.github/workflows/community-parity.yml
@@ -80,6 +80,8 @@ jobs:
             spec/channels/room_channel_spec.rb \
             spec/services/evo_auth/identity_resolver_spec.rb \
             spec/lib/action_cable_log_redaction_spec.rb \
+            spec/channels/room_channel_realtime_audience_spec.rb \
+            spec/listeners/action_cable_listener_audience_spec.rb \
             spec/rbac \
             spec/requests/api/v1/*_rbac_spec.rb \
             --format progress

--- a/app/listeners/action_cable_listener.rb
+++ b/app/listeners/action_cable_listener.rb
@@ -1,6 +1,7 @@
 class ActionCableListener < BaseListener
   include Events::Types
   include HubChannelConnectionEvents
+  include RealtimeAudience
 
   def notification_created(event)
     notification, account, unread_count, count = extract_notification_and_account(event)
@@ -34,7 +35,7 @@ class ActionCableListener < BaseListener
   def message_created(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = (user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]).compact
+    tokens = (user_tokens(account, audience(conversation)) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]).compact
 
     broadcast(account, tokens, MESSAGE_CREATED, message.push_event_data)
   end
@@ -42,7 +43,7 @@ class ActionCableListener < BaseListener
   def message_updated(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = (user_tokens(account, conversation.inbox.members) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]).compact
+    tokens = (user_tokens(account, audience(conversation)) + contact_tokens(conversation.contact_inbox, message) + [account_token(account)]).compact
 
     broadcast(account, tokens, MESSAGE_UPDATED, message.push_event_data.merge(previous_changes: event.data[:previous_changes]))
   end
@@ -50,14 +51,14 @@ class ActionCableListener < BaseListener
   def first_reply_created(event)
     message, account = extract_message_and_account(event)
     conversation = message.conversation
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, audience(conversation))
 
     broadcast(account, tokens, FIRST_REPLY_CREATED, message.push_event_data)
   end
 
   def conversation_created(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = (user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]).compact
+    tokens = (user_tokens(account, audience(conversation)) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]).compact
 
     broadcast(account, tokens, CONVERSATION_CREATED, conversation.push_event_data)
   end
@@ -66,21 +67,21 @@ class ActionCableListener < BaseListener
   # push_event_data from a fresh find_by! to avoid stale out-of-order data.
   def conversation_read(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, audience(conversation))
 
     broadcast(account, tokens, CONVERSATION_READ, { id: conversation.id })
   end
 
   def conversation_status_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox)
+    tokens = user_tokens(account, audience(conversation)) + contact_inbox_tokens(conversation.contact_inbox)
 
     broadcast(account, tokens, CONVERSATION_STATUS_CHANGED, { id: conversation.id })
   end
 
   def conversation_updated(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = (user_tokens(account, conversation.inbox.members) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]).compact
+    tokens = (user_tokens(account, audience(conversation)) + contact_inbox_tokens(conversation.contact_inbox) + [account_token(account)]).compact
 
     broadcast(account, tokens, CONVERSATION_UPDATED, { id: conversation.id })
   end
@@ -119,21 +120,21 @@ class ActionCableListener < BaseListener
 
   def assignee_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, audience(conversation))
 
     broadcast(account, tokens, ASSIGNEE_CHANGED, { id: conversation.id })
   end
 
   def team_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, audience(conversation))
 
     broadcast(account, tokens, TEAM_CHANGED, { id: conversation.id })
   end
 
   def conversation_contact_changed(event)
     conversation, account = extract_conversation_and_account(event)
-    tokens = user_tokens(account, conversation.inbox.members)
+    tokens = user_tokens(account, audience(conversation))
 
     broadcast(account, tokens, CONVERSATION_CONTACT_CHANGED, conversation.push_event_data)
   end
@@ -179,11 +180,11 @@ class ActionCableListener < BaseListener
 
   def typing_event_listener_tokens(account, conversation, user)
     current_user_token = user.is_a?(Contact) ? conversation.contact_inbox.pubsub_token : user.pubsub_token
-    (user_tokens(account, conversation.inbox.members) + [conversation.contact_inbox.pubsub_token]) - [current_user_token]
+    (user_tokens(account, audience(conversation)) + [conversation.contact_inbox.pubsub_token]) - [current_user_token]
   end
 
+  # Only the given agents, de-duplicated (CRM-185): never a global broadcast.
   def user_tokens(_account, agents)
-    # Members only: an admin wanting realtime on someone else's inbox joins it.
     agents.filter_map(&:pubsub_token).uniq
   end
 

--- a/app/listeners/concerns/realtime_audience.rb
+++ b/app/listeners/concerns/realtime_audience.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
-# Whoever can read a conversation over HTTP gets its realtime frames: inbox
-# members plus administrators (User#assigned_inboxes opens Inbox.all to them).
-# The audience is widened HERE, in what the events hand to user_tokens, never
-# inside user_tokens: a consumer intersecting user_tokens with the given agents
-# keeps working and the wider set survives (CRM-546).
+# Inbox members plus administrators — whoever reads the conversation over HTTP
+# (User#assigned_inboxes). Widened HERE and never inside user_tokens, so a consumer
+# intersecting user_tokens with the given agents keeps working (CRM-546).
 module RealtimeAudience
   READERS_CACHE_KEY = 'action_cable_listener:reader_ids'
   READERS_CACHE_TTL = 30.seconds
-  # Same rule the auth uses to pick a user's effective role (User#primary_user_role):
-  # derived roles last, then the newest grant, then the key. An older admin row that
-  # outlived a demotion is a role the user no longer holds.
+  # A demotion leaves the old grant in place (the auth destroys only non-system
+  # rows), so one row per user: derived keys last, newest grant first.
   DERIVED_ROLE_KEY_PREFIX = 'evo_derived_'
+  # A column left out raises MissingAttributeError on access; the enterprise reads agency_id.
+  READER_COLUMNS = %w[id pubsub_token agency_id].freeze
 
   private
 
@@ -19,12 +18,15 @@ module RealtimeAudience
     (conversation.inbox.members.to_a + realtime_readers(conversation)).uniq
   end
 
-  # Administrators by role. Its own seam so a consumer can narrow it (per
-  # agency/tenant, in SQL); it only needs pubsub_token on the returned users.
-  # Ids cached briefly: a rotated pubsub_token goes stale for READERS_CACHE_TTL at most.
+  # The seam a consumer narrows (per agency/tenant, in SQL).
   def realtime_readers(_conversation)
     ids = Rails.cache.fetch(READERS_CACHE_KEY, expires_in: READERS_CACHE_TTL) { administrator_ids }
-    ids.empty? ? [] : User.where(id: ids).to_a
+    ids.empty? ? [] : User.where(id: ids).select(*reader_columns).to_a
+  end
+
+  # agency_id is a consumer's column: absent from a community install.
+  def reader_columns
+    @reader_columns ||= READER_COLUMNS & User.column_names
   end
 
   def administrator_ids

--- a/app/listeners/concerns/realtime_audience.rb
+++ b/app/listeners/concerns/realtime_audience.rb
@@ -8,6 +8,10 @@
 module RealtimeAudience
   READERS_CACHE_KEY = 'action_cable_listener:reader_ids'
   READERS_CACHE_TTL = 30.seconds
+  # Same rule the auth uses to pick a user's effective role (User#primary_user_role):
+  # derived roles last, then the newest grant, then the key. An older admin row that
+  # outlived a demotion is a role the user no longer holds.
+  DERIVED_ROLE_KEY_PREFIX = 'evo_derived_'
 
   private
 
@@ -19,9 +23,17 @@ module RealtimeAudience
   # agency/tenant, in SQL); it only needs pubsub_token on the returned users.
   # Ids cached briefly: a rotated pubsub_token goes stale for READERS_CACHE_TTL at most.
   def realtime_readers(_conversation)
-    ids = Rails.cache.fetch(READERS_CACHE_KEY, expires_in: READERS_CACHE_TTL) do
-      User.joins(:roles).where(roles: { key: Role::ADMIN_ROLE_KEYS }).distinct.pluck(:id)
-    end
+    ids = Rails.cache.fetch(READERS_CACHE_KEY, expires_in: READERS_CACHE_TTL) { administrator_ids }
     ids.empty? ? [] : User.where(id: ids).to_a
+  end
+
+  def administrator_ids
+    derived_last = "starts_with(roles.key, #{UserRole.connection.quote(DERIVED_ROLE_KEY_PREFIX)})"
+    primary_roles = UserRole.joins(:role)
+                            .select('DISTINCT ON (user_roles.user_id) user_roles.user_id, roles.key AS role_key')
+                            .order(Arel.sql("user_roles.user_id, #{derived_last}, user_roles.created_at DESC, roles.key DESC"))
+    UserRole.from(primary_roles, :primary_roles)
+            .where(primary_roles: { role_key: Role::ADMIN_ROLE_KEYS })
+            .pluck(Arel.sql('primary_roles.user_id'))
   end
 end

--- a/app/listeners/concerns/realtime_audience.rb
+++ b/app/listeners/concerns/realtime_audience.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Whoever can read a conversation over HTTP gets its realtime frames: inbox
+# members plus administrators (User#assigned_inboxes opens Inbox.all to them).
+# The audience is widened HERE, in what the events hand to user_tokens, never
+# inside user_tokens: a consumer intersecting user_tokens with the given agents
+# keeps working and the wider set survives (CRM-546).
+module RealtimeAudience
+  READERS_CACHE_KEY = 'action_cable_listener:reader_ids'
+  READERS_CACHE_TTL = 30.seconds
+
+  private
+
+  def audience(conversation)
+    (conversation.inbox.members.to_a + realtime_readers(conversation)).uniq
+  end
+
+  # Administrators by role. Its own seam so a consumer can narrow it (per
+  # agency/tenant, in SQL); it only needs pubsub_token on the returned users.
+  # Ids cached briefly: a rotated pubsub_token goes stale for READERS_CACHE_TTL at most.
+  def realtime_readers(_conversation)
+    ids = Rails.cache.fetch(READERS_CACHE_KEY, expires_in: READERS_CACHE_TTL) do
+      User.joins(:roles).where(roles: { key: Role::ADMIN_ROLE_KEYS }).distinct.pluck(:id)
+    end
+    ids.empty? ? [] : User.where(id: ids).to_a
+  end
+end

--- a/spec/channels/room_channel_realtime_audience_spec.rb
+++ b/spec/channels/room_channel_realtime_audience_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-546 — realtime audience must match HTTP visibility.
+#
+# `User#assigned_inboxes` lets an admin / `conversations.read_all` holder read every
+# conversation over HTTP, but `ActionCableListener#user_tokens` (CRM-185) targets inbox
+# members only. A reader who never joined the inbox sees the message only after a
+# refresh. These examples pin the invariant "whoever can read it gets the frame" without
+# prescribing the delivery mechanism: any stream the subscription listens to counts.
+RSpec.describe RoomChannel, type: :channel do
+  include ActiveJob::TestHelper
+
+  let(:web_channel) { Channel::WebWidget.create!(website_url: 'https://audience.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Audience Inbox', channel: web_channel) }
+  let(:contact) { Contact.create!(name: 'Visitor', email: "visitor-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: "aud-#{SecureRandom.hex(4)}") }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+  let(:user) { User.create!(name: 'Reader', email: "reader-#{SecureRandom.hex(4)}@test.com") }
+
+  before do
+    allow(OnlineStatusTracker).to receive(:update_presence)
+    allow(OnlineStatusTracker).to receive(:get_available_users).and_return([])
+    allow(OnlineStatusTracker).to receive(:get_available_contacts).and_return([])
+    allow(EvoExtensionPoints::PermissionResolver).to receive(:allowed?).and_return(false)
+    stub_connection(warden_user: nil)
+  end
+
+  def grant_read_all(reader)
+    allow(EvoExtensionPoints::PermissionResolver).to receive(:allowed?)
+      .with(hash_including(user_id: reader.id, permission_key: 'conversations.read_all'))
+      .and_return(true)
+  end
+
+  def subscribe_as(reader)
+    subscribe(user_id: reader.id.to_s, pubsub_token: reader.pubsub_token)
+    expect(subscription).to be_confirmed
+  end
+
+  # The broadcast job is what actually hits the cable, so it runs inline here.
+  def deliver_incoming_message
+    perform_enqueued_jobs(only: ActionCableBroadcastJob) do
+      Message.create!(inbox: inbox, conversation: conversation, message_type: :incoming, content: 'hello')
+    end
+  end
+
+  def frames_received_for(message)
+    subscription.streams
+                .flat_map { |stream| ActionCable.server.pubsub.broadcasts(stream) }
+                .map { |raw| JSON.parse(raw) }
+                .select { |frame| frame['event'] == 'message.created' && frame.dig('data', 'id') == message.id }
+  end
+
+  describe 'inbound message.created audience' do
+    it 'reaches an inbox member live (control)' do
+      InboxMember.create!(inbox: inbox, user: user)
+      subscribe_as(user)
+
+      message = deliver_incoming_message
+
+      expect(frames_received_for(message)).not_to be_empty
+    end
+
+    it 'reaches a conversations.read_all holder who is not an inbox member' do
+      grant_read_all(user)
+      subscribe_as(user)
+
+      message = deliver_incoming_message
+
+      expect(frames_received_for(message)).not_to be_empty
+    end
+
+    it 'never reaches a user who is neither member nor reader' do
+      subscribe_as(user)
+
+      message = deliver_incoming_message
+
+      expect(frames_received_for(message)).to be_empty
+    end
+  end
+end

--- a/spec/channels/room_channel_realtime_audience_spec.rb
+++ b/spec/channels/room_channel_realtime_audience_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 
 # CRM-546 — realtime audience must match HTTP visibility.
 #
-# `User#assigned_inboxes` lets an admin / `conversations.read_all` holder read every
-# conversation over HTTP, but `ActionCableListener#user_tokens` (CRM-185) targets inbox
-# members only. A reader who never joined the inbox sees the message only after a
-# refresh. These examples pin the invariant "whoever can read it gets the frame" without
-# prescribing the delivery mechanism: any stream the subscription listens to counts.
+# `User#assigned_inboxes` lets an administrator read every conversation over HTTP, but
+# `ActionCableListener#user_tokens` (CRM-185) targets inbox members only. An admin who
+# never joined the inbox saw the message only after a refresh. These examples pin the
+# invariant "whoever can read it gets the frame" without prescribing the delivery
+# mechanism: any stream the subscription listens to counts.
 RSpec.describe RoomChannel, type: :channel do
   include ActiveJob::TestHelper
 
@@ -18,23 +18,28 @@ RSpec.describe RoomChannel, type: :channel do
   let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: "aud-#{SecureRandom.hex(4)}") }
   let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
   let(:user) { User.create!(name: 'Reader', email: "reader-#{SecureRandom.hex(4)}@test.com") }
+  let(:auth_service) { instance_double(EvoAuthService) }
 
   before do
     allow(OnlineStatusTracker).to receive(:update_presence)
     allow(OnlineStatusTracker).to receive(:get_available_users).and_return([])
     allow(OnlineStatusTracker).to receive(:get_available_contacts).and_return([])
-    allow(EvoExtensionPoints::PermissionResolver).to receive(:allowed?).and_return(false)
+    # Agent subscriptions authenticate with the auth-service token (CRM-537).
+    allow(EvoAuthService).to receive(:new).and_return(auth_service)
     stub_connection(warden_user: nil)
   end
 
-  def grant_read_all(reader)
-    allow(EvoExtensionPoints::PermissionResolver).to receive(:allowed?)
-      .with(hash_including(user_id: reader.id, permission_key: 'conversations.read_all'))
-      .and_return(true)
+  def grant_administrator(reader)
+    role = Role.find_by(key: 'administrator') || Role.create!(key: 'administrator', name: 'Administrator')
+    UserRole.create!(user: reader, role: role)
   end
 
   def subscribe_as(reader)
-    subscribe(user_id: reader.id.to_s, pubsub_token: reader.pubsub_token)
+    token = "jwt-#{SecureRandom.hex(8)}"
+    allow(auth_service).to receive(:validate_token)
+      .with(token: token, token_type: 'bearer')
+      .and_return({ 'user' => { 'id' => reader.id, 'email' => reader.email } })
+    subscribe(user_id: reader.id.to_s, pubsub_token: reader.pubsub_token, access_token: token)
     expect(subscription).to be_confirmed
   end
 
@@ -62,8 +67,8 @@ RSpec.describe RoomChannel, type: :channel do
       expect(frames_received_for(message)).not_to be_empty
     end
 
-    it 'reaches a conversations.read_all holder who is not an inbox member' do
-      grant_read_all(user)
+    it 'reaches an administrator who is not an inbox member' do
+      grant_administrator(user)
       subscribe_as(user)
 
       message = deliver_incoming_message
@@ -71,7 +76,8 @@ RSpec.describe RoomChannel, type: :channel do
       expect(frames_received_for(message)).not_to be_empty
     end
 
-    it 'never reaches a user who is neither member nor reader' do
+    it 'never reaches an agent who is neither member nor administrator' do
+      UserRole.create!(user: user, role: Role.create!(key: 'agent', name: 'Agent'))
       subscribe_as(user)
 
       message = deliver_incoming_message

--- a/spec/channels/room_channel_realtime_audience_spec.rb
+++ b/spec/channels/room_channel_realtime_audience_spec.rb
@@ -2,13 +2,9 @@
 
 require 'rails_helper'
 
-# CRM-546 — realtime audience must match HTTP visibility.
-#
-# `User#assigned_inboxes` lets an administrator read every conversation over HTTP, but
-# `ActionCableListener#user_tokens` (CRM-185) targets inbox members only. An admin who
-# never joined the inbox saw the message only after a refresh. These examples pin the
-# invariant "whoever can read it gets the frame" without prescribing the delivery
-# mechanism: any stream the subscription listens to counts.
+# CRM-546 — the realtime audience has to match HTTP visibility. Pins the invariant
+# "whoever can read it gets the frame" without prescribing the delivery mechanism:
+# any stream the subscription listens to counts.
 RSpec.describe RoomChannel, type: :channel do
   include ActiveJob::TestHelper
 
@@ -29,8 +25,8 @@ RSpec.describe RoomChannel, type: :channel do
     stub_connection(warden_user: nil)
   end
 
-  def grant_administrator(reader)
-    role = Role.find_by(key: 'administrator') || Role.create!(key: 'administrator', name: 'Administrator')
+  def grant_role(reader, key, name)
+    role = Role.find_by(key: key) || Role.create!(key: key, name: name)
     UserRole.create!(user: reader, role: role)
   end
 
@@ -68,7 +64,7 @@ RSpec.describe RoomChannel, type: :channel do
     end
 
     it 'reaches an administrator who is not an inbox member' do
-      grant_administrator(user)
+      grant_role(user, 'administrator', 'Administrator')
       subscribe_as(user)
 
       message = deliver_incoming_message
@@ -77,7 +73,7 @@ RSpec.describe RoomChannel, type: :channel do
     end
 
     it 'never reaches an agent who is neither member nor administrator' do
-      UserRole.create!(user: user, role: Role.create!(key: 'agent', name: 'Agent'))
+      grant_role(user, 'agent', 'Agent')
       subscribe_as(user)
 
       message = deliver_incoming_message

--- a/spec/listeners/action_cable_listener_audience_spec.rb
+++ b/spec/listeners/action_cable_listener_audience_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-546: the realtime audience of a conversation is inbox members plus
+# administrators, widened in what the events hand to user_tokens (never inside it).
+RSpec.describe ActionCableListener do
+  let(:listener) { described_class.instance }
+  let(:admin_role) { Role.create!(key: 'administrator', name: 'Administrator') }
+  let(:agent_role) { Role.create!(key: 'agent', name: 'Agent') }
+  let(:member) { User.create!(name: 'Member', email: "member-#{SecureRandom.hex(4)}@test.com") }
+  let(:admin) { User.create!(name: 'Admin', email: "admin-#{SecureRandom.hex(4)}@test.com") }
+  let(:agent) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://audience.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Audience Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Visitor', email: "visitor-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: "aud-#{SecureRandom.hex(4)}") }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  before do
+    InboxMember.create!(inbox: inbox, user: member)
+    UserRole.create!(user: admin, role: admin_role)
+    UserRole.create!(user: agent, role: agent_role)
+  end
+
+  describe '#audience' do
+    it 'is the inbox members plus every administrator, without duplicates' do
+      UserRole.create!(user: member, role: admin_role)
+
+      audience = listener.send(:audience, conversation)
+
+      expect(audience).to contain_exactly(member, admin)
+    end
+
+    it 'reaches administrators even when the inbox has no members' do
+      InboxMember.where(inbox: inbox).destroy_all
+
+      expect(listener.send(:audience, conversation)).to contain_exactly(admin)
+    end
+
+    it 'never includes an agent who is not a member' do
+      expect(listener.send(:audience, conversation)).not_to include(agent)
+    end
+
+    it 'falls back to members only when there is no administrator' do
+      UserRole.where(role: admin_role).destroy_all
+
+      expect(listener.send(:audience, conversation)).to contain_exactly(member)
+    end
+  end
+
+  describe '#realtime_readers cache' do
+    let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+    before { allow(Rails).to receive(:cache).and_return(cache) }
+
+    it 'resolves the administrator ids once per TTL' do
+      allow(User).to receive(:joins).and_call_original
+
+      2.times { listener.send(:realtime_readers, conversation) }
+
+      expect(User).to have_received(:joins).once
+    end
+  end
+
+  describe 'message.created' do
+    it 'is enqueued for the members and the administrators, not for other agents' do
+      message = Message.create!(inbox: inbox, conversation: conversation, message_type: :incoming, content: 'hi')
+      allow(ActionCableBroadcastJob).to receive(:perform_later)
+
+      listener.message_created(Struct.new(:data).new({ message: message }))
+
+      expect(ActionCableBroadcastJob).to have_received(:perform_later) do |tokens, event_name, _payload|
+        expect(event_name).to eq(Events::Types::MESSAGE_CREATED)
+        expect(tokens).to include(member.pubsub_token, admin.pubsub_token)
+        expect(tokens).not_to include(agent.pubsub_token)
+      end
+    end
+  end
+
+  describe '#user_tokens (CRM-185 guard stays)' do
+    it 'still returns only the tokens of the agents it is given' do
+      expect(listener.send(:user_tokens, nil, [member])).to eq([member.pubsub_token])
+      expect(listener.send(:user_tokens, nil, [])).to eq([])
+    end
+  end
+end

--- a/spec/listeners/action_cable_listener_audience_spec.rb
+++ b/spec/listeners/action_cable_listener_audience_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ActionCableListener do
       expect(listener.send(:audience, conversation)).to contain_exactly(member)
     end
 
-    # Mirrors the auth's effective-role rule: a newer grant replaces the older one.
+    # A demotion leaves the old grant behind, so the newest one has to win here.
     context 'when a user changed role' do
       let(:demoted) { User.create!(name: 'Demoted', email: "demoted-#{SecureRandom.hex(4)}@test.com") }
       let(:promoted) { User.create!(name: 'Promoted', email: "promoted-#{SecureRandom.hex(4)}@test.com") }
@@ -68,8 +68,9 @@ RSpec.describe ActionCableListener do
       end
 
       it 'ignores derived roles even when they are the newest row' do
+        UserRole.find_by!(user: admin, role: admin_role).update!(created_at: 2.days.ago)
         derived = Role.create!(key: "evo_derived_#{admin.id}_global", name: "Derived #{admin.id}")
-        UserRole.create!(user: admin, role: derived, created_at: 1.second.ago)
+        UserRole.create!(user: admin, role: derived, created_at: 1.minute.ago)
 
         expect(listener.send(:audience, conversation)).to include(admin)
       end
@@ -121,6 +122,22 @@ RSpec.describe ActionCableListener do
     end
   end
 
+  describe '#realtime_readers' do
+    it 'loads the audience columns and leaves the credential ones behind' do
+      reader = listener.send(:realtime_readers, conversation).first
+
+      expect(reader.pubsub_token).to eq(admin.pubsub_token)
+      expect { reader.encrypted_password }.to raise_error(ActiveModel::MissingAttributeError)
+    end
+
+    # The enterprise overlay narrows the readers per agency; the audience must shrink with it.
+    it 'is the seam a consumer narrows the audience through' do
+      allow(listener).to receive(:realtime_readers).and_return([])
+
+      expect(listener.send(:audience, conversation)).to contain_exactly(member)
+    end
+  end
+
   describe 'message.created' do
     it 'is enqueued for the members and the administrators, not for other agents' do
       message = Message.create!(inbox: inbox, conversation: conversation, message_type: :incoming, content: 'hi')
@@ -130,6 +147,20 @@ RSpec.describe ActionCableListener do
 
       expect(ActionCableBroadcastJob).to have_received(:perform_later) do |tokens, event_name, _payload|
         expect(event_name).to eq(Events::Types::MESSAGE_CREATED)
+        expect(tokens).to include(member.pubsub_token, admin.pubsub_token)
+        expect(tokens).not_to include(agent.pubsub_token)
+      end
+    end
+  end
+
+  describe 'message.created on an outbound message' do
+    it 'reaches the same audience as an inbound one' do
+      message = Message.create!(inbox: inbox, conversation: conversation, message_type: :outgoing, content: 'hi')
+      allow(ActionCableBroadcastJob).to receive(:perform_later)
+
+      listener.message_created(Struct.new(:data).new({ message: message }))
+
+      expect(ActionCableBroadcastJob).to have_received(:perform_later) do |tokens, _event_name, _payload|
         expect(tokens).to include(member.pubsub_token, admin.pubsub_token)
         expect(tokens).not_to include(agent.pubsub_token)
       end

--- a/spec/listeners/action_cable_listener_audience_spec.rb
+++ b/spec/listeners/action_cable_listener_audience_spec.rb
@@ -47,6 +47,64 @@ RSpec.describe ActionCableListener do
 
       expect(listener.send(:audience, conversation)).to contain_exactly(member)
     end
+
+    # Mirrors the auth's effective-role rule: a newer grant replaces the older one.
+    context 'when a user changed role' do
+      let(:demoted) { User.create!(name: 'Demoted', email: "demoted-#{SecureRandom.hex(4)}@test.com") }
+      let(:promoted) { User.create!(name: 'Promoted', email: "promoted-#{SecureRandom.hex(4)}@test.com") }
+
+      it 'drops an admin row superseded by a newer agent row' do
+        UserRole.create!(user: demoted, role: admin_role, created_at: 2.days.ago)
+        UserRole.create!(user: demoted, role: agent_role, created_at: 1.minute.ago)
+
+        expect(listener.send(:audience, conversation)).not_to include(demoted)
+      end
+
+      it 'admits an agent row superseded by a newer admin row' do
+        UserRole.create!(user: promoted, role: agent_role, created_at: 2.days.ago)
+        UserRole.create!(user: promoted, role: admin_role, created_at: 1.minute.ago)
+
+        expect(listener.send(:audience, conversation)).to include(promoted)
+      end
+
+      it 'ignores derived roles even when they are the newest row' do
+        derived = Role.create!(key: "evo_derived_#{admin.id}_global", name: "Derived #{admin.id}")
+        UserRole.create!(user: admin, role: derived, created_at: 1.second.ago)
+
+        expect(listener.send(:audience, conversation)).to include(admin)
+      end
+    end
+  end
+
+  describe 'every conversation event widens its audience' do
+    let(:message) { Message.create!(inbox: inbox, conversation: conversation, message_type: :incoming, content: 'hi') }
+    let(:events) do
+      conversation_data = { conversation: conversation }
+      {
+        message_created: { message: message },
+        message_updated: { message: message, previous_changes: {} },
+        first_reply_created: { message: message },
+        conversation_created: conversation_data,
+        conversation_read: conversation_data,
+        conversation_status_changed: conversation_data,
+        conversation_updated: conversation_data,
+        conversation_typing_on: { conversation: conversation, user: member },
+        conversation_typing_off: { conversation: conversation, user: member },
+        assignee_changed: conversation_data,
+        team_changed: conversation_data,
+        conversation_contact_changed: conversation_data
+      }
+    end
+
+    it 'resolves the audience for the conversation on each of them' do
+      message # created before spying: its own commit callbacks dispatch real events
+      allow(ActionCableBroadcastJob).to receive(:perform_later)
+      allow(listener).to receive(:audience).and_call_original
+
+      events.each { |method, data| listener.public_send(method, Struct.new(:data).new(data)) }
+
+      expect(listener).to have_received(:audience).with(conversation).exactly(events.size).times
+    end
   end
 
   describe '#realtime_readers cache' do
@@ -55,11 +113,11 @@ RSpec.describe ActionCableListener do
     before { allow(Rails).to receive(:cache).and_return(cache) }
 
     it 'resolves the administrator ids once per TTL' do
-      allow(User).to receive(:joins).and_call_original
+      allow(listener).to receive(:administrator_ids).and_call_original
 
       2.times { listener.send(:realtime_readers, conversation) }
 
-      expect(User).to have_received(:joins).once
+      expect(listener).to have_received(:administrator_ids).once
     end
   end
 


### PR DESCRIPTION
## Summary
- Desde o CRM-185 o `ActionCableListener` manda os frames de conversa só aos **membros do inbox**, mas a leitura HTTP libera `Inbox.all` para administradores. Um canal criado por API, pelo front ou pelo assistente nasce com zero membros, então quem o criou via a conversa no refresh e nunca ao vivo (mensagem recebida "só aparece depois do F5").
- A audiência passa a ser **membros ∪ administradores**, alargada no que os 12 eventos de conversa passam ao `user_tokens` (concern `RealtimeAudience#audience`), nunca dentro do `user_tokens`, que segue devolvendo só os `agents` recebidos (guard do CRM-185 intacto). Um consumidor que interseta `user_tokens` com os `agents` recebidos continua funcionando e o conjunto maior sobrevive.
- "Administrador" é **uma linha por usuário**: derivadas por último (são baldes de permissão por escopo, não posto), depois a concessão mais nova, e só então `Role::ADMIN_ROLE_KEYS`. A regra existe porque **rebaixar não apaga a concessão antiga** — `Api::V1::UsersController#update_user_role` no auth destrói só as linhas `system: false`, e `account_owner`/`agent` são ambas `system: true`, então as duas coexistem. É uma regra **mais estrita que a do próprio auth**, que serializa `User#role_data` = `user_roles.first`, sem ordenação. Ids em cache por 30s (token rotacionado envelhece no máximo isso). `realtime_readers` é um seam próprio para um consumidor estreitar o conjunto (por conta/agência, em SQL).

## Limitação registrada
- `conversations.read_all` concedido por papel customizado (não admin) não é resolvido publish-side: a permissão vive no auth, não no banco do CRM, e resolver por usuário a cada mensagem é inviável. Fica como follow-up (precisa de um seam para o catálogo de permissões).

## Security
- O conjunto só cresce com quem **já lê tudo por HTTP**; agentes não-membros seguem fora. `user_tokens` não muda.
- Rebaixamento respeitado: a regra de papel efetivo espelha a do auth, com spec do caso rebaixado/promovido/derivado.

## Test plan
- `bundle exec rspec spec/listeners/action_cable_listener_audience_spec.rb spec/channels/room_channel_realtime_audience_spec.rb` (novos, na lane `community-parity`)
- `bundle exec rspec spec/listeners/action_cable_listener_conversation_update_spec.rb` (guard do CRM-185)
- `bundle exec rspec spec/channels spec/services/evo_auth spec/lib/action_cable_log_redaction_spec.rb` (66 verdes no total pós-rebase)
- Prova ao vivo: inbound real num inbox com 0 membros → frame `message.created` chega ao `account_owner` (não membro) e não chega a um `agent` não-membro; contato do widget inalterado.
- Pré-existente, fora desta PR: `spec/listeners/action_cable_listener_spec.rb` bloco CB-3 (4 exemplos) já falha na `develop` (`RuntimeConfig.account` nil no test; arquivo fora das lanes de CI).

## Changed Files
- `app/listeners/action_cable_listener.rb`
- `app/listeners/concerns/realtime_audience.rb`
- `spec/listeners/action_cable_listener_audience_spec.rb`
- `spec/channels/room_channel_realtime_audience_spec.rb`
- `.github/workflows/community-parity.yml`

## Correções da 1a rodada de review (commit `00c3ab6b`)

- **O guard de papel derivado não mordia.** O exemplo "ignores derived roles even when they are the newest row" criava a `UserRole` derivada com `created_at: 1.second.ago` — mais VELHA que a linha admin que o `before` cria em `Time.now`. A linha derivada nunca era a mais nova, e o exemplo passava com o `#{derived_last}` removido do `ORDER BY`. A linha admin agora é envelhecida explicitamente e a derivada é de fato a mais nova; a mutação derruba o exemplo.
- **`User#primary_user_role` não existe** em lugar nenhum do ecossistema. Comentários, spec e a descrição acima passam a dizer a regra real e por que ela existe.
- **`realtime_readers` hidratava as 37 colunas de `users`** — `encrypted_password`, `otp_secret`, `otp_backup_codes` — de cada administrador, em CADA evento de conversa, para ler um token. Passa a selecionar só as colunas da audiência, intersectadas com o schema (`agency_id` é coluna de consumidor, ausente num install community). ⚠️ Quem consumir e precisar de outra coluna a mantém em `READER_COLUMNS`: o que ficar de fora levanta `MissingAttributeError`, e um consumidor que faz rescue entregaria para ninguém em silêncio.
- **Specs novos:** os readers carregam as colunas da audiência e não as de credencial; o seam que o cabeçalho anuncia realmente estreita a audiência; e outbound alcança a mesma audiência que inbound (AC 2). Cada um fica vermelho sob a própria mutação (4/4).
- **Cosmético:** cabeçalho do spec de canal reduzido a 3 linhas (o histórico já está aqui) e criação de role unificada num só helper (`roles.key` é único).

### Em aberto, fora desta PR

O AC "spec de overlay no `evo-enterprise-docker`" **não** foi atendido: o `Makefile` de lá só tem harness de overlay para a imagem do **auth** (`test-auth-overlay`), não para a do CRM, e `docker/initializers/spec/` não tem nenhum spec de ActionCable. Como o overlay é o que decide o conjunto entregue em prod (`scoped & community_tokens`), a composição community+overlay segue sem teste automatizado — só a prova ao vivo registrada acima.

## Linked Issue
- CRM-546

## Summary by Sourcery

Include effective administrators alongside inbox members in realtime conversation event audiences without changing the existing user-token filtering contract.

New Features:
- Expand realtime conversation event delivery to include administrators who can read all inboxes, while continuing to exclude non-member agents.

Bug Fixes:
- Fix missing live conversation updates for administrators and creators of conversations in inboxes with no members.
- Respect effective role changes and prevent stale administrator grants from expanding realtime access.

Enhancements:
- Centralize realtime audience resolution for conversation events and provide a consumer override seam for narrowing readers.
- Cache administrator identification briefly and load only the user fields required for realtime delivery.

CI:
- Add the new realtime audience and channel coverage to the community parity workflow.

Tests:
- Add coverage for administrator, member, and non-member agent delivery; role precedence; reader scoping; caching; and inbound/outbound event parity.
