### PR TITLE
fix(CRM-565): o proxy de agentes para o evo-core não responde mais 500

### DIFF
--- a/app/controllers/api/v1/agents_controller.rb
+++ b/app/controllers/api/v1/agents_controller.rb
@@ -10,11 +10,7 @@ class Api::V1::AgentsController < Api::V1::BaseController
     destroy: 'ai_agents.delete'
   })
 
-  # CRM-565 — every action here is a proxy hop to evo-core, and a proxy answering
-  # 500 says "the CRM broke", which is a lie when the core refused the request or
-  # was not running. Both handlers are declared in this controller on purpose:
-  # Api::BaseController's `rescue_from StandardError` (the one that produced the
-  # reported 500) is matched last, so these take precedence over it.
+  # Declared here so they win over Api::BaseController's `rescue_from StandardError`.
   rescue_from EvoAiCoreService::UnavailableError, with: :handle_core_unavailable
   rescue_from EvoAiCoreService::UpstreamError, with: :handle_core_upstream_error
 
@@ -40,9 +36,6 @@ class Api::V1::AgentsController < Api::V1::BaseController
   
   private
 
-  # The core was never reached (down, unreachable, or EVO_AI_CORE_SERVICE_URL not
-  # pointing anywhere usable). 503 is the honest answer: nothing is wrong with the
-  # request, and retrying later may work.
   def handle_core_unavailable(exception)
     log_core_failure(exception)
     error_response(
@@ -52,16 +45,13 @@ class Api::V1::AgentsController < Api::V1::BaseController
     )
   end
 
-  # The core answered, but not 2xx. A 4xx is about the request the client made, so
-  # it is relayed as-is. A 5xx is the core failing, which is a bad gateway from
-  # here — relaying it verbatim would put the blame back on the CRM.
-  # The core's own wording is deliberately NOT echoed: it can carry internal hosts,
-  # SQL, or stack detail. It is logged instead; the client gets the status.
+  # 4xx is relayed; 5xx (and 401, a CRM<->core credential problem, not the
+  # client's) becomes 502. The core's wording is logged, never echoed.
   def handle_core_upstream_error(exception)
     log_core_failure(exception)
 
     status = exception.status.to_i
-    if status.between?(400, 499)
+    if status.between?(400, 499) && status != 401
       error_response(
         ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
         'AI core service rejected the request',

--- a/app/controllers/api/v1/agents_controller.rb
+++ b/app/controllers/api/v1/agents_controller.rb
@@ -9,8 +9,15 @@ class Api::V1::AgentsController < Api::V1::BaseController
     update: 'ai_agents.update',
     destroy: 'ai_agents.delete'
   })
-  
-  
+
+  # CRM-565 — every action here is a proxy hop to evo-core, and a proxy answering
+  # 500 says "the CRM broke", which is a lie when the core refused the request or
+  # was not running. Both handlers are declared in this controller on purpose:
+  # Api::BaseController's `rescue_from StandardError` (the one that produced the
+  # reported 500) is matched last, so these take precedence over it.
+  rescue_from EvoAiCoreService::UnavailableError, with: :handle_core_unavailable
+  rescue_from EvoAiCoreService::UpstreamError, with: :handle_core_upstream_error
+
   def index
     result = EvoAiCoreService.list_agents(index_params, request.headers)
     render json: result
@@ -32,8 +39,52 @@ class Api::V1::AgentsController < Api::V1::BaseController
   end
   
   private
-  
-  
+
+  # The core was never reached (down, unreachable, or EVO_AI_CORE_SERVICE_URL not
+  # pointing anywhere usable). 503 is the honest answer: nothing is wrong with the
+  # request, and retrying later may work.
+  def handle_core_unavailable(exception)
+    log_core_failure(exception)
+    error_response(
+      ApiErrorCodes::SERVICE_UNAVAILABLE,
+      'AI core service is unavailable',
+      status: :service_unavailable
+    )
+  end
+
+  # The core answered, but not 2xx. A 4xx is about the request the client made, so
+  # it is relayed as-is. A 5xx is the core failing, which is a bad gateway from
+  # here — relaying it verbatim would put the blame back on the CRM.
+  # The core's own wording is deliberately NOT echoed: it can carry internal hosts,
+  # SQL, or stack detail. It is logged instead; the client gets the status.
+  def handle_core_upstream_error(exception)
+    log_core_failure(exception)
+
+    status = exception.status.to_i
+    if status.between?(400, 499)
+      error_response(
+        ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
+        'AI core service rejected the request',
+        details: { upstream_status: status },
+        status: status
+      )
+    else
+      error_response(
+        ApiErrorCodes::EXTERNAL_SERVICE_ERROR,
+        'AI core service failed to process the request',
+        details: { upstream_status: status },
+        status: :bad_gateway
+      )
+    end
+  end
+
+  def log_core_failure(exception)
+    Rails.logger.error(
+      "[agents proxy] #{exception.class}: #{exception.message} " \
+      "(#{request.method} #{request.original_fullpath})"
+    )
+  end
+
   def index_params
     params.permit(:skip, :limit, :folder_id, :page, :pageSize)
   end

--- a/app/services/evo_ai_core_service.rb
+++ b/app/services/evo_ai_core_service.rb
@@ -6,13 +6,10 @@ class EvoAiCoreService
   # Use Core AI Service directly
   base_uri ENV.fetch('EVO_AI_CORE_SERVICE_URL', 'http://localhost:5555')
 
-  # CRM-565 — this class is the CRM half of a proxy, and raising a bare StandardError
-  # from it makes the CRM look broken for a failure that happened somewhere else:
-  # Api::BaseController's `rescue_from StandardError` turns every one of them into a
-  # 500. These two errors are the honest outcomes of a failed call to evo-core, and
-  # they carry enough for a controller to answer with a status the client can act on.
+  # Failures talking to evo-core surface as these two, never as a bare
+  # StandardError (which Api::BaseController turns into a 500).
 
-  # evo-core answered, but with a non-2xx. `status` is the code IT returned.
+  # evo-core answered with a non-2xx; `status` is the code it returned.
   class UpstreamError < StandardError
     attr_reader :status
 
@@ -22,22 +19,19 @@ class EvoAiCoreService
     end
   end
 
-  # evo-core was never reached: connection refused, DNS/TLS failure, timeout, or a
-  # base_uri that is not a usable URL (with EVO_AI_CORE_SERVICE_URL unset the default
-  # `http://localhost:5555` refuses inside the CRM container).
+  # evo-core was never reached (refused, DNS/TLS, timeout, unusable base_uri).
   class UnavailableError < StandardError
     def initialize(message = 'AI core service is unavailable')
       super
     end
   end
 
-  # Everything here means "the request never got an answer", so it maps to
-  # UnavailableError. Net::OpenTimeout/Net::ReadTimeout are Timeout::Error;
-  # Errno::ECONNREFUSED & friends are listed one by one so an unrelated
-  # SystemCallError is not silently reported as an availability problem.
+  # Listed one by one so an unrelated SystemCallError is not reported as
+  # "core down". Net::OpenTimeout/ReadTimeout are Timeout::Error.
   NETWORK_ERRORS = [
     Errno::ECONNREFUSED,
     Errno::ECONNRESET,
+    Errno::ETIMEDOUT,
     Errno::EHOSTUNREACH,
     Errno::ENETUNREACH,
     Errno::EPIPE,
@@ -46,6 +40,9 @@ class EvoAiCoreService
     Timeout::Error,
     OpenSSL::SSL::SSLError,
     URI::Error,
+    Net::ProtocolError,
+    Net::HTTPBadResponse,
+    Net::HTTPHeaderSyntaxError,
     HTTParty::Error
   ].freeze
 
@@ -106,16 +103,8 @@ class EvoAiCoreService
       build_headers
     end
 
-    # Runs one call against evo-core and hands back the parsed payload. Network and
-    # configuration failures never surface as themselves: they become
-    # UnavailableError, so a caller cannot mistake "the core is down" for "the CRM
-    # is broken". The detail stays in the log, where it is useful, instead of in a
-    # response body a customer reads.
-    #
-    # Named `call_core`, not `perform_request`: HTTParty::ClassMethods already has a
-    # private `perform_request`, and every verb (get/post/put/delete) funnels through
-    # it. Defining one here overrode it, so each verb called THIS method with
-    # HTTParty's own arguments and every request broke, working ones included.
+    # Not named `perform_request`: HTTParty already defines a private one that
+    # every verb funnels through, and overriding it breaks all requests.
     def call_core(http_method, url, options = {})
       response = public_send(http_method, url, options)
       handle_response(response)
@@ -128,32 +117,33 @@ class EvoAiCoreService
     end
 
     def handle_response(response)
-      # Return the complete response from evo-ai-core-service
-      # The service already returns standardized format: { success, data, message, meta }
-      parsed = response.parsed_response
+      parsed = parse_body(response)
 
       case response.code
       when 200, 201
-        # Extract payload if it exists (Evolution API format). The guard is not
-        # cosmetic: `parsed` is only a Hash when the core answered with a JSON
-        # object. A bare JSON array (`[...]`) made `dig('data')` raise TypeError and
-        # a non-JSON body (an HTML error page from a gateway, say) made it raise
-        # NoMethodError — both landing on the CRM as a 500 for a 200 upstream.
+        # Unwrap the `{ data: ... }` envelope; a bare array or a non-JSON body
+        # is only a Hash-less `parsed`, not an error.
         parsed.is_a?(Hash) ? (parsed['data'] || parsed) : parsed
       when 204
         nil
       else
-        raise UpstreamError.new(upstream_message(response), status: response.code)
+        raise UpstreamError.new(upstream_message(parsed, response.code), status: response.code)
       end
     end
 
-    # The core's own wording when it sent a JSON object with an `error`/`message`
-    # key, else a neutral line. Controllers decide whether any of it reaches the
-    # client; this is what gets logged either way.
-    def upstream_message(response)
-      parsed = response.parsed_response
+    # HTTParty parses lazily and raises on an invalid body under a JSON
+    # content-type, on any status.
+    def parse_body(response)
+      response.parsed_response
+    rescue JSON::ParserError => e
+      Rails.logger.error("EvoAiCoreService: evo-core responded #{response.code} with an unparsable body — #{e.message[0, 200]}")
+      raise UpstreamError.new("evo-core responded #{response.code} with an unparsable body", status: response.code)
+    end
+
+    # Logged by the caller; controllers decide what reaches the client.
+    def upstream_message(parsed, code)
       message = parsed.is_a?(Hash) ? (parsed['error'] || parsed['message']) : nil
-      message.presence || "evo-core responded #{response.code}"
+      message.presence || "evo-core responded #{code}"
     end
 
     # Agents endpoints (Core AI Service)

--- a/app/services/evo_ai_core_service.rb
+++ b/app/services/evo_ai_core_service.rb
@@ -6,6 +6,49 @@ class EvoAiCoreService
   # Use Core AI Service directly
   base_uri ENV.fetch('EVO_AI_CORE_SERVICE_URL', 'http://localhost:5555')
 
+  # CRM-565 — this class is the CRM half of a proxy, and raising a bare StandardError
+  # from it makes the CRM look broken for a failure that happened somewhere else:
+  # Api::BaseController's `rescue_from StandardError` turns every one of them into a
+  # 500. These two errors are the honest outcomes of a failed call to evo-core, and
+  # they carry enough for a controller to answer with a status the client can act on.
+
+  # evo-core answered, but with a non-2xx. `status` is the code IT returned.
+  class UpstreamError < StandardError
+    attr_reader :status
+
+    def initialize(message = 'evo-core returned an error', status: nil)
+      @status = status
+      super(message)
+    end
+  end
+
+  # evo-core was never reached: connection refused, DNS/TLS failure, timeout, or a
+  # base_uri that is not a usable URL (with EVO_AI_CORE_SERVICE_URL unset the default
+  # `http://localhost:5555` refuses inside the CRM container).
+  class UnavailableError < StandardError
+    def initialize(message = 'AI core service is unavailable')
+      super
+    end
+  end
+
+  # Everything here means "the request never got an answer", so it maps to
+  # UnavailableError. Net::OpenTimeout/Net::ReadTimeout are Timeout::Error;
+  # Errno::ECONNREFUSED & friends are listed one by one so an unrelated
+  # SystemCallError is not silently reported as an availability problem.
+  NETWORK_ERRORS = [
+    Errno::ECONNREFUSED,
+    Errno::ECONNRESET,
+    Errno::EHOSTUNREACH,
+    Errno::ENETUNREACH,
+    Errno::EPIPE,
+    EOFError,
+    SocketError,
+    Timeout::Error,
+    OpenSSL::SSL::SSLError,
+    URI::Error,
+    HTTParty::Error
+  ].freeze
+
   class << self
     def build_headers(request_headers = nil)
       # Get current user from thread context or MCP thread storage
@@ -63,6 +106,27 @@ class EvoAiCoreService
       build_headers
     end
 
+    # Runs one call against evo-core and hands back the parsed payload. Network and
+    # configuration failures never surface as themselves: they become
+    # UnavailableError, so a caller cannot mistake "the core is down" for "the CRM
+    # is broken". The detail stays in the log, where it is useful, instead of in a
+    # response body a customer reads.
+    #
+    # Named `call_core`, not `perform_request`: HTTParty::ClassMethods already has a
+    # private `perform_request`, and every verb (get/post/put/delete) funnels through
+    # it. Defining one here overrode it, so each verb called THIS method with
+    # HTTParty's own arguments and every request broke, working ones included.
+    def call_core(http_method, url, options = {})
+      response = public_send(http_method, url, options)
+      handle_response(response)
+    rescue *NETWORK_ERRORS => e
+      Rails.logger.error(
+        "EvoAiCoreService: #{http_method.to_s.upcase} #{base_uri}#{url} did not reach evo-core — " \
+        "#{e.class}: #{e.message}"
+      )
+      raise UnavailableError
+    end
+
     def handle_response(response)
       # Return the complete response from evo-ai-core-service
       # The service already returns standardized format: { success, data, message, meta }
@@ -70,22 +134,26 @@ class EvoAiCoreService
 
       case response.code
       when 200, 201
-        parsed = response.parsed_response
-        # Extract payload if it exists (Evolution API format)
-        parsed.dig('data') || parsed
+        # Extract payload if it exists (Evolution API format). The guard is not
+        # cosmetic: `parsed` is only a Hash when the core answered with a JSON
+        # object. A bare JSON array (`[...]`) made `dig('data')` raise TypeError and
+        # a non-JSON body (an HTML error page from a gateway, say) made it raise
+        # NoMethodError — both landing on the CRM as a 500 for a 200 upstream.
+        parsed.is_a?(Hash) ? (parsed['data'] || parsed) : parsed
       when 204
         nil
-      when 400
-        raise StandardError, response.parsed_response['error'] || 'Bad Request'
-      when 401
-        raise StandardError, 'Unauthorized'
-      when 404
-        raise ActiveRecord::RecordNotFound
-      when 422
-        raise StandardError, response.parsed_response['error'] || 'Unprocessable Entity'
       else
-        raise StandardError, "Unexpected response: #{response.code}"
+        raise UpstreamError.new(upstream_message(response), status: response.code)
       end
+    end
+
+    # The core's own wording when it sent a JSON object with an `error`/`message`
+    # key, else a neutral line. Controllers decide whether any of it reaches the
+    # client; this is what gets logged either way.
+    def upstream_message(response)
+      parsed = response.parsed_response
+      message = parsed.is_a?(Hash) ? (parsed['error'] || parsed['message']) : nil
+      message.presence || "evo-core responded #{response.code}"
     end
 
     # Agents endpoints (Core AI Service)
@@ -93,56 +161,48 @@ class EvoAiCoreService
       url = "/api/v1/agents"
       Rails.logger.info "EvoAiCoreService.list_agents - Params: #{params}"
 
-      response = get(url, {
+      call_core(:get, url, {
         query: params,
         headers: build_headers(request_headers)
       })
-
-      Rails.logger.info "EvoAiCoreService.list_agents - Response code: #{response.code}, Body: #{response.body[0..500]}"
-      handle_response(response)
     end
 
     def get_agent(agent_id, request_headers = nil)
       url = "/api/v1/agents/#{agent_id}"
-      response = get(url, {
+      call_core(:get, url, {
         headers: build_headers(request_headers)
       })
-      handle_response(response)
     end
 
     def create_agent(agent_data, request_headers = nil)
       url = "/api/v1/agents"
-      response = post(url, {
+      call_core(:post, url, {
         body: agent_data.to_json,
         headers: build_headers(request_headers)
       })
-      handle_response(response)
     end
 
     def update_agent(agent_id, agent_data, request_headers = nil)
       url = "/api/v1/agents/#{agent_id}"
-      response = put(url, {
+      call_core(:put, url, {
         body: agent_data.to_json,
         headers: build_headers(request_headers)
       })
-      handle_response(response)
     end
 
     def delete_agent(agent_id, request_headers = nil)
       url = "/api/v1/agents/#{agent_id}"
-      response = delete(url, {
+      call_core(:delete, url, {
         headers: build_headers(request_headers)
       })
-      handle_response(response)
     end
 
     def sync_evolution_bot(agent_id, request_headers = nil)
       url = "/api/v1/agents/#{agent_id}/sync_evolution"
-      response = post(url, {
+      call_core(:post, url, {
         body: {}.to_json,
         headers: build_headers(request_headers)
       })
-      handle_response(response)
     end
 
     def assign_folder(agent_id, folder_id)

--- a/spec/requests/api/v1/agents_spec.rb
+++ b/spec/requests/api/v1/agents_spec.rb
@@ -123,12 +123,9 @@ RSpec.describe 'Api::V1::Agents (ai_agents gate)', type: :request do
     end
   end
 
-  # CRM-565 — the reported bug. These examples let the real EvoAiCoreService run
-  # (the outer `before` stub is undone with and_call_original) and cut the wire at
-  # the HTTP boundary instead, so the whole proxy path is exercised: the HTTParty
-  # call, handle_response, and the controller's translation. Each one asserts the
-  # absence of 500 explicitly — that is the symptom the customer reported.
-  context 'when evo-core fails (CRM-565)' do
+  # The real service runs here (and_call_original); WebMock cuts the wire at
+  # the HTTP boundary so the whole proxy path is exercised.
+  context 'when evo-core fails' do
     let(:core_agents_url) { %r{\A#{Regexp.escape(EvoAiCoreService.base_uri)}/api/v1/agents} }
 
     before do
@@ -183,6 +180,22 @@ RSpec.describe 'Api::V1::Agents (ai_agents gate)', type: :request do
         expect(response).to have_http_status(:service_unavailable)
       end
 
+      it 'answers 503 on a TCP-level timeout' do
+        stub_request(:get, core_agents_url).to_raise(Errno::ETIMEDOUT)
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
+      it 'answers 503 when the port does not speak HTTP' do
+        stub_request(:get, core_agents_url).to_raise(Net::HTTPBadResponse)
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
       it 'keeps the failure detail in the log and out of the body' do
         stub_request(:get, core_agents_url).to_raise(Errno::ECONNREFUSED)
         allow(Rails.logger).to receive(:error)
@@ -223,6 +236,26 @@ RSpec.describe 'Api::V1::Agents (ai_agents gate)', type: :request do
         expect(response).to have_http_status(:bad_request)
         expect(response.body).not_to include('evo_core_agents')
       end
+
+      it 'turns a 401 into 502: the token was already accepted by the CRM' do
+        stub_request(:get, core_agents_url).to_return(core_json(401, { error: 'invalid token' }))
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).to have_http_status(:bad_gateway)
+        expect(json_response['error']['details']['upstream_status']).to eq(401)
+      end
+
+      it 'relays a 400 whose body is not valid JSON, without echoing it' do
+        stub_request(:get, core_agents_url)
+          .to_return(status: 400, body: '{bad', headers: { 'Content-Type' => 'application/json' })
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).not_to include('{bad')
+      end
     end
 
     context 'when the core answers 5xx' do
@@ -249,8 +282,6 @@ RSpec.describe 'Api::V1::Agents (ai_agents gate)', type: :request do
       end
 
       it 'returns 200 for a bare JSON array (the payload shape that used to raise)' do
-        # `parsed.dig('data')` on an Array raises TypeError, which the base
-        # controller turned into a 500 for a perfectly good 200 upstream.
         stub_request(:get, core_agents_url).to_return(core_json(200, [{ id: 'agent-1' }]))
 
         get '/api/v1/agents', headers: headers, as: :json
@@ -258,6 +289,17 @@ RSpec.describe 'Api::V1::Agents (ai_agents gate)', type: :request do
         expect(response).not_to have_http_status(:internal_server_error)
         expect(response).to have_http_status(:ok)
         expect(json_response.first['id']).to eq('agent-1')
+      end
+
+      it 'answers 502 when a 200 carries an unparsable JSON body' do
+        stub_request(:get, core_agents_url)
+          .to_return(status: 200, body: '{bad', headers: { 'Content-Type' => 'application/json' })
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:bad_gateway)
+        expect(json_response['error']['details']['upstream_status']).to eq(200)
       end
 
       it 'returns 200 when the body is not JSON at all' do

--- a/spec/requests/api/v1/agents_spec.rb
+++ b/spec/requests/api/v1/agents_spec.rb
@@ -122,4 +122,153 @@ RSpec.describe 'Api::V1::Agents (ai_agents gate)', type: :request do
       expect(response).to have_http_status(:forbidden)
     end
   end
+
+  # CRM-565 — the reported bug. These examples let the real EvoAiCoreService run
+  # (the outer `before` stub is undone with and_call_original) and cut the wire at
+  # the HTTP boundary instead, so the whole proxy path is exercised: the HTTParty
+  # call, handle_response, and the controller's translation. Each one asserts the
+  # absence of 500 explicitly — that is the symptom the customer reported.
+  context 'when evo-core fails (CRM-565)' do
+    let(:core_agents_url) { %r{\A#{Regexp.escape(EvoAiCoreService.base_uri)}/api/v1/agents} }
+
+    before do
+      stub_auth(role_key: 'custom_ai_manager',
+                granted: %w[ai_agents.read ai_agents.create ai_agents.update ai_agents.delete])
+
+      allow(EvoAiCoreService).to receive(:list_agents).and_call_original
+      allow(EvoAiCoreService).to receive(:create_agent).and_call_original
+      allow(EvoAiCoreService).to receive(:update_agent).and_call_original
+      allow(EvoAiCoreService).to receive(:delete_agent).and_call_original
+    end
+
+    def core_json(status, body)
+      { status: status, body: body.to_json, headers: { 'Content-Type' => 'application/json' } }
+    end
+
+    context 'when the core is unreachable' do
+      it 'answers 503 on index, never 500' do
+        stub_request(:get, core_agents_url).to_raise(Errno::ECONNREFUSED)
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:service_unavailable)
+        expect(json_response['error']['code']).to eq('SERVICE_UNAVAILABLE')
+      end
+
+      it 'answers 503 on create, never 500' do
+        stub_request(:post, core_agents_url).to_raise(Errno::ECONNREFUSED)
+
+        post '/api/v1/agents', params: { name: 'Bot' }, headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
+      it 'answers 503 on update, never 500' do
+        stub_request(:put, core_agents_url).to_timeout
+
+        patch '/api/v1/agents/agent-1', params: { name: 'Bot 2' }, headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
+      it 'answers 503 on destroy, never 500' do
+        stub_request(:delete, core_agents_url).to_raise(SocketError)
+
+        delete '/api/v1/agents/agent-1', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
+      it 'keeps the failure detail in the log and out of the body' do
+        stub_request(:get, core_agents_url).to_raise(Errno::ECONNREFUSED)
+        allow(Rails.logger).to receive(:error)
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(Rails.logger).to have_received(:error).with(/did not reach evo-core/)
+        expect(response.body).not_to include('ECONNREFUSED')
+      end
+    end
+
+    context 'when the core answers 4xx' do
+      it 'relays 422 instead of 500' do
+        stub_request(:post, core_agents_url).to_return(core_json(422, { error: 'model is required' }))
+
+        post '/api/v1/agents', params: { name: 'Bot' }, headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response['error']['details']['upstream_status']).to eq(422)
+      end
+
+      it 'relays 404 instead of 500' do
+        stub_request(:delete, core_agents_url).to_return(core_json(404, { error: 'agent not found' }))
+
+        delete '/api/v1/agents/agent-1', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'does not echo the core wording back to the client' do
+        stub_request(:get, core_agents_url)
+          .to_return(core_json(400, { error: 'pq: relation "evo_core_agents" does not exist' }))
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).not_to include('evo_core_agents')
+      end
+    end
+
+    context 'when the core answers 5xx' do
+      it 'answers 502, so the CRM is not blamed for the core breaking' do
+        stub_request(:get, core_agents_url).to_return(core_json(500, { error: 'boom' }))
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:bad_gateway)
+        expect(json_response['error']['details']['upstream_status']).to eq(500)
+      end
+    end
+
+    context 'when the core answers 2xx' do
+      it 'still returns 200 with the data payload unwrapped' do
+        stub_request(:get, core_agents_url)
+          .to_return(core_json(200, { data: [{ id: 'agent-1', name: 'Bot' }] }))
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(json_response.first['id']).to eq('agent-1')
+      end
+
+      it 'returns 200 for a bare JSON array (the payload shape that used to raise)' do
+        # `parsed.dig('data')` on an Array raises TypeError, which the base
+        # controller turned into a 500 for a perfectly good 200 upstream.
+        stub_request(:get, core_agents_url).to_return(core_json(200, [{ id: 'agent-1' }]))
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:ok)
+        expect(json_response.first['id']).to eq('agent-1')
+      end
+
+      it 'returns 200 when the body is not JSON at all' do
+        stub_request(:get, core_agents_url)
+          .to_return(status: 200, body: '', headers: { 'Content-Type' => 'text/plain' })
+
+        get '/api/v1/agents', headers: headers, as: :json
+
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problema

Reportado via **SUPORTEEVO-23**: `GET /api/v1/agents` devolvia **500**. O cliente concluiu que era rota legada esquecida no ar — **não é**: a rota é viva e proxia o CRUD de agentes de IA para o evo-core. O 500 vinha do **proxy**.

## Causa raiz

O `AgentsController` não tinha `rescue` nenhum e o `EvoAiCoreService` levantava exceções cruas, então o `rescue_from StandardError` do `Api::BaseController` (`app/controllers/api/base_controller.rb:13`) transformava **toda** falha do core em 500. São **quatro caminhos distintos** na mesma rota:

| Caminho | O que acontecia |
|---|---|
| **Rede/config** | Sem `EVO_AI_CORE_SERVICE_URL`, a `base_uri` cai no default `http://localhost:5555` (`evo_ai_core_service.rb:7`) e o container do CRM chama **a si mesmo** → `Errno::ECONNREFUSED` sem captura. É o cenário mais provável do relato. |
| **Não-2xx do core** | `handle_response` levantava `StandardError` puro → um **401** ou um **502** do core viravam **500** aqui. |
| **200 com array** | `parsed.dig('data')` levanta `TypeError` quando o core devolve `[...]` em vez de `{data: [...]}` — um 200 perfeito virava 500. |
| **200 sem JSON** | Mesma linha, `NoMethodError` em `String#dig`. |

## Fix

- **`EvoAiCoreService`**: duas classes de erro (`UpstreamError`, que carrega o status do core, e `UnavailableError`), a lista `NETWORK_ERRORS` e o wrapper `call_core`, que traduz falha de rede em `UnavailableError` e loga o detalhe. `handle_response` passa a levantar `UpstreamError` com status; o unwrap do payload ganha guarda de tipo. As outras famílias (folders, apikeys, mcp, custom tools) **não** foram convertidas: seus controllers já têm `rescue` e nunca produziram 500 — não alarguei escopo.
- **`AgentsController`**: dois `rescue_from` próprios, que têm precedência sobre o `StandardError` da base. Indisponível → **503** `SERVICE_UNAVAILABLE`; **4xx do core relayado** com o mesmo status; **5xx do core → 502** (relayar 5xx verbatim poria a culpa no CRM). O **texto do core nunca é ecoado** — pode carregar host interno, SQL ou stack; vai para o log, e o cliente recebe `upstream_status` como diagnóstico. Usa `ApiErrorCodes`/`error_response`, o padrão da casa.

## Consumidores: nenhum — e mesmo assim a rota FICA

Busca nos sete repos, com evidência:

- O bundle do CRM no front usa **outro client**: `vendor/crm/src/services/agents/agentService.ts:27` chama `evoaiApi.get('/agents')`, e `apiEvoAI.ts:6` aponta para `VITE_EVOAI_API_URL`, que o `vite.config.ts:82` mapeia para `/evoai` — o **core na 5555**.
- O **Darwin** bate no core e diz isso por escrito: `evo-skyway-service/internal/agent/catalog.go:341` — "tools que batem no AI Core (:5555), não no CRM".
- O **evo-flow** tem client do CRM (porta 3000) mas **zero** ocorrências de `api/v1/agents`.
- O **processor** é servidor dessa superfície, não cliente. O enterprise só toca a tabela `evo_core_agents`.
- Nenhum helper `api_v1_agents_path`, nenhuma coleção Postman. O único chamador no community é o próprio spec.

**Não removi a rota.** O card levanta a hipótese, mas remover é decisão de contrato de API — e o proxy agora está honesto de qualquer forma. Fica registrado aqui para a decisão de vocês.

## Cobertura — 19 exemplos (12 novos), 0 falhas

Os specs cortam o fio no WebMock e deixam o **serviço real** rodar: core indisponível → 503; 4xx relayado com o mesmo status; 5xx → 502; 200 com array e 200 não-JSON **não estouram**; caminho feliz segue 200; e o corpo do core **não aparece** na resposta.

**Contraprova RED:** removendo os dois `rescue_from`, **8 exemplos voltam a receber 500** — o sintoma exato do relato.

## Auto-sinalizado

**Achado fora do escopo, não corrigido:** `config/routes.rb:207` declara `post :bulk_create`, mas o controller **não tem a ação**. O `require_permissions` a lista, então o guard de RBAC passa e a rota devolve 404 do Rails. Vale um card à parte.

## E2E ao vivo — PASSOU

App real (não a suíte), banco migrado, **token real emitido pelo auth-service** (autenticação de verdade, sem stub) e o evo-core apontado para uma porta morta — o cenário do relato.

`GET /api/v1/agents` respondeu **503**, não 500, com o envelope da casa (`SERVICE_UNAVAILABLE`), e o corpo **não vaza** host interno nem `ECONNREFUSED`.

*Nota de ambiente:* a primeira tentativa deu 500 com página HTML — era `ActiveRecord::PendingMigrationError` no banco de dev, a requisição nem chegava ao controller. Num banco migrado, o resultado é o 503 acima.

## Summary by Sourcery

Make the agents proxy report evo-core failures with appropriate service errors instead of exposing them as CRM 500 responses.

Bug Fixes:
- Prevent agent proxy requests from returning 500 when evo-core is unavailable or returns an error.
- Preserve successful agent responses for bare arrays and non-JSON bodies instead of raising payload-shape exceptions.

Enhancements:
- Return 503 for connectivity failures, relay appropriate upstream 4xx statuses, map upstream 5xx responses to 502, and keep upstream error details out of client responses.
- Centralize evo-core error classification and response handling for agent operations.

Tests:
- Add request coverage for network failures, upstream status handling, malformed responses, payload variations, and prevention of sensitive upstream error leakage.