### PR TITLE
fix(CRM-566): atribuir a conversa a um funil não apaga mais os cards dos outros

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -352,6 +352,7 @@ jobs:
         run: |
           bundle exec rspec \
             spec/services/automation_rules/action_service_spec.rb \
+            spec/services/automation_rules/pipeline_assignment_multi_pipeline_spec.rb \
             spec/services/automation_rules/conditions_filter_service_spec.rb \
             spec/services/automation_rules/conditions_filter_service_contact_spec.rb \
             spec/services/pipelines/stage_automation_service_spec.rb \

--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -57,6 +57,7 @@ on:
       - 'app/controllers/api/v1/pipeline_tasks_controller.rb'
       - 'spec/requests/api/v1/pipeline_items_archived_spec.rb'
       - 'spec/controllers/api/v1/pipeline_tasks_controller_spec.rb'
+      - 'spec/controllers/api/v1/pipeline_items_controller_spec.rb'
       # The resolver picks the service every new blob is born on, and the test
       # service is what an operator trusts to confirm it. Only these specs prove
       # both read the ENV ahead of a stale DB row instead of the ephemeral disk.
@@ -378,6 +379,7 @@ jobs:
             spec/policies/pipeline_policy/scope_spec.rb \
             spec/requests/api/v1/pipeline_items_archived_spec.rb \
             spec/controllers/api/v1/pipeline_tasks_controller_spec.rb \
+            spec/controllers/api/v1/pipeline_items_controller_spec.rb \
             spec/jobs/delete_object_job_spec.rb \
             spec/channels/room_channel_spec.rb \
             spec/lib/global_config_service_spec.rb \

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -27,10 +27,6 @@ module AutomationRules
         return
       end
 
-      # An archived pipeline is hidden from every picker, so a rule written months ago must not
-      # keep pushing conversations into it. (Until CRM-566 this guard carried a second job:
-      # execute_pipeline_assignment opened with a destroy_all, so reaching it also wiped every
-      # OTHER pipeline membership of the conversation. That wipe is gone — see the comment there.)
       return if skip_archived_pipeline(pipeline, action: 'assign_to_pipeline')
 
       log_pipeline_assignment(pipeline)
@@ -47,7 +43,7 @@ module AutomationRules
       log_stage_update_attempt(stage)
       @conversation.reload
 
-      pipeline_item = @conversation.pipeline_items.find_by(pipeline: stage.pipeline)
+      pipeline_item = @conversation.pipeline_items.active.find_by(pipeline: stage.pipeline)
 
       if pipeline_item
         move_to_existing_stage(pipeline_item, stage)
@@ -118,19 +114,6 @@ module AutomationRules
       Rails.logger.warn "Automation Rule #{@rule.id}: Pipeline #{pipeline_id.inspect} not found; skipping assign_to_pipeline for conversation #{@conversation.id}"
     end
 
-    # CRM-566: this used to open with `@conversation.pipeline_items.destroy_all`, so assigning
-    # a conversation to funnel B hard-deleted its card in funnel A — taking stage_movements,
-    # PipelineTasks and pipeline_item_products with it (all `dependent: :destroy`). The wipe
-    # contradicted the very schema it leaned on: `idx_pipeline_items_active_conversation_per_pipeline`
-    # is unique on (conversation_id, pipeline_id), not on conversation_id, precisely BECAUSE a
-    # conversation may live in several funnels at once. Only "twice in the SAME funnel" is
-    # forbidden, and the unique index plus PipelineItem's uniqueness validation already forbid it.
-    #
-    # So the only thing this action has to avoid is a second ACTIVE item in the target pipeline,
-    # which is now a no-op instead of a delete-and-recreate. A COMPLETED item in the target
-    # pipeline is deliberately not treated as "already there": the index is partial on
-    # `completed_at IS NULL`, so a closed journey is history and a fresh assignment is a new
-    # active card next to it.
     def execute_pipeline_assignment(pipeline)
       @conversation.reload
 
@@ -149,6 +132,11 @@ module AutomationRules
     def log_assignment_noop(pipeline)
       Rails.logger.info "Automation Rule #{@rule.id}: Conversation #{@conversation.id} is already active in " \
                         "pipeline #{pipeline.name}; assign_to_pipeline is a no-op"
+      # info, not action_skipped!: the conversation IS in the pipeline, so the run is not degraded.
+      @recorder&.add_step(
+        'assign_to_pipeline: already in the pipeline',
+        data: { pipeline_id: pipeline.id, pipeline_name: pipeline.name }
+      )
     end
 
     def log_assignment_success(pipeline)
@@ -207,7 +195,7 @@ module AutomationRules
 
     def move_to_target_stage_after_assignment(stage, service)
       @conversation.reload
-      pipeline_item = @conversation.pipeline_items.find_by(pipeline: stage.pipeline)
+      pipeline_item = @conversation.pipeline_items.active.find_by(pipeline: stage.pipeline)
 
       return unless pipeline_item && stage != stage.pipeline.pipeline_stages.first
 

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -27,9 +27,10 @@ module AutomationRules
         return
       end
 
-      # Guarded before execute_pipeline_assignment, which starts with destroy_all: assigning
-      # to an archived pipeline would first wipe every other pipeline membership of this
-      # conversation, and pipeline_items are hard-deleted.
+      # An archived pipeline is hidden from every picker, so a rule written months ago must not
+      # keep pushing conversations into it. (Until CRM-566 this guard carried a second job:
+      # execute_pipeline_assignment opened with a destroy_all, so reaching it also wiped every
+      # OTHER pipeline membership of the conversation. That wipe is gone — see the comment there.)
       return if skip_archived_pipeline(pipeline, action: 'assign_to_pipeline')
 
       log_pipeline_assignment(pipeline)
@@ -117,8 +118,25 @@ module AutomationRules
       Rails.logger.warn "Automation Rule #{@rule.id}: Pipeline #{pipeline_id.inspect} not found; skipping assign_to_pipeline for conversation #{@conversation.id}"
     end
 
+    # CRM-566: this used to open with `@conversation.pipeline_items.destroy_all`, so assigning
+    # a conversation to funnel B hard-deleted its card in funnel A — taking stage_movements,
+    # PipelineTasks and pipeline_item_products with it (all `dependent: :destroy`). The wipe
+    # contradicted the very schema it leaned on: `idx_pipeline_items_active_conversation_per_pipeline`
+    # is unique on (conversation_id, pipeline_id), not on conversation_id, precisely BECAUSE a
+    # conversation may live in several funnels at once. Only "twice in the SAME funnel" is
+    # forbidden, and the unique index plus PipelineItem's uniqueness validation already forbid it.
+    #
+    # So the only thing this action has to avoid is a second ACTIVE item in the target pipeline,
+    # which is now a no-op instead of a delete-and-recreate. A COMPLETED item in the target
+    # pipeline is deliberately not treated as "already there": the index is partial on
+    # `completed_at IS NULL`, so a closed journey is history and a fresh assignment is a new
+    # active card next to it.
     def execute_pipeline_assignment(pipeline)
-      @conversation.pipeline_items.destroy_all
+      @conversation.reload
+
+      existing_item = @conversation.pipeline_items.active.find_by(pipeline_id: pipeline.id)
+      return log_assignment_noop(pipeline) if existing_item
+
       result = Pipelines::ConversationService.new(pipeline: pipeline, user: nil).add_conversation(@conversation)
 
       if result
@@ -126,6 +144,11 @@ module AutomationRules
       else
         log_assignment_failure(pipeline)
       end
+    end
+
+    def log_assignment_noop(pipeline)
+      Rails.logger.info "Automation Rule #{@rule.id}: Conversation #{@conversation.id} is already active in " \
+                        "pipeline #{pipeline.name}; assign_to_pipeline is a no-op"
     end
 
     def log_assignment_success(pipeline)

--- a/app/services/pipelines/conversation_service.rb
+++ b/app/services/pipelines/conversation_service.rb
@@ -101,16 +101,23 @@ class Pipelines::ConversationService
     @analytics_service ||= Pipelines::AnalyticsService.new(@pipeline)
   end
 
+  # CRM-566: this used to destroy every item the conversation had in OTHER pipelines before
+  # creating the new one — the second half of the same bug as
+  # AutomationRules::PipelineActionHandlers#execute_pipeline_assignment. Adding a conversation
+  # to funnel B is not a statement about funnel A: the unique index behind pipeline_items is
+  # (conversation_id, pipeline_id) WHERE completed_at IS NULL, so being active in several
+  # funnels at once is the supported shape and only a duplicate inside ONE funnel is not.
+  # Deleting was also unrecoverable — pipeline_items are hard-deleted and cascade into
+  # stage_movements, PipelineTasks and pipeline_item_products.
+  #
+  # Callers that genuinely want a MOVE (the conversation leaves the old funnel) already have
+  # one that keeps the row, its history and its tasks: #move_to_pipeline_stage, which is what
+  # PipelineItemsController#relocate_conversation and StageAutomationService#move_to_pipeline
+  # use. #add_conversation only adds.
+  #
+  # The reload stays: callers reach here with a conversation loaded before the rule ran, and
+  # create_pipeline_item's uniqueness validation has to see the current items.
   def prepare_conversation_for_pipeline(conversation)
-    conversation.reload
-
-    # Only remove active items from OTHER pipelines (not this one)
-    # This preserves completed journey history in the current pipeline
-    other_pipeline_items = conversation.pipeline_items.where.not(pipeline_id: @pipeline.id)
-    return unless other_pipeline_items.exists?
-
-    Rails.logger.info "Pipeline Service: Removing conversation #{conversation.id} from #{other_pipeline_items.count} other pipeline(s)"
-    other_pipeline_items.destroy_all
     conversation.reload
   end
 

--- a/app/services/pipelines/conversation_service.rb
+++ b/app/services/pipelines/conversation_service.rb
@@ -4,11 +4,13 @@ class Pipelines::ConversationService
     @user = user
   end
 
+  # Adds only. A real move — the conversation leaves the old funnel — is #move_to_pipeline_stage,
+  # which keeps the row, its history and its tasks.
   def add_conversation(conversation, stage: nil, custom_fields: {})
     stage ||= @pipeline.pipeline_stages.first
     return false unless stage
 
-    prepare_conversation_for_pipeline(conversation)
+    conversation.reload
     create_pipeline_item(conversation, stage, custom_fields)
   end
 
@@ -99,26 +101,6 @@ class Pipelines::ConversationService
 
   def analytics_service
     @analytics_service ||= Pipelines::AnalyticsService.new(@pipeline)
-  end
-
-  # CRM-566: this used to destroy every item the conversation had in OTHER pipelines before
-  # creating the new one — the second half of the same bug as
-  # AutomationRules::PipelineActionHandlers#execute_pipeline_assignment. Adding a conversation
-  # to funnel B is not a statement about funnel A: the unique index behind pipeline_items is
-  # (conversation_id, pipeline_id) WHERE completed_at IS NULL, so being active in several
-  # funnels at once is the supported shape and only a duplicate inside ONE funnel is not.
-  # Deleting was also unrecoverable — pipeline_items are hard-deleted and cascade into
-  # stage_movements, PipelineTasks and pipeline_item_products.
-  #
-  # Callers that genuinely want a MOVE (the conversation leaves the old funnel) already have
-  # one that keeps the row, its history and its tasks: #move_to_pipeline_stage, which is what
-  # PipelineItemsController#relocate_conversation and StageAutomationService#move_to_pipeline
-  # use. #add_conversation only adds.
-  #
-  # The reload stays: callers reach here with a conversation loaded before the rule ran, and
-  # create_pipeline_item's uniqueness validation has to see the current items.
-  def prepare_conversation_for_pipeline(conversation)
-    conversation.reload
   end
 
   def create_pipeline_item(conversation, stage, custom_fields)

--- a/spec/controllers/api/v1/pipeline_items_controller_spec.rb
+++ b/spec/controllers/api/v1/pipeline_items_controller_spec.rb
@@ -211,11 +211,8 @@ RSpec.describe Api::V1::PipelineItemsController, type: :controller do
       let(:other_pipeline) { Pipeline.create!(name: 'Support', pipeline_type: 'sales', created_by: user) }
       let!(:other_stage) { PipelineStage.create!(pipeline: other_pipeline, name: 'Triage', position: 1) }
 
-      # The contact already holds a lead card in `pipeline`, which Conversation#promote_lead_card
-      # turns into this conversation's card on create — so the conversation starts INSIDE the
-      # target pipeline. Until CRM-566, add_conversation silently destroyed that card and the
-      # cross-pipeline scenario appeared by accident; now that adding to a funnel no longer
-      # empties the others, the scenario this context is named after has to be set up on purpose.
+      # Conversation#promote_lead_card turns the contact's lead card into this conversation's
+      # card in `pipeline` on create, so "not in the target pipeline" has to be made true.
       before do
         Pipelines::ConversationService.new(pipeline: other_pipeline, user: user).add_conversation(conversation, stage: other_stage)
         conversation.pipeline_items.where(pipeline: pipeline).destroy_all
@@ -237,8 +234,7 @@ RSpec.describe Api::V1::PipelineItemsController, type: :controller do
     end
 
     context 'when the conversation is not in any pipeline (auto-assign)' do
-      # Same reason as the cross-pipeline context: the promoted lead card puts the conversation
-      # in `pipeline` the moment it is created, so "in no pipeline" has to be made true.
+      # Same promoted lead card as above.
       before { conversation.pipeline_items.destroy_all }
 
       it 'creates a pipeline_item in the target pipeline at the target stage' do

--- a/spec/controllers/api/v1/pipeline_items_controller_spec.rb
+++ b/spec/controllers/api/v1/pipeline_items_controller_spec.rb
@@ -211,8 +211,14 @@ RSpec.describe Api::V1::PipelineItemsController, type: :controller do
       let(:other_pipeline) { Pipeline.create!(name: 'Support', pipeline_type: 'sales', created_by: user) }
       let!(:other_stage) { PipelineStage.create!(pipeline: other_pipeline, name: 'Triage', position: 1) }
 
+      # The contact already holds a lead card in `pipeline`, which Conversation#promote_lead_card
+      # turns into this conversation's card on create — so the conversation starts INSIDE the
+      # target pipeline. Until CRM-566, add_conversation silently destroyed that card and the
+      # cross-pipeline scenario appeared by accident; now that adding to a funnel no longer
+      # empties the others, the scenario this context is named after has to be set up on purpose.
       before do
         Pipelines::ConversationService.new(pipeline: other_pipeline, user: user).add_conversation(conversation, stage: other_stage)
+        conversation.pipeline_items.where(pipeline: pipeline).destroy_all
       end
 
       it 'relocates the item to the target pipeline/stage and removes it from the previous pipeline' do
@@ -231,6 +237,10 @@ RSpec.describe Api::V1::PipelineItemsController, type: :controller do
     end
 
     context 'when the conversation is not in any pipeline (auto-assign)' do
+      # Same reason as the cross-pipeline context: the promoted lead card puts the conversation
+      # in `pipeline` the moment it is created, so "in no pipeline" has to be made true.
+      before { conversation.pipeline_items.destroy_all }
+
       it 'creates a pipeline_item in the target pipeline at the target stage' do
         expect do
           patch :move_conversation, params: {

--- a/spec/services/automation_rules/action_service_spec.rb
+++ b/spec/services/automation_rules/action_service_spec.rb
@@ -12,6 +12,16 @@ require 'rails_helper'
 # move_to_target_stage_after_assignment to move it to the requested stage.
 # This spec is a regression guard for that two-step sequence; removing the
 # follow-up move would silently leave conversations on the wrong stage.
+#
+# CRM-566: the auto-assign step used to hard-delete the conversation's cards in every OTHER
+# pipeline, because add_conversation did — an inheritance this spec named out loud
+# ("assign_to_pipeline-style behaviour"). That was the reported bug, not an acceptance
+# criterion of EVO-1080: the wipe cascaded into stage_movements, PipelineTasks and
+# pipeline_item_products, and the schema behind pipeline_items (unique on
+# (conversation_id, pipeline_id) WHERE completed_at IS NULL) exists precisely so a
+# conversation can sit in several funnels at once. Landing on the REQUESTED stage is what
+# EVO-1080 locks, and that is unchanged; the assertions below now expect the source funnel's
+# card to survive instead of being destroyed.
 
 RSpec.describe AutomationRules::ActionService do
   let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
@@ -44,7 +54,7 @@ RSpec.describe AutomationRules::ActionService do
 
   describe '#update_pipeline_stage (auto-assign-and-move path)' do
     context 'when the conversation belongs to a different pipeline and the target stage is NOT the first of the new pipeline' do
-      before do
+      let!(:card_a) do
         PipelineItem.create!(pipeline: pipeline_a, pipeline_stage: stage_a1, conversation: conversation)
       end
 
@@ -53,19 +63,21 @@ RSpec.describe AutomationRules::ActionService do
         described_class.new(rule, nil, conversation).perform
 
         conversation.reload
-        items = conversation.pipeline_items
-        expect(items.count).to eq(1)
-        expect(items.first.pipeline).to eq(pipeline_b)
-        expect(items.first.pipeline_stage).to eq(stage_b3)
+        item = conversation.pipeline_items.find_by(pipeline: pipeline_b)
+        expect(item).to be_present
+        expect(item.pipeline_stage).to eq(stage_b3)
       end
 
-      it 'destroys the previous pipeline assignment (assign_to_pipeline-style behaviour)' do
+      # CRM-566: was 'destroys the previous pipeline assignment'. Adding the conversation to
+      # pipeline B says nothing about pipeline A, and the delete was unrecoverable.
+      it 'leaves the previous pipeline assignment untouched' do
         rule = build_rule_with_stage_action(stage_b2)
         described_class.new(rule, nil, conversation).perform
 
         conversation.reload
-        expect(conversation.pipeline_items.where(pipeline: pipeline_a)).to be_empty
         expect(conversation.pipeline_items.where(pipeline: pipeline_b)).to exist
+        expect(PipelineItem.find_by(id: card_a.id)).to be_present
+        expect(card_a.reload.pipeline_stage).to eq(stage_a1)
       end
     end
 

--- a/spec/services/automation_rules/action_service_spec.rb
+++ b/spec/services/automation_rules/action_service_spec.rb
@@ -12,16 +12,6 @@ require 'rails_helper'
 # move_to_target_stage_after_assignment to move it to the requested stage.
 # This spec is a regression guard for that two-step sequence; removing the
 # follow-up move would silently leave conversations on the wrong stage.
-#
-# CRM-566: the auto-assign step used to hard-delete the conversation's cards in every OTHER
-# pipeline, because add_conversation did — an inheritance this spec named out loud
-# ("assign_to_pipeline-style behaviour"). That was the reported bug, not an acceptance
-# criterion of EVO-1080: the wipe cascaded into stage_movements, PipelineTasks and
-# pipeline_item_products, and the schema behind pipeline_items (unique on
-# (conversation_id, pipeline_id) WHERE completed_at IS NULL) exists precisely so a
-# conversation can sit in several funnels at once. Landing on the REQUESTED stage is what
-# EVO-1080 locks, and that is unchanged; the assertions below now expect the source funnel's
-# card to survive instead of being destroyed.
 
 RSpec.describe AutomationRules::ActionService do
   let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
@@ -68,8 +58,6 @@ RSpec.describe AutomationRules::ActionService do
         expect(item.pipeline_stage).to eq(stage_b3)
       end
 
-      # CRM-566: was 'destroys the previous pipeline assignment'. Adding the conversation to
-      # pipeline B says nothing about pipeline A, and the delete was unrecoverable.
       it 'leaves the previous pipeline assignment untouched' do
         rule = build_rule_with_stage_action(stage_b2)
         described_class.new(rule, nil, conversation).perform

--- a/spec/services/automation_rules/pipeline_assignment_multi_pipeline_spec.rb
+++ b/spec/services/automation_rules/pipeline_assignment_multi_pipeline_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-566 (SUPORTEEVO-23): `assign_to_pipeline` opened with
+# `@conversation.pipeline_items.destroy_all`, and Pipelines::ConversationService#add_conversation
+# destroyed every item in the OTHER pipelines right after. On an account with two funnels,
+# sending a conversation to funnel B hard-deleted its card in funnel A — cascading into
+# stage_movements, PipelineTasks and pipeline_item_products. Nothing recovers that from the app.
+#
+# The schema always said otherwise: idx_pipeline_items_active_conversation_per_pipeline is unique
+# on (conversation_id, pipeline_id) WHERE completed_at IS NULL. Several funnels at once is the
+# supported shape; twice in ONE funnel is what is forbidden, and the index already forbids it.
+#
+# The guard lives in the shared PipelineActionHandlers module, so it covers both executor
+# surfaces (modal-style ActionService and flow-canvas FlowExecutionService).
+RSpec.describe 'Automation rule pipeline assignment across several pipelines' do
+  let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  # Two commercial funnels on the same account, the shape the customer reported.
+  let(:funnel_a) { Pipeline.create!(name: 'Funnel A', pipeline_type: 'sales', created_by: user) }
+  let!(:stage_a1) { PipelineStage.create!(pipeline: funnel_a, name: 'A1', position: 1) }
+  let!(:stage_a2) { PipelineStage.create!(pipeline: funnel_a, name: 'A2', position: 2) }
+
+  let(:funnel_b) { Pipeline.create!(name: 'Funnel B', pipeline_type: 'sales', created_by: user) }
+  let!(:stage_b1) { PipelineStage.create!(pipeline: funnel_b, name: 'B1', position: 1) }
+
+  def rule_with(action_name, params)
+    AutomationRule.create!(
+      name: "Rule #{SecureRandom.hex(3)}",
+      event_name: 'conversation_created',
+      conditions: [],
+      actions: [{ 'action_name' => action_name, 'action_params' => params }],
+      active: true
+    )
+  end
+
+  def run(rule)
+    AutomationRules::ActionService.new(rule, nil, conversation).perform
+  end
+
+  after { Current.reset }
+
+  describe 'assigning to a funnel the conversation is NOT in yet (AC1)' do
+    # A card with real history behind it: it moved a stage (so stage_movements has more than the
+    # entry row) and carries a task. Those are the associations `dependent: :destroy` took down.
+    let!(:card_a) do
+      item = PipelineItem.create!(pipeline: funnel_a, pipeline_stage: stage_a1, conversation: conversation)
+      item.move_to_stage(stage_a2)
+      PipelineTask.create!(pipeline_item: item, created_by: user, title: 'Call the customer')
+      item
+    end
+
+    it 'leaves the card in funnel A alive' do
+      run(rule_with('assign_to_pipeline', [funnel_b.id]))
+
+      expect(PipelineItem.find_by(id: card_a.id)).to be_present
+    end
+
+    it 'keeps the funnel A card in its own stage, not dragged to the new funnel' do
+      run(rule_with('assign_to_pipeline', [funnel_b.id]))
+
+      expect(card_a.reload.pipeline_id).to eq(funnel_a.id)
+      expect(card_a.pipeline_stage_id).to eq(stage_a2.id)
+    end
+
+    it 'keeps the task on the funnel A card' do
+      expect { run(rule_with('assign_to_pipeline', [funnel_b.id])) }
+        .not_to change { PipelineTask.where(pipeline_item_id: card_a.id).count }.from(1)
+    end
+
+    it 'keeps the stage movement history of the funnel A card' do
+      movements_before = card_a.stage_movements.count
+      expect(movements_before).to be >= 2 # entry + the A1 -> A2 move
+
+      expect { run(rule_with('assign_to_pipeline', [funnel_b.id])) }
+        .not_to change { StageMovement.where(pipeline_item_id: card_a.id).count }.from(movements_before)
+    end
+
+    it 'creates the card in funnel B' do
+      expect { run(rule_with('assign_to_pipeline', [funnel_b.id])) }
+        .to change { conversation.reload.pipeline_items.active.where(pipeline: funnel_b).count }.from(0).to(1)
+    end
+
+    it 'ends with the conversation active in BOTH funnels' do
+      run(rule_with('assign_to_pipeline', [funnel_b.id]))
+
+      expect(conversation.reload.pipeline_items.active.map(&:pipeline_id))
+        .to contain_exactly(funnel_a.id, funnel_b.id)
+    end
+  end
+
+  describe 'assigning to a funnel the conversation is ALREADY in (AC2)' do
+    let!(:card_b) do
+      item = PipelineItem.create!(pipeline: funnel_b, pipeline_stage: stage_b1, conversation: conversation)
+      PipelineTask.create!(pipeline_item: item, created_by: user, title: 'Send the proposal')
+      item
+    end
+
+    it 'does not raise' do
+      expect { run(rule_with('assign_to_pipeline', [funnel_b.id])) }.not_to raise_error
+    end
+
+    it 'creates no duplicate item' do
+      expect { run(rule_with('assign_to_pipeline', [funnel_b.id])) }
+        .not_to change { conversation.reload.pipeline_items.count }.from(1)
+    end
+
+    # The pre-fix code deleted and recreated the card, so the row was a different one and the
+    # task went with it. A no-op has to be the SAME row.
+    it 'keeps the very same card, with its task' do
+      run(rule_with('assign_to_pipeline', [funnel_b.id]))
+
+      expect(conversation.reload.pipeline_items.active.first.id).to eq(card_b.id)
+      expect(card_b.reload.tasks.map(&:title)).to eq(['Send the proposal'])
+    end
+
+    it 'reports the no-op instead of a failure' do
+      allow(Rails.logger).to receive(:info)
+      allow(Rails.logger).to receive(:error)
+
+      run(rule_with('assign_to_pipeline', [funnel_b.id]))
+
+      expect(Rails.logger).to have_received(:info).with(/already active in pipeline Funnel B.*no-op/)
+      expect(Rails.logger).not_to have_received(:error).with(/Failed to assign/)
+    end
+  end
+
+  # The unique index is partial on `completed_at IS NULL`, so a closed journey is history, not
+  # an occupied slot: assigning again opens a NEW active card next to it.
+  describe 'assigning to a funnel where an earlier journey was completed' do
+    let!(:closed_card_b) do
+      PipelineItem.create!(
+        pipeline: funnel_b, pipeline_stage: stage_b1, conversation: conversation, completed_at: 1.day.ago
+      )
+    end
+
+    it 'opens a new active card without touching the completed one' do
+      expect { run(rule_with('assign_to_pipeline', [funnel_b.id])) }
+        .to change { conversation.reload.pipeline_items.active.where(pipeline: funnel_b).count }.from(0).to(1)
+
+      expect(PipelineItem.find_by(id: closed_card_b.id)).to be_present
+      expect(closed_card_b.reload.completed_at).to be_present
+    end
+  end
+
+  # update_pipeline_stage auto-assigns through the same Pipelines::ConversationService, so the
+  # other half of the fix (prepare_conversation_for_pipeline) needs its own proof.
+  describe 'update_pipeline_stage auto-assigning into a second funnel' do
+    let!(:card_a) do
+      PipelineItem.create!(pipeline: funnel_a, pipeline_stage: stage_a1, conversation: conversation)
+    end
+
+    it 'does not destroy the card the conversation has in the other funnel' do
+      run(rule_with('update_pipeline_stage', [stage_b1.id]))
+
+      expect(PipelineItem.find_by(id: card_a.id)).to be_present
+      expect(conversation.reload.pipeline_items.active.map(&:pipeline_id))
+        .to contain_exactly(funnel_a.id, funnel_b.id)
+    end
+  end
+
+  # Same handler module, second executor surface — the canvas node must not wipe funnels either.
+  describe 'flow-canvas surface' do
+    let(:flow_rule) { rule_with('assign_to_pipeline', [funnel_b.id]) }
+    let(:flow_service) { AutomationRules::FlowExecutionService.new(flow_rule, nil, conversation) }
+    let!(:card_a) do
+      PipelineItem.create!(pipeline: funnel_a, pipeline_stage: stage_a1, conversation: conversation)
+    end
+
+    it 'adds the funnel B card and keeps the funnel A card' do
+      node = { 'type' => 'assign-to-pipeline-node', 'id' => 'n1', 'data' => { 'pipeline_id' => funnel_b.id } }
+
+      expect { flow_service.send(:execute_node_action, node) }
+        .to change { conversation.reload.pipeline_items.active.count }.from(1).to(2)
+
+      expect(PipelineItem.find_by(id: card_a.id)).to be_present
+    end
+  end
+end

--- a/spec/services/automation_rules/pipeline_assignment_multi_pipeline_spec.rb
+++ b/spec/services/automation_rules/pipeline_assignment_multi_pipeline_spec.rb
@@ -2,18 +2,8 @@
 
 require 'rails_helper'
 
-# CRM-566 (SUPORTEEVO-23): `assign_to_pipeline` opened with
-# `@conversation.pipeline_items.destroy_all`, and Pipelines::ConversationService#add_conversation
-# destroyed every item in the OTHER pipelines right after. On an account with two funnels,
-# sending a conversation to funnel B hard-deleted its card in funnel A — cascading into
-# stage_movements, PipelineTasks and pipeline_item_products. Nothing recovers that from the app.
-#
-# The schema always said otherwise: idx_pipeline_items_active_conversation_per_pipeline is unique
-# on (conversation_id, pipeline_id) WHERE completed_at IS NULL. Several funnels at once is the
-# supported shape; twice in ONE funnel is what is forbidden, and the index already forbids it.
-#
-# The guard lives in the shared PipelineActionHandlers module, so it covers both executor
-# surfaces (modal-style ActionService and flow-canvas FlowExecutionService).
+# The handlers are shared, so these examples drive both executor surfaces: the modal-style
+# ActionService and the flow-canvas FlowExecutionService.
 RSpec.describe 'Automation rule pipeline assignment across several pipelines' do
   let(:user) { User.create!(name: 'Agent', email: "agent-#{SecureRandom.hex(4)}@test.com") }
   let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
@@ -129,6 +119,19 @@ RSpec.describe 'Automation rule pipeline assignment across several pipelines' do
       expect(Rails.logger).to have_received(:info).with(/already active in pipeline Funnel B.*no-op/)
       expect(Rails.logger).not_to have_received(:error).with(/Failed to assign/)
     end
+
+    it 'records the no-op on the run timeline without degrading the run' do
+      rule = rule_with('assign_to_pipeline', [funnel_b.id])
+      recorder = AutomationRules::RunRecorder.new(rule: rule, event_name: 'conversation_created')
+
+      AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.matched!
+
+      run_record = recorder.persist!
+      expect(run_record.status).to eq(AutomationRules::RunRecorder::STATUS_MATCHED)
+      expect(run_record.steps.map { |step| step['label'] })
+        .to include('assign_to_pipeline: already in the pipeline')
+    end
   end
 
   # The unique index is partial on `completed_at IS NULL`, so a closed journey is history, not
@@ -149,8 +152,6 @@ RSpec.describe 'Automation rule pipeline assignment across several pipelines' do
     end
   end
 
-  # update_pipeline_stage auto-assigns through the same Pipelines::ConversationService, so the
-  # other half of the fix (prepare_conversation_for_pipeline) needs its own proof.
   describe 'update_pipeline_stage auto-assigning into a second funnel' do
     let!(:card_a) do
       PipelineItem.create!(pipeline: funnel_a, pipeline_stage: stage_a1, conversation: conversation)
@@ -162,6 +163,46 @@ RSpec.describe 'Automation rule pipeline assignment across several pipelines' do
       expect(PipelineItem.find_by(id: card_a.id)).to be_present
       expect(conversation.reload.pipeline_items.active.map(&:pipeline_id))
         .to contain_exactly(funnel_a.id, funnel_b.id)
+    end
+  end
+
+  describe 'update_pipeline_stage on a funnel that also holds a completed card' do
+    let!(:closed_card_b) do
+      PipelineItem.create!(pipeline: funnel_b, pipeline_stage: stage_b1, conversation: conversation,
+                           completed_at: 1.day.ago)
+    end
+    let!(:stage_b2) { PipelineStage.create!(pipeline: funnel_b, name: 'B2', position: 2) }
+
+    context 'when an active card sits beside it' do
+      let!(:active_card_b) do
+        PipelineItem.create!(pipeline: funnel_b, pipeline_stage: stage_b1, conversation: conversation)
+      end
+
+      it 'moves the active card and leaves the completed one where it closed' do
+        run(rule_with('update_pipeline_stage', [stage_b2.id]))
+
+        expect(active_card_b.reload.pipeline_stage_id).to eq(stage_b2.id)
+        expect(closed_card_b.reload.pipeline_stage_id).to eq(stage_b1.id)
+      end
+
+      it 'does not report a failure' do
+        allow(Rails.logger).to receive(:error)
+
+        run(rule_with('update_pipeline_stage', [stage_b2.id]))
+
+        expect(Rails.logger).not_to have_received(:error).with(/Failed to move conversation/)
+      end
+    end
+
+    # The auto-assign branch resolves the freshly created card the same way.
+    context 'when the completed card is the only one in the funnel' do
+      it 'auto-assigns a new card and lands it on the requested stage' do
+        run(rule_with('update_pipeline_stage', [stage_b2.id]))
+
+        new_card = conversation.reload.pipeline_items.active.find_by(pipeline: funnel_b)
+        expect(new_card.pipeline_stage_id).to eq(stage_b2.id)
+        expect(closed_card_b.reload.pipeline_stage_id).to eq(stage_b1.id)
+      end
     end
   end
 


### PR DESCRIPTION
## Problema

Reportado via **SUPORTEEVO-23**. A ação `assign_to_pipeline` de uma regra de automação abria com `@conversation.pipeline_items.destroy_all`: numa conta com mais de um funil, mandar a conversa para o **funil B destruía o card dela no funil A**. Hard delete, sem aviso e sem confirmação, levando junto `stage_movements`, `PipelineTask` e `pipeline_item_products` — todos `dependent: :destroy`. **Não há recuperação pela aplicação**; o que existir só sai de backup.

O apagamento **contradizia o schema em que se apoiava**: o índice único `idx_pipeline_items_active_conversation_per_pipeline` é em `(conversation_id, pipeline_id) WHERE completed_at IS NULL` — não em `conversation_id`. Ele existe justamente **porque** uma conversa pode viver em vários funis ao mesmo tempo. Só "duas vezes no mesmo funil" é proibido, e disso já cuidam o índice e a validação de unicidade do `PipelineItem`.

## O alcance é maior que o card descreve: eram DOIS sítios

- **`AutomationRules::PipelineActionHandlers#execute_pipeline_assignment`** — o que o card nomeia. Em vez de apagar tudo e recriar, agora checa se já existe item **ativo** no funil alvo e vira **no-op** (com log) se existir.
- **`Pipelines::ConversationService#add_conversation`** — fazia o **mesmo `destroy_all`**, e este é o caminho de mais gente. Além das duas chamadas da automação, ele é usado por `PipelineItemsController#relocate_conversation` (atribuir a conversa a um funil **pela tela**) e pela promoção de card de lead em `Conversation`. **O apagamento acontecia fora da automação também** — corrigir só o handler deixaria o bug vivo pela UI.

Adicionar a conversa ao funil B não é uma afirmação sobre o funil A. Quem quer **mover** de verdade já tem `#move_to_pipeline_stage`, que preserva a linha, o histórico e as tarefas — é o que o `relocate_conversation` e o `StageAutomationService#move_to_pipeline` usam.

**Item `completed` no funil alvo** não conta como "já está lá": o índice é parcial em `completed_at IS NULL`, então jornada encerrada é histórico e a atribuição nova cria um card ativo ao lado.

O guard de pipeline arquivado continua, agora com um papel só (não empurrar conversa para funil escondido dos seletores); o comentário registra que ele também servia de escudo contra o `destroy_all` e não precisa mais disso.

## Cobertura — 33 exemplos, 0 falhas

`pipeline_assignment_multi_pipeline_spec.rb` (novo), cobrindo os três aceites do card:

1. conta com **2 funis**, card em A **com tarefa e movimentações**, a regra atribui a B → o card de A **sobrevive com tarefa e histórico intactos** e nasce um card em B;
2. atribuir ao funil onde a conversa **já está ativa** → no-op, sem duplicata e sem exceção;
3. item **completed** no alvo não bloqueia um card novo.

Mais o `action_service_spec` e o `pipeline_items_controller_spec` (o caminho da tela). O arquivo novo foi **acrescentado à allowlist do `spec-staleness-guard`**: aquela lane só executa spec **nomeado na lista**, então sem isso o teste nunca rodaria na CI.

**Contraprova RED:** repondo o `destroy_all`, o card do funil A é apagado (`PipelineItem.find_by` → `nil`), `PipelineTask` cai de **1 para 0** e `StageMovement` de **2 para 0`.

## A pergunta do card sobre o estrago já feito

O card pede para avaliar quantas contas já perderam card por isso. Respondo no comentário do card com o que a investigação encontrou — sendo hard delete com cascade, a resposta curta é que **não há trilha na aplicação** que permita reconstruir o que sumiu; só backup.

## Specs existentes alterados (auto-sinalizado)

Dois specs **afirmavam o comportamento destrutivo** e foram ajustados — vale a revisão de vocês:

- `spec/services/automation_rules/action_service_spec.rb`: o teste chamado *"destroys the previous pipeline assignment (assign_to_pipeline-style behaviour)"* herdou o bug pelo próprio nome. O AC real do EVO-1080 (aterrissar na etapa pedida) segue intacto; o teste virou *"leaves the previous pipeline assignment untouched"*.
- `spec/controllers/api/v1/pipeline_items_controller_spec.rb`: dois contextos do EVO-1272 quebraram por **setup**, não por contrato. O contato tem um lead card que `Conversation#promote_lead_card` converte no card da conversa dentro do funil alvo; antes, o `add_conversation` do setup apagava esse card por acidente e o cenário aparecia sozinho. O cenário passou a ser explícito com um `before`.

**Mudança de produto a declarar:** `update_pipeline_stage` apontando para uma etapa de **outro** funil agora **adiciona** a conversa ao funil de destino **sem tirá-la** do de origem. Antes ela era arrancada com hard delete.

## Baseline de falhas pré-existentes

Um lote paralelo acusou uma falha em `spec/requests/api/v1/webhooks/purchases_spec.rb`. **Baselineado e descartado:** rodado isolado, dá **32 exemplos, 0 falhas** tanto na `develop` limpa (`7a39a0a`) quanto nesta branch — a falha era contenção do lote concorrente, não regressão. Nem o spec nem o controller de compras passam pelo caminho alterado (os `pipeline_items` de lá são do eixo **contato**).

`cascade-deletion-guard` não é afetado: a linha `pipeline_items conversations` da allowlist continua coberta pelos cleanups em `contacts_controller.rb` e `delete_object_job.rb`.

## E2E ao vivo — PASSOU

Contra o banco real, com a **ação de verdade** (`AutomationRules::ActionService#perform`, o caminho de produção). Dois funis; card no A com **1 tarefa** e **2 movimentações**; a regra atribui ao **B**:

| | antes | depois |
|---|---|---|
| card do funil A | existe | **existe, a MESMA linha** |
| tarefas | 1 | **1** |
| movimentações | 2 | **2** |
| funis da conversa | só A | **A e B** |

Rodando a regra de novo com a conversa já ativa em B: contagem segue 2 (sem duplicata) e **nada levantado** — o no-op do aceite 2. Tudo em transação com rollback; o banco de dev ficou intocado.

## Summary by Sourcery

Preserve existing pipeline memberships when assigning or auto-assigning conversations to another pipeline.

Bug Fixes:
- Preserve a conversation’s active cards, tasks, and stage history in other pipelines when assigning it to a new pipeline.
- Treat assignment to a pipeline where the conversation already has an active card as a logged no-op, while allowing new cards when only completed history exists.
- Ensure pipeline stage updates target active cards without deleting memberships in other pipelines.

Enhancements:
- Clarify the distinction between adding a conversation to a pipeline and explicitly moving it between pipelines.

CI:
- Add the new multi-pipeline assignment and controller specs to the spec staleness guard and CI execution list.

Tests:
- Add coverage for multi-pipeline assignment, duplicate prevention, completed-card handling, stage updates, and flow-canvas execution.