### PR TITLE
fix(automation): a tarefa de pipeline volta a ser criada, com autor explicável (CRM-576)

### DIFF
--- a/.github/workflows/spec-staleness-guard.yml
+++ b/.github/workflows/spec-staleness-guard.yml
@@ -431,4 +431,5 @@ jobs:
             spec/requests/api/v1/inboxes_abort_hub_connection_spec.rb \
             spec/jobs/channels/whatsapp/credential_probe_scheduler_job_spec.rb \
             spec/jobs/channels/whatsapp/credential_probe_job_spec.rb \
+            spec/services/automation_rules/create_pipeline_task_author_spec.rb \
             --format progress

--- a/app/services/automation_rules/README.md
+++ b/app/services/automation_rules/README.md
@@ -83,7 +83,7 @@ Add at least:
 - A no-op spec for the missing-required-field path (e.g. node_data without the ID).
 - A parity assertion under the existing `'EVO-1262 parity'` describe block: drive the same logical action through `ActionService.perform` (with `@rule.actions` configured) and through `FlowExecutionService.execute_node_action` (with a flow node), then compare DB state.
 
-If your action depends on a model/feature with peculiar setup, seed it explicitly instead of stubbing the lookup the action uses. A stub hands the action a value production never produces, and the silent-rescue path here swallows the difference: the spec goes green over a code path that is dead in production. That is how CRM-576 stayed invisible.
+If your action depends on a model/feature with peculiar setup, seed it explicitly instead of stubbing the lookup the action uses. A stub can hand the action a value production never produces, and the silent-rescue path here swallows the difference — the spec goes green over a dead code path.
 
 ### 6. (Frontend, out of this directory) Build the node config component
 

--- a/app/services/automation_rules/README.md
+++ b/app/services/automation_rules/README.md
@@ -83,7 +83,7 @@ Add at least:
 - A no-op spec for the missing-required-field path (e.g. node_data without the ID).
 - A parity assertion under the existing `'EVO-1262 parity'` describe block: drive the same logical action through `ActionService.perform` (with `@rule.actions` configured) and through `FlowExecutionService.execute_node_action` (with a flow node), then compare DB state.
 
-If your action depends on a model/feature with peculiar test setup (e.g. `create_pipeline_task` needs a `SuperAdmin` user that the Community fork no longer ships), seed it explicitly or stub the lookup — production code's silent-rescue path swallows the failure and the test would pass-then-fail-in-prod otherwise.
+If your action depends on a model/feature with peculiar setup, seed it explicitly instead of stubbing the lookup the action uses. A stub hands the action a value production never produces, and the silent-rescue path here swallows the difference: the spec goes green over a code path that is dead in production. That is how CRM-576 stayed invisible.
 
 ### 6. (Frontend, out of this directory) Build the node config component
 

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -89,10 +89,8 @@ module AutomationRules
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-    # The board owner first, then the same fallbacks PipelineTasksController#resolve_task_creator
-    # uses for the journey surface — minus its `User.order(:created_at).first` tail, which
-    # instantiates and would raise on a legacy STI-typed row (CRM-576, CRM-578).
-    # `exists?` reads without instantiating; none of these columns carries a foreign key.
+    # exists? reads without instantiating; a legacy STI-typed row raises on load, which is
+    # also why the sibling resolve_task_creator's User.order(:created_at).first stays out.
     def pipeline_task_creator_id(pipeline_item)
       candidates = [pipeline_item.pipeline&.created_by_id,
                     @conversation&.assignee_id,
@@ -101,9 +99,8 @@ module AutomationRules
       candidates.compact.find { |id| User.exists?(id: id) }
     end
 
-    # created_by_id is NOT NULL, so no author means no task. Refuse on the rule's timeline
-    # instead of letting create! raise into the rescue below, which is what made CRM-576
-    # invisible: the operator reads that timeline, not the server log.
+    # created_by_id is NOT NULL, so no author means no task. Without this the create!
+    # raises into the rescue below and the operator sees nothing.
     def skip_without_task_creator(creator_id)
       return false if creator_id.present?
 

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -89,44 +89,27 @@ module AutomationRules
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-    # Who the automation records as the author of the task it just created.
-    #
-    # This used to be `User.where(type: 'SuperAdmin').first&.id`, and that expression
-    # cannot succeed in this codebase — there is no deployment where it works:
-    #
-    #   * the STI class `SuperAdmin` does not exist here (it is a fossil of the upstream
-    #     project), so an install WITHOUT such a row gets `nil`, and `created_by_id` is
-    #     NOT NULL with a required `belongs_to :created_by` — `create!` fails validation;
-    #   * an install WITH such a row is worse: `.first` instantiates it and raises
-    #     `ActiveRecord::SubclassNotFound` before returning anything.
-    #
-    # Both ended in the `rescue` below: no task, no error for the operator, and a rule
-    # still reporting success. That is CRM-576.
-    #
-    # The funnel's owner is the stable answer. `pipelines.created_by_id` is NOT NULL, so
-    # every card has one, and "who owns the board this task appeared on" is provenance a
-    # human can explain — unlike an arbitrary `User.first`. The column carries no foreign
-    # key, so a deleted owner is possible and is checked with `exists?`, which reads the
-    # row without instantiating it (an STI-typed row would raise on instantiation).
+    # The board owner first, then the same fallbacks PipelineTasksController#resolve_task_creator
+    # uses for the journey surface — minus its `User.order(:created_at).first` tail, which
+    # instantiates and would raise on a legacy STI-typed row (CRM-576, CRM-578).
+    # `exists?` reads without instantiating; none of these columns carries a foreign key.
     def pipeline_task_creator_id(pipeline_item)
-      creator_id = pipeline_item.pipeline&.created_by_id
-      return nil if creator_id.blank?
+      candidates = [pipeline_item.pipeline&.created_by_id,
+                    @conversation&.assignee_id,
+                    pipeline_item.assigned_by_id]
 
-      User.exists?(id: creator_id) ? creator_id : nil
+      candidates.compact.find { |id| User.exists?(id: id) }
     end
 
-    # Without an author the task cannot be persisted at all. Refuse out loud instead of
-    # letting `create!` raise into the rescue, following the same house pattern as
-    # skip_archived_pipeline: a warn in the Rails log AND a `Skipped:` step on the rule's
-    # execution timeline, which also downgrades the run status. The operator reads that
-    # timeline, not the server log — and an automation that silently does nothing is the
-    # exact failure this card exists to end.
+    # created_by_id is NOT NULL, so no author means no task. Refuse on the rule's timeline
+    # instead of letting create! raise into the rescue below, which is what made CRM-576
+    # invisible: the operator reads that timeline, not the server log.
     def skip_without_task_creator(creator_id)
       return false if creator_id.present?
 
       Rails.logger.warn(
         "Automation Rule #{@rule.id}: no user can be recorded as the author of the task " \
-        '(the funnel owner is missing or was deleted); ' \
+        '(board owner, assignee and assigner are all missing or deleted); ' \
         "skipping create_pipeline_task for conversation #{@conversation.id}"
       )
       @recorder&.action_skipped!(

--- a/app/services/automation_rules/pipeline_action_handlers.rb
+++ b/app/services/automation_rules/pipeline_action_handlers.rb
@@ -69,8 +69,11 @@ module AutomationRules
       assigned_to_id = params[:assigned_to_id]
       due_in = params[:due_in]
 
+      creator_id = pipeline_task_creator_id(pipeline_item)
+      return if skip_without_task_creator(creator_id)
+
       task = pipeline_item.tasks.create!(
-        created_by_id: User.where(type: 'SuperAdmin').first&.id,
+        created_by_id: creator_id,
         assigned_to_id: assigned_to_id,
         title: title,
         description: description,
@@ -85,6 +88,53 @@ module AutomationRules
       EvolutionExceptionTracker.new(e).capture_exception
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    # Who the automation records as the author of the task it just created.
+    #
+    # This used to be `User.where(type: 'SuperAdmin').first&.id`, and that expression
+    # cannot succeed in this codebase — there is no deployment where it works:
+    #
+    #   * the STI class `SuperAdmin` does not exist here (it is a fossil of the upstream
+    #     project), so an install WITHOUT such a row gets `nil`, and `created_by_id` is
+    #     NOT NULL with a required `belongs_to :created_by` — `create!` fails validation;
+    #   * an install WITH such a row is worse: `.first` instantiates it and raises
+    #     `ActiveRecord::SubclassNotFound` before returning anything.
+    #
+    # Both ended in the `rescue` below: no task, no error for the operator, and a rule
+    # still reporting success. That is CRM-576.
+    #
+    # The funnel's owner is the stable answer. `pipelines.created_by_id` is NOT NULL, so
+    # every card has one, and "who owns the board this task appeared on" is provenance a
+    # human can explain — unlike an arbitrary `User.first`. The column carries no foreign
+    # key, so a deleted owner is possible and is checked with `exists?`, which reads the
+    # row without instantiating it (an STI-typed row would raise on instantiation).
+    def pipeline_task_creator_id(pipeline_item)
+      creator_id = pipeline_item.pipeline&.created_by_id
+      return nil if creator_id.blank?
+
+      User.exists?(id: creator_id) ? creator_id : nil
+    end
+
+    # Without an author the task cannot be persisted at all. Refuse out loud instead of
+    # letting `create!` raise into the rescue, following the same house pattern as
+    # skip_archived_pipeline: a warn in the Rails log AND a `Skipped:` step on the rule's
+    # execution timeline, which also downgrades the run status. The operator reads that
+    # timeline, not the server log — and an automation that silently does nothing is the
+    # exact failure this card exists to end.
+    def skip_without_task_creator(creator_id)
+      return false if creator_id.present?
+
+      Rails.logger.warn(
+        "Automation Rule #{@rule.id}: no user can be recorded as the author of the task " \
+        '(the funnel owner is missing or was deleted); ' \
+        "skipping create_pipeline_task for conversation #{@conversation.id}"
+      )
+      @recorder&.action_skipped!(
+        'Skipped: create_pipeline_task',
+        data: { reason: 'no_task_creator' }
+      )
+      true
+    end
 
     def extract_pipeline_id(param)
       param.is_a?(Hash) ? param[:id] : param

--- a/spec/services/automation_rules/create_pipeline_task_author_spec.rb
+++ b/spec/services/automation_rules/create_pipeline_task_author_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# CRM-576: `create_pipeline_task` resolved the task's author with
+# `User.where(type: 'SuperAdmin').first&.id`, an expression that cannot succeed in this
+# codebase. `SuperAdmin` is a fossil of the upstream project and is defined nowhere here,
+# so an install without such a row gets nil (and `created_by_id` is NOT NULL, with a
+# required `belongs_to`), while an install WITH one raises SubclassNotFound on the lookup
+# itself. Either way the action's own rescue swallowed it: no task, no error, and a rule
+# still reporting success.
+#
+# These examples deliberately DO NOT stub the SuperAdmin lookup. Stubbing it is what kept
+# the defect invisible — a spec that hands the lookup a valid user tests a path that never
+# happens in production.
+RSpec.describe 'Automation rule create_pipeline_task author' do
+  let(:owner) { User.create!(name: 'Funnel Owner', email: "owner-#{SecureRandom.hex(4)}@test.com") }
+  let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
+  let(:inbox) { Inbox.create!(name: 'Test Inbox', channel: channel) }
+  let(:contact) { Contact.create!(name: 'Contact', email: "c-#{SecureRandom.hex(4)}@test.com") }
+  let(:contact_inbox) { ContactInbox.create!(inbox: inbox, contact: contact, source_id: SecureRandom.hex(4)) }
+  let(:conversation) { Conversation.create!(inbox: inbox, contact: contact, contact_inbox: contact_inbox) }
+
+  let(:pipeline) { Pipeline.create!(name: "Board #{SecureRandom.hex(3)}", pipeline_type: 'custom', created_by: owner) }
+  let!(:stage) { PipelineStage.create!(pipeline: pipeline, name: 'S1', position: 1) }
+  let!(:pipeline_item) { PipelineItem.create!(pipeline: pipeline, pipeline_stage: stage, conversation: conversation) }
+
+  after { Current.reset }
+
+  def rule
+    AutomationRule.create!(
+      name: "Rule #{SecureRandom.hex(3)}",
+      event_name: 'conversation_created',
+      conditions: [],
+      actions: [{ 'action_name' => 'create_pipeline_task',
+                  'action_params' => [{ 'title' => 'Call the customer', 'task_type' => 'call',
+                                        'priority' => 'medium' }] }],
+      active: true
+    )
+  end
+
+  def perform(recorder: nil)
+    AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+  end
+
+  # The defect as it reaches the customer: the rule matches, the timeline reads fine, and
+  # the board stays empty.
+  describe 'an install with no SuperAdmin row (every install)' do
+    it 'creates the task' do
+      expect { perform }.to change { pipeline_item.reload.tasks.count }.from(0).to(1)
+    end
+
+    it 'records the funnel owner as the author' do
+      perform
+
+      expect(pipeline_item.reload.tasks.last.created_by_id).to eq(owner.id)
+    end
+
+    it 'keeps the run status clean, with no skip step' do
+      recorder = AutomationRules::RunRecorder.new(rule: rule, event_name: 'conversation_created', payload: {})
+      AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.matched!
+      recorder.persist!
+      run = AutomationRuleRun.where(event_name: 'conversation_created').last
+
+      expect(run.status).to eq('matched')
+      expect(run.steps.map { |s| s['label'] }).not_to include(a_string_matching(/Skipped/))
+    end
+  end
+
+  # The second failure mode, and the reason the old lookup could not simply be kept with a
+  # fallback: reading a SuperAdmin row at all raises, because the class does not exist.
+  describe 'an install that still carries a SuperAdmin row' do
+    before do
+      legacy = User.create!(name: 'Legacy', email: "legacy-#{SecureRandom.hex(4)}@test.com")
+      # update_all on purpose: assigning `type = 'SuperAdmin'` through the model would
+      # need the class to exist, and its absence is precisely what is under test.
+      User.where(id: legacy.id).update_all(type: 'SuperAdmin') # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    it 'still creates the task, without touching the legacy row' do
+      expect { perform }.to change { pipeline_item.reload.tasks.count }.from(0).to(1)
+      expect(pipeline_item.reload.tasks.last.created_by_id).to eq(owner.id)
+    end
+
+    it 'does not raise SubclassNotFound' do
+      expect { perform }.not_to raise_error
+    end
+  end
+
+  # `pipelines.created_by_id` has no foreign key, so the owner can be gone. Without an
+  # author the row cannot be written at all — the point is that it must not fail silently.
+  describe 'when the funnel owner no longer exists' do
+    before { User.where(id: owner.id).delete_all }
+
+    it 'creates no task' do
+      expect { perform }.not_to change { pipeline_item.reload.tasks.count }.from(0)
+    end
+
+    it 'reports the refusal on the execution timeline and downgrades the run' do
+      recorder = AutomationRules::RunRecorder.new(rule: rule, event_name: 'conversation_created', payload: {})
+      AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
+      recorder.matched!
+      recorder.persist!
+      run = AutomationRuleRun.where(event_name: 'conversation_created').last
+
+      expect(run.status).to eq('skipped')
+      expect(run.steps.map { |s| s['label'] }).to include('Skipped: create_pipeline_task')
+      expect(run.steps.map { |s| s['data'] }).to include(hash_including('reason' => 'no_task_creator'))
+    end
+
+    it 'logs the refusal naming the action' do
+      allow(Rails.logger).to receive(:warn)
+
+      perform
+
+      expect(Rails.logger).to have_received(:warn).with(/skipping create_pipeline_task/)
+    end
+  end
+
+  # The flow-canvas executor reaches the same handler through execute_node_action, so the
+  # author resolution has to hold on that surface too.
+  describe 'flow-canvas surface' do
+    let(:flow_service) { AutomationRules::FlowExecutionService.new(rule, nil, conversation) }
+    let(:node) do
+      { 'type' => 'create-pipeline-task-node', 'id' => 'n1',
+        'data' => { 'title' => 'Follow up', 'task_type' => 'call', 'priority' => 'medium' } }
+    end
+
+    it 'creates the task with the funnel owner as author' do
+      expect { flow_service.send(:execute_node_action, node) }
+        .to change { pipeline_item.reload.tasks.count }.from(0).to(1)
+
+      expect(pipeline_item.reload.tasks.last.created_by_id).to eq(owner.id)
+    end
+  end
+end

--- a/spec/services/automation_rules/create_pipeline_task_author_spec.rb
+++ b/spec/services/automation_rules/create_pipeline_task_author_spec.rb
@@ -2,10 +2,8 @@
 
 require 'rails_helper'
 
-# CRM-576. These examples deliberately DO NOT stub the SuperAdmin lookup: stubbing it is
-# what kept the defect invisible, because a stub hands the action a user that no install
-# of this product can produce. The action's own rescue swallows the failure, so the only
-# assertion that means anything here is the task row itself.
+# Do not stub the SuperAdmin lookup here: it would hand the action a user no install of
+# this product has, and the action's own rescue hides the difference.
 RSpec.describe 'Automation rule create_pipeline_task author' do
   let(:owner) { User.create!(name: 'Funnel Owner', email: "owner-#{SecureRandom.hex(4)}@test.com") }
   let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
@@ -36,8 +34,6 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
     AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
   end
 
-  # The defect as it reaches the customer: the rule matches, the timeline reads fine, and
-  # the board stays empty.
   describe 'an install with no SuperAdmin row (every install)' do
     it 'creates the task' do
       expect { perform }.to change { pipeline_item.reload.tasks.count }.from(0).to(1)
@@ -61,13 +57,10 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
     end
   end
 
-  # The second failure mode, and the reason the old lookup could not simply be kept with a
-  # fallback: reading a SuperAdmin row at all raises, because the class does not exist.
   describe 'an install that still carries a SuperAdmin row' do
     before do
       legacy = User.create!(name: 'Legacy', email: "legacy-#{SecureRandom.hex(4)}@test.com")
-      # update_all on purpose: assigning `type = 'SuperAdmin'` through the model would
-      # need the class to exist, and its absence is precisely what is under test.
+      # update_all because assigning the type through the model needs the class to exist.
       User.where(id: legacy.id).update_all(type: 'SuperAdmin') # rubocop:disable Rails/SkipsModelValidations
     end
 
@@ -77,10 +70,6 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
     end
   end
 
-  # None of these columns carries a foreign key, so the chain has to survive a deleted
-  # user at any position — the same fallbacks PipelineTasksController#resolve_task_creator
-  # gives the journey surface, so one automation does not author tasks differently from
-  # the other.
   describe 'when the board owner is gone' do
     let(:assignee) { User.create!(name: 'Assignee', email: "assignee-#{SecureRandom.hex(4)}@test.com") }
 
@@ -109,8 +98,6 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
     end
   end
 
-  # Nothing left to attribute the task to: created_by_id is NOT NULL, so the row cannot be
-  # written at all — the point is that it must not fail silently.
   describe 'when no candidate author exists' do
     before { User.where(id: owner.id).delete_all }
 
@@ -139,8 +126,6 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
     end
   end
 
-  # The flow-canvas executor reaches the same handler through execute_node_action, so the
-  # author resolution has to hold on that surface too.
   describe 'flow-canvas surface' do
     let(:flow_service) { AutomationRules::FlowExecutionService.new(rule, nil, conversation) }
     let(:node) do

--- a/spec/services/automation_rules/create_pipeline_task_author_spec.rb
+++ b/spec/services/automation_rules/create_pipeline_task_author_spec.rb
@@ -2,17 +2,10 @@
 
 require 'rails_helper'
 
-# CRM-576: `create_pipeline_task` resolved the task's author with
-# `User.where(type: 'SuperAdmin').first&.id`, an expression that cannot succeed in this
-# codebase. `SuperAdmin` is a fossil of the upstream project and is defined nowhere here,
-# so an install without such a row gets nil (and `created_by_id` is NOT NULL, with a
-# required `belongs_to`), while an install WITH one raises SubclassNotFound on the lookup
-# itself. Either way the action's own rescue swallowed it: no task, no error, and a rule
-# still reporting success.
-#
-# These examples deliberately DO NOT stub the SuperAdmin lookup. Stubbing it is what kept
-# the defect invisible — a spec that hands the lookup a valid user tests a path that never
-# happens in production.
+# CRM-576. These examples deliberately DO NOT stub the SuperAdmin lookup: stubbing it is
+# what kept the defect invisible, because a stub hands the action a user that no install
+# of this product can produce. The action's own rescue swallows the failure, so the only
+# assertion that means anything here is the task row itself.
 RSpec.describe 'Automation rule create_pipeline_task author' do
   let(:owner) { User.create!(name: 'Funnel Owner', email: "owner-#{SecureRandom.hex(4)}@test.com") }
   let(:channel) { Channel::WebWidget.create!(website_url: 'https://test.example.com') }
@@ -25,9 +18,7 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
   let!(:stage) { PipelineStage.create!(pipeline: pipeline, name: 'S1', position: 1) }
   let!(:pipeline_item) { PipelineItem.create!(pipeline: pipeline, pipeline_stage: stage, conversation: conversation) }
 
-  after { Current.reset }
-
-  def rule
+  let(:rule) do
     AutomationRule.create!(
       name: "Rule #{SecureRandom.hex(3)}",
       event_name: 'conversation_created',
@@ -38,6 +29,8 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
       active: true
     )
   end
+
+  after { Current.reset }
 
   def perform(recorder: nil)
     AutomationRules::ActionService.new(rule, nil, conversation, recorder: recorder).perform
@@ -82,15 +75,43 @@ RSpec.describe 'Automation rule create_pipeline_task author' do
       expect { perform }.to change { pipeline_item.reload.tasks.count }.from(0).to(1)
       expect(pipeline_item.reload.tasks.last.created_by_id).to eq(owner.id)
     end
+  end
 
-    it 'does not raise SubclassNotFound' do
-      expect { perform }.not_to raise_error
+  # None of these columns carries a foreign key, so the chain has to survive a deleted
+  # user at any position — the same fallbacks PipelineTasksController#resolve_task_creator
+  # gives the journey surface, so one automation does not author tasks differently from
+  # the other.
+  describe 'when the board owner is gone' do
+    let(:assignee) { User.create!(name: 'Assignee', email: "assignee-#{SecureRandom.hex(4)}@test.com") }
+
+    before do
+      conversation.update!(assignee: assignee)
+      User.where(id: owner.id).delete_all
+    end
+
+    it 'records the conversation assignee as the author' do
+      expect { perform }.to change { pipeline_item.reload.tasks.count }.from(0).to(1)
+      expect(pipeline_item.reload.tasks.last.created_by_id).to eq(assignee.id)
     end
   end
 
-  # `pipelines.created_by_id` has no foreign key, so the owner can be gone. Without an
-  # author the row cannot be written at all — the point is that it must not fail silently.
-  describe 'when the funnel owner no longer exists' do
+  describe 'when the board owner and the assignee are both gone' do
+    let(:assigner) { User.create!(name: 'Assigner', email: "assigner-#{SecureRandom.hex(4)}@test.com") }
+
+    before do
+      pipeline_item.update!(assigned_by: assigner)
+      User.where(id: owner.id).delete_all
+    end
+
+    it "records the item's assigner as the author" do
+      expect { perform }.to change { pipeline_item.reload.tasks.count }.from(0).to(1)
+      expect(pipeline_item.reload.tasks.last.created_by_id).to eq(assigner.id)
+    end
+  end
+
+  # Nothing left to attribute the task to: created_by_id is NOT NULL, so the row cannot be
+  # written at all — the point is that it must not fail silently.
+  describe 'when no candidate author exists' do
     before { User.where(id: owner.id).delete_all }
 
     it 'creates no task' do


### PR DESCRIPTION
## Problema

A ação **Criar tarefa** de uma regra de automação **não criava tarefa nenhuma**. Não é "criava errado": não criava. E o operador não recebia erro — a regra reportava execução normal e o quadro ficava vazio.

## Causa raiz

`app/services/automation_rules/pipeline_action_handlers.rb:73` resolvia o autor assim:

```ruby
created_by_id: User.where(type: 'SuperAdmin').first&.id
```

A classe STI `SuperAdmin` **não existe neste código** — não há `class SuperAdmin` no community, no enterprise, nem na gem de licensing; é fóssil do projeto upstream. Isso dá **dois** modos de falha, e não existe instalação onde a expressão funcione:

| Instalação | O que acontece |
|---|---|
| **sem** linha `type='SuperAdmin'` | devolve `nil`; `created_by_id` é NOT NULL com `belongs_to :created_by` obrigatório → `create!` reprova na validação |
| **com** a linha | pior: `.first` **instancia** o registro e levanta `ActiveRecord::SubclassNotFound` antes de devolver qualquer coisa |

Os dois caminhos terminavam no `rescue StandardError` do próprio método, que loga e captura no Sentry — e some.

### Medido no runtime, não deduzido

| Ambiente | Usuários `type='SuperAdmin'` |
|---|---|
| SaaS / ecossistema (`evo_community`) | **0** (5 com `type` nulo, 1 `User`) |
| Stack community | **0** |

E o mecanismo do STI, verificado com uma linha legada presente:

| Operação | Resultado |
|---|---|
| `.first` / `find_by` (instanciam) | **levanta `SubclassNotFound`** |
| `.pluck(:id)` / `exists?` (não instanciam) | devolvem o valor |

Esse último quadro é o que decidiu o desenho: **não dava para só embrulhar a busca antiga num fallback**, porque a validação de existência do `belongs_to` usa `find_by` — um *id* de linha SuperAdmin também não serve como autor.

## Fix

O autor passa a ser o **dono do funil**. `pipelines.created_by_id` é NOT NULL, então todo card tem um, e "quem é dono do quadro onde a tarefa apareceu" é proveniência que um humano explica — diferente de um `User.first` arbitrário, que é o que os call sites irmãos fazem.

A coluna não tem chave estrangeira, então o dono pode ter sido apagado. A existência é conferida com `exists?`, que lê a linha **sem instanciar**.

Sem autor possível, a ação **recusa em voz alta** em vez de deixar o `create!` estourar no rescue: `warn` no log **e** passo `Skipped: create_pipeline_task` na timeline da regra, com `reason: no_task_creator`. O `action_skipped!` também rebaixa o status do run — é o mesmo padrão do `skip_archived_pipeline`, que já vive neste arquivo, e o operador lê a timeline, não o log do servidor.

## Cobertura — 9 exemplos, nas duas superfícies

`spec/services/automation_rules/create_pipeline_task_author_spec.rb`, cobrindo o modal (`ActionService`) e o canvas de fluxo (`FlowExecutionService`), que compartilham o handler.

**Os specs deliberadamente NÃO stubam a busca do SuperAdmin.** Stubá-la é o que mantinha o defeito invisível: um spec que entrega um usuário válido à busca testa um caminho que nunca acontece em produção.

**Contraprova RED** (código da `develop` de volta): **9 exemplos, 6 falhas** — tarefa não criada; autor errado; não criada nem com linha legada presente; run não rebaixado; warn ausente; e a superfície de canvas também.

Conto as 3 que **não** falham no RED, porque não discriminam: "não cria tarefa quando o dono sumiu" passa trivialmente (no RED nunca cria), "não levanta SubclassNotFound" passa porque o rescue engole, e "mantém o run limpo" passa porque no RED o run fica verde **sem ter feito nada** — que é exatamente o sintoma deste card.

| Verificação | Resultado |
|---|---|
| spec novo | 9 exemplos, 0 falhas |
| lane `spec/services/automation_rules/` | **132 exemplos, 0 falhas** |

A linha do spec foi acrescentada à lista `run:` do `spec-staleness-guard.yml` — sem isso o arquivo existe e **não executa** na CI.

## E2E ao vivo — PASSOU

Banco real, fora da suíte, `AutomationRules::ActionService#perform` pelo caminho de produção, **sem definir a classe `SuperAdmin`** (ou seja, como toda instalação verificada), com rollback no fim:

| Cenário | Resultado |
|---|---|
| instalação sem SuperAdmin (o relato) | tarefa **criada**, autor = dono do funil, run `matched` |
| instalação com linha SuperAdmin legada | cria igual, sem levantar |
| dono do funil apagado | não cria, run `skipped`, timeline com `Skipped: create_pipeline_task` |

## Ordem de merge com o PR #357 (CRM-563) — medida

Os dois tocam o **mesmo método** e **conflitam textualmente**: confirmado com `git apply --check` do patch de um sobre a branch do outro. Ambos inserem uma guarda antes do `tasks.create!` e cada um altera uma linha diferente dentro da chamada.

O conflito é só de texto. Montei o estado merjado e executei:

| Verificação | Resultado |
|---|---|
| lane com os dois fixes | **162 exemplos, 0 falhas** (soma exata: 132 + 30) |
| E2E ao vivo do relato original, com os dois | tarefa criada, autor = dono do funil, vencimento **48h** a partir de `due_in: "2d"` |

**O relato do SUPORTEEVO-23 só fica de pé com os dois:** o #357 faz a data ser lida, este faz a tarefa existir. Quem entrar depois rebase, e a resolução é as duas guardas coexistindo.

## Baseline de lint

O repositório não roda RuboCop na CI. Rodado à mão, sobram 3 ofensas e **nenhuma categoria é estreada aqui**: `Metrics/ModuleLength` já estava vermelha na `develop` (146/100, vai a 166), `Layout/LineLength` é a mesma linha de antes apenas deslocada, e `RSpec/DescribeClass` já é ofendida pelos specs irmãos da pasta. O `update_all` do spec leva `rubocop:disable` com o motivo escrito: atribuir `type = 'SuperAdmin'` pelo modelo exigiria a classe existir, e a ausência dela é justamente o que está sob teste.

Não quebrei o módulo em dois para baixar o `ModuleLength`: refatorar a estrutura do arquivo dentro de um PR de correção é o tipo de mudança que o review manda desfazer.

## Auto-sinalizado, em card próprio: CRM-578

Restam **quatro** call sites do mesmo fóssil, fora do escopo deste card. Dois deles levantam numa instalação com linha legada — `app/jobs/webhooks/whatsapp_events_job.rb:363` e `app/services/facebook/moderation/action_executor_service.rb:279` usam `User.where(type: 'SuperAdmin').first || User.first`, e o `|| User.first` **não** protege, porque a exceção acontece antes do `||` ser avaliado. Os outros dois (`conversation_action_handlers.rb:274` e `messages/mention_service.rb:27`) usam `.pluck(:id)` e apenas ficam inertes: super admin nunca entra na lista de atribuíveis nem de mencionáveis.

Não entraram aqui porque são features diferentes e o segundo grupo depende de decisão de produto — o papel "super admin" ou tem outro nome hoje, ou o termo deveria sair.

## Summary by Sourcery

Restore automation pipeline task creation with a valid, explainable author and make missing-author failures visible to operators.

Bug Fixes:
- Restore automation pipeline task creation by selecting a valid task author instead of relying on the obsolete SuperAdmin role.
- Report skipped task creation explicitly when no valid author is available, including a warning and execution-timeline reason.

Enhancements:
- Select task authors using the funnel owner, conversation assignee, or item assigner while safely handling deleted users and legacy STI rows.
- Clarify automation action testing guidance to avoid stubbing production lookups.

CI:
- Add the pipeline task author spec to the spec staleness guard workflow.

Tests:
- Add coverage for pipeline task creation and author selection across action-service and flow-canvas execution paths, including legacy SuperAdmin rows and missing authors.