### PR TITLE
fix(webhooks): handle 'send.message' event in Evolution channel

### DIFF
--- a/app/services/whatsapp/incoming_message_evolution_service.rb
+++ b/app/services/whatsapp/incoming_message_evolution_service.rb
@@ -11,7 +11,7 @@ class Whatsapp::IncomingMessageEvolutionService < Whatsapp::IncomingMessageBaseS
     Rails.logger.debug { "Evolution API: Full payload: #{processed_params.inspect}" }
 
     case event_type
-    when 'messages.upsert'
+    when 'messages.upsert', 'send.message'
       process_messages_upsert
     when 'messages.update'
       process_messages_update


### PR DESCRIPTION
## Summary

Messages sent through a direct REST call to an Evolution API instance's
send endpoint (i.e. by any external system integrating with that instance,
not through this CRM's own UI and not from the linked WhatsApp app) never
appear in the conversation history. They are silently dropped with a
`Unsupported event type: send.message` warning.

## Root cause

- `app/controllers/api/v1/evolution/authorizations_controller.rb` already
  subscribes the instance's webhook to the `SEND_MESSAGE` event
  (`webhook_events` array, line ~130).
- `app/services/whatsapp/incoming_message_evolution_service.rb#perform`
  only handled `'messages.upsert'` in its `case event_type` — there was no
  branch for `'send.message'`, so it fell through to the `else` and the
  payload was discarded.

Evolution API fires `send.message` (not `messages.upsert`) specifically
when the instance's own Baileys session is the *origin* of the send via a
direct REST call — the session does not echo its own outbound send back to
itself through `messages.upsert` the way it does for messages coming from
another linked device (e.g. the WhatsApp phone app) or from a different
account. This means:

- Messages from the WhatsApp app → arrive as genuine `messages.upsert` →
  handled correctly.
- Messages sent through this CRM's own UI → written directly to the
  database at send time → unaffected by this bug.
- Messages sent via any other direct call to the instance's send endpoint
  → only produce `send.message` → were being dropped.

## Fix

Route `'send.message'` through the same handler as `'messages.upsert'`.
`process_messages_upsert` already decides everything from
`processed_params[:data]` (in particular `key.fromMe`) and does not depend
on the event name, so reusing it is safe. It is also already idempotent
for messages this CRM created itself via its own send flow —
`message_processable?` (`evolution_handlers/messages_upsert.rb`) skips
creation via `find_message_by_source_id` when a message with that
`source_id` already exists, which is the case for anything already saved
through this CRM's own outbound-send path.

```diff
     case event_type
-    when 'messages.upsert'
+    when 'messages.upsert', 'send.message'
       process_messages_upsert
```

## Reproduction

1. Configure an Evolution channel/inbox as usual (the instance is created
   with `SEND_MESSAGE` already in its subscribed webhook events).
2. From outside this CRM — a plain `curl` against the instance's own send
   endpoint, or any third-party system integrated the same way — send a
   text message using that instance's credentials, to a phone number that
   is **not** itself another Evolution instance tracked by this CRM (to
   avoid the message being picked up incidentally as an unrelated inbound
   `messages.upsert` on a different inbox).
3. Observe the webhook consumer's log (the Sidekiq worker that processes
   `Webhooks::WhatsappEventsJob`, since the job runs asynchronously): the
   channel is found correctly, but the event is logged as
   `Unsupported event type: send.message` and no message is created in any
   conversation.
4. With this fix applied, the same payload creates an outgoing message on
   the correct conversation, exactly as an app-originated message would.

## Test plan

- [x] Verified in a local self-hosted deployment via a read-only bind mount
      replacing this file inside the official
      `evoapicloud/evo-ai-crm-community:1.1.0` image — no other code path
      changed.
- [x] Confirmed messages sent through the CRM's own UI are unaffected
      (deduplicated via existing `source_id` — no doubles).
- [x] Confirmed messages sent via a direct API call now appear in the
      correct conversation, with logs showing `Message created
      successfully` tied to the same job that processed the `send.message`
      event.

## Summary by Sourcery

Bug Fixes:
- Process Evolution API `send.message` webhooks so externally sent messages are recorded in the correct conversation instead of being discarded.